### PR TITLE
Improve player strength score rule panel

### DIFF
--- a/src/main/java/featurecat/lizzie/gui/LizzieFrame.java
+++ b/src/main/java/featurecat/lizzie/gui/LizzieFrame.java
@@ -14466,6 +14466,11 @@ public class LizzieFrame extends JFrame {
       setOpaque(false);
       setPreferredSize(new Dimension(430, 360));
       setMinimumSize(new Dimension(360, 300));
+      setToolTipText(playerStrengthRankScaleTooltip(report));
+      getAccessibleContext()
+          .setAccessibleName(
+              sideName + " " + Lizzie.resourceBundle.getString("PlayerStrengthEstimate.title"));
+      getAccessibleContext().setAccessibleDescription(playerStrengthRankScalePlainText(report));
     }
 
     @Override
@@ -14479,9 +14484,9 @@ public class LizzieFrame extends JFrame {
       playerStrengthDrawRoundedCard(g2, 0, 0, width, height);
 
       playerStrengthDrawGeneratedStone(g2, black, 30, 38, 72, 1.0f);
-      int ladderWidth = Math.max(96, Math.min(112, width / 4));
-      int ladderX = Math.max(292, width - ladderWidth - 28);
-      int contentRight = Math.max(260, ladderX - 24);
+      int scaleWidth = Math.max(136, Math.min(180, width / 3));
+      int scaleX = Math.max(286, width - scaleWidth - 28);
+      int contentRight = Math.max(260, scaleX - 24);
       playerStrengthDrawFittedText(
           g2,
           sideName + Lizzie.resourceBundle.getString("PlayerStrengthEstimate.performanceSuffix"),
@@ -14512,7 +14517,7 @@ public class LizzieFrame extends JFrame {
           Font.PLAIN,
           Config.frameFontSize + 1);
 
-      drawRankLadder(g2, ladderX, 68, ladderWidth, Math.max(178, height - 116));
+      drawRankScalePanel(g2, scaleX, 68, scaleWidth, Math.max(178, height - 116));
       int rowY = 186;
       drawMetricRow(
           g2,
@@ -14594,44 +14599,122 @@ public class LizzieFrame extends JFrame {
       playerStrengthDrawBar(g2, barX, y - 9, barWidth, fraction, color);
     }
 
-    private void drawRankLadder(Graphics2D g2, int x, int y, int width, int height) {
-      String[] labels = {
-        Lizzie.resourceBundle.getString("PlayerStrengthEstimate.rank.scale.ai"),
-        Lizzie.resourceBundle.getString("PlayerStrengthEstimate.rank.scale.topPro"),
-        Lizzie.resourceBundle.getString("PlayerStrengthEstimate.rank.scale.pro"),
-        Lizzie.resourceBundle.getString("PlayerStrengthEstimate.rank.scale.fox")
-      };
+    private void drawRankScalePanel(Graphics2D g2, int x, int y, int width, int height) {
+      String[][] rows = playerStrengthRankScaleRows();
       int selected =
-          report.rankValue >= 12.0
-              ? 0
-              : report.rankValue >= 11.0 ? 1 : report.rankValue >= 10.0 ? 2 : 3;
-      int rowHeight = Math.max(26, height / labels.length);
+          playerStrengthRankScaleSelectedIndex(report == null ? Double.NaN : report.rankValue);
+      int panelY = y;
+      int panelHeight = Math.max(154, height);
       playerStrengthDrawFittedText(
           g2,
           Lizzie.resourceBundle.getString("PlayerStrengthEstimate.rank.scale"),
           x,
-          y - 13,
+          panelY - 13,
           width,
           PlayerStrengthDashboardRoot.MUTED_TEXT,
           Font.PLAIN,
           Math.max(10, Config.frameFontSize - 1));
+      g2.setColor(new Color(252, 249, 241, 176));
+      g2.fillRoundRect(x, panelY, width, panelHeight, 16, 16);
+      g2.setColor(new Color(220, 209, 192));
+      g2.drawRoundRect(x, panelY, width, panelHeight, 16, 16);
       g2.setFont(
           new Font(Config.sysDefaultFontName, Font.PLAIN, Math.max(11, Config.frameFontSize - 1)));
-      for (int i = 0; i < labels.length; i++) {
-        int rowY = y + i * rowHeight;
-        g2.setColor(i == selected ? new Color(235, 222, 199) : new Color(249, 246, 238));
-        g2.fillRoundRect(x, rowY, width, rowHeight - 2, 10, 10);
-        g2.setColor(new Color(220, 209, 192));
-        g2.drawRoundRect(x, rowY, width, rowHeight - 2, 10, 10);
+      int rowHeight = Math.max(34, (panelHeight - 12) / rows.length);
+      int rowTop = panelY + 6;
+      for (int i = 0; i < rows.length; i++) {
+        int rowY = rowTop + i * rowHeight;
+        boolean active = i == selected;
+        if (active) {
+          g2.setColor(new Color(235, 222, 199, 235));
+          g2.fillRoundRect(x + 6, rowY, width - 12, rowHeight - 4, 12, 12);
+        }
         g2.setColor(
-            i == selected
+            active ? PlayerStrengthDashboardRoot.ACCENT_DARK : PlayerStrengthDashboardRoot.MUTED_TEXT);
+        g2.fillOval(x + 13, rowY + rowHeight / 2 - 4, 8, 8);
+        playerStrengthDrawFittedText(
+            g2,
+            rows[i][0],
+            x + 28,
+            rowY + rowHeight / 2 + 5,
+            34,
+            active
                 ? PlayerStrengthDashboardRoot.ACCENT_DARK
-                : PlayerStrengthDashboardRoot.MUTED_TEXT);
-        String label = playerStrengthEllipsize(labels[i], g2.getFontMetrics(), width - 14);
-        int textWidth = g2.getFontMetrics().stringWidth(label);
-        g2.drawString(label, x + Math.max(7, (width - textWidth) / 2), rowY + rowHeight / 2 + 5);
+                : PlayerStrengthDashboardRoot.MUTED_TEXT,
+            Font.BOLD,
+            Math.max(10, Config.frameFontSize - 1));
+        playerStrengthDrawFittedText(
+            g2,
+            rows[i][1],
+            x + 66,
+            rowY + rowHeight / 2 + 5,
+            width - 74,
+            active ? PlayerStrengthDashboardRoot.ACCENT_DARK : PlayerStrengthDashboardRoot.TEXT,
+            Font.PLAIN,
+            Math.max(10, Config.frameFontSize - 1));
       }
     }
+  }
+
+  private static int playerStrengthRankScaleSelectedIndex(double rankValue) {
+    if (!Double.isFinite(rankValue)) {
+      return 3;
+    }
+    if (rankValue >= 12.0) {
+      return 0;
+    }
+    if (rankValue >= 11.0) {
+      return 1;
+    }
+    return rankValue >= 10.0 ? 2 : 3;
+  }
+
+  private static String[][] playerStrengthRankScaleRows() {
+    return new String[][] {
+      {"12+", Lizzie.resourceBundle.getString("PlayerStrengthEstimate.rank.scale.ai")},
+      {"11+", Lizzie.resourceBundle.getString("PlayerStrengthEstimate.rank.scale.topPro")},
+      {"10+", Lizzie.resourceBundle.getString("PlayerStrengthEstimate.rank.scale.pro")},
+      {"<10", Lizzie.resourceBundle.getString("PlayerStrengthEstimate.rank.scale.fox")}
+    };
+  }
+
+  private static String playerStrengthRankScalePlainText(
+      PlayerStrengthEstimator.SideReport report) {
+    StringBuilder builder =
+        new StringBuilder(Lizzie.resourceBundle.getString("PlayerStrengthEstimate.rank.scale"));
+    String current =
+        report == null || !report.hasSamples() ? "-" : playerStrengthRankValueText(report);
+    builder.append(": ").append(current);
+    for (String[] row : playerStrengthRankScaleRows()) {
+      builder.append("; ").append(row[0]).append(" ").append(row[1]);
+    }
+    return builder.toString();
+  }
+
+  private static String playerStrengthRankScaleTooltip(PlayerStrengthEstimator.SideReport report) {
+    StringBuilder builder = new StringBuilder("<html>");
+    builder.append(
+        playerStrengthHtmlEscape(
+            Lizzie.resourceBundle.getString("PlayerStrengthEstimate.rank.scale")));
+    String current =
+        report == null || !report.hasSamples() ? "-" : playerStrengthRankValueText(report);
+    builder.append(": ").append(playerStrengthHtmlEscape(current));
+    for (String[] row : playerStrengthRankScaleRows()) {
+      builder
+          .append("<br>")
+          .append(playerStrengthHtmlEscape(row[0]))
+          .append(" ")
+          .append(playerStrengthHtmlEscape(row[1]));
+    }
+    builder.append("</html>");
+    return builder.toString();
+  }
+
+  private static String playerStrengthHtmlEscape(String value) {
+    if (value == null || value.isEmpty()) {
+      return "";
+    }
+    return value.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;");
   }
 
   private static final class PlayerStrengthMatchSummaryCard extends JPanel {

--- a/src/main/resources/l10n/DisplayStrings_zh_HK.properties
+++ b/src/main/resources/l10n/DisplayStrings_zh_HK.properties
@@ -1624,10 +1624,10 @@ PlayerStrengthEstimate.rank.danRange=\u696d\u9918%s\u6bb5-%s\u6bb5
 PlayerStrengthEstimate.rank.danSingle=\u696d\u9918%s\u6bb5
 PlayerStrengthEstimate.rank.reference=\u53c3\u8003\u5340\u9593
 PlayerStrengthEstimate.rank.scale=\u8a55\u5206\u898f\u5247
-PlayerStrengthEstimate.rank.scale.ai=>=12: \u534a\u795e/AI
-PlayerStrengthEstimate.rank.scale.topPro=>=11, <12: \u4e00\u7dda\u8077\u696d
-PlayerStrengthEstimate.rank.scale.pro=>=10, <11: \u8077\u696d
-PlayerStrengthEstimate.rank.scale.fox=<10: \u91ce\u72d0\u6bb5\u4f4d/\u7b49\u7d1a
+PlayerStrengthEstimate.rank.scale.ai=\u534a\u795e/AI
+PlayerStrengthEstimate.rank.scale.topPro=\u4e00\u7dda\u8077\u696d
+PlayerStrengthEstimate.rank.scale.pro=\u8077\u696d
+PlayerStrengthEstimate.rank.scale.fox=\u696d\u9918\u6bb5\u7d1a
 PlayerStrengthEstimate.rank.pro=\u8077\u696d\u68cb\u624b
 PlayerStrengthEstimate.rank.topPro=\u4e00\u7dda\u8077\u696d
 PlayerStrengthEstimate.rank.ai=AI\u6c34\u5e73

--- a/src/main/resources/l10n/DisplayStrings_zh_TW.properties
+++ b/src/main/resources/l10n/DisplayStrings_zh_TW.properties
@@ -1626,10 +1626,10 @@ PlayerStrengthEstimate.rank.danRange=\u696d\u9918%s\u6bb5-%s\u6bb5
 PlayerStrengthEstimate.rank.danSingle=\u696d\u9918%s\u6bb5
 PlayerStrengthEstimate.rank.reference=\u53c3\u8003\u5340\u9593
 PlayerStrengthEstimate.rank.scale=\u8a55\u5206\u898f\u5247
-PlayerStrengthEstimate.rank.scale.ai=>=12: \u534a\u795e/AI
-PlayerStrengthEstimate.rank.scale.topPro=>=11, <12: \u4e00\u7dda\u8077\u696d
-PlayerStrengthEstimate.rank.scale.pro=>=10, <11: \u8077\u696d
-PlayerStrengthEstimate.rank.scale.fox=<10: \u91ce\u72d0\u6bb5\u4f4d/\u7b49\u7d1a
+PlayerStrengthEstimate.rank.scale.ai=\u534a\u795e/AI
+PlayerStrengthEstimate.rank.scale.topPro=\u4e00\u7dda\u8077\u696d
+PlayerStrengthEstimate.rank.scale.pro=\u8077\u696d
+PlayerStrengthEstimate.rank.scale.fox=\u696d\u9918\u6bb5\u7d1a
 PlayerStrengthEstimate.rank.pro=\u8077\u696d\u68cb\u624b
 PlayerStrengthEstimate.rank.topPro=\u4e00\u7dda\u8077\u696d
 PlayerStrengthEstimate.rank.ai=AI\u6c34\u5e73

--- a/src/test/java/featurecat/lizzie/gui/LizzieFrameRegressionTest.java
+++ b/src/test/java/featurecat/lizzie/gui/LizzieFrameRegressionTest.java
@@ -201,6 +201,27 @@ class LizzieFrameRegressionTest {
   }
 
   @Test
+  void playerStrengthAssessmentCardExposesCompleteScoreRuleText() throws Exception {
+    Class<?> cardClass =
+        Class.forName("featurecat.lizzie.gui.LizzieFrame$PlayerStrengthAssessmentCard");
+    java.lang.reflect.Constructor<?> constructor =
+        cardClass.getDeclaredConstructor(
+            String.class, boolean.class, PlayerStrengthEstimator.SideReport.class);
+    constructor.setAccessible(true);
+    javax.swing.JComponent card =
+        (javax.swing.JComponent)
+            constructor.newInstance("黑棋", true, playerStrengthReportWithSamples().black);
+
+    String tooltip = card.getToolTipText();
+
+    assertTrue(tooltip.contains("12+"), "score rule tooltip should show the AI band.");
+    assertTrue(tooltip.contains("11+"), "score rule tooltip should show the top-pro band.");
+    assertTrue(tooltip.contains("10+"), "score rule tooltip should show the pro band.");
+    assertTrue(tooltip.contains("&lt;10"), "score rule tooltip should show the amateur band.");
+    assertFalse(tooltip.contains("..."), "score rule text should not be ellipsized in tooltip.");
+  }
+
+  @Test
   void openBoardSyncCoalescesConsecutiveRestartsOnEdt() throws Exception {
     TestEnvironment env = TestEnvironment.open();
     try {


### PR DESCRIPTION
## Summary

- Fixes #82 by replacing the cramped player-strength score rule ladder with a wider, readable score-scale panel.
- Keeps the score bands visible in the main card and exposes the full score-scale text through tooltip/accessibility metadata.
- Normalizes Traditional Chinese score-scale strings so the threshold is shown once by the UI instead of being duplicated in localized labels.
- Leaves #66 and #68 open intentionally: #66 is waiting for reporter/discussion confirmation, and #68 is a separate threshold-calibration tracking issue that should not be changed without sample data.

## Validation

- `git diff --check`
- `mvn -B -Dfmt.skip=true -Dtest=LizzieFrameRegressionTest test`
- `mvn -B -Dfmt.skip=true test`
- `mvn -B -Dfmt.skip=true -DskipTests package`

## Notes

No release assets or packaging files are changed in this PR.
