### PR TITLE
Restore decimal strength rank display

### DIFF
--- a/src/main/java/featurecat/lizzie/gui/LizzieFrame.java
+++ b/src/main/java/featurecat/lizzie/gui/LizzieFrame.java
@@ -13637,7 +13637,7 @@ public class LizzieFrame extends JFrame {
     if (report == null || !report.hasSamples()) {
       return "-";
     }
-    return playerStrengthDisplayRank(report.strengthBand);
+    return playerStrengthRankValueText(report);
   }
 
   private static String playerStrengthRankValueText(PlayerStrengthEstimator.SideReport report) {
@@ -16030,7 +16030,7 @@ public class LizzieFrame extends JFrame {
       if (report == null || !report.hasSamples()) {
         return "-";
       }
-      return playerStrengthEstimateText(report);
+      return playerStrengthDisplayRank(report.strengthBand);
     }
 
     private String percentText(double value) {


### PR DESCRIPTION
## Summary

- Restore the main player strength assessment cards to show decimal rank values again.
- Keep the compact strength label in the match chart so small bars do not overflow or become noisy.
- Preserve the detailed/reference rank band data for users who want the broader model bucket.

## Validation

- `git diff --check`
- `mvn -B -Dfmt.skip=true -Dtest=LizzieFrameRegressionTest#playerStrengthRankWindowLabelUsesCompactRankText,PlayerStrengthEstimatorTest test`
- `mvn -B -Dfmt.skip=true test`
- `mvn -B -Dfmt.skip=true -DskipTests package`
