### PR TITLE
Stabilize remote quick winrate analysis

### DIFF
--- a/src/main/java/featurecat/lizzie/analysis/AnalysisEngine.java
+++ b/src/main/java/featurecat/lizzie/analysis/AnalysisEngine.java
@@ -37,6 +37,8 @@ import java.util.Set;
 import java.util.Stack;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
 import org.jdesktop.swingx.util.OS;
 import org.json.JSONArray;
 import org.json.JSONObject;
@@ -48,6 +50,14 @@ public class AnalysisEngine {
   private static final int REMOTE_GTP_OVERVIEW_THRESHOLD = 24;
   private static final int REMOTE_GTP_RAW_NN_VISITS = 1;
   private static final long REMOTE_GTP_STOP_ACK_TIMEOUT_MILLIS = 180L;
+  private static final long REMOTE_GTP_RAW_NN_STALL_TIMEOUT_MILLIS = 8000L;
+  private static final ScheduledExecutorService REMOTE_GTP_WATCHDOG_EXECUTOR =
+      Executors.newSingleThreadScheduledExecutor(
+          runnable -> {
+            Thread thread = new Thread(runnable, "remote-gtp-watchdog");
+            thread.setDaemon(true);
+            return thread;
+          });
   public Process process;
   public boolean isNormalEnd = false;
   private final ResourceBundle resourceBundle = Lizzie.resourceBundle;
@@ -95,6 +105,7 @@ public class AnalysisEngine {
   private boolean remoteGtpRawNnSawEmptySuccess;
   private boolean remoteGtpStopAckOptional;
   private long remoteGtpStopAckGeneration;
+  private ScheduledFuture<?> remoteGtpRawNnStallTask;
 
   public AnalysisEngine(boolean isPreLoad) throws IOException {
     int maxVisits =
@@ -507,6 +518,7 @@ public class AnalysisEngine {
     if (remoteGtpActiveJob != job) {
       return;
     }
+    cancelRemoteGtpRawNnStallFallback();
     remoteGtpActiveJob = null;
     remoteGtpRawNnSawEmptySuccess = false;
     if (!shouldKeepForegroundAnalysis(job.node)) {
@@ -547,6 +559,7 @@ public class AnalysisEngine {
     if (remoteGtpActiveJob != job) {
       return;
     }
+    cancelRemoteGtpRawNnStallFallback();
     remoteGtpActiveJob =
         new RemoteGtpAnalyzeJob(
             job.id,
@@ -560,6 +573,34 @@ public class AnalysisEngine {
       remoteGtpActiveJob = null;
       requestDispatchFailed = true;
     }
+  }
+
+  private void scheduleRemoteGtpRawNnStallFallback(RemoteGtpAnalyzeJob job) {
+    cancelRemoteGtpRawNnStallFallback();
+    remoteGtpRawNnStallTask =
+        REMOTE_GTP_WATCHDOG_EXECUTOR.schedule(
+            () -> {
+              synchronized (AnalysisEngine.this) {
+                handleRemoteGtpRawNnStall(job);
+              }
+            },
+            REMOTE_GTP_RAW_NN_STALL_TIMEOUT_MILLIS,
+            TimeUnit.MILLISECONDS);
+  }
+
+  private void cancelRemoteGtpRawNnStallFallback() {
+    ScheduledFuture<?> task = remoteGtpRawNnStallTask;
+    remoteGtpRawNnStallTask = null;
+    if (task != null) {
+      task.cancel(false);
+    }
+  }
+
+  private void handleRemoteGtpRawNnStall(RemoteGtpAnalyzeJob job) {
+    if (job == null || remoteGtpActiveJob != job || job.mode != RemoteGtpAnalyzeMode.RAW_NN) {
+      return;
+    }
+    fallbackRemoteGtpRawNnJob(job);
   }
 
   private void completeRemoteGtpJob(RemoteGtpAnalyzeJob job, List<MoveData> moves) {
@@ -712,6 +753,7 @@ public class AnalysisEngine {
     remoteGtpStopSent = false;
     remoteGtpRawNnResponse = null;
     remoteGtpRawNnSawEmptySuccess = false;
+    cancelRemoteGtpRawNnStallFallback();
     resultCount = 0;
     runCompletionCallback();
   }
@@ -804,6 +846,7 @@ public class AnalysisEngine {
     remoteGtpStopSent = false;
     remoteGtpRawNnResponse = null;
     remoteGtpRawNnSawEmptySuccess = false;
+    cancelRemoteGtpRawNnStallFallback();
     remoteGtpStopAckGeneration++;
     if (globalID <= 0) globalID = 1;
     resultCount = 0;
@@ -996,6 +1039,7 @@ public class AnalysisEngine {
     if (job == null) {
       return true;
     }
+    job = downgradeRawNnJobIfNeeded(job);
     remoteGtpActiveJob = job;
     remoteGtpStopSent = false;
     remoteGtpRawNnResponse = null;
@@ -1007,7 +1051,27 @@ public class AnalysisEngine {
         return false;
       }
     }
+    if (job.mode == RemoteGtpAnalyzeMode.RAW_NN) {
+      scheduleRemoteGtpRawNnStallFallback(job);
+    }
     return true;
+  }
+
+  private RemoteGtpAnalyzeJob downgradeRawNnJobIfNeeded(RemoteGtpAnalyzeJob job) {
+    if (job == null
+        || job.mode != RemoteGtpAnalyzeMode.RAW_NN
+        || !remoteGtpRawNnUnsupported) {
+      return job;
+    }
+    List<String> commands = new ArrayList<String>(job.commands);
+    String fallbackCommand = buildRemoteGtpAnalyzeCommand(job.node);
+    if (commands.isEmpty()) {
+      commands.add(fallbackCommand);
+    } else {
+      commands.set(commands.size() - 1, fallbackCommand);
+    }
+    return new RemoteGtpAnalyzeJob(
+        job.id, job.node, job.targetVisits, commands, RemoteGtpAnalyzeMode.KATA_ANALYZE);
   }
 
   private List<String> buildRemoteGtpSetupCommands(

--- a/src/main/java/featurecat/lizzie/analysis/remote/ZhiziGtpTransport.java
+++ b/src/main/java/featurecat/lizzie/analysis/remote/ZhiziGtpTransport.java
@@ -619,6 +619,8 @@ public class ZhiziGtpTransport implements EngineTransport {
       String normalized = firstCommandLine(command).trim();
       return normalized.startsWith("kata-analyze ")
           || normalized.startsWith("kata-analyze_interval ")
+          || normalized.equals("kata-raw-nn")
+          || normalized.startsWith("kata-raw-nn ")
           || normalized.startsWith("lz-analyze ")
           || normalized.startsWith("analyze ");
     }

--- a/src/test/java/featurecat/lizzie/analysis/AnalysisEngineRequestTest.java
+++ b/src/test/java/featurecat/lizzie/analysis/AnalysisEngineRequestTest.java
@@ -629,6 +629,74 @@ class AnalysisEngineRequestTest {
   }
 
   @Test
+  void remoteGtpSilentQuickCurveFallsBackWhenRawNnStaysSilent() throws Exception {
+    try (TestEnvironment env = TestEnvironment.open()) {
+      BoardHistoryNode node = singleUnanalyzedMoveNode();
+      TrackingAnalysisEngine engine = TrackingAnalysisEngine.create();
+      setField(AnalysisEngine.class, engine, "useRemoteCompute", true);
+      engine.setKeepAliveAfterCurrentRequest(true);
+
+      engine.startRequest(-1, -1, false);
+
+      assertEquals("kata-raw-nn 0", lastCommand(engine.sentCommands));
+      invokeRemoteGtpRawNnStall(engine);
+
+      assertEquals(
+          "kata-analyze W 1",
+          lastCommand(engine.sentCommands),
+          "a silent raw-nn request must downgrade instead of holding the quick curve forever.");
+
+      invokeAnalysisEngineParseLine(
+          engine, "info move B2 visits 2 winrate 0.62 scoreLead 1.5 order 0 pv B2");
+      assertEquals("stop", lastCommand(engine.sentCommands));
+      invokeAnalysisEngineParseLine(engine, "=");
+
+      assertEquals(2, node.getData().getPlayouts());
+      assertFalse(engine.isAnalysisInProgress());
+      waitForMovelistRefreshThreads();
+    }
+  }
+
+  @Test
+  void remoteGtpSilentQuickCurveDowngradesQueuedRawNnAfterFallback() throws Exception {
+    try (TestEnvironment env = TestEnvironment.open()) {
+      BoardHistoryList history = new BoardHistoryList(BoardData.empty(BOARD_SIZE, BOARD_SIZE));
+      history.add(
+          moveNode(stones(placement(0, 0, Stone.BLACK)), new int[] {0, 0}, Stone.BLACK, false, 1));
+      history.add(
+          moveNode(
+              stones(placement(0, 0, Stone.BLACK), placement(1, 0, Stone.WHITE)),
+              new int[] {1, 0},
+              Stone.WHITE,
+              true,
+              2));
+      boardWithHistory(history);
+      TrackingAnalysisEngine engine = TrackingAnalysisEngine.create();
+      setField(AnalysisEngine.class, engine, "useRemoteCompute", true);
+      engine.setKeepAliveAfterCurrentRequest(true);
+
+      engine.startRequest(-1, -1, false);
+
+      assertEquals("kata-raw-nn 0", lastCommand(engine.sentCommands));
+      invokeAnalysisEngineParseLine(engine, "? unknown command");
+      assertEquals("kata-analyze W 1", lastCommand(engine.sentCommands));
+
+      invokeAnalysisEngineParseLine(
+          engine, "info move B2 visits 2 winrate 0.62 scoreLead 1.5 order 0 pv B2");
+      assertEquals("stop", lastCommand(engine.sentCommands));
+      invokeAnalysisEngineParseLine(engine, "=");
+
+      assertEquals(
+          1,
+          countCommand(engine.sentCommands, "kata-raw-nn 0"),
+          "after raw-nn is disabled, queued nodes in the same quick-curve pass must not keep using it.");
+      assertTrue(engine.sentCommands.contains("play W B3"));
+      assertEquals("kata-analyze B 1", lastCommand(engine.sentCommands));
+      waitForMovelistRefreshThreads();
+    }
+  }
+
+  @Test
   void remoteGtpMissingStopAckDoesNotStallQueuedQuickCurve() throws Exception {
     try (TestEnvironment env = TestEnvironment.open()) {
       BoardHistoryList history = new BoardHistoryList(BoardData.empty(BOARD_SIZE, BOARD_SIZE));
@@ -1435,6 +1503,16 @@ class AnalysisEngineRequestTest {
       Thread.sleep(20);
     }
     assertTrue(condition.getAsBoolean(), "condition was not met before timeout.");
+  }
+
+  private static void invokeRemoteGtpRawNnStall(AnalysisEngine engine) throws Exception {
+    Field activeJobField = AnalysisEngine.class.getDeclaredField("remoteGtpActiveJob");
+    activeJobField.setAccessible(true);
+    Object activeJob = activeJobField.get(engine);
+    Method method =
+        AnalysisEngine.class.getDeclaredMethod("handleRemoteGtpRawNnStall", activeJob.getClass());
+    method.setAccessible(true);
+    method.invoke(engine, activeJob);
   }
 
   private static Placement placement(int x, int y, Stone color) {

--- a/src/test/java/featurecat/lizzie/analysis/remote/ZhiziGtpTransportTest.java
+++ b/src/test/java/featurecat/lizzie/analysis/remote/ZhiziGtpTransportTest.java
@@ -96,6 +96,39 @@ class ZhiziGtpTransportTest {
   }
 
   @Test
+  void commandStreamRestartsRawNnAfterReconnectWhenNoNewAnalysisWasQueued() throws Exception {
+    FakeEmitter connected = new FakeEmitter(true);
+    ZhiziGtpTransport.SocketCommandOutputStream stream =
+        new ZhiziGtpTransport.SocketCommandOutputStream(connected);
+    send(stream, "kata-raw-nn 0");
+
+    FakeEmitter reconnected = new FakeEmitter(true);
+    stream.bind(reconnected);
+
+    assertEquals(true, stream.resumeLastAnalysisIfIdle());
+    assertEquals(List.of("kata-raw-nn 0\n"), reconnected.commands);
+  }
+
+  @Test
+  void commandStreamQueuedRawNnSuppressesStaleAnalysisResume() throws Exception {
+    FakeEmitter connected = new FakeEmitter(true);
+    ZhiziGtpTransport.SocketCommandOutputStream stream =
+        new ZhiziGtpTransport.SocketCommandOutputStream(connected);
+    send(stream, "kata-analyze B 10");
+
+    FakeEmitter disconnected = new FakeEmitter(false);
+    stream.bind(disconnected);
+    send(stream, "kata-raw-nn 0");
+
+    FakeEmitter reconnected = new FakeEmitter(true);
+    stream.bind(reconnected);
+
+    assertEquals(1, stream.flushQueuedCommands());
+    assertEquals(false, stream.resumeLastAnalysisIfIdle());
+    assertEquals(List.of("kata-raw-nn 0\n"), reconnected.commands);
+  }
+
+  @Test
   void commandStreamDoesNotRestartAnalysisAfterStop() throws Exception {
     FakeEmitter connected = new FakeEmitter(true);
     ZhiziGtpTransport.SocketCommandOutputStream stream =


### PR DESCRIPTION
## Summary
- Treat `kata-raw-nn` as a resumable Zhizi analysis command, so reconnects can restore remote quick winrate requests.
- Add a remote quick-curve raw-nn watchdog that downgrades silent raw-nn jobs to `kata-analyze` instead of leaving analysis stuck forever.
- Downgrade already queued raw-nn jobs in the same quick-curve pass after raw-nn is proven unavailable.
- Add regression tests for reconnect recovery, silent raw-nn fallback, and queued-job downgrade.

## Root Cause
Remote Zhizi quick winrate analysis uses `kata-raw-nn 0` for fast one-shot evaluations. The transport reconnect logic only remembered streaming analysis commands like `kata-analyze`, so a reconnect could lose an in-flight raw-nn request while `AnalysisEngine` still believed a quick-curve job was active. Separately, a raw-nn request that returned no line had no timeout fallback, and queued nodes could continue using raw-nn even after the first job had already fallen back.

## Validation
- `mvn -Dfmt.skip=true -Dtest=AnalysisEngineRequestTest test`
- `mvn -Dfmt.skip=true -Dtest=ZhiziGtpTransportTest test`
- `mvn -Dfmt.skip=true test`
- `mvn -Dfmt.skip=true -DskipTests package`

Note: plain `mvn test` also passed locally, but the formatter rewrote many unrelated files; those formatting-only changes were reverted so this PR stays focused.