### PR TITLE
Fix Windows remote compute startup

### DIFF
--- a/src/main/java/featurecat/lizzie/analysis/Leelaz.java
+++ b/src/main/java/featurecat/lizzie/analysis/Leelaz.java
@@ -62,6 +62,12 @@ import org.json.JSONObject;
  * www.github.com/gcp/leela-zero
  */
 public class Leelaz {
+  private enum StartupCommandAction {
+    NONE,
+    KATA,
+    LEELA_SAI
+  }
+
   // private static final long MINUTE = 60 * 1000; // number of milliseconds in a minute
   private static final Runnable NO_OP_RESPONSE_HANDLER = () -> {};
   private static final int NO_RESPONSE_COMMAND_ID = -1;
@@ -1259,7 +1265,7 @@ public class Leelaz {
           return;
         }
       }
-      checkNameAndVersion(params);
+      runStartupCommandAction(checkNameAndVersion(params));
     } else if (line.startsWith("?")) {
       isCommandLine = true;
       if (consumeReadBoardGmaEngineErrorLine(line)) {
@@ -1273,8 +1279,9 @@ public class Leelaz {
     }
   }
 
-  private void checkNameAndVersion(String[] params) {
+  private StartupCommandAction checkNameAndVersion(String[] params) {
     // TODO Auto-generated method stub
+    StartupCommandAction startupCommandAction = StartupCommandAction.NONE;
     if (isCheckingName) {
       noAnalyze = false;
       isCheckingName = false;
@@ -1311,30 +1318,11 @@ public class Leelaz {
           isKatagoCustom = true;
           isCheckingPda = true;
           isKataGoPda = true;
-          sendCommand("getpda");
-          sendCommand("getdympdacap");
-          Runnable runnable =
-              new Runnable() {
-                public void run() {
-                  try {
-                    Thread.sleep(5000);
-                  } catch (InterruptedException e) {
-                    // TODO Auto-generated catch block
-                    e.printStackTrace();
-                  }
-                  isCheckingPda = false;
-                }
-              };
-          Thread thread = new Thread(runnable);
-          thread.start();
         }
-        setKataEnginePara();
-        if (Lizzie.config.autoLoadKataRules)
-          sendCommand("kata-set-rules " + Lizzie.config.kataRules);
-        getParameterScadule(true);
         this.isKatago = true;
         if (params[1].startsWith("KataGoCustom")) isKatagoCustom = true;
         this.version = 17;
+        startupCommandAction = StartupCommandAction.KATA;
 
         if (this.currentEngineN == EngineManager.currentEngineNo) {
           Lizzie.config.leelaversion = version;
@@ -1357,7 +1345,7 @@ public class Leelaz {
         closeBundledStartupDialog();
         isTuning = false;
         isKatago = false;
-        setLeelaSaiEnginePara();
+        startupCommandAction = StartupCommandAction.LEELA_SAI;
       }
       if (params[1].toLowerCase().startsWith("katajigo")) {
         this.isKatago = true;
@@ -1413,6 +1401,39 @@ public class Leelaz {
         }
       }
     }
+    return startupCommandAction;
+  }
+
+  private StartupCommandAction mergeStartupCommandAction(
+      StartupCommandAction current, StartupCommandAction next) {
+    return current == StartupCommandAction.NONE ? next : current;
+  }
+
+  private void runStartupCommandAction(StartupCommandAction action) {
+    if (action == StartupCommandAction.KATA) {
+      if (isKataGoPda) {
+        sendCommand("getpda");
+        sendCommand("getdympdacap");
+        Thread thread =
+            new Thread(
+                () -> {
+                  try {
+                    Thread.sleep(5000);
+                  } catch (InterruptedException e) {
+                    e.printStackTrace();
+                  }
+                  isCheckingPda = false;
+                });
+        thread.start();
+      }
+      setKataEnginePara();
+      if (Lizzie.config.autoLoadKataRules) {
+        sendCommand("kata-set-rules " + Lizzie.config.kataRules);
+      }
+      getParameterScadule(true);
+    } else if (action == StartupCommandAction.LEELA_SAI) {
+      setLeelaSaiEnginePara();
+    }
   }
 
   private void checkForGomokuFullBoard(boolean isGenmove) {
@@ -1454,6 +1475,7 @@ public class Leelaz {
     boolean notifyAutoPKAfterInfo = false;
     boolean notifyAutoPlayAfterInfo = false;
     int autoAnalyzeAfterInfo = 0;
+    StartupCommandAction startupCommandAction = StartupCommandAction.NONE;
     synchronized (this) {
       if (line.startsWith("info")) {
         boolean upToDate = isResponseUpToDate();
@@ -1851,7 +1873,8 @@ public class Leelaz {
             isInputCommand = false;
           }
         }
-        checkNameAndVersion(params);
+        startupCommandAction =
+            mergeStartupCommandAction(startupCommandAction, checkNameAndVersion(params));
       } else if (line.startsWith("?")) {
         isCommandLine = true;
         if (consumeReadBoardGmaEngineErrorLine(line)) {
@@ -1863,6 +1886,7 @@ public class Leelaz {
       }
       parseHeatMap(line);
     }
+    runStartupCommandAction(startupCommandAction);
     if (handledInfoLine) {
       runPostInfoActions(notifyAutoPKAfterInfo, notifyAutoPlayAfterInfo, autoAnalyzeAfterInfo);
     }

--- a/src/main/java/featurecat/lizzie/analysis/remote/KataGoAnalysisWebSocketTransport.java
+++ b/src/main/java/featurecat/lizzie/analysis/remote/KataGoAnalysisWebSocketTransport.java
@@ -139,17 +139,18 @@ public class KataGoAnalysisWebSocketTransport implements EngineTransport {
     String lower = line.toLowerCase(Locale.ROOT);
     try {
       if (lower.equals("name")) {
-        writeOk(responseId, "LizzieYzy Next 自建远程 KataGo");
+        writeOk(responseId, "KataGo");
       } else if (lower.equals("protocol_version")) {
         writeOk(responseId, "2");
       } else if (lower.equals("version")) {
-        writeOk(responseId, "remote-websocket");
+        writeOk(responseId, "1.16.4");
       } else if (lower.equals("list_commands")) {
         writeOk(
             responseId,
             "protocol_version\nname\nversion\nlist_commands\nboardsize\nrectangular_boardsize\n"
-                + "komi\nkata-set-rules\nclear_board\nplay\nundo\nkata-analyze\n"
-                + "kata-genmove_analyze\ngenmove\nstop\nquit");
+                + "komi\nkata-get-rules\nkata-get-param\nkata-set-param\nkata-set-rules\n"
+                + "clear_board\nplay\nundo\nkata-analyze\nkata-genmove_analyze\n"
+                + "genmove\nkata-time_settings\ntime_settings\nstop\nquit");
       } else if (lower.startsWith("boardsize ")) {
         int size = parseIntToken(line, 1, DEFAULT_BOARD_SIZE);
         boardWidth = Math.max(1, size);
@@ -164,6 +165,14 @@ public class KataGoAnalysisWebSocketTransport implements EngineTransport {
       } else if (lower.startsWith("komi ")) {
         komi = parseDoubleToken(line, 1, komi);
         writeOk(responseId, "");
+      } else if (lower.startsWith("kata-get-rules")) {
+        writeOk(
+            responseId,
+            "{\"friendlyPassOk\":false,\"hasButton\":false,\"ko\":\"POSITIONAL\","
+                + "\"scoring\":\"AREA\",\"suicide\":true,\"tax\":\"NONE\","
+                + "\"whiteHandicapBonus\":\"0\"}");
+      } else if (lower.startsWith("kata-get-param ")) {
+        writeKnownKataGoParam(responseId, line);
       } else if (lower.startsWith("kata-set-rules ")) {
         rules = token(line, 1, "chinese");
         writeOk(responseId, "");
@@ -222,6 +231,17 @@ public class KataGoAnalysisWebSocketTransport implements EngineTransport {
     int intervalCentisec = Math.max(10, analyzeIntervalCentisec(command, genmove));
     JSONObject query = buildAnalysisQuery(queryId, genmove, ownership, intervalCentisec, player);
     current.sendText(query.toString(), true);
+  }
+
+  private void writeKnownKataGoParam(String responseId, String command) {
+    String param = token(command, 1, "");
+    if ("playoutDoublingAdvantage".equals(param)) {
+      writeOk(responseId, "0.0");
+    } else if ("analysisWideRootNoise".equals(param)) {
+      writeOk(responseId, "0.04");
+    } else {
+      writeOk(responseId, "");
+    }
   }
 
   private JSONObject buildAnalysisQuery(

--- a/src/main/java/featurecat/lizzie/util/KataGoAutoSetupHelper.java
+++ b/src/main/java/featurecat/lizzie/util/KataGoAutoSetupHelper.java
@@ -1805,6 +1805,9 @@ public final class KataGoAutoSetupHelper {
       return false;
     }
     String command = startupEngine.commands == null ? "" : startupEngine.commands.trim();
+    if (command.startsWith("remote-compute://")) {
+      return false;
+    }
     if (isTensorRtManagedCommand(startupEngine.name, command)) {
       return false;
     }
@@ -1823,6 +1826,9 @@ public final class KataGoAutoSetupHelper {
   }
 
   private static boolean isLegacyStartupCommandBroken(String name, String command) {
+    if (command != null && command.trim().startsWith("remote-compute://")) {
+      return false;
+    }
     List<String> commandParts = Utils.splitCommand(command);
     if (commandParts == null || commandParts.isEmpty()) {
       return true;

--- a/src/main/java/featurecat/lizzie/util/Utils.java
+++ b/src/main/java/featurecat/lizzie/util/Utils.java
@@ -36,6 +36,7 @@ import java.io.OutputStreamWriter;
 import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
@@ -417,16 +418,24 @@ public class Utils {
         continue;
       }
       if (!OS.isWindows() || hasExtension) {
-        Path direct = toExistingPath(baseDir.resolve(executable).toString());
-        if (direct != null) {
-          return direct;
+        try {
+          Path direct = toExistingPath(baseDir.resolve(executable).toString());
+          if (direct != null) {
+            return direct;
+          }
+        } catch (InvalidPathException | SecurityException e) {
+          continue;
         }
       }
       if (OS.isWindows()) {
         for (String suffix : suffixes) {
-          Path candidate = toExistingPath(baseDir.resolve(executable + suffix).toString());
-          if (candidate != null) {
-            return candidate;
+          try {
+            Path candidate = toExistingPath(baseDir.resolve(executable + suffix).toString());
+            if (candidate != null) {
+              return candidate;
+            }
+          } catch (InvalidPathException | SecurityException e) {
+            continue;
           }
         }
       }

--- a/src/test/java/featurecat/lizzie/analysis/LeelazPonderStateTest.java
+++ b/src/test/java/featurecat/lizzie/analysis/LeelazPonderStateTest.java
@@ -1,14 +1,25 @@
 package featurecat.lizzie.analysis;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import featurecat.lizzie.Config;
+import featurecat.lizzie.ExtraMode;
 import featurecat.lizzie.Lizzie;
 import featurecat.lizzie.gui.GtpConsolePane;
 import featurecat.lizzie.gui.LizzieFrame;
+import featurecat.lizzie.gui.Menu;
 import java.awt.Window;
+import java.io.BufferedOutputStream;
+import java.io.ByteArrayOutputStream;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
+import java.util.ArrayDeque;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.Test;
 
 class LeelazPonderStateTest {
@@ -25,10 +36,77 @@ class LeelazPonderStateTest {
     }
   }
 
+  @Test
+  void kataNameStartupCommandsDoNotHoldEngineMonitorWhileCommandQueueIsBlocked()
+      throws Exception {
+    try (TestHarness ignored = TestHarness.open()) {
+      Leelaz engine = new Leelaz("");
+      Lizzie.leelaz = engine;
+      engine.isCheckingName = true;
+      engine.isCheckingVersion = true;
+      setOutputStream(engine, new BufferedOutputStream(new ByteArrayOutputStream()));
+      Object commandQueue = commandQueue(engine);
+      ExecutorService executor = Executors.newFixedThreadPool(2);
+      Future<?> parseFuture = null;
+      try {
+        synchronized (commandQueue) {
+          CountDownLatch parseStarted = new CountDownLatch(1);
+          parseFuture =
+              executor.submit(
+                  () -> {
+                    parseStarted.countDown();
+                    invokeParseLineUnchecked(engine, "= KataGo");
+                  });
+          assertTrue(parseStarted.await(1, TimeUnit.SECONDS));
+          Thread.sleep(200);
+
+          CountDownLatch engineLockAcquired = new CountDownLatch(1);
+          Future<?> lockFuture =
+              executor.submit(
+                  () -> {
+                    synchronized (engine) {
+                      engineLockAcquired.countDown();
+                    }
+                  });
+
+          assertTrue(
+              engineLockAcquired.await(1, TimeUnit.SECONDS),
+              "KataGo startup command initialization must not wait for the command queue while holding the engine monitor");
+          assertFalse(parseFuture.isDone());
+          lockFuture.get(1, TimeUnit.SECONDS);
+        }
+        parseFuture.get(1, TimeUnit.SECONDS);
+      } finally {
+        executor.shutdownNow();
+      }
+    }
+  }
+
   private static void invokeParseLine(Leelaz engine, String line) throws Exception {
     Method method = Leelaz.class.getDeclaredMethod("parseLine", String.class);
     method.setAccessible(true);
     method.invoke(engine, line);
+  }
+
+  private static void invokeParseLineUnchecked(Leelaz engine, String line) {
+    try {
+      invokeParseLine(engine, line);
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private static ArrayDeque<?> commandQueue(Leelaz engine) throws Exception {
+    Field field = Leelaz.class.getDeclaredField("cmdQueue");
+    field.setAccessible(true);
+    return (ArrayDeque<?>) field.get(engine);
+  }
+
+  private static void setOutputStream(Leelaz engine, BufferedOutputStream outputStream)
+      throws Exception {
+    Field field = Leelaz.class.getDeclaredField("outputStream");
+    field.setAccessible(true);
+    field.set(engine, outputStream);
   }
 
   @SuppressWarnings("unchecked")
@@ -56,24 +134,41 @@ class LeelazPonderStateTest {
     public void addLine(String line) {}
   }
 
+  private static final class SilentMenu extends Menu {
+    private SilentMenu() {}
+
+    @Override
+    public void changeEngineIcon(int index, int mode) {}
+
+    @Override
+    public void changeEngineIcon2(int index, int mode) {}
+  }
+
   private static final class TestHarness implements AutoCloseable {
     private final Config previousConfig;
     private final LizzieFrame previousFrame;
     private final GtpConsolePane previousGtpConsole;
+    private final Leelaz previousLeelaz;
+    private final Menu previousMenu;
     private final boolean previousEngineGame;
 
     private TestHarness() {
       previousConfig = Lizzie.config;
       previousFrame = Lizzie.frame;
       previousGtpConsole = Lizzie.gtpConsole;
+      previousLeelaz = Lizzie.leelaz;
+      previousMenu = LizzieFrame.menu;
       previousEngineGame = EngineManager.isEngineGame;
     }
 
     private static TestHarness open() throws Exception {
       TestHarness harness = new TestHarness();
       Lizzie.config = allocate(Config.class);
+      Lizzie.config.extraMode = ExtraMode.Normal;
       Lizzie.frame = allocate(SilentFrame.class);
       Lizzie.gtpConsole = allocate(SilentGtpConsole.class);
+      Lizzie.leelaz = null;
+      LizzieFrame.menu = allocate(SilentMenu.class);
       EngineManager.isEngineGame = false;
       return harness;
     }
@@ -83,6 +178,8 @@ class LeelazPonderStateTest {
       Lizzie.config = previousConfig;
       Lizzie.frame = previousFrame;
       Lizzie.gtpConsole = previousGtpConsole;
+      Lizzie.leelaz = previousLeelaz;
+      LizzieFrame.menu = previousMenu;
       EngineManager.isEngineGame = previousEngineGame;
     }
   }

--- a/src/test/java/featurecat/lizzie/analysis/remote/KataGoAnalysisWebSocketTransportTest.java
+++ b/src/test/java/featurecat/lizzie/analysis/remote/KataGoAnalysisWebSocketTransportTest.java
@@ -3,6 +3,9 @@ package featurecat.lizzie.analysis.remote;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.junit.jupiter.api.Test;
@@ -43,5 +46,40 @@ class KataGoAnalysisWebSocketTransportTest {
 
     assertTrue(line.startsWith("info move pass visits 1 order 0 ownership "));
     assertTrue(line.contains("0.250000 -0.500000"));
+  }
+
+  @Test
+  void reportsKataGoCompatibleHandshakeForLizzieStartup() throws Exception {
+    KataGoAnalysisWebSocketTransport transport =
+        new KataGoAnalysisWebSocketTransport("ws://127.0.0.1:1");
+
+    assertEquals("= KataGo\n\n", sendGtp(transport, "name"));
+    assertEquals("= 1.16.4\n\n", sendGtp(transport, "version"));
+
+    String commands = sendGtp(transport, "list_commands");
+    assertTrue(commands.contains("kata-analyze"));
+    assertTrue(commands.contains("kata-get-param"));
+    assertTrue(commands.contains("kata-get-rules"));
+
+    assertEquals("= 0.0\n\n", sendGtp(transport, "kata-get-param playoutDoublingAdvantage"));
+    assertEquals("= 0.04\n\n", sendGtp(transport, "kata-get-param analysisWideRootNoise"));
+    assertTrue(sendGtp(transport, "kata-get-rules").contains("\"scoring\":\"AREA\""));
+  }
+
+  private static String sendGtp(KataGoAnalysisWebSocketTransport transport, String command)
+      throws Exception {
+    OutputStream stdin = transport.stdin();
+    stdin.write((command + "\n").getBytes(StandardCharsets.UTF_8));
+    stdin.flush();
+    InputStream stdout = transport.stdout();
+    long deadline = System.currentTimeMillis() + 1000;
+    while (stdout.available() == 0 && System.currentTimeMillis() < deadline) {
+      Thread.sleep(10);
+    }
+    int available = stdout.available();
+    assertTrue(available > 0, "no GTP response for " + command);
+    byte[] buffer = new byte[available];
+    int read = stdout.read(buffer);
+    return new String(buffer, 0, read, StandardCharsets.UTF_8);
   }
 }

--- a/src/test/java/featurecat/lizzie/util/KataGoAutoSetupHelperTest.java
+++ b/src/test/java/featurecat/lizzie/util/KataGoAutoSetupHelperTest.java
@@ -2,6 +2,7 @@ package featurecat.lizzie.util;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -333,6 +334,33 @@ public class KataGoAutoSetupHelperTest {
                   .uiConfig
                   .optString("analysis-engine-command")
                   .contains("windows-x64-nvidia-tensorrt"));
+        });
+  }
+
+  @Test
+  void startupRepairLeavesRemoteComputeEngineAlone() throws Exception {
+    Path tempRoot = Files.createTempDirectory("katago-remote-compute-repair");
+
+    withUserDirAndConfig(
+        tempRoot,
+        () -> {
+          ArrayList<EngineData> engines = new ArrayList<>();
+          EngineData remote = new EngineData();
+          remote.index = 0;
+          remote.name = "自建算力 · 127.0.0.1:8765";
+          remote.commands = "remote-compute://custom-websocket";
+          remote.isDefault = true;
+          engines.add(remote);
+          Utils.saveEngineSettings(engines);
+          Lizzie.config.uiConfig.put("default-engine", 0);
+
+          assertNull(Utils.resolveExistingExecutable(remote.commands));
+          assertFalse(KataGoAutoSetupHelper.repairBrokenStartupEngineIfNeeded());
+
+          ArrayList<EngineData> repairedEngines = Utils.getEngineData();
+          assertEquals("remote-compute://custom-websocket", repairedEngines.get(0).commands);
+          assertTrue(repairedEngines.get(0).isDefault);
+          assertEquals(0, Lizzie.config.uiConfig.optInt("default-engine"));
         });
   }
 


### PR DESCRIPTION
## Summary
- Fixes Windows self-hosted remote compute startup so a connected WebSocket engine is recognized as KataGo and immediately receives `kata-analyze`.
- Prevents startup auto-repair from treating `remote-compute://...` commands as broken local executables.
- Keeps startup initialization commands out of the `Leelaz` monitor to avoid a fast-response deadlock seen with remote compute adapters.

## Root Cause
A low-latency remote compute adapter could answer `name` while the startup thread was still sending `version` / `list_commands`. `Leelaz` then held its engine monitor while queuing KataGo startup commands, while the startup sender held the command queue lock and waited for the engine monitor. That lock inversion left the remote engine connected but never analyzing. The custom WebSocket adapter also returned a non-standard engine name/version and missed a few KataGo startup commands, which made the problem easier to hit.

## Windows Real-Machine Validation
- Local KataGo bundle: launched the Windows app from the packaged OpenCL test directory and confirmed both bundled `katago.exe gtp` and `katago.exe analysis` processes started and the UI showed candidates, visit counts, winrate, and the lower-right mini board.
- Self-hosted remote compute: launched a local KaTrain-compatible WebSocket mock at `ws://127.0.0.1:8765`, set it as the default engine, started the Windows app, confirmed the mock received real `kata-analyze` JSON and the UI updated with candidates / visits / winrate.
- Board sync smoke: ran `scripts/windows_smoke_test.ps1 -ProbeBoardSync`; bundled `readboard.exe` pipe launch passed and the app stayed alive.

## Tests
- `mvn -Dfmt.skip=true -Dtest=LeelazPonderStateTest,KataGoAnalysisWebSocketTransportTest,KataGoAutoSetupHelperTest,RemoteComputeConfigTest test`
- `mvn -Dfmt.skip=true test` (1021 tests, 0 failures, 0 errors, 1 skipped)
- `mvn -Dfmt.skip=true -DskipTests package`
- `git diff --check` (only CRLF warnings)