### PR TITLE
修复引擎槽位 1 的自定义引擎重启后被还原成默认引擎的问题

### DIFF
--- a/src/main/java/featurecat/lizzie/Config.java
+++ b/src/main/java/featurecat/lizzie/Config.java
@@ -761,18 +761,30 @@ public class Config {
     JSONObject bundledEngine;
     boolean reusedAutoSetupEntry = false;
     boolean createdBundledEngine = bundledIndex < 0;
+    // Only refresh the managed command when the slot still holds a bundled KataGo command. A user
+    // may repurpose the default slot (usually engine 1) with their own engine while keeping the
+    // default name; in that case the entry still matches by name, but overwriting its command would
+    // silently replace the user's engine with the bundled default on every restart. Preserve any
+    // command that is no longer a bundled KataGo command so custom engines survive restarts.
+    boolean refreshBundledCommand;
     if (bundledIndex >= 0) {
       bundledEngine = engineSettings.getJSONObject(bundledIndex);
       reusedAutoSetupEntry = "KataGo Auto Setup".equals(bundledEngine.optString("name", ""));
+      String existingCommand = bundledEngine.optString("command", "");
+      refreshBundledCommand =
+          existingCommand.trim().isEmpty() || isBundledKataGoCommand(existingCommand);
     } else {
       bundledEngine = new JSONObject();
       engineSettings.put(bundledEngine);
       bundledIndex = engineSettings.length() - 1;
+      refreshBundledCommand = true;
     }
 
-    bundledEngine.put("command", bundledConfig.engineCommand);
-    if (!reusedAutoSetupEntry) {
-      bundledEngine.put("name", BUNDLED_ENGINE_NAME);
+    if (refreshBundledCommand) {
+      bundledEngine.put("command", bundledConfig.engineCommand);
+      if (!reusedAutoSetupEntry) {
+        bundledEngine.put("name", BUNDLED_ENGINE_NAME);
+      }
     }
     if (createdBundledEngine) {
       bundledEngine.put("preload", false);

--- a/src/test/java/featurecat/lizzie/ConfigBundledKataGoDefaultsTest.java
+++ b/src/test/java/featurecat/lizzie/ConfigBundledKataGoDefaultsTest.java
@@ -110,6 +110,36 @@ public class ConfigBundledKataGoDefaultsTest {
   }
 
   @Test
+  void customCommandInDefaultSlotSurvivesRestart() throws Exception {
+    Path tempRoot = Files.createTempDirectory("lizzie-bundled-katago-custom");
+    createBundledKataGoAssets(tempRoot);
+
+    Config config = ConfigTestHelper.createForTests(tempRoot);
+    JSONObject ui = new JSONObject();
+    ui.put("first-time-load", false);
+    ui.put("default-engine", 0);
+
+    // The user kept the default name in engine 1 but pointed the command at their own engine.
+    String customCommand = "\"/opt/my-katago/katago\" gtp -model \"/opt/my-katago/net.bin.gz\"";
+    JSONObject customEngine = new JSONObject();
+    customEngine.put("name", "KataGo Bundled");
+    customEngine.put("command", customCommand);
+    customEngine.put("isDefault", true);
+
+    JSONObject leelaz = new JSONObject();
+    leelaz.put("engine-settings-list", new JSONArray().put(customEngine));
+    config.config = new JSONObject().put("ui", ui).put("leelaz", leelaz);
+
+    withUserDir(tempRoot, () -> applyBundledKataGoDefaults(config));
+
+    JSONObject storedEngine = leelaz.getJSONArray("engine-settings-list").getJSONObject(0);
+    assertEquals(
+        customCommand,
+        storedEngine.getString("command"),
+        "a custom command in the default slot must not be overwritten by the bundled default.");
+  }
+
+  @Test
   void freshInstallStillSelectsBundledEngineAsDefault() throws Exception {
     Path tempRoot = Files.createTempDirectory("lizzie-bundled-katago-fresh");
     createBundledKataGoAssets(tempRoot);


### PR DESCRIPTION
## 问题

用户在**引擎槽位 1** 里配置自定义引擎后重启，命令会被悄悄替换回内置 KataGo 默认引擎。放在**其它槽位**的自定义引擎则能正常保存——只有槽位 1 会出问题。

## 根因

`Config.applyBundledKataGoDefaults()` 在**每次启动**都会执行（`Config.java:1532`）。它先按名称（`KataGo Bundled` / `KataGo Auto Setup`）**或**命令包含 `engines/katago` 来定位「内置引擎」槽位，然后**无条件覆盖**该槽位的 `command`。

默认情况下内置 KataGo 引擎就占用槽位 1（index 0）。当用户把这个槽位改成自己的引擎、但保留了默认名字时，重启后该条目仍会因为名字匹配被认成内置引擎，命令被写回内置默认值——这就是「只有槽位 1 会被还原、其它槽位正常」的不对称现象。

## 修复

只有当槽位为空、或命令仍是内置 KataGo 命令（`isBundledKataGoCommand`）时才刷新命令。一旦用户把槽位指向非内置引擎，命令就会在重启后保留。新建槽位的行为保持不变。

## 测试

- 新增回归测试 `customCommandInDefaultSlotSurvivesRestart` —— **修复前失败、修复后通过**。
- 相关测试套件全部通过：`ConfigBundledKataGoDefaultsTest`、`KataGoAutoSetupHelperTest`、`UtilsEngineSettingsTest`、`AnalysisEngineCommandHelperTest`（共 31 项）。

```
mvn -o test -Dtest='ConfigBundledKataGoDefaultsTest,KataGoAutoSetupHelperTest,UtilsEngineSettingsTest,AnalysisEngineCommandHelperTest' -Dfmt.skip=true
```