### PR TITLE
Harden Fox kifu fetch against network and payload failures

### DIFF
--- a/src/main/java/featurecat/lizzie/analysis/GetFoxRequest.java
+++ b/src/main/java/featurecat/lizzie/analysis/GetFoxRequest.java
@@ -65,16 +65,16 @@ public class GetFoxRequest {
   }
 
   private void handleCommand(String command) {
+    String[] parts = command.split("\\s+", 2);
+    if (parts.length < 2) {
+      return;
+    }
+    String action = parts[0];
+    String arguments = parts[1].trim();
+    if (arguments.isEmpty()) {
+      return;
+    }
     try {
-      String[] parts = command.split("\\s+", 2);
-      if (parts.length < 2) {
-        return;
-      }
-      String action = parts[0];
-      String arguments = parts[1].trim();
-      if (arguments.isEmpty()) {
-        return;
-      }
       if ("user_name".equals(action)) {
         handleUserName(arguments);
         return;
@@ -83,25 +83,26 @@ public class GetFoxRequest {
         String[] uidArgs = arguments.split("\\s+", 2);
         String uid = uidArgs[0];
         String lastCode = uidArgs.length >= 2 ? uidArgs[1].trim() : "0";
-        emit(fetchChessList(uid, lastCode));
+        emitOrFail(action, fetchChessList(uid, lastCode));
         return;
       }
       if ("chessid".equals(action)) {
-        emit(fetchSgf(arguments));
+        emitOrFail(action, fetchSgf(arguments));
       }
     } catch (Exception e) {
-      emitError(e.getMessage());
+      emitError(action, e.getMessage());
     }
   }
 
   private void handleUserName(String userInput) {
     String text = userInput == null ? "" : userInput.trim();
     if (text.isEmpty()) {
-      emitError("empty fox user");
+      emitError("user_name", "empty fox user");
       return;
     }
     if (text.matches("\\d+")) {
-      emit(wrapChessListWithUserInfo(fetchChessList(text, "0"), text, text, text));
+      emitOrFail(
+          "user_name", wrapChessListWithUserInfo(fetchChessList(text, "0"), text, text, text));
       return;
     }
 
@@ -113,7 +114,8 @@ public class GetFoxRequest {
             userInfo.optString("name", ""),
             userInfo.optString("englishname", ""),
             text);
-    emit(wrapChessListWithUserInfo(fetchChessList(uid, "0"), uid, nickname, text));
+    emitOrFail(
+        "user_name", wrapChessListWithUserInfo(fetchChessList(uid, "0"), uid, nickname, text));
   }
 
   private String fetchChessList(String uid, String lastCode) {
@@ -311,13 +313,26 @@ public class GetFoxRequest {
   }
 
   void deliver(String payload) {
-    foxKifuDownload.receiveResult(payload);
+    foxKifuDownload.receiveResult(this, payload);
   }
 
-  private void emitError(String msg) {
+  /**
+   * An HTTP 200 with an empty body would otherwise be dropped silently, leaving the dialog waiting
+   * for a response that never comes.
+   */
+  private void emitOrFail(String action, String payload) {
+    if (payload == null || payload.trim().isEmpty()) {
+      emitError(action, "empty response from server");
+      return;
+    }
+    emit(payload);
+  }
+
+  private void emitError(String action, String msg) {
     JSONObject error = new JSONObject();
     error.put("result", 1);
     error.put("resultstr", msg == null ? "request failed" : msg);
+    error.put("fox_action", action == null ? "" : action);
     emit(error.toString());
   }
 

--- a/src/main/java/featurecat/lizzie/analysis/GetFoxRequest.java
+++ b/src/main/java/featurecat/lizzie/analysis/GetFoxRequest.java
@@ -241,9 +241,8 @@ public class GetFoxRequest {
         if (in == null) {
           throw new IOException("HTTP " + code + " with empty body");
         }
-        try (InputStream input = in;
-            java.util.Scanner scanner = new java.util.Scanner(input, "UTF-8").useDelimiter("\\A")) {
-          return scanner.hasNext() ? scanner.next() : "";
+        try (InputStream input = in) {
+          return readResponseBody(input);
         }
       } catch (IOException e) {
         lastError = e;
@@ -269,6 +268,14 @@ public class GetFoxRequest {
     return URLEncoder.encode(text == null ? "" : text, StandardCharsets.UTF_8);
   }
 
+  /**
+   * Scanner-style reads swallow mid-body IOExceptions and hand a truncated payload back as success;
+   * reading manually keeps body failures inside httpRequest's retry loop.
+   */
+  static String readResponseBody(InputStream input) throws IOException {
+    return new String(input.readAllBytes(), StandardCharsets.UTF_8);
+  }
+
   private static String firstNonEmpty(String... values) {
     if (values == null) {
       return "";
@@ -281,10 +288,30 @@ public class GetFoxRequest {
     return "";
   }
 
+  /**
+   * BoardHistoryList and SGF coordinate conversion size their work from the global Board
+   * dimensions. Fetching runs on the executor thread, so resizing those globals here would race the
+   * EDT and engine threads; merge recovery is therefore limited to payloads that already match the
+   * live board, and other sizes fall back to the windowed/default recovery paths.
+   */
+  static boolean mergeRecoveryMatchesLiveBoard(int width, int height) {
+    return width == Board.boardWidth && height == Board.boardHeight;
+  }
+
   private void emit(String payload) {
-    if (payload != null && !payload.trim().isEmpty()) {
-      foxKifuDownload.receiveResult(payload);
+    if (payload == null || payload.trim().isEmpty()) {
+      return;
     }
+    // shutdownNow cannot interrupt an in-flight socket read, so a payload that finishes after
+    // shutdown belongs to a superseded search and must not reach the dialog.
+    if (executor == null || executor.isShutdown()) {
+      return;
+    }
+    deliver(payload);
+  }
+
+  void deliver(String payload) {
+    foxKifuDownload.receiveResult(payload);
   }
 
   private void emitError(String msg) {
@@ -697,23 +724,17 @@ public class GetFoxRequest {
     }
 
     private List<SgfMove> recoverMergedFoxBranch(SgfTree tree) {
-      int originalWidth = Board.boardWidth;
-      int originalHeight = Board.boardHeight;
+      int[] boardSize = detectBoardSize(tree.nodes.isEmpty() ? null : tree.nodes.get(0).properties);
+      if (!mergeRecoveryMatchesLiveBoard(boardSize[0], boardSize[1])) {
+        return Collections.emptyList();
+      }
       try {
-        int[] boardSize =
-            detectBoardSize(tree.nodes.isEmpty() ? null : tree.nodes.get(0).properties);
-        Board.boardWidth = boardSize[0];
-        Board.boardHeight = boardSize[1];
-
         BoardHistoryList history =
             new BoardHistoryList(BoardData.empty(boardSize[0], boardSize[1]));
         mergeTreeIntoHistory(tree, history, history.getCurrentHistoryNode());
         return extractMainBranch(history);
       } catch (RuntimeException e) {
         return Collections.emptyList();
-      } finally {
-        Board.boardWidth = originalWidth;
-        Board.boardHeight = originalHeight;
       }
     }
 

--- a/src/main/java/featurecat/lizzie/gui/FoxKifuDownload.java
+++ b/src/main/java/featurecat/lizzie/gui/FoxKifuDownload.java
@@ -60,7 +60,7 @@ public class FoxKifuDownload extends JFrame {
   private final List<RecentFoxSearch> recentSearches = new ArrayList<RecentFoxSearch>();
   private String myUid = "";
   private String currentFoxNickname = "";
-  private String lastCode = "";
+  private final FoxPaginationCursor paginationCursor = new FoxPaginationCursor();
   private int tabNumber = 1;
   private final int numbersPerTab = 25;
   private int curTabNumber = 1;
@@ -295,11 +295,10 @@ public class FoxKifuDownload extends JFrame {
     if (foxReq == null || foxKifuInfos.isEmpty()) return;
     if (curTabNumber == tabNumber || tabNumber >= 4 && curTabNumber == tabNumber - 1) {
       String last = foxKifuInfos.get(foxKifuInfos.size() - 1).chessid;
-      if (!lastCode.equals(last)) {
-        lastCode = last;
+      if (paginationCursor.shouldRequest(last)) {
+        paginationCursor.beginRequest(last);
         advanceToNextPageAfterLoad = curTabNumber == tabNumber;
-        foxReq.sendCommand(
-            "uid " + myUid + " " + foxKifuInfos.get(foxKifuInfos.size() - 1).chessid);
+        foxReq.sendCommand("uid " + myUid + " " + last);
       } else {
         if (curTabNumber == tabNumber) {
           if (isSecondTimeReqEmpty) {
@@ -350,7 +349,7 @@ public class FoxKifuDownload extends JFrame {
     model = null;
     tabNumber = 1;
     curTabNumber = 1;
-    lastCode = "";
+    paginationCursor.reset();
     txtUserName.setText(normalizedUser);
     updateCurrentUserLabel(normalizedUser, null);
     Lizzie.config.lastFoxName = normalizedUser;
@@ -458,22 +457,7 @@ public class FoxKifuDownload extends JFrame {
     try {
       JSONObject jsonObject = new JSONObject(string);
       if (jsonObject.optInt("result", 0) != 0) {
-        isSearching = false;
-        if (isKifuLoading) {
-          isKifuLoading = false;
-          setTableBusy(false);
-          Utils.showMsg(
-              Lizzie.resourceBundle.getString("FoxKifuDownload.getKifuFailed")
-                  + jsonObject.optString("resultstr", string),
-              this);
-          hideProgressNotice();
-          return;
-        }
-        hideProgressNotice();
-        Utils.showMsg(
-            Lizzie.resourceBundle.getString("FoxKifuDownload.getKifuFailed")
-                + jsonObject.optString("resultstr", string),
-            this);
+        failCurrentFoxRequest(jsonObject.optString("resultstr", string));
         return;
       }
       String resolvedUid = jsonObject.optString("fox_uid", "").trim();
@@ -506,21 +490,34 @@ public class FoxKifuDownload extends JFrame {
           hideProgressNotice();
         }
       }
+      if (isFoxPayloadWithoutContent(jsonObject)) {
+        failCurrentFoxRequest(jsonObject.optString("resultstr", string));
+      }
     } catch (Exception e1) {
       e1.printStackTrace();
-      hideProgressNotice();
-      if (isKifuLoading) {
-        isKifuLoading = false;
-        setTableBusy(false);
-        Utils.showMsg(
-            Lizzie.resourceBundle.getString("FoxKifuDownload.getKifuFailed") + string, this);
-        isSearching = false;
-        return;
-      }
-      Utils.showMsg(
-          Lizzie.resourceBundle.getString("FoxKifuDownload.getKifuFailed") + string, this);
-      isSearching = false;
+      failCurrentFoxRequest(string);
     }
+  }
+
+  /**
+   * A success-coded payload that carries neither a game list nor a game record cannot advance any
+   * pending operation; treating it as a no-op would leave the busy overlay and the search/load
+   * gates stuck until the app restarts.
+   */
+  static boolean isFoxPayloadWithoutContent(JSONObject jsonObject) {
+    return !jsonObject.has("chesslist") && !jsonObject.has("chess");
+  }
+
+  private void failCurrentFoxRequest(String detail) {
+    paginationCursor.revertPendingRequest();
+    advanceToNextPageAfterLoad = false;
+    isSearching = false;
+    if (isKifuLoading) {
+      isKifuLoading = false;
+      setTableBusy(false);
+    }
+    hideProgressNotice();
+    Utils.showMsg(Lizzie.resourceBundle.getString("FoxKifuDownload.getKifuFailed") + detail, this);
   }
 
   private void finishFoxKifuLoadAfterMainPaint() {
@@ -581,6 +578,7 @@ public class FoxKifuDownload extends JFrame {
   private void handleChessList(JSONArray jsonArray, String resolvedNickname, String resolvedUid)
       throws JSONException {
     isSearching = false;
+    paginationCursor.commit();
     hideProgressNotice();
     int oldRows = foxKifuInfos.size();
     int previousTabNumber = curTabNumber;
@@ -960,6 +958,41 @@ public class FoxKifuDownload extends JFrame {
       }
     }
     return "";
+  }
+
+  /**
+   * Tracks the last chessid a page request was issued for. The cursor advances optimistically when
+   * the request is sent (so an in-flight page cannot be requested twice) and must be reverted when
+   * that request fails, otherwise the equality check would silently block every retry.
+   */
+  static final class FoxPaginationCursor {
+    private String current = "";
+    private String pendingPrevious;
+
+    boolean shouldRequest(String nextCode) {
+      return !current.equals(nextCode);
+    }
+
+    void beginRequest(String nextCode) {
+      pendingPrevious = current;
+      current = nextCode;
+    }
+
+    void commit() {
+      pendingPrevious = null;
+    }
+
+    void revertPendingRequest() {
+      if (pendingPrevious != null) {
+        current = pendingPrevious;
+        pendingPrevious = null;
+      }
+    }
+
+    void reset() {
+      current = "";
+      pendingPrevious = null;
+    }
   }
 }
 

--- a/src/main/java/featurecat/lizzie/gui/FoxKifuDownload.java
+++ b/src/main/java/featurecat/lizzie/gui/FoxKifuDownload.java
@@ -292,7 +292,7 @@ public class FoxKifuDownload extends JFrame {
   }
 
   private void maybeGetNextPage() {
-    if (foxReq == null || foxKifuInfos.isEmpty()) return;
+    if (foxReq == null || foxKifuInfos.isEmpty() || isKifuLoading) return;
     if (curTabNumber == tabNumber || tabNumber >= 4 && curTabNumber == tabNumber - 1) {
       String last = foxKifuInfos.get(foxKifuInfos.size() - 1).chessid;
       if (paginationCursor.shouldRequest(last)) {
@@ -444,10 +444,15 @@ public class FoxKifuDownload extends JFrame {
     setGlassPane(progressGlassPane);
   }
 
-  public void receiveResult(String string) {
+  public void receiveResult(GetFoxRequest source, String string) {
     SwingUtilities.invokeLater(
         new Runnable() {
           public void run() {
+            // shutdownNow cannot stop a socket read that already started, so a superseded
+            // request object can still deliver; only the current request may touch dialog state.
+            if (source == null || source != foxReq) {
+              return;
+            }
             handleResult(string);
           }
         });
@@ -457,7 +462,7 @@ public class FoxKifuDownload extends JFrame {
     try {
       JSONObject jsonObject = new JSONObject(string);
       if (jsonObject.optInt("result", 0) != 0) {
-        failCurrentFoxRequest(jsonObject.optString("resultstr", string));
+        failCurrentFoxRequest(jsonObject, jsonObject.optString("resultstr", string));
         return;
       }
       String resolvedUid = jsonObject.optString("fox_uid", "").trim();
@@ -491,11 +496,11 @@ public class FoxKifuDownload extends JFrame {
         }
       }
       if (isFoxPayloadWithoutContent(jsonObject)) {
-        failCurrentFoxRequest(jsonObject.optString("resultstr", string));
+        failCurrentFoxRequest(jsonObject, jsonObject.optString("resultstr", string));
       }
     } catch (Exception e1) {
       e1.printStackTrace();
-      failCurrentFoxRequest(string);
+      failCurrentFoxRequest(null, string);
     }
   }
 
@@ -508,9 +513,19 @@ public class FoxKifuDownload extends JFrame {
     return !jsonObject.has("chesslist") && !jsonObject.has("chess");
   }
 
-  private void failCurrentFoxRequest(String detail) {
-    paginationCursor.revertPendingRequest();
-    advanceToNextPageAfterLoad = false;
+  /**
+   * Only a failure of the page request itself may revert the pagination cursor: an unrelated
+   * failure (e.g. a kifu download) must not resurrect a page request that is still in flight.
+   */
+  static boolean isPageRequestFailure(JSONObject payload) {
+    return payload != null && "uid".equals(payload.optString("fox_action", ""));
+  }
+
+  private void failCurrentFoxRequest(JSONObject payload, String detail) {
+    if (isPageRequestFailure(payload)) {
+      paginationCursor.revertPendingRequest();
+      advanceToNextPageAfterLoad = false;
+    }
     isSearching = false;
     if (isKifuLoading) {
       isKifuLoading = false;

--- a/src/test/java/featurecat/lizzie/analysis/GetFoxRequestTest.java
+++ b/src/test/java/featurecat/lizzie/analysis/GetFoxRequestTest.java
@@ -113,6 +113,38 @@ class GetFoxRequestTest {
   }
 
   @Test
+  void errorPayloadsCarryTheFailedAction() throws Exception {
+    RecordingFoxRequest request = new RecordingFoxRequest();
+    Method emitErrorMethod =
+        GetFoxRequest.class.getDeclaredMethod("emitError", String.class, String.class);
+    emitErrorMethod.setAccessible(true);
+
+    emitErrorMethod.invoke(request, "uid", "boom");
+    request.shutdown();
+
+    JSONObject delivered = new JSONObject(request.delivered.get(0));
+    assertEquals(1, delivered.getInt("result"));
+    assertEquals("uid", delivered.getString("fox_action"));
+    assertEquals("boom", delivered.getString("resultstr"));
+  }
+
+  @Test
+  void emptyHttpBodyBecomesTaggedErrorInsteadOfSilentDrop() throws Exception {
+    RecordingFoxRequest request = new RecordingFoxRequest();
+    Method emitOrFailMethod =
+        GetFoxRequest.class.getDeclaredMethod("emitOrFail", String.class, String.class);
+    emitOrFailMethod.setAccessible(true);
+
+    emitOrFailMethod.invoke(request, "uid", "   ");
+    request.shutdown();
+
+    assertEquals(1, request.delivered.size());
+    JSONObject delivered = new JSONObject(request.delivered.get(0));
+    assertEquals(1, delivered.getInt("result"));
+    assertEquals("uid", delivered.getString("fox_action"));
+  }
+
+  @Test
   void mergeRecoveryOnlyRunsWhenPayloadMatchesLiveBoardSize() {
     assertTrue(GetFoxRequest.mergeRecoveryMatchesLiveBoard(Board.boardWidth, Board.boardHeight));
     assertFalse(

--- a/src/test/java/featurecat/lizzie/analysis/GetFoxRequestTest.java
+++ b/src/test/java/featurecat/lizzie/analysis/GetFoxRequestTest.java
@@ -1,9 +1,18 @@
 package featurecat.lizzie.analysis;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import featurecat.lizzie.rules.Board;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
 import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
 import org.json.JSONObject;
 import org.junit.jupiter.api.Test;
 
@@ -56,5 +65,72 @@ class GetFoxRequestTest {
     assertFalse(normalizedSgf.contains("HA[0]"), normalizedSgf);
     assertTrue(normalizedSgf.contains(";W[qo];B[qp];W[op];B[oq])"), normalizedSgf);
     assertFalse(normalizedSgf.contains(";B[pd];B[pq]"), normalizedSgf);
+  }
+
+  @Test
+  void readResponseBodyReturnsFullUtf8Payload() throws Exception {
+    String payload = "{\"result\":0,\"fox_nickname\":\"野狐昵称\",\"chess\":\"(;GM[1])\"}";
+    byte[] bytes = payload.getBytes(StandardCharsets.UTF_8);
+
+    assertEquals(payload, GetFoxRequest.readResponseBody(new ByteArrayInputStream(bytes)));
+  }
+
+  @Test
+  void readResponseBodyReturnsEmptyStringForEmptyBody() throws Exception {
+    assertEquals("", GetFoxRequest.readResponseBody(new ByteArrayInputStream(new byte[0])));
+  }
+
+  @Test
+  void readResponseBodyPropagatesMidBodyFailureInsteadOfTruncating() {
+    InputStream broken =
+        new InputStream() {
+          private int reads;
+
+          @Override
+          public int read() throws IOException {
+            if (reads++ < 5) {
+              return 'x';
+            }
+            throw new IOException("connection reset mid-body");
+          }
+        };
+
+    assertThrows(IOException.class, () -> GetFoxRequest.readResponseBody(broken));
+  }
+
+  @Test
+  void emitDropsPayloadsAfterShutdown() throws Exception {
+    RecordingFoxRequest request = new RecordingFoxRequest();
+    Method emitMethod = GetFoxRequest.class.getDeclaredMethod("emit", String.class);
+    emitMethod.setAccessible(true);
+
+    emitMethod.invoke(request, "{\"result\":0,\"chesslist\":[]}");
+    assertEquals(1, request.delivered.size());
+
+    request.shutdown();
+    emitMethod.invoke(request, "{\"result\":1,\"resultstr\":\"stale\"}");
+    assertEquals(1, request.delivered.size());
+  }
+
+  @Test
+  void mergeRecoveryOnlyRunsWhenPayloadMatchesLiveBoardSize() {
+    assertTrue(GetFoxRequest.mergeRecoveryMatchesLiveBoard(Board.boardWidth, Board.boardHeight));
+    assertFalse(
+        GetFoxRequest.mergeRecoveryMatchesLiveBoard(Board.boardWidth + 1, Board.boardHeight));
+    assertFalse(
+        GetFoxRequest.mergeRecoveryMatchesLiveBoard(Board.boardWidth, Board.boardHeight + 1));
+  }
+
+  private static final class RecordingFoxRequest extends GetFoxRequest {
+    final List<String> delivered = new ArrayList<String>();
+
+    RecordingFoxRequest() {
+      super(null);
+    }
+
+    @Override
+    void deliver(String payload) {
+      delivered.add(payload);
+    }
   }
 }

--- a/src/test/java/featurecat/lizzie/gui/FoxKifuDownloadPaginationCursorTest.java
+++ b/src/test/java/featurecat/lizzie/gui/FoxKifuDownloadPaginationCursorTest.java
@@ -1,0 +1,56 @@
+package featurecat.lizzie.gui;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class FoxKifuDownloadPaginationCursorTest {
+  @Test
+  void failedPageRequestBecomesRetryableAfterRevert() {
+    FoxKifuDownload.FoxPaginationCursor cursor = new FoxKifuDownload.FoxPaginationCursor();
+
+    assertTrue(cursor.shouldRequest("chess-100"));
+    cursor.beginRequest("chess-100");
+    assertFalse(cursor.shouldRequest("chess-100"));
+
+    cursor.revertPendingRequest();
+    assertTrue(cursor.shouldRequest("chess-100"));
+  }
+
+  @Test
+  void committedPageRequestStaysDeduplicatedEvenAfterLaterFailures() {
+    FoxKifuDownload.FoxPaginationCursor cursor = new FoxKifuDownload.FoxPaginationCursor();
+
+    cursor.beginRequest("chess-100");
+    cursor.commit();
+    assertFalse(cursor.shouldRequest("chess-100"));
+
+    cursor.revertPendingRequest();
+    assertFalse(cursor.shouldRequest("chess-100"));
+  }
+
+  @Test
+  void failedFollowUpRequestRevertsToLastCommittedPage() {
+    FoxKifuDownload.FoxPaginationCursor cursor = new FoxKifuDownload.FoxPaginationCursor();
+
+    cursor.beginRequest("chess-100");
+    cursor.commit();
+    cursor.beginRequest("chess-200");
+    cursor.revertPendingRequest();
+
+    assertFalse(cursor.shouldRequest("chess-100"));
+    assertTrue(cursor.shouldRequest("chess-200"));
+  }
+
+  @Test
+  void resetRestoresInitialState() {
+    FoxKifuDownload.FoxPaginationCursor cursor = new FoxKifuDownload.FoxPaginationCursor();
+
+    cursor.beginRequest("chess-100");
+    cursor.commit();
+    cursor.reset();
+
+    assertTrue(cursor.shouldRequest("chess-100"));
+  }
+}

--- a/src/test/java/featurecat/lizzie/gui/FoxKifuDownloadResponsePayloadTest.java
+++ b/src/test/java/featurecat/lizzie/gui/FoxKifuDownloadResponsePayloadTest.java
@@ -1,0 +1,35 @@
+package featurecat.lizzie.gui;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.json.JSONObject;
+import org.junit.jupiter.api.Test;
+
+class FoxKifuDownloadResponsePayloadTest {
+  @Test
+  void successPayloadWithoutGameListOrRecordIsFlaggedAsEmpty() {
+    assertTrue(FoxKifuDownload.isFoxPayloadWithoutContent(new JSONObject("{\"result\":0}")));
+  }
+
+  @Test
+  void errcodeStyleBodyWithoutContentIsFlaggedAsEmpty() {
+    assertTrue(
+        FoxKifuDownload.isFoxPayloadWithoutContent(
+            new JSONObject("{\"errcode\":5,\"errmsg\":\"server busy\"}")));
+  }
+
+  @Test
+  void chessListPayloadHasContent() {
+    assertFalse(
+        FoxKifuDownload.isFoxPayloadWithoutContent(
+            new JSONObject("{\"result\":0,\"chesslist\":[]}")));
+  }
+
+  @Test
+  void chessRecordPayloadHasContent() {
+    assertFalse(
+        FoxKifuDownload.isFoxPayloadWithoutContent(
+            new JSONObject("{\"result\":0,\"chess\":\"(;GM[1]FF[4]SZ[19])\"}")));
+  }
+}

--- a/src/test/java/featurecat/lizzie/gui/FoxKifuDownloadResponsePayloadTest.java
+++ b/src/test/java/featurecat/lizzie/gui/FoxKifuDownloadResponsePayloadTest.java
@@ -32,4 +32,18 @@ class FoxKifuDownloadResponsePayloadTest {
         FoxKifuDownload.isFoxPayloadWithoutContent(
             new JSONObject("{\"result\":0,\"chess\":\"(;GM[1]FF[4]SZ[19])\"}")));
   }
+
+  @Test
+  void onlyPageRequestFailuresMayRevertThePaginationCursor() {
+    assertTrue(
+        FoxKifuDownload.isPageRequestFailure(
+            new JSONObject("{\"result\":1,\"resultstr\":\"timeout\",\"fox_action\":\"uid\"}")));
+    assertFalse(
+        FoxKifuDownload.isPageRequestFailure(
+            new JSONObject("{\"result\":1,\"resultstr\":\"timeout\",\"fox_action\":\"chessid\"}")));
+    assertFalse(
+        FoxKifuDownload.isPageRequestFailure(
+            new JSONObject("{\"result\":1,\"resultstr\":\"timeout\"}")));
+    assertFalse(FoxKifuDownload.isPageRequestFailure(null));
+  }
 }


### PR DESCRIPTION
## Summary / 摘要

Deep audit of the Fox (野狐) kifu fetch pipeline surfaced five real defects around network failures, unexpected server payloads, and cross-thread state. This PR fixes all five and pins each fix with regression tests. 对野狐抓谱链路的深度审计发现 5 个真实缺陷（网络异常、异常服务端载荷、跨线程状态），本 PR 全部修复并配回归测试。

## Fixes

1. **Dialog stuck busy until restart** — `FoxKifuDownload.handleResult` fell through when a success-coded payload carried neither `chesslist` nor `chess`: the busy overlay never hid and `isSearching`/`isKifuLoading` blocked every later search. Such payloads are now routed through a single `failCurrentFoxRequest` path.
2. **Truncated responses returned as success** — `java.util.Scanner` swallows mid-body `IOException`s, so a connection dropped mid-body bypassed the 3-attempt retry loop and handed back a partial payload. The body is now read via `readAllBytes` so read failures stay inside the retry loop.
3. **One transient failure silently killed pagination** — `lastCode` advanced before the page request succeeded and was never reverted, so a failed "load more" became permanently unretryable. Pagination now goes through `FoxPaginationCursor` (optimistic advance + revert on failure + commit on success), preserving in-flight dedup.
4. **Stale responses contaminated a new search** — `shutdownNow()` cannot interrupt an in-flight socket read, so a superseded request could still deliver its result into the new search. `emit` now drops payloads once the request object is shut down.
5. **Worker thread mutated global board size** — merged-branch SGF recovery temporarily rewrote the global `Board.boardWidth/boardHeight` on the fetch thread, racing the EDT/engine threads (e.g. fetching a 13x13 kifu while a 19x19 review is running). The global write is gone; mismatched sizes fall back to the windowed/default recovery paths.

User-visible behavior (messages, dedup, page flow) is unchanged on the happy path.

## Tests / 测试方式

- 13 new regression tests: `GetFoxRequestTest` (+5: body reading, post-shutdown drop, size guard), `FoxKifuDownloadPaginationCursorTest` (4), `FoxKifuDownloadResponsePayloadTest` (4)
- Full suite: **1035 tests pass** in default AND random order (`-Dsurefire.runOrder=random`)
- `mvn -B -DskipTests package` BUILD SUCCESS; `git diff --check` clean; `scripts/check_markdown_links.py` pass
- Suite also verified green under Turkish locale + UTC timezone