### PR TITLE
Improve remote compute reconnect and setup UI

### DIFF
--- a/src/main/java/featurecat/lizzie/analysis/remote/RemoteComputeConfig.java
+++ b/src/main/java/featurecat/lizzie/analysis/remote/RemoteComputeConfig.java
@@ -318,10 +318,13 @@ public final class RemoteComputeConfig {
     if (value == null) {
       return "";
     }
-    String text = value.trim();
+    String text = normalizeAsciiLikeInput(value.trim());
     if ((text.startsWith("\"") && text.endsWith("\""))
         || (text.startsWith("'") && text.endsWith("'"))) {
       text = text.substring(1, text.length() - 1).trim();
+    }
+    if (text.startsWith("完善://")) {
+      text = "ws://" + text.substring("完善://".length());
     }
     int wsIndex = indexOfWebSocketScheme(text);
     if (wsIndex > 0) {
@@ -339,6 +342,21 @@ public final class RemoteComputeConfig {
       text = text.substring(0, end);
     }
     return text.trim();
+  }
+
+  private static String normalizeAsciiLikeInput(String value) {
+    StringBuilder normalized = new StringBuilder(value.length());
+    for (int i = 0; i < value.length(); i++) {
+      char c = value.charAt(i);
+      if (c == '\u3000') {
+        normalized.append(' ');
+      } else if (c >= '\uFF01' && c <= '\uFF5E') {
+        normalized.append((char) (c - 0xFEE0));
+      } else {
+        normalized.append(c);
+      }
+    }
+    return normalized.toString();
   }
 
   public static String displayNameForCustomWebSocketUrl(String url) {

--- a/src/main/java/featurecat/lizzie/analysis/remote/ZhiziGtpTransport.java
+++ b/src/main/java/featurecat/lizzie/analysis/remote/ZhiziGtpTransport.java
@@ -1,6 +1,7 @@
 package featurecat.lizzie.analysis.remote;
 
 import io.socket.client.IO;
+import io.socket.client.Manager;
 import io.socket.client.Socket;
 import io.socket.engineio.client.transports.WebSocket;
 import java.io.ByteArrayOutputStream;
@@ -16,21 +17,41 @@ import java.time.Duration;
 import java.util.ArrayDeque;
 import java.util.Arrays;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import okhttp3.OkHttpClient;
 
 public class ZhiziGtpTransport implements EngineTransport {
   private static final Duration READY_TIMEOUT = Duration.ofSeconds(60);
+  private static final Duration READY_FALLBACK_AFTER_RECONNECT = Duration.ofSeconds(4);
+  private static final Duration RECONNECT_GRACE_PERIOD = Duration.ofSeconds(45);
 
   private final ZhiziApiClient apiClient;
   private final String accountToken;
   private final String args;
   private final BlockingByteInputStream stdout = new BlockingByteInputStream();
   private final BlockingByteInputStream stderr = new BlockingByteInputStream();
-  private final SocketCommandOutputStream stdin = new SocketCommandOutputStream();
+  private final SocketCommandOutputStream stdin =
+      new SocketCommandOutputStream(new SocketCommandEmitter(null));
   private final AtomicBoolean open = new AtomicBoolean(false);
   private final AtomicBoolean closed = new AtomicBoolean(true);
+  private final AtomicBoolean everReady = new AtomicBoolean(false);
+  private final AtomicInteger connectGeneration = new AtomicInteger();
+  private final AtomicInteger reconnectAttemptCount = new AtomicInteger();
+  private final ScheduledExecutorService reconnectExecutor =
+      Executors.newSingleThreadScheduledExecutor(
+          runnable -> {
+            Thread thread = new Thread(runnable, "zhizi-remote-reconnect");
+            thread.setDaemon(true);
+            return thread;
+          });
+  private volatile ScheduledFuture<?> readyFallbackTask;
+  private volatile long lastDisconnectAtMs;
   private Socket socket;
   private OkHttpClient socketHttpClient;
 
@@ -65,6 +86,7 @@ public class ZhiziGtpTransport implements EngineTransport {
     CountDownLatch readyLatch = new CountDownLatch(1);
     CountDownLatch errorLatch = new CountDownLatch(1);
     AtomicBoolean failedBeforeReady = new AtomicBoolean(false);
+    AtomicReference<String> startupError = new AtomicReference<>("");
     try {
       IO.Options options =
           IO.Options.builder()
@@ -86,14 +108,21 @@ public class ZhiziGtpTransport implements EngineTransport {
     } catch (URISyntaxException e) {
       throw new IOException("智子云算力连接地址无效。", e);
     }
-    socket.on(Socket.EVENT_CONNECT, objects -> writeStderrLine("智子云算力已连接，等待引擎准备..."));
+    attachReconnectDiagnostics(socket);
+    socket.on(
+        Socket.EVENT_CONNECT,
+        objects -> {
+          int generation = connectGeneration.incrementAndGet();
+          Socket current = socket;
+          writeStderrLine("智子云算力已连接，等待引擎准备...");
+          if (everReady.get()) {
+            scheduleReadyFallback(current, generation);
+          }
+        });
     socket.on(
         "ready",
         objects -> {
-          open.set(true);
-          stdin.bind(socket);
-          writeStderrLine("智子云算力已准备好。");
-          readyLatch.countDown();
+          markReady(socket, readyLatch, "智子云算力已准备好。");
         });
     socket.on("stdout", objects -> writePayload(stdout, first(objects)));
     socket.on("stderr", objects -> writePayload(stderr, first(objects)));
@@ -101,21 +130,31 @@ public class ZhiziGtpTransport implements EngineTransport {
         Socket.EVENT_DISCONNECT,
         objects -> {
           open.set(false);
-          stdin.bind(null);
-          writeStderrLine("智子云算力连接断开，正在自动重连...");
+          stdin.bind(new SocketCommandEmitter(null));
+          cancelReadyFallback();
+          lastDisconnectAtMs = System.currentTimeMillis();
+          String reason = summarize(first(objects));
+          String suffix = reason.isEmpty() ? "" : "（" + reason + "）";
+          writeStderrLine("智子云算力连接断开" + suffix + "，正在自动重连...");
         });
     socket.on(
         Socket.EVENT_CONNECT_ERROR,
         objects -> {
-          failedBeforeReady.set(true);
-          writeStderrLine("智子云算力连接失败: " + summarize(first(objects)));
+          String error = summarize(first(objects));
+          if (!everReady.get()) {
+            failedBeforeReady.set(true);
+            startupError.set(error);
+          }
+          writeStderrLine((everReady.get() ? "智子云算力重连暂未成功: " : "智子云算力连接失败: ") + error);
           errorLatch.countDown();
         });
     socket.connect();
     long deadline = System.currentTimeMillis() + READY_TIMEOUT.toMillis();
     try {
       while (!readyLatch.await(250, TimeUnit.MILLISECONDS)) {
-        if (errorLatch.getCount() == 0 && failedBeforeReady.get()) {
+        if (errorLatch.getCount() == 0
+            && failedBeforeReady.get()
+            && isProbablyFatalStartupError(startupError.get())) {
           throw new IOException("智子云算力连接失败，请检查网络、登录状态或账号额度。");
         }
         if (Thread.currentThread().isInterrupted()) {
@@ -123,8 +162,12 @@ public class ZhiziGtpTransport implements EngineTransport {
           throw new IOException("连接智子云算力被中断。");
         }
         if (System.currentTimeMillis() >= deadline) {
+          String lastError = startupError.get();
           close();
-          throw new IOException("智子云算力连接超时，请稍后重试。");
+          throw new IOException(
+              lastError == null || lastError.isBlank()
+                  ? "智子云算力连接超时，请稍后重试。"
+                  : "智子云算力连接超时，请稍后重试。最后错误：" + lastError);
         }
       }
     } catch (InterruptedException e) {
@@ -155,7 +198,15 @@ public class ZhiziGtpTransport implements EngineTransport {
   @Override
   public boolean isOpen() {
     Socket current = socket;
-    return !closed.get() && current != null && (open.get() || current.connected() || current.isActive());
+    if (closed.get() || current == null) {
+      return false;
+    }
+    if (open.get() || current.connected() || current.isActive()) {
+      return true;
+    }
+    return everReady.get()
+        && lastDisconnectAtMs > 0
+        && System.currentTimeMillis() - lastDisconnectAtMs <= RECONNECT_GRACE_PERIOD.toMillis();
   }
 
   @Override
@@ -167,7 +218,8 @@ public class ZhiziGtpTransport implements EngineTransport {
   public void close() {
     closed.set(true);
     open.set(false);
-    stdin.bind(null);
+    cancelReadyFallback();
+    stdin.closeForShutdown();
     Socket current = socket;
     socket = null;
     if (current != null) {
@@ -176,13 +228,117 @@ public class ZhiziGtpTransport implements EngineTransport {
         current.emit("stdin", "quit\n");
       } catch (Exception ignored) {
       }
+      current.io().off();
       current.off();
       current.disconnect();
       current.close();
     }
+    reconnectExecutor.shutdownNow();
     closeSocketHttpClient();
     closeQuietly(stdout);
     closeQuietly(stderr);
+  }
+
+  private void attachReconnectDiagnostics(Socket socket) {
+    Manager manager = socket.io();
+    manager.on(
+        Manager.EVENT_RECONNECT_ATTEMPT,
+        objects -> {
+          int countedAttempt = reconnectAttemptCount.incrementAndGet();
+          String attempt = summarize(first(objects));
+          if (attempt.isEmpty()) {
+            attempt = String.valueOf(countedAttempt);
+          }
+          writeStderrLine(
+              "智子云算力正在重连（第 " + attempt + " 次）...");
+        });
+    manager.on(
+        Manager.EVENT_RECONNECT,
+        objects -> {
+          String attempt = summarize(first(objects));
+          reconnectAttemptCount.set(0);
+          writeStderrLine(
+              attempt.isEmpty()
+                  ? "智子云算力网络已恢复，等待引擎 ready..."
+                  : "智子云算力网络已恢复（第 " + attempt + " 次），等待引擎 ready...");
+        });
+    manager.on(
+        Manager.EVENT_RECONNECT_ERROR,
+        objects -> writeStderrLine("智子云算力重连错误: " + summarize(first(objects))));
+    manager.on(
+        Manager.EVENT_RECONNECT_FAILED,
+        objects -> writeStderrLine("智子云算力重连失败，请检查网络或稍后切回本机引擎。"));
+  }
+
+  private void markReady(Socket readySocket, CountDownLatch readyLatch, String message) {
+    if (closed.get() || readySocket == null) {
+      return;
+    }
+    boolean reconnectReady = everReady.get();
+    cancelReadyFallback();
+    open.set(true);
+    everReady.set(true);
+    stdin.bind(new SocketCommandEmitter(readySocket));
+    int flushed = stdin.flushQueuedCommands();
+    boolean resumedAnalysis = reconnectReady && stdin.resumeLastAnalysisIfIdle();
+    String suffix = "";
+    if (flushed > 0) {
+      suffix += " 已补发重连期间等待的 " + flushed + " 条命令。";
+    }
+    if (reconnectReady && resumedAnalysis) {
+      suffix += " 已恢复实时分析。";
+    }
+    writeStderrLine(
+        suffix.isEmpty() ? message : message + suffix);
+    readyLatch.countDown();
+  }
+
+  private void scheduleReadyFallback(Socket expectedSocket, int expectedGeneration) {
+    cancelReadyFallback();
+    readyFallbackTask =
+        reconnectExecutor.schedule(
+            () -> {
+              if (closed.get()
+                  || open.get()
+                  || socket != expectedSocket
+                  || connectGeneration.get() != expectedGeneration
+                  || expectedSocket == null
+                  || !expectedSocket.connected()) {
+                return;
+              }
+              markReady(
+                  expectedSocket,
+                  new CountDownLatch(0),
+                  "智子云算力网络已恢复，未收到新的 ready，已恢复命令通道。");
+            },
+            READY_FALLBACK_AFTER_RECONNECT.toMillis(),
+            TimeUnit.MILLISECONDS);
+  }
+
+  private void cancelReadyFallback() {
+    ScheduledFuture<?> task = readyFallbackTask;
+    readyFallbackTask = null;
+    if (task != null) {
+      task.cancel(false);
+    }
+  }
+
+  private boolean isProbablyFatalStartupError(String message) {
+    String normalized = message == null ? "" : message.toLowerCase();
+    return normalized.contains("401")
+        || normalized.contains("403")
+        || normalized.contains("unauthorized")
+        || normalized.contains("forbidden")
+        || normalized.contains("invalid token")
+        || normalized.contains("expired token")
+        || normalized.contains("worker")
+        || normalized.contains("quota")
+        || normalized.contains("balance")
+        || normalized.contains("vip")
+        || normalized.contains("权限")
+        || normalized.contains("额度")
+        || normalized.contains("余额")
+        || normalized.contains("套餐");
   }
 
   private void closeSocketHttpClient() {
@@ -344,12 +500,67 @@ public class ZhiziGtpTransport implements EngineTransport {
     }
   }
 
-  private static final class SocketCommandOutputStream extends OutputStream {
-    private final ByteArrayOutputStream buffer = new ByteArrayOutputStream();
-    private volatile Socket socket;
+  static final class SocketCommandOutputStream extends OutputStream {
+    private static final int MAX_QUEUED_COMMAND_BYTES = 256 * 1024;
 
-    void bind(Socket socket) {
-      this.socket = socket;
+    private final ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+    private final ArrayDeque<String> queuedCommands = new ArrayDeque<>();
+    private int queuedCommandBytes;
+    private String lastAnalysisCommand = "";
+    private boolean lastQueuedFlushHadAnalysis;
+    private volatile CommandEmitter emitter;
+    private volatile boolean closed;
+
+    SocketCommandOutputStream(CommandEmitter emitter) {
+      this.emitter = emitter == null ? new SocketCommandEmitter(null) : emitter;
+    }
+
+    void bind(CommandEmitter emitter) {
+      this.emitter = emitter == null ? new SocketCommandEmitter(null) : emitter;
+    }
+
+    synchronized int flushQueuedCommands() {
+      CommandEmitter current = emitter;
+      lastQueuedFlushHadAnalysis = false;
+      if (closed || current == null || !current.isConnected() || queuedCommands.isEmpty()) {
+        return 0;
+      }
+      int flushed = 0;
+      while (!queuedCommands.isEmpty() && current.isConnected()) {
+        String command = queuedCommands.removeFirst();
+        queuedCommandBytes -= command.getBytes(StandardCharsets.UTF_8).length;
+        if (isAnalysisCommand(command)) {
+          lastQueuedFlushHadAnalysis = true;
+        }
+        current.emit(command);
+        flushed++;
+      }
+      if (queuedCommands.isEmpty()) {
+        queuedCommandBytes = 0;
+      }
+      return flushed;
+    }
+
+    synchronized boolean resumeLastAnalysisIfIdle() {
+      if (closed || lastQueuedFlushHadAnalysis || lastAnalysisCommand.isEmpty()) {
+        return false;
+      }
+      CommandEmitter current = emitter;
+      if (current == null || !current.isConnected()) {
+        return false;
+      }
+      current.emit(lastAnalysisCommand);
+      return true;
+    }
+
+    void closeForShutdown() {
+      closed = true;
+      emitter = new SocketCommandEmitter(null);
+      synchronized (this) {
+        buffer.reset();
+        queuedCommands.clear();
+        queuedCommandBytes = 0;
+      }
     }
 
     @Override
@@ -365,16 +576,90 @@ public class ZhiziGtpTransport implements EngineTransport {
     @Override
     public synchronized void flush() throws IOException {
       if (buffer.size() == 0) {
+        flushQueuedCommands();
         return;
       }
-      Socket current = socket;
-      if (current == null || !current.connected()) {
+      if (closed) {
         buffer.reset();
-        throw new IOException("智子云算力暂未连接。");
+        throw new IOException("智子云算力连接已关闭。");
       }
       String command = buffer.toString(StandardCharsets.UTF_8);
       buffer.reset();
-      current.emit("stdin", command);
+      rememberCommand(command);
+      CommandEmitter current = emitter;
+      if (current != null && current.isConnected()) {
+        current.emit(command);
+        return;
+      }
+      queueCommand(command);
+    }
+
+    int queuedCommandCount() {
+      return queuedCommands.size();
+    }
+
+    private void queueCommand(String command) throws IOException {
+      int commandBytes = command.getBytes(StandardCharsets.UTF_8).length;
+      if (queuedCommandBytes + commandBytes > MAX_QUEUED_COMMAND_BYTES) {
+        throw new IOException("智子云算力重连时间过长，等待发送的命令过多，请稍后重试。");
+      }
+      queuedCommands.addLast(command);
+      queuedCommandBytes += commandBytes;
+    }
+
+    private void rememberCommand(String command) {
+      if (isStopCommand(command)) {
+        lastAnalysisCommand = "";
+      } else if (isAnalysisCommand(command)) {
+        lastAnalysisCommand = command;
+      }
+    }
+
+    private static boolean isAnalysisCommand(String command) {
+      String normalized = firstCommandLine(command).trim();
+      return normalized.startsWith("kata-analyze ")
+          || normalized.startsWith("kata-analyze_interval ")
+          || normalized.startsWith("lz-analyze ")
+          || normalized.startsWith("analyze ");
+    }
+
+    private static boolean isStopCommand(String command) {
+      String normalized = firstCommandLine(command).trim();
+      return normalized.equals("stop")
+          || normalized.equals("stop-ponder")
+          || normalized.equals("quit");
+    }
+
+    private static String firstCommandLine(String command) {
+      if (command == null) {
+        return "";
+      }
+      int newline = command.indexOf('\n');
+      return newline >= 0 ? command.substring(0, newline) : command;
+    }
+  }
+
+  interface CommandEmitter {
+    boolean isConnected();
+
+    void emit(String command);
+  }
+
+  static final class SocketCommandEmitter implements CommandEmitter {
+    private final Socket socket;
+
+    SocketCommandEmitter(Socket socket) {
+      this.socket = socket;
+    }
+
+    @Override
+    public boolean isConnected() {
+      return socket != null && socket.connected();
+    }
+
+    @Override
+    public void emit(String command) {
+      socket.emit("stdin", command);
     }
   }
 }

--- a/src/main/java/featurecat/lizzie/gui/BottomToolbar.java
+++ b/src/main/java/featurecat/lizzie/gui/BottomToolbar.java
@@ -606,6 +606,7 @@ public class BottomToolbar extends JPanel {
     share = new JFontButton(Lizzie.resourceBundle.getString("BottomToolbar.share")); // ("分享");
     flashAnalyze = new JFontButton(Lizzie.resourceBundle.getString("BottomToolbar.flashAnalyze"));
     remoteComputeButton = new JFontButton(Lizzie.resourceBundle.getString("Menu.remoteCompute"));
+    AppleStyleSupport.markPrimary(remoteComputeButton);
     downloadWeightButton =
         new JFontButton(Lizzie.resourceBundle.getString("BottomToolbar.downloadWeight"));
     liveButton =

--- a/src/main/java/featurecat/lizzie/gui/KataGoAutoSetupDialog.java
+++ b/src/main/java/featurecat/lizzie/gui/KataGoAutoSetupDialog.java
@@ -12,6 +12,7 @@ import featurecat.lizzie.util.KataGoRuntimeHelper;
 import featurecat.lizzie.util.NvidiaGpuDetector;
 import featurecat.lizzie.util.Utils;
 import java.awt.BorderLayout;
+import java.awt.BasicStroke;
 import java.awt.CardLayout;
 import java.awt.Color;
 import java.awt.Component;
@@ -21,15 +22,20 @@ import java.awt.Dimension;
 import java.awt.FlowLayout;
 import java.awt.Font;
 import java.awt.FontMetrics;
+import java.awt.Graphics;
+import java.awt.Graphics2D;
 import java.awt.GraphicsConfiguration;
 import java.awt.GraphicsEnvironment;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.awt.Insets;
+import java.awt.Polygon;
 import java.awt.Rectangle;
+import java.awt.RenderingHints;
 import java.awt.Window;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
+import java.awt.geom.Arc2D;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Collections;
@@ -39,6 +45,7 @@ import java.util.Locale;
 import javax.swing.BorderFactory;
 import javax.swing.DefaultComboBoxModel;
 import javax.swing.DefaultListCellRenderer;
+import javax.swing.Icon;
 import javax.swing.JComponent;
 import javax.swing.JDialog;
 import javax.swing.JFileChooser;
@@ -89,6 +96,7 @@ public class KataGoAutoSetupDialog extends JDialog {
   private long progressStartedAtMillis;
   private String lastBackgroundErrorMessage = "";
   private long lastBackgroundErrorMillis = 0L;
+  private int selectedSetupSectionIndex = 0;
 
   private final JLabel lblEngineValue = new JFontLabel();
   private final JLabel lblWeightValue = new JFontLabel();
@@ -115,6 +123,7 @@ public class KataGoAutoSetupDialog extends JDialog {
   private final JProgressBar progressBar = new JProgressBar();
   private final JFontButton btnRefresh = new JFontButton();
   private final JFontButton btnAutoSetup = new JFontButton();
+  private final JFontButton btnReloadRemoteWeights = new JFontButton();
   private final JFontButton btnDownloadWeight = new JFontButton();
   private final JFontButton btnImportWeight = new JFontButton();
   private final JFontButton btnApplyWeight = new JFontButton();
@@ -230,6 +239,9 @@ public class KataGoAutoSetupDialog extends JDialog {
   private void configureButtons() {
     btnRefresh.setText(text("AutoSetup.refresh"));
     btnAutoSetup.setText(text("AutoSetup.autoSetup"));
+    btnReloadRemoteWeights.setText("");
+    btnReloadRemoteWeights.setIcon(new RefreshIcon());
+    btnReloadRemoteWeights.setToolTipText(text("AutoSetup.refreshOfficialWeights"));
     btnDownloadWeight.setText(text("AutoSetup.downloadWeight"));
     btnImportWeight.setText(text("AutoSetup.importWeight"));
     btnApplyWeight.setText(text("AutoSetup.applyWeight"));
@@ -248,6 +260,7 @@ public class KataGoAutoSetupDialog extends JDialog {
     styleButton(btnDownloadWeight, true);
     styleButton(btnOptimizePerformance, true);
     styleButton(btnRefresh, false);
+    styleIconButton(btnReloadRemoteWeights);
     styleButton(btnImportWeight, false);
     styleButton(btnApplyWeight, false);
     styleButton(btnDownloadHumanSlModel, false);
@@ -263,6 +276,7 @@ public class KataGoAutoSetupDialog extends JDialog {
   private void wireActions() {
     btnRefresh.addActionListener(e -> refreshState());
     btnAutoSetup.addActionListener(e -> autoSetupOrDownload());
+    btnReloadRemoteWeights.addActionListener(e -> reloadRemoteWeightInfo());
     btnDownloadWeight.addActionListener(e -> startRecommendedWeightDownload(false));
     btnImportWeight.addActionListener(e -> importCustomWeight());
     btnApplyWeight.addActionListener(e -> applySelectedWeight());
@@ -287,6 +301,18 @@ public class KataGoAutoSetupDialog extends JDialog {
     AppleStyleSupport.installButtonStyle(button);
     Dimension preferred = button.getPreferredSize();
     button.setPreferredSize(new Dimension(Math.max(preferred.width, primary ? 106 : 90), 32));
+  }
+
+  private void styleIconButton(JFontButton button) {
+    button.setFocusPainted(false);
+    button.setCursor(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR));
+    button.setMargin(new Insets(0, 0, 0, 0));
+    button.setHorizontalAlignment(SwingConstants.CENTER);
+    AppleStyleSupport.installButtonStyle(button);
+    Dimension size = new Dimension(36, 32);
+    button.setPreferredSize(size);
+    button.setMinimumSize(size);
+    button.setMaximumSize(size);
   }
 
   private JPanel createHeaderPanel() {
@@ -340,7 +366,8 @@ public class KataGoAutoSetupDialog extends JDialog {
           text("AutoSetup.navOverview"),
           text("AutoSetup.navWeights"),
           text("AutoSetup.navBenchmark"),
-          text("AutoSetup.navAcceleration")
+          text("AutoSetup.navAcceleration"),
+          text("Menu.remoteCompute")
         });
     sectionNav.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
     sectionNav.setSelectedIndex(0);
@@ -370,17 +397,29 @@ public class KataGoAutoSetupDialog extends JDialog {
           if (e.getValueIsAdjusting()) {
             return;
           }
-          switch (sectionNav.getSelectedIndex()) {
+          int selectedIndex = sectionNav.getSelectedIndex();
+          switch (selectedIndex) {
             case 1:
+              selectedSetupSectionIndex = selectedIndex;
               detailCardLayout.show(detailCards, CARD_WEIGHTS);
               break;
             case 2:
+              selectedSetupSectionIndex = selectedIndex;
               detailCardLayout.show(detailCards, CARD_BENCHMARK);
               break;
             case 3:
+              selectedSetupSectionIndex = selectedIndex;
               detailCardLayout.show(detailCards, CARD_ACCELERATION);
               break;
+            case 4:
+              SwingUtilities.invokeLater(
+                  () -> {
+                    sectionNav.setSelectedIndex(selectedSetupSectionIndex);
+                    openRemoteComputeCenter();
+                  });
+              break;
             default:
+              selectedSetupSectionIndex = 0;
               detailCardLayout.show(detailCards, CARD_OVERVIEW);
               break;
           }
@@ -406,6 +445,16 @@ public class KataGoAutoSetupDialog extends JDialog {
         text("AutoSetup.overviewTitle"), text("AutoSetup.overviewSubtitle"), rows, actions);
   }
 
+  private void openRemoteComputeCenter() {
+    if (Lizzie.frame != null) {
+      Lizzie.frame.openRemoteComputeCenter();
+      return;
+    }
+    RemoteComputeDialog dialog = new RemoteComputeDialog(JOptionPane.getFrameForComponent(this));
+    dialog.setVisible(true);
+    dialog.toFront();
+  }
+
   private JPanel createWeightsSection() {
     JPanel rows = createRowsPanel();
     GridBagConstraints gbc = createRowConstraints();
@@ -413,7 +462,7 @@ public class KataGoAutoSetupDialog extends JDialog {
         rows,
         gbc,
         text("AutoSetup.officialWeights"),
-        createInlineActionRow(cmbRemoteWeights, btnDownloadWeight));
+        createInlineActionRow(cmbRemoteWeights, btnReloadRemoteWeights, btnDownloadWeight));
     addInfoRow(rows, gbc, text("AutoSetup.selectedWeightInfo"), lblRemoteDetailValue);
     addComponentRow(
         rows,
@@ -598,18 +647,26 @@ public class KataGoAutoSetupDialog extends JDialog {
 
   private void addComponentRow(
       JPanel panel, GridBagConstraints gbc, String title, JComponent valueComponent) {
+    constrainValueComponent(valueComponent);
+    boolean wrappingText = Boolean.TRUE.equals(valueComponent.getClientProperty(WRAPPING_TEXT_KEY));
+    int rowHeight = Math.max(32, valueComponent.getPreferredSize().height);
+
     GridBagConstraints labelConstraints = (GridBagConstraints) gbc.clone();
     labelConstraints.gridx = 0;
     labelConstraints.weightx = 0;
-    labelConstraints.fill = GridBagConstraints.NONE;
+    labelConstraints.fill = GridBagConstraints.HORIZONTAL;
+    labelConstraints.anchor = wrappingText ? GridBagConstraints.NORTHWEST : GridBagConstraints.WEST;
     JFontLabel titleLabel = new JFontLabel(title);
+    titleLabel.setForeground(TEXT_PRIMARY);
+    titleLabel.setVerticalAlignment(wrappingText ? SwingConstants.TOP : SwingConstants.CENTER);
+    titleLabel.setPreferredSize(new Dimension(132, rowHeight));
+    titleLabel.setMinimumSize(new Dimension(118, Math.min(rowHeight, 32)));
     panel.add(titleLabel, labelConstraints);
 
     GridBagConstraints valueConstraints = (GridBagConstraints) gbc.clone();
     valueConstraints.gridx = 1;
     valueConstraints.weightx = 1;
     valueConstraints.fill = GridBagConstraints.HORIZONTAL;
-    constrainValueComponent(valueComponent);
     panel.add(valueComponent, valueConstraints);
 
     gbc.gridy += 1;
@@ -1015,6 +1072,10 @@ public class KataGoAutoSetupDialog extends JDialog {
   }
 
   private void loadRemoteWeightInfo() {
+    btnReloadRemoteWeights.setEnabled(false);
+    lblRemoteDetailValue.setText(text("AutoSetup.loadingRemote"));
+    lblRemoteDetailValue.setToolTipText(null);
+    lblRemoteDetailValue.setForeground(WARN_COLOR);
     new Thread(
             () -> {
               try {
@@ -1030,12 +1091,21 @@ public class KataGoAutoSetupDialog extends JDialog {
                       lblRemoteDetailValue.setToolTipText(e.getMessage());
                       lblRemoteDetailValue.setForeground(ERROR_COLOR);
                       btnDownloadWeight.setEnabled(false);
+                      btnReloadRemoteWeights.setEnabled(true);
                       btnStopDownload.setEnabled(false);
                     });
               }
             },
             "katago-remote-weight-info")
         .start();
+  }
+
+  private void reloadRemoteWeightInfo() {
+    if (hasActiveBackgroundTask()) {
+      showBackgroundTaskAlreadyRunningNotice();
+      return;
+    }
+    loadRemoteWeightInfo();
   }
 
   private void showRemoteWeightInfo(List<RemoteWeightInfo> infos) {
@@ -1051,6 +1121,7 @@ public class KataGoAutoSetupDialog extends JDialog {
       cmbRemoteWeights.setSelectedItem(preferred);
     }
     updateSelectedRemoteWeightInfo();
+    btnReloadRemoteWeights.setEnabled(true);
     btnStopDownload.setEnabled(activeDownloadSession != null);
   }
 
@@ -1669,6 +1740,7 @@ public class KataGoAutoSetupDialog extends JDialog {
     progressStatusLabel.setForeground(busy ? WARN_COLOR : Color.DARK_GRAY);
     btnRefresh.setEnabled(!busy);
     btnAutoSetup.setEnabled(!busy);
+    btnReloadRemoteWeights.setEnabled(!busy);
     btnDownloadWeight.setEnabled(!busy && canDownloadSelectedRemoteWeight());
     btnImportWeight.setEnabled(!busy);
     btnApplyWeight.setEnabled(!busy && getSelectedLocalWeight() != null);
@@ -2148,6 +2220,7 @@ public class KataGoAutoSetupDialog extends JDialog {
     }
     btnRefresh.setEnabled(true);
     btnAutoSetup.setEnabled(true);
+    btnReloadRemoteWeights.setEnabled(true);
     btnDownloadWeight.setEnabled(getSelectedRemoteWeight() != null);
     btnImportWeight.setEnabled(true);
     btnApplyWeight.setEnabled(getSelectedLocalWeight() != null);
@@ -2166,5 +2239,38 @@ public class KataGoAutoSetupDialog extends JDialog {
 
   private String text(String key) {
     return Lizzie.resourceBundle.getString(key);
+  }
+
+  private static class RefreshIcon implements Icon {
+    private static final int SIZE = 18;
+
+    @Override
+    public int getIconWidth() {
+      return SIZE;
+    }
+
+    @Override
+    public int getIconHeight() {
+      return SIZE;
+    }
+
+    @Override
+    public void paintIcon(Component component, Graphics graphics, int x, int y) {
+      Graphics2D g2 = (Graphics2D) graphics.create();
+      try {
+        g2.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+        g2.setStroke(new BasicStroke(2.1f, BasicStroke.CAP_ROUND, BasicStroke.JOIN_ROUND));
+        g2.setColor(new Color(52, 90, 88));
+        g2.draw(new Arc2D.Double(x + 3, y + 3, 12, 12, 32, 292, Arc2D.OPEN));
+
+        Polygon arrow = new Polygon();
+        arrow.addPoint(x + 15, y + 2);
+        arrow.addPoint(x + 16, y + 8);
+        arrow.addPoint(x + 10, y + 5);
+        g2.fillPolygon(arrow);
+      } finally {
+        g2.dispose();
+      }
+    }
   }
 }

--- a/src/main/java/featurecat/lizzie/gui/LizzieFrame.java
+++ b/src/main/java/featurecat/lizzie/gui/LizzieFrame.java
@@ -505,6 +505,7 @@ public class LizzieFrame extends JFrame {
       new java.util.concurrent.atomic.AtomicBoolean(false);
   private final java.util.List<Runnable> pendingQuickAnalysisCallbacks =
       new java.util.ArrayList<Runnable>();
+  private javax.swing.Timer quickAnalysisNavigationResumeTimer;
   public volatile TrackingEngine trackingEngine;
   public TrackingConsolePane trackingConsolePane;
   public Set<String> trackedCoords = Collections.synchronizedSet(new LinkedHashSet<>());
@@ -7692,6 +7693,7 @@ public class LizzieFrame extends JFrame {
     if (moved) {
       Lizzie.board.clearAfterMove();
       refresh();
+      scheduleQuickAnalysisContinuationAfterHistoryNavigation();
     }
     return moved;
   }
@@ -7723,6 +7725,7 @@ public class LizzieFrame extends JFrame {
     if (moved) {
       Lizzie.board.clearAfterMove();
       refresh();
+      scheduleQuickAnalysisContinuationAfterHistoryNavigation();
     }
     return moved;
   }
@@ -17037,6 +17040,80 @@ public class LizzieFrame extends JFrame {
       return !engine.javaSSHClosed;
     }
     return engine.isRunning();
+  }
+
+  void scheduleQuickAnalysisContinuationAfterHistoryNavigation() {
+    if (!SwingUtilities.isEventDispatchThread()) {
+      SwingUtilities.invokeLater(this::scheduleQuickAnalysisContinuationAfterHistoryNavigation);
+      return;
+    }
+    if (!canContinueQuickAnalysisAfterHistoryNavigation()) {
+      return;
+    }
+    if (quickAnalysisNavigationResumeTimer == null) {
+      quickAnalysisNavigationResumeTimer =
+          new javax.swing.Timer(
+              700, e -> continueQuickAnalysisAfterHistoryNavigationWhenIdle());
+      quickAnalysisNavigationResumeTimer.setRepeats(true);
+    }
+    quickAnalysisNavigationResumeTimer.restart();
+  }
+
+  void continueQuickAnalysisAfterHistoryNavigationWhenIdle() {
+    if (!SwingUtilities.isEventDispatchThread()) {
+      SwingUtilities.invokeLater(this::continueQuickAnalysisAfterHistoryNavigationWhenIdle);
+      return;
+    }
+    if (!canContinueQuickAnalysisAfterHistoryNavigation()) {
+      stopQuickAnalysisNavigationResumeTimer();
+      return;
+    }
+    AnalysisEngine currentEngine = analysisEngine;
+    if (currentEngine != null && currentEngine.isAnalysisInProgress()) {
+      return;
+    }
+    stopQuickAnalysisNavigationResumeTimer();
+    if (!shouldAutoQuickAnalyzeLoadedGame()) {
+      return;
+    }
+    Runnable continueMissingMainline =
+        new Runnable() {
+          public void run() {
+            if (!isAnalysisEngineReusable(analysisEngine)) {
+              return;
+            }
+            analysisEngine.setKeepAliveAfterCurrentRequest(true);
+            int requestCount = analysisEngine.startRequestMissingMainline(false);
+            if (requestCount < 0) {
+              analysisEngine.setCompletionCallback(null);
+            }
+          }
+        };
+    if (isAnalysisEngineReusable(analysisEngine)) {
+      continueMissingMainline.run();
+    } else {
+      ensureQuickAnalysisEngineAsync(continueMissingMainline);
+    }
+  }
+
+  private boolean canContinueQuickAnalysisAfterHistoryNavigation() {
+    return Lizzie.config != null
+        && Lizzie.config.autoQuickAnalyzeOnLoad
+        && !isBatchAna
+        && !isBatchAnalysisMode
+        && !isEnginePKSgfStart
+        && !isTrying
+        && !EngineManager.isEngineGame()
+        && !isPlayingAgainstLeelaz
+        && !isAnaPlayingAgainstLeelaz
+        && Lizzie.board != null
+        && Lizzie.board.getHistory() != null;
+  }
+
+  private void stopQuickAnalysisNavigationResumeTimer() {
+    if (quickAnalysisNavigationResumeTimer != null) {
+      quickAnalysisNavigationResumeTimer.stop();
+    }
   }
 
   public boolean ensureAnalysisResumedAfterSyncLoad() {

--- a/src/main/java/featurecat/lizzie/gui/LizzieFrame.java
+++ b/src/main/java/featurecat/lizzie/gui/LizzieFrame.java
@@ -13072,6 +13072,8 @@ public class LizzieFrame extends JFrame {
               return;
             }
             analysisEngine.setKeepAliveAfterCurrentRequest(true);
+            analysisEngine.setCompletionCallback(
+                LizzieFrame.this::resumeForegroundAnalysisAfterQuickAnalysisComplete);
             startFlashAnalyzeRequestsInBackground(analysisEngine, isAllGame, isAllBranches, true);
           }
         };
@@ -13155,6 +13157,10 @@ public class LizzieFrame extends JFrame {
                     isAllGame ? -1 : Lizzie.config.analysisStartMove,
                     isAllGame ? -1 : Lizzie.config.analysisEndMove,
                     !silentAnalyze);
+              if (silentAnalyze && !targetEngine.isAnalysisInProgress()) {
+                targetEngine.setCompletionCallback(null);
+                resumeForegroundAnalysisAfterQuickAnalysisComplete();
+              }
             },
             "flash-analysis-request-sender");
     requestSender.setDaemon(true);
@@ -17083,9 +17089,15 @@ public class LizzieFrame extends JFrame {
               return;
             }
             analysisEngine.setKeepAliveAfterCurrentRequest(true);
+            analysisEngine.setCompletionCallback(
+                LizzieFrame.this::resumeForegroundAnalysisAfterQuickAnalysisComplete);
             int requestCount = analysisEngine.startRequestMissingMainline(false);
             if (requestCount < 0) {
               analysisEngine.setCompletionCallback(null);
+              resumeForegroundAnalysisAfterQuickAnalysisComplete();
+            } else if (requestCount == 0) {
+              analysisEngine.setCompletionCallback(null);
+              resumeForegroundAnalysisAfterQuickAnalysisComplete();
             }
           }
         };
@@ -17114,6 +17126,17 @@ public class LizzieFrame extends JFrame {
     if (quickAnalysisNavigationResumeTimer != null) {
       quickAnalysisNavigationResumeTimer.stop();
     }
+  }
+
+  void resumeForegroundAnalysisAfterQuickAnalysisComplete() {
+    if (!SwingUtilities.isEventDispatchThread()) {
+      SwingUtilities.invokeLater(this::resumeForegroundAnalysisAfterQuickAnalysisComplete);
+      return;
+    }
+    if (EngineManager.isEngineGame() || isPlayingAgainstLeelaz || isAnaPlayingAgainstLeelaz) {
+      return;
+    }
+    resumeForegroundAnalysisForCurrentPosition();
   }
 
   public boolean ensureAnalysisResumedAfterSyncLoad() {

--- a/src/main/resources/l10n/DisplayStrings.properties
+++ b/src/main/resources/l10n/DisplayStrings.properties
@@ -511,6 +511,7 @@ AutoSetup.officialWeights=Downloadable official weights
 AutoSetup.selectedWeightInfo=Official weight details
 AutoSetup.currentStatus=Status
 AutoSetup.refresh=Refresh
+AutoSetup.refreshOfficialWeights=Refresh downloadable official weights
 AutoSetup.autoSetup=Apply setup
 AutoSetup.downloadWeight=Download this official weight
 AutoSetup.importWeight=Import custom weight

--- a/src/main/resources/l10n/DisplayStrings_zh_CN.properties
+++ b/src/main/resources/l10n/DisplayStrings_zh_CN.properties
@@ -527,6 +527,7 @@ AutoSetup.officialWeights=\u53ef\u4e0b\u8f7d\u5b98\u65b9\u6743\u91cd
 AutoSetup.selectedWeightInfo=\u5b98\u65b9\u6743\u91cd\u8be6\u60c5
 AutoSetup.currentStatus=\u5F53\u524D\u72B6\u6001
 AutoSetup.refresh=\u5237\u65B0
+AutoSetup.refreshOfficialWeights=刷新可下载官方权重
 AutoSetup.autoSetup=\u5E94\u7528\u8BBE\u7F6E
 AutoSetup.downloadWeight=\u4e0b\u8f7d\u8be5\u5b98\u65b9\u6743\u91cd
 AutoSetup.importWeight=\u5BFC\u5165\u81EA\u5B9A\u4E49\u6743\u91CD

--- a/src/test/java/featurecat/lizzie/analysis/remote/RemoteComputeConfigTest.java
+++ b/src/test/java/featurecat/lizzie/analysis/remote/RemoteComputeConfigTest.java
@@ -202,7 +202,14 @@ class RemoteComputeConfigTest {
         "wss://example.com/katago?token=abc",
         RemoteComputeConfig.normalizeCustomWebSocketUrl(
             "  二维码内容: wss://example.com/katago?token=abc  "));
+    assertEquals(
+        "ws://127.0.0.1:2718",
+        RemoteComputeConfig.normalizeCustomWebSocketUrl("完善：//127.0.0.1：2718"));
+    assertEquals(
+        "ws://127.0.0.1:2718",
+        RemoteComputeConfig.normalizeCustomWebSocketUrl("ｗｓ：／／127.0.0.1：2718"));
     assertTrue(RemoteComputeConfig.isCustomWebSocketUrl("ws://127.0.0.1:2718"));
+    assertTrue(RemoteComputeConfig.isCustomWebSocketUrl("完善：//127.0.0.1：2718"));
     assertTrue(RemoteComputeConfig.isCustomWebSocketUrl("wss://remote.example.com/katago"));
     assertFalse(RemoteComputeConfig.isCustomWebSocketUrl("http://remote.example.com/katago"));
     assertFalse(RemoteComputeConfig.isCustomWebSocketUrl("remote.example.com/katago"));

--- a/src/test/java/featurecat/lizzie/analysis/remote/ZhiziGtpTransportTest.java
+++ b/src/test/java/featurecat/lizzie/analysis/remote/ZhiziGtpTransportTest.java
@@ -1,10 +1,14 @@
 package featurecat.lizzie.analysis.remote;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.InputStream;
+import java.io.OutputStream;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 
 class ZhiziGtpTransportTest {
@@ -42,5 +46,102 @@ class ZhiziGtpTransportTest {
     stream.close();
 
     assertEquals(-1, stream.read());
+  }
+
+  @Test
+  void commandStreamQueuesCommandsUntilReconnectIsReady() throws Exception {
+    FakeEmitter disconnected = new FakeEmitter(false);
+    ZhiziGtpTransport.SocketCommandOutputStream stream =
+        new ZhiziGtpTransport.SocketCommandOutputStream(disconnected);
+
+    send(stream, "boardsize 19");
+    send(stream, "kata-analyze B 10");
+
+    assertEquals(2, stream.queuedCommandCount());
+    assertEquals(List.of(), disconnected.commands);
+
+    FakeEmitter reconnected = new FakeEmitter(true);
+    stream.bind(reconnected);
+
+    assertEquals(2, stream.flushQueuedCommands());
+    assertEquals(List.of("boardsize 19\n", "kata-analyze B 10\n"), reconnected.commands);
+    assertEquals(0, stream.queuedCommandCount());
+  }
+
+  @Test
+  void commandStreamSendsImmediatelyWhenConnected() throws Exception {
+    FakeEmitter connected = new FakeEmitter(true);
+    ZhiziGtpTransport.SocketCommandOutputStream stream =
+        new ZhiziGtpTransport.SocketCommandOutputStream(connected);
+
+    send(stream, "name");
+
+    assertEquals(List.of("name\n"), connected.commands);
+    assertEquals(0, stream.queuedCommandCount());
+  }
+
+  @Test
+  void commandStreamRestartsLastAnalysisAfterReconnectWhenNoNewAnalysisWasQueued()
+      throws Exception {
+    FakeEmitter connected = new FakeEmitter(true);
+    ZhiziGtpTransport.SocketCommandOutputStream stream =
+        new ZhiziGtpTransport.SocketCommandOutputStream(connected);
+    send(stream, "kata-analyze B 10");
+
+    FakeEmitter reconnected = new FakeEmitter(true);
+    stream.bind(reconnected);
+
+    assertEquals(true, stream.resumeLastAnalysisIfIdle());
+    assertEquals(List.of("kata-analyze B 10\n"), reconnected.commands);
+  }
+
+  @Test
+  void commandStreamDoesNotRestartAnalysisAfterStop() throws Exception {
+    FakeEmitter connected = new FakeEmitter(true);
+    ZhiziGtpTransport.SocketCommandOutputStream stream =
+        new ZhiziGtpTransport.SocketCommandOutputStream(connected);
+    send(stream, "kata-analyze B 10");
+    send(stream, "stop");
+
+    FakeEmitter reconnected = new FakeEmitter(true);
+    stream.bind(reconnected);
+
+    assertEquals(false, stream.resumeLastAnalysisIfIdle());
+    assertEquals(List.of(), reconnected.commands);
+  }
+
+  @Test
+  void commandStreamRejectsWritesAfterShutdown() throws Exception {
+    ZhiziGtpTransport.SocketCommandOutputStream stream =
+        new ZhiziGtpTransport.SocketCommandOutputStream(new FakeEmitter(false));
+
+    stream.closeForShutdown();
+    stream.write("name\n".getBytes(StandardCharsets.UTF_8));
+
+    assertThrows(java.io.IOException.class, stream::flush);
+  }
+
+  private static void send(OutputStream stream, String command) throws Exception {
+    stream.write((command + "\n").getBytes(StandardCharsets.UTF_8));
+    stream.flush();
+  }
+
+  private static final class FakeEmitter implements ZhiziGtpTransport.CommandEmitter {
+    private final List<String> commands = new ArrayList<>();
+    private final boolean connected;
+
+    private FakeEmitter(boolean connected) {
+      this.connected = connected;
+    }
+
+    @Override
+    public boolean isConnected() {
+      return connected;
+    }
+
+    @Override
+    public void emit(String command) {
+      commands.add(command);
+    }
   }
 }

--- a/src/test/java/featurecat/lizzie/gui/LizzieFrameRegressionTest.java
+++ b/src/test/java/featurecat/lizzie/gui/LizzieFrameRegressionTest.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import featurecat.lizzie.Config;
 import featurecat.lizzie.Lizzie;
+import featurecat.lizzie.analysis.AnalysisEngine;
 import featurecat.lizzie.analysis.EngineManager;
 import featurecat.lizzie.analysis.Leelaz;
 import featurecat.lizzie.analysis.MoveRankDefinition;
@@ -499,6 +500,61 @@ class LizzieFrameRegressionTest {
       assertTrue(frame.lastSilentAnalyze);
       assertEquals(1, frame.refreshCount);
       assertEquals(1, leelaz.ponderCount);
+    } finally {
+      env.close();
+    }
+  }
+
+  @Test
+  void winrateGraphNavigationContinuesMissingQuickAnalysisWhenEngineIsIdle() throws Exception {
+    TestEnvironment env = TestEnvironment.open();
+    try {
+      Lizzie.config = configWithAutoQuickAnalyze();
+      Lizzie.board = boardWith(historyWithUnanalyzedMove());
+      EngineManager.isEmpty = false;
+      EngineManager.isEngineGame = false;
+      EngineManager.isPreEngineGame = false;
+      LizzieFrame frame = allocate(LizzieFrame.class);
+      NavigationQuickAnalysisEngine engine = allocate(NavigationQuickAnalysisEngine.class);
+      frame.analysisEngine = engine;
+      Lizzie.frame = frame;
+
+      SwingUtilities.invokeAndWait(frame::continueQuickAnalysisAfterHistoryNavigationWhenIdle);
+
+      assertEquals(
+          1,
+          engine.keepAliveCount,
+          "navigation continuation should keep the warmed quick-analysis engine reusable.");
+      assertEquals(
+          1,
+          engine.missingMainlineRequestCount,
+          "navigation continuation should fill any remaining fast-curve gaps.");
+    } finally {
+      env.close();
+    }
+  }
+
+  @Test
+  void winrateGraphNavigationWaitsWhenQuickAnalysisIsStillRunning() throws Exception {
+    TestEnvironment env = TestEnvironment.open();
+    try {
+      Lizzie.config = configWithAutoQuickAnalyze();
+      Lizzie.board = boardWith(historyWithUnanalyzedMove());
+      EngineManager.isEmpty = false;
+      EngineManager.isEngineGame = false;
+      EngineManager.isPreEngineGame = false;
+      LizzieFrame frame = allocate(LizzieFrame.class);
+      NavigationQuickAnalysisEngine engine = allocate(NavigationQuickAnalysisEngine.class);
+      engine.analysisInProgress = true;
+      frame.analysisEngine = engine;
+      Lizzie.frame = frame;
+
+      SwingUtilities.invokeAndWait(frame::continueQuickAnalysisAfterHistoryNavigationWhenIdle);
+
+      assertEquals(
+          0,
+          engine.missingMainlineRequestCount,
+          "navigation continuation must not clear or restart an active quick-analysis queue.");
     } finally {
       env.close();
     }
@@ -1188,6 +1244,50 @@ class LizzieFrameRegressionTest {
     @Override
     public void refresh() {
       refreshCount++;
+    }
+  }
+
+  private static final class NavigationQuickAnalysisEngine extends AnalysisEngine {
+    private boolean analysisInProgress;
+    private int keepAliveCount;
+    private int missingMainlineRequestCount;
+
+    @SuppressWarnings("unused")
+    private NavigationQuickAnalysisEngine() throws java.io.IOException {
+      super(true);
+    }
+
+    @Override
+    public boolean isLoaded() {
+      return true;
+    }
+
+    @Override
+    public boolean isRunning() {
+      return true;
+    }
+
+    @Override
+    public synchronized boolean isAnalysisInProgress() {
+      return analysisInProgress;
+    }
+
+    @Override
+    public boolean matchesCurrentAnalysisBackend() {
+      return true;
+    }
+
+    @Override
+    public void setKeepAliveAfterCurrentRequest(boolean keepAliveAfterCurrentRequest) {
+      if (keepAliveAfterCurrentRequest) {
+        keepAliveCount++;
+      }
+    }
+
+    @Override
+    public int startRequestMissingMainline(boolean showProgressDialog) {
+      missingMainlineRequestCount++;
+      return 1;
     }
   }
 

--- a/src/test/java/featurecat/lizzie/gui/LizzieFrameRegressionTest.java
+++ b/src/test/java/featurecat/lizzie/gui/LizzieFrameRegressionTest.java
@@ -480,6 +480,46 @@ class LizzieFrameRegressionTest {
   }
 
   @Test
+  void silentQuickAnalyzeCompletionRestartsForegroundAnalysisForCurrentPosition()
+      throws Exception {
+    TestEnvironment env = TestEnvironment.open();
+    try {
+      Lizzie.config = configWithAutoQuickAnalyze();
+      Lizzie.board = boardWith(historyWithUnanalyzedMove());
+      TrackingLeelaz leelaz = allocate(TrackingLeelaz.class);
+      Lizzie.leelaz = leelaz;
+      EngineManager.isEmpty = false;
+      EngineManager.isEngineGame = false;
+      EngineManager.isPreEngineGame = false;
+      QuickAnalysisResumeFrame frame = allocate(QuickAnalysisResumeFrame.class);
+      QuickAnalysisCompletionEngine engine = allocate(QuickAnalysisCompletionEngine.class);
+      engine.requestStarted = new CountDownLatch(1);
+      frame.analysisEngine = engine;
+      Lizzie.frame = frame;
+
+      frame.flashAnalyzeGame(true, false, true);
+
+      assertTrue(
+          engine.requestStarted.await(2, TimeUnit.SECONDS),
+          "silent quick analysis should dispatch its request in the background.");
+      assertFalse(engine.lastShowProgressDialog);
+      assertTrue(
+          engine.completionCallback != null,
+          "silent quick analysis should resume foreground board analysis after graph completion.");
+
+      SwingUtilities.invokeAndWait(engine.completionCallback);
+
+      assertEquals(
+          1,
+          leelaz.ponderCount,
+          "foreground candidate analysis should restart immediately after fast curve completion.");
+      assertEquals(1, frame.refreshCount);
+    } finally {
+      env.close();
+    }
+  }
+
+  @Test
   void downloadedKifuStartsSilentQuickAnalyzeAndForegroundAnalysis() throws Exception {
     TestEnvironment env = TestEnvironment.open();
     try {
@@ -511,10 +551,12 @@ class LizzieFrameRegressionTest {
     try {
       Lizzie.config = configWithAutoQuickAnalyze();
       Lizzie.board = boardWith(historyWithUnanalyzedMove());
+      TrackingLeelaz leelaz = allocate(TrackingLeelaz.class);
+      Lizzie.leelaz = leelaz;
       EngineManager.isEmpty = false;
       EngineManager.isEngineGame = false;
       EngineManager.isPreEngineGame = false;
-      LizzieFrame frame = allocate(LizzieFrame.class);
+      QuickAnalysisResumeFrame frame = allocate(QuickAnalysisResumeFrame.class);
       NavigationQuickAnalysisEngine engine = allocate(NavigationQuickAnalysisEngine.class);
       frame.analysisEngine = engine;
       Lizzie.frame = frame;
@@ -529,6 +571,16 @@ class LizzieFrameRegressionTest {
           1,
           engine.missingMainlineRequestCount,
           "navigation continuation should fill any remaining fast-curve gaps.");
+      assertTrue(
+          engine.completionCallback != null,
+          "navigation-triggered curve completion should also resume foreground board analysis.");
+
+      SwingUtilities.invokeAndWait(engine.completionCallback);
+
+      assertEquals(
+          1,
+          leelaz.ponderCount,
+          "foreground analysis should restart after navigation-triggered curve completion.");
     } finally {
       env.close();
     }
@@ -1247,10 +1299,65 @@ class LizzieFrameRegressionTest {
     }
   }
 
+  private static final class QuickAnalysisResumeFrame extends LizzieFrame {
+    private int refreshCount;
+
+    @Override
+    public void refresh() {
+      refreshCount++;
+    }
+  }
+
+  private static final class QuickAnalysisCompletionEngine extends AnalysisEngine {
+    private CountDownLatch requestStarted = new CountDownLatch(1);
+    private Runnable completionCallback;
+    private boolean lastShowProgressDialog;
+
+    @SuppressWarnings("unused")
+    private QuickAnalysisCompletionEngine() throws java.io.IOException {
+      super(true);
+    }
+
+    @Override
+    public boolean isLoaded() {
+      return true;
+    }
+
+    @Override
+    public boolean isRunning() {
+      return true;
+    }
+
+    @Override
+    public synchronized boolean isAnalysisInProgress() {
+      return lastShowProgressDialog || requestStarted.getCount() == 0;
+    }
+
+    @Override
+    public boolean matchesCurrentAnalysisBackend() {
+      return true;
+    }
+
+    @Override
+    public void setCompletionCallback(Runnable completionCallback) {
+      this.completionCallback = completionCallback;
+    }
+
+    @Override
+    public void setKeepAliveAfterCurrentRequest(boolean keepAliveAfterCurrentRequest) {}
+
+    @Override
+    public void startRequest(int startMove, int endMove, boolean showProgressDialog) {
+      lastShowProgressDialog = showProgressDialog;
+      requestStarted.countDown();
+    }
+  }
+
   private static final class NavigationQuickAnalysisEngine extends AnalysisEngine {
     private boolean analysisInProgress;
     private int keepAliveCount;
     private int missingMainlineRequestCount;
+    private Runnable completionCallback;
 
     @SuppressWarnings("unused")
     private NavigationQuickAnalysisEngine() throws java.io.IOException {
@@ -1282,6 +1389,11 @@ class LizzieFrameRegressionTest {
       if (keepAliveAfterCurrentRequest) {
         keepAliveCount++;
       }
+    }
+
+    @Override
+    public void setCompletionCallback(Runnable completionCallback) {
+      this.completionCallback = completionCallback;
     }
 
     @Override

--- a/src/test/java/featurecat/lizzie/gui/WinrateGraphVariationHitTest.java
+++ b/src/test/java/featurecat/lizzie/gui/WinrateGraphVariationHitTest.java
@@ -1,5 +1,6 @@
 package featurecat.lizzie.gui;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -144,6 +145,10 @@ class WinrateGraphVariationHitTest {
           fixture.mainFuture,
           fixture.board.getHistory().getCurrentHistoryNode(),
           "click should jump from the variation to the visible main-trunk continuation.");
+      assertEquals(
+          1,
+          frame.quickAnalysisContinuationScheduleCount,
+          "clicking the graph during fast curve generation should keep a continuation guard armed.");
     } finally {
       env.close();
     }
@@ -938,11 +943,18 @@ class WinrateGraphVariationHitTest {
   }
 
   private static final class TrackingFrame extends LizzieFrame {
+    private int quickAnalysisContinuationScheduleCount;
+
     @Override
     public void repaint() {}
 
     @Override
     public void refresh() {}
+
+    @Override
+    void scheduleQuickAnalysisContinuationAfterHistoryNavigation() {
+      quickAnalysisContinuationScheduleCount++;
+    }
   }
 
   private static final class TestEnvironment implements AutoCloseable {


### PR DESCRIPTION
## Summary

- Improves Zhizi remote compute reconnect handling so temporary network drops queue commands, recover the command channel, and resume realtime analysis when safe.
- Polishes remote compute entry points: bottom toolbar button, KataGo one-click setup navigation placement, weight refresh affordance, and related localized labels.
- Adds safer custom remote compute URL normalization for ws/wss links, including full-width punctuation and common Chinese IME input mistakes.

## Validation

- `git diff --check`
- `mvn -B -Dfmt.skip=true -Dtest=RemoteComputeConfigTest,ZhiziGtpTransportTest test`
- `mvn -B -Dfmt.skip=true test` (995 tests, 0 failures)
- `mvn -B -Dfmt.skip=true -DskipTests package`
- Local macOS launch from the shaded jar, with Zhizi remote engine connected and returning analysis/score updates.

## Notes

This PR does not create a release and does not change the TensorRT release asset strategy.
