### PR TITLE
Add release notes for next-2026-06-30.1

### DIFF
--- a/scripts/generate_release_notes.py
+++ b/scripts/generate_release_notes.py
@@ -4178,6 +4178,8 @@ def build_release_notes(asset_map: dict[str, str | None], bundle: dict[str, str]
         return build_next_2026_06_21_2_notes(asset_map, bundle, repo, release_tag)
     if release_tag == 'next-2026-06-29.1':
         return build_next_2026_06_29_1_notes(asset_map, bundle, repo, release_tag)
+    if release_tag == 'next-2026-06-30.1':
+        return build_next_2026_06_30_1_notes(asset_map, bundle, repo, release_tag)
 
     assets_cn = {
         key: format_asset(asset_map[key], repo, release_tag)
@@ -7386,6 +7388,109 @@ def build_next_2026_06_29_1_notes(
             'ถ้าคุณใช้ readboard sync และ autoplay บ่อย รุ่นนี้ทำให้เส้นทาง “ให้ engine ตัดสิน final move” ใกล้เคียงเกม KataGo จริงมากขึ้น',
         'release notes นี้เน้น PR #77 ที่ merge หลัง release ก่อนหน้า และไม่ซ้ำรายละเอียดของ release ที่เก่ากว่า':
             'release notes นี้เน้นการเปลี่ยนแปลง #81 และ #83 ที่ merge ใหม่ และไม่ซ้ำรายละเอียดของ release ที่เก่ากว่า',
+    }
+    for old, new in replacements.items():
+        notes = notes.replace(old, new)
+    return notes
+
+
+def build_next_2026_06_30_1_notes(
+    asset_map: dict[str, str | None],
+    bundle: dict[str, str],
+    repo: str,
+    release_tag: str | None,
+) -> str:
+    notes = build_next_2026_06_29_1_notes(asset_map, bundle, repo, release_tag)
+    replacements = {
+        '这一版命名为“首冠版”，纪念开发者女儿首次获得围棋比赛小组冠军。版本同时合并两项新的预览能力：感谢 @qiyi71w 提交 PR #81，ReadBoard 棋盘同步新增可信 GMA 自动落子；同时新增“远程算力中心”，可以登录智子云算力，把云端 KataGo 像本机引擎一样用于分析。':
+            '这一版聚焦远程算力入口和配置体验：底部工具栏把重复的野狐棋谱按钮替换为远程算力，保留顶部野狐入口；智子云算力和自建算力也整理成更清楚的一键启用流程。',
+        '合并 PR #81：棋盘同步的 `play>... gma` 会使用 KataGo `kata-genmove_analyze` 等待引擎最终决策落子，而不是只取当前一选。':
+            '底部工具栏现在显示“远程算力”，点击即可打开远程算力中心；顶部“野狐棋谱 / 腾讯棋谱 / 棋力评估”入口保持不变。',
+        'ReadBoard 会根据可信的末手来源和轮次判断启动 GMA，避免启发式来源误判导致错方自动落子，并在 pass、resign、失效请求和点击失败后强制恢复引擎局面。':
+            '智子云算力登录后会隐藏多余输入状态，支持显示密码、记住密码/登录，并在已启用时禁用重复启用按钮。',
+        '新增“设置 -> 远程算力中心”：支持智子云算力账号/密码或验证码登录，默认 VIP 包月，也可切换按量档位；主引擎、快速曲线、形势判断等路径统一走远程 GTP 桥接。':
+            '智子配置页增加官网与充值提示，可直接打开 `www.zhizigo.cn`；普通用户默认 VIP 包月，高级用户仍可切换按量档位。',
+        '自建算力入口当前只保存连接码，不会伪装成已启用的远程引擎；需要立刻使用远程算力的用户请先使用智子云算力。':
+            '自建算力支持粘贴 KaTrain 兼容的 `ws://` / `wss://` 链接，也支持导入二维码；已启用时按钮显示“已启用自建算力”，避免重复点击。',
+        '如果你经常用 readboard 同步和自动落子，这一版能让“由引擎最终决策落子”的路径更接近真实 KataGo 对局。':
+            '如果你正在测试智子云算力或自建远程算力，这一版入口更容易找、状态更明确，也更不容易误点重复启用。',
+        '这一版只写 #81 和 #83 的新增变化，不重复更早版本已经介绍过的内容。':
+            '这一版只写 PR #85 的远程算力交互变化，不重复更早版本已经介绍过的内容。',
+
+        '這一版命名為「首冠版」，紀念開發者女兒首次獲得圍棋比賽小組冠軍。版本同時合併兩項新的預覽能力：感謝 @qiyi71w 提交 PR #81，ReadBoard 棋盤同步新增可信 GMA 自動落子；同時新增「遠端算力中心」，可以登入智子雲算力，像本機引擎一樣使用雲端 KataGo 分析。':
+            '這一版聚焦遠端算力入口和設定體驗：底部工具列把重複的野狐棋譜按鈕替換為遠端算力，保留頂部野狐入口；智子雲算力和自建算力也整理成更清楚的一鍵啟用流程。',
+        '合併 PR #81：棋盤同步的 `play>... gma` 會使用 KataGo `kata-genmove_analyze` 等待引擎最終決策落子，而不是只取目前一選。':
+            '底部工具列現在顯示「遠端算力」，點擊即可打開遠端算力中心；頂部「野狐棋譜 / 騰訊棋譜 / 棋力評估」入口保持不變。',
+        'ReadBoard 會根據可信的末手來源和輪次判斷啟動 GMA，避免啟發式來源誤判導致錯方自動落子，並在 pass、resign、失效請求和點擊失敗後強制恢復引擎局面。':
+            '智子雲算力登入後會隱藏多餘輸入狀態，支援顯示密碼、記住密碼/登入，並在已啟用時停用重複啟用按鈕。',
+        '新增「設定 -> 遠端算力中心」：支援智子雲算力帳號/密碼或驗證碼登入，預設 VIP 包月，也可切換按量檔位；主引擎、快速曲線、形勢判斷等路徑統一走遠端 GTP 橋接。':
+            '智子設定頁增加官網與儲值提示，可直接打開 `www.zhizigo.cn`；普通使用者預設 VIP 包月，高階使用者仍可切換按量檔位。',
+        '自建算力入口目前只保存連接碼，不會偽裝成已啟用的遠端引擎；需要立即使用遠端算力的使用者請先使用智子雲算力。':
+            '自建算力支援貼上 KaTrain 相容的 `ws://` / `wss://` 連結，也支援匯入 QR code；已啟用時按鈕顯示「已啟用自建算力」，避免重複點擊。',
+        '如果你經常用 readboard 同步和自動落子，這一版能讓「由引擎最終決策落子」的路徑更接近真實 KataGo 對局。':
+            '如果你正在測試智子雲算力或自建遠端算力，這一版入口更容易找、狀態更明確，也更不容易誤點重複啟用。',
+        '這一版只寫 #81 和 #83 的新增變化，不重複更早版本已經介紹過的內容。':
+            '這一版只寫 PR #85 的遠端算力互動變化，不重複更早版本已經介紹過的內容。',
+
+        'This prerelease is named the First Crown Edition, commemorating the developer’s daughter winning her first group championship in a Go tournament. It also combines two new preview capabilities: thanks to @qiyi71w for PR #81, ReadBoard now supports trusted GMA autoplay, and the new Remote Compute Center can log in to Zhizi cloud compute so cloud KataGo works like a local engine.':
+            'This prerelease focuses on the Remote Compute entry and setup flow: the duplicated bottom Fox Kifu button is replaced with Remote Compute while the top Fox shortcut remains, and Zhizi Cloud plus self-hosted compute now use clearer one-click enable flows.',
+        'PR #81 is merged: `play>... gma` now waits for KataGo `kata-genmove_analyze` final decisions instead of simply using the current top candidate.':
+            'The bottom toolbar now shows Remote Compute and opens the Remote Compute Center directly; the top Fox Kifu, Tencent Kifu, and strength-evaluation shortcuts stay in place.',
+        'ReadBoard starts GMA only from trusted last-move sources and turns, avoiding wrong-side autoplay from heuristic guesses, and it forces engine-state recovery after pass, resign, stale requests, or failed clicks.':
+            'After Zhizi Cloud login, redundant account inputs are hidden, password visibility and remember-login/password controls are available, and the enable button is disabled while Zhizi is already active.',
+        'A new Settings -> Remote Compute Center supports Zhizi login by password or verification code, defaults to VIP monthly compute, allows metered tiers, and routes main analysis, quick curves, and score judgment through a unified remote GTP bridge.':
+            'The Zhizi page now includes official website and recharge guidance with a direct `www.zhizigo.cn` link; VIP monthly remains the default while metered tiers stay available for advanced users.',
+        'The self-hosted compute entry currently saves connection codes only and does not pretend to be an enabled remote engine; use Zhizi cloud compute first if you need remote compute immediately.':
+            'Self-hosted compute accepts KaTrain-compatible `ws://` / `wss://` links and QR-code import; once active, the button reads “Self-hosted compute enabled” and cannot be clicked again accidentally.',
+        'If you rely on readboard sync and autoplay, this build makes the “let the engine decide the final move” path much closer to a real KataGo game.':
+            'If you are testing Zhizi Cloud or self-hosted remote compute, this build makes the entry easier to find, the current state clearer, and repeated accidental enables less likely.',
+        'These notes only cover the newly merged #81 and #83 changes, without repeating older release highlights.':
+            'These notes only cover the Remote Compute interaction changes from PR #85, without repeating older release highlights.',
+
+        'この prerelease は「首冠版」と名付けました。開発者の娘が囲碁大会で初めてグループ優勝したことを記念する版です。あわせて 2 つの preview 機能を取り込みました。PR #81 を送ってくれた @qiyi71w さんに感謝します。ReadBoard は信頼済み GMA 自動着手に対応し、新しい「リモート計算センター」では智子クラウド計算にログインして、クラウド KataGo をローカルエンジンのように使えます。':
+            'この prerelease は Remote Compute の入口と設定体験を整えた版です。下部ツールバーの重複した Fox Kifu ボタンを Remote Compute に置き換え、上部の Fox shortcut は残しました。Zhizi Cloud と self-hosted compute も、より分かりやすい one-click enable flow になりました。',
+        'PR #81 を merge しました。棋盤同期の `play>... gma` は、現在の一選をそのまま使うのではなく、KataGo `kata-genmove_analyze` の最終決定を待って着手します。':
+            '下部ツールバーには Remote Compute が表示され、クリックすると Remote Compute Center を直接開きます。上部の Fox Kifu、Tencent Kifu、棋力評価 shortcut はそのままです。',
+        'ReadBoard は信頼できる最終手ソースと手番から GMA 開始を判断し、推測ソースの誤判定による逆側自動着手を避けます。pass、resign、失効リクエスト、クリック失敗後はエンジン局面を強制復旧します。':
+            'Zhizi Cloud ログイン後は余分な account 入力を隠し、password visibility と remember-login/password controls を使えます。既に Zhizi が有効な場合、enable button は無効になります。',
+        '新しい「設定 -> リモート計算センター」では、智子クラウド計算へパスワードまたは確認コードでログインできます。既定は VIP 月額で、従量 tier にも切り替えられ、主解析、quick curve、形勢判断を統一した remote GTP bridge で扱います。':
+            'Zhizi ページには公式サイトと recharge guidance を追加し、`www.zhizigo.cn` を直接開けます。既定は VIP monthly のまま、advanced users は metered tiers に切り替えられます。',
+        '自建リモート計算の入口は現時点では接続コード保存のみで、有効化済み remote engine のようには見せません。すぐ遠隔計算を使う場合は、まず智子クラウド計算を使ってください。':
+            'Self-hosted compute は KaTrain-compatible な `ws://` / `wss://` links と QR-code import に対応しました。有効化済みの場合、button は「Self-hosted compute enabled」となり、誤って再クリックできません。',
+        'readboard 同期と自動着手をよく使う場合、この build では「エンジンの最終決定で着手する」流れがより実際の KataGo 対局に近くなります。':
+            'Zhizi Cloud または self-hosted remote compute を試している場合、この build では入口が見つけやすく、現在状態が分かりやすく、誤って何度も enable しにくくなります。',
+        'この説明は新しく merged された #81 と #83 の変更に絞り、より古いリリース内容は繰り返しません。':
+            'この説明は PR #85 の Remote Compute interaction changes に絞り、より古い release highlights は繰り返しません。',
+
+        '이번 prerelease 는 “첫 우승 기념판”입니다. 개발자의 딸이 바둑 대회에서 처음으로 조별 우승을 한 것을 기념합니다. 또한 두 가지 preview 기능을 합쳤습니다. PR #81 을 제출한 @qiyi71w 님께 감사드립니다. ReadBoard 는 신뢰된 GMA 자동 착수를 지원하고, 새 Remote Compute Center 는 Zhizi cloud compute 에 로그인해 cloud KataGo 를 로컬 엔진처럼 사용할 수 있게 합니다.':
+            '이번 prerelease 는 Remote Compute entry 와 setup flow 를 정리했습니다. 하단 toolbar 의 중복 Fox Kifu 버튼을 Remote Compute 로 바꾸고 상단 Fox shortcut 은 유지했습니다. Zhizi Cloud 와 self-hosted compute 도 더 명확한 one-click enable flow 를 사용합니다.',
+        'PR #81 을 merge 했습니다. board sync 의 `play>... gma` 는 현재 top candidate 를 바로 쓰지 않고 KataGo `kata-genmove_analyze` 의 최종 결정을 기다려 착수합니다.':
+            '하단 toolbar 는 이제 Remote Compute 를 표시하고 Remote Compute Center 를 직접 엽니다. 상단 Fox Kifu, Tencent Kifu, strength-evaluation shortcut 은 그대로 유지됩니다.',
+        'ReadBoard 는 신뢰 가능한 last-move source 와 turn 으로 GMA 시작을 판단해 heuristic guess 때문에 반대쪽이 자동 착수하는 일을 피하고, pass, resign, stale request, click 실패 뒤에는 engine state 를 강제로 복구합니다.':
+            'Zhizi Cloud 로그인 뒤에는 불필요한 account input 을 숨기고, password visibility 와 remember-login/password controls 를 제공합니다. Zhizi 가 이미 active 일 때 enable button 은 disabled 상태가 됩니다.',
+        '새 Settings -> Remote Compute Center 는 Zhizi password 또는 verification code login 을 지원하고, 기본은 VIP monthly compute 이며 metered tier 로도 전환할 수 있습니다. main analysis, quick curve, score judgment 는 unified remote GTP bridge 를 사용합니다.':
+            'Zhizi page 에 official website 와 recharge guidance 를 추가하고 `www.zhizigo.cn` 링크를 바로 열 수 있게 했습니다. 기본값은 VIP monthly 이며 advanced users 는 metered tiers 로 전환할 수 있습니다.',
+        'Self-hosted compute entry 는 현재 connection code 만 저장하며 enabled remote engine 처럼 보이게 하지 않습니다. 바로 remote compute 가 필요하면 먼저 Zhizi cloud compute 를 사용하세요.':
+            'Self-hosted compute 는 KaTrain-compatible `ws://` / `wss://` links 와 QR-code import 를 지원합니다. 이미 active 이면 button 은 “Self-hosted compute enabled” 로 표시되고 실수로 다시 누를 수 없습니다.',
+        'readboard sync 와 autoplay 를 자주 쓴다면, 이번 build 는 “engine final decision 으로 착수”하는 경로를 실제 KataGo 대국에 더 가깝게 만듭니다.':
+            'Zhizi Cloud 또는 self-hosted remote compute 를 테스트한다면, 이번 build 는 entry 를 더 찾기 쉽고 current state 를 더 명확하게 보여 주며 반복 enable 실수를 줄입니다.',
+        '이번 설명은 새로 merge 된 #81 과 #83 변경만 다루며, 더 오래된 릴리스 내용은 반복하지 않습니다.':
+            '이번 설명은 PR #85 의 Remote Compute interaction changes 만 다루며, 더 오래된 release highlights 는 반복하지 않습니다.',
+
+        'prerelease นี้ใช้ชื่อ First Crown Edition เพื่อฉลองที่ลูกสาวของผู้พัฒนาได้แชมป์กลุ่มครั้งแรกในการแข่งขันโกะ และยังรวมความสามารถ preview ใหม่ 2 อย่าง: ขอบคุณ @qiyi71w สำหรับ PR #81 ที่ทำให้ ReadBoard รองรับ trusted GMA autoplay และเพิ่ม Remote Compute Center สำหรับ login เข้า Zhizi cloud compute เพื่อใช้ cloud KataGo เหมือน engine ในเครื่อง':
+            'prerelease นี้ปรับ entry และ setup flow ของ Remote Compute: เปลี่ยนปุ่ม Fox Kifu ที่ซ้ำอยู่ด้านล่างเป็น Remote Compute แต่ยังคง shortcut Fox ด้านบนไว้ และทำให้ Zhizi Cloud กับ self-hosted compute ใช้ one-click enable flow ที่ชัดเจนขึ้น',
+        'merge PR #81 แล้ว: `play>... gma` ใน board sync จะรอ final decision จาก KataGo `kata-genmove_analyze` แทนการใช้ top candidate ปัจจุบันทันที':
+            'toolbar ด้านล่างตอนนี้แสดง Remote Compute และเปิด Remote Compute Center ได้โดยตรง; shortcut ด้านบนของ Fox Kifu, Tencent Kifu และ strength evaluation ยังคงอยู่',
+        'ReadBoard จะเริ่ม GMA จาก last-move source และ turn ที่เชื่อถือได้เท่านั้น ลด autoplay ผิดฝ่ายจาก heuristic guess และบังคับ restore engine state หลัง pass, resign, stale request หรือ click fail':
+            'หลัง login Zhizi Cloud แล้ว input บัญชีที่ไม่จำเป็นจะถูกซ่อน มีตัวเลือก show password และ remember-login/password และปุ่ม enable จะ disabled เมื่อ Zhizi active อยู่แล้ว',
+        'เพิ่ม Settings -> Remote Compute Center: รองรับ Zhizi login ด้วย password หรือ verification code, ค่าเริ่มต้นเป็น VIP monthly compute, เปลี่ยนเป็น metered tier ได้ และใช้ remote GTP bridge เดียวกันกับ main analysis, quick curve และ score judgment':
+            'หน้า Zhizi เพิ่มคำแนะนำ official website และ recharge พร้อมลิงก์ `www.zhizigo.cn`; ค่าเริ่มต้นยังเป็น VIP monthly และผู้ใช้ขั้นสูงยังเปลี่ยนเป็น metered tiers ได้',
+        'ส่วน self-hosted compute ตอนนี้เก็บเฉพาะ connection code และจะไม่แสดงเหมือน remote engine ที่เปิดใช้งานแล้ว หากต้องใช้ remote compute ทันที แนะนำใช้ Zhizi cloud compute ก่อน':
+            'Self-hosted compute รองรับ KaTrain-compatible `ws://` / `wss://` links และ QR-code import; เมื่อ active แล้วปุ่มจะแสดง “Self-hosted compute enabled” และกดซ้ำโดยไม่ตั้งใจไม่ได้',
+        'ถ้าคุณใช้ readboard sync และ autoplay บ่อย รุ่นนี้ทำให้เส้นทาง “ให้ engine ตัดสิน final move” ใกล้เคียงเกม KataGo จริงมากขึ้น':
+            'ถ้าคุณกำลังทดสอบ Zhizi Cloud หรือ self-hosted remote compute รุ่นนี้ทำให้ entry หาเจอง่ายขึ้น สถานะชัดขึ้น และลดการกด enable ซ้ำโดยไม่ตั้งใจ',
+        'release notes นี้เน้นการเปลี่ยนแปลง #81 และ #83 ที่ merge ใหม่ และไม่ซ้ำรายละเอียดของ release ที่เก่ากว่า':
+            'release notes นี้เน้น Remote Compute interaction changes จาก PR #85 และไม่ซ้ำรายละเอียดของ release เก่ากว่า',
     }
     for old, new in replacements.items():
         notes = notes.replace(old, new)


### PR DESCRIPTION
## Summary

- Adds a dedicated release-notes generator branch for `next-2026-06-30.1`.
- Keeps the six-language, five-section structure consistent.
- Removes stale First Crown / PR #81 / PR #83 wording from the new release body.
- Focuses the new notes on PR #85 remote compute interaction changes.

## Validation

- `python3 -m py_compile scripts/generate_release_notes.py` passed.
- Generated notes from the published GitHub release assets with `--from-gh`.
- Verified all six languages have five sections.
- Verified no stale `首冠`, `First Crown`, `#81`, `#83`, or `GMA` wording remains in the generated notes.
- `git diff --check` passed.
