### PR TITLE
Stabilize Windows remote analysis regression test

### DIFF
--- a/src/test/java/featurecat/lizzie/analysis/AnalysisEngineRequestTest.java
+++ b/src/test/java/featurecat/lizzie/analysis/AnalysisEngineRequestTest.java
@@ -25,6 +25,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.BooleanSupplier;
 import org.json.JSONArray;
 import org.json.JSONObject;
@@ -1631,7 +1632,7 @@ class AnalysisEngineRequestTest {
 
     private static TrackingAnalysisEngine create() throws Exception {
       TrackingAnalysisEngine engine = allocate(TrackingAnalysisEngine.class);
-      engine.sentCommands = new ArrayList<>();
+      engine.sentCommands = new CopyOnWriteArrayList<>();
       setField(
           AnalysisEngine.class, engine, "analyzeMap", new java.util.HashMap<Integer, Object>());
       setIntField(AnalysisEngine.class, engine, "globalID", 1);


### PR DESCRIPTION
## Summary
- Audited recent Windows-sensitive changes since `next-2026-06-29.1`.
- Stabilized the remote analysis request test harness by making the async command recorder thread-safe.
- Prevents intermittent `ConcurrentModificationException` from hiding real remote-compute / quick-winrate regressions during Windows validation.

## Windows validation
- `mvn -Dfmt.skip=true -Dtest=AnalysisEngineRequestTest,RemoteComputeConfigTest,ZhiziGtpTransportTest,KataGoAnalysisWebSocketTransportTest,LizzieFrameRegressionTest,WinrateGraphVariationHitTest,PlayerStrengthEstimatorTest test`
- `mvn -Dfmt.skip=true test`
- `mvn -Dfmt.skip=true -DskipTests package`
- `scripts/windows_smoke_test.ps1 -AppExe .win-realtest/windows-audit-20260704/LizzieYzy Next OpenCL.exe -WaitSeconds 70 -ProbeBoardSync`
- Windows GUI smoke with current shaded jar inside full OpenCL portable app: main window launch, native readboard probe, Remote Compute Center, custom compute tab, Shift+O Yike live list, Yike game double-click sync.

## Notes
- No product behavior was changed; this PR only makes the regression suite reliable for the async remote-compute path.
- `.win-realtest/` screenshots and copied portable app were local-only test artifacts and are intentionally not included.