### PR TITLE
feat(proxy): add application-wide Java proxy settings

### DIFF
--- a/docs/plans/2026-07-08-network-proxy-settings.md
+++ b/docs/plans/2026-07-08-network-proxy-settings.md
@@ -205,16 +205,16 @@
 
 - [ ] Migrate KataGo and runtime download/probe helpers.
   - Files:
-    - `src/main/java/featurecat/lizzie/analysis/KataGoAutoSetupHelper.java`
-    - `src/main/java/featurecat/lizzie/analysis/KataGoRuntimeHelper.java`
+    - `src/main/java/featurecat/lizzie/util/KataGoAutoSetupHelper.java`
+    - `src/main/java/featurecat/lizzie/util/KataGoRuntimeHelper.java`
   - Replace direct `openConnection()` calls with `NetworkProxy.openConnection(url)`.
   - Preserve existing timeouts, User-Agent, progress callbacks, and file streaming logic.
 
 - [ ] Migrate Fox, Tencent, Yike, and SGF fetch URLConnection callers.
   - Files:
-    - `src/main/java/featurecat/lizzie/rules/GetFoxRequest.java`
-    - `src/main/java/featurecat/lizzie/rules/GetTencentRequest.java`
-    - `src/main/java/featurecat/lizzie/rules/YikeApiClient.java`
+    - `src/main/java/featurecat/lizzie/analysis/GetFoxRequest.java`
+    - `src/main/java/featurecat/lizzie/analysis/GetTencentRequest.java`
+    - `src/main/java/featurecat/lizzie/gui/YikeApiClient.java`
     - `src/main/java/featurecat/lizzie/gui/OnlineDialog.java`
   - Replace `openConnection(Proxy.NO_PROXY)` and direct `url.openConnection()` with `NetworkProxy.openConnection(url)`.
   - Preserve request headers and timeouts.
@@ -271,11 +271,11 @@
     git status --short
     git add \
       src/main/java/featurecat/lizzie/update/WindowsUpdateService.java \
-      src/main/java/featurecat/lizzie/analysis/KataGoAutoSetupHelper.java \
-      src/main/java/featurecat/lizzie/analysis/KataGoRuntimeHelper.java \
-      src/main/java/featurecat/lizzie/rules/GetFoxRequest.java \
-      src/main/java/featurecat/lizzie/rules/GetTencentRequest.java \
-      src/main/java/featurecat/lizzie/rules/YikeApiClient.java \
+      src/main/java/featurecat/lizzie/util/KataGoAutoSetupHelper.java \
+      src/main/java/featurecat/lizzie/util/KataGoRuntimeHelper.java \
+      src/main/java/featurecat/lizzie/analysis/GetFoxRequest.java \
+      src/main/java/featurecat/lizzie/analysis/GetTencentRequest.java \
+      src/main/java/featurecat/lizzie/gui/YikeApiClient.java \
       src/main/java/featurecat/lizzie/gui/OnlineDialog.java \
       src/main/java/featurecat/lizzie/analysis/remote/ZhiziApiClient.java \
       src/main/java/featurecat/lizzie/analysis/remote/KataGoAnalysisWebSocketTransport.java \

--- a/docs/plans/2026-07-08-network-proxy-settings.md
+++ b/docs/plans/2026-07-08-network-proxy-settings.md
@@ -57,6 +57,7 @@
     - `direct` -> `Proxy.NO_PROXY`
     - `manual` with `127.0.0.1:7897` -> HTTP proxy address and port
     - `manual` with blank host, non-numeric port, out-of-range port -> invalid config exception
+    - stored port as a non-numeric JSON string -> invalid config exception, not fallback to `7897`
     - unknown mode -> invalid config exception
     - `ws://host/path` maps to system lookup URI `http://host/path`
     - `wss://host/path` maps to system lookup URI `https://host/path`
@@ -87,13 +88,15 @@
 
       public static void installSystemProxyPropertyFromSavedConfig();
       public static URLConnection openConnection(URL url) throws IOException;
+      public static ProxySelector proxySelector();
       public static HttpClient.Builder configure(HttpClient.Builder builder);
       public static OkHttpClient.Builder configure(OkHttpClient.Builder builder);
       public static void configure(WebSocketClient client);
     }
     ```
   - Internal helpers should keep tests simple:
-    - read from `Lizzie.config.uiConfig.optString/optInt`
+    - read raw values from `Lizzie.config.uiConfig` and validate them
+    - do not use `optInt(..., 7897)` for stored manual port, because that would hide a bad hand-edited config
     - `Proxy proxyForUrl(URL url)`
     - `ProxySelector proxySelector()`
     - `URI systemLookupUriForWebSocket(URI uri)`
@@ -104,7 +107,7 @@
     - `manual`: `url.openConnection(manualProxy)`
     - `system`: `url.openConnection()`
   - `configure(HttpClient.Builder)` behavior:
-    - `direct`: `builder.proxy(ProxySelector.of(null))` is not valid; use a helper `ProxySelector` that always returns `Proxy.NO_PROXY`, or omit proxy only if tests prove Java will not use ambient system proxy.
+    - `direct`: use a helper `ProxySelector` that always returns `Proxy.NO_PROXY`; do not leave the builder on an ambient default selector.
     - `manual`: `builder.proxy(ProxySelector.of(manualSocketAddress))`
     - `system`: `builder.proxy(ProxySelector.getDefault())`
   - `configure(OkHttpClient.Builder)` behavior:
@@ -249,6 +252,12 @@
     ```
   - Preserve callbacks and reconnect behavior.
 
+- [ ] Surface invalid stored proxy config without falling back to direct.
+  - Files: all files touched in this section.
+  - If a caller already catches broad `Exception` and shows/logs the operation failure, no extra catch is needed.
+  - If a caller only catches `IOException` and would let `NetworkProxy.InvalidNetworkProxyConfigException` escape silently, add a narrow catch beside the existing network failure handling.
+  - Do not add per-caller proxy parsing or direct fallback.
+
 - [ ] Verify targeted compile and helper tests.
   - Run:
     ```bash
@@ -290,6 +299,11 @@
     - `new WebSocketClient(` in `OnlineDialog.java` only when the same file also contains `NetworkProxy.configure(client)`
     - local/test-only WebSocket clients if they exist outside `src/main/java`
   - Keep the guard narrow. Do not block the raw socket exception classes unless this test explicitly scans `new Socket(`.
+
+- [ ] Add one cheap update-path assertion required by the spec.
+  - Prefer adding this to `NetworkProxyInventoryTest` instead of creating network mocks.
+  - Assert `src/main/java/featurecat/lizzie/update/WindowsUpdateService.java` contains the expected `NetworkProxy.openConnection(` calls and no direct `.openConnection(` outside helper use.
+  - Do not perform real network requests.
 
 - [ ] Add an optional raw socket inventory assertion if it is cheap.
   - If scanning `new Socket(`, allow only:

--- a/docs/plans/2026-07-08-network-proxy-settings.md
+++ b/docs/plans/2026-07-08-network-proxy-settings.md
@@ -1,0 +1,367 @@
+# Network Proxy Settings Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add one application-level proxy setting for Java-side outbound networking, with modes `direct`, `system`, and `manual`. The first manual default should be `127.0.0.1:7897`. Existing update, download, API, HttpClient, OkHttp, and Java-WebSocket callers must use the shared decision path.
+
+**Architecture:** Introduce a small `featurecat.lizzie.util.NetworkProxy` helper as the only proxy decision point for Java URLConnection, Java `HttpClient`, OkHttp, and Java-WebSocket clients. Persist settings in existing `ui` config JSON and expose controls in `ConfigDialog2` Advanced settings. Callers do not parse proxy config directly.
+
+**Tech Stack:** Java 11+, Swing, `java.net.Proxy`, `java.net.ProxySelector`, Java `HttpClient`, OkHttp, Java-WebSocket, Maven/JUnit.
+
+---
+
+## Source Documents
+
+- Spec: `docs/specs/2026-07-08-network-proxy-settings-design.md`
+- Target baseline: branch `proxy-settings-design`, based on current `upstream/main`
+
+## Assumptions
+
+- Implement in a clean worktree checked out at `proxy-settings-design`; do not implement on the currently dirty feature branch.
+- `manual` mode supports HTTP proxy only in v1.
+- `system` mode relies on Java's default `ProxySelector`; switching into or out of `system` mode during one app session shows a restart notice instead of promising immediate global behavior.
+- Raw `java.net.Socket` classes listed in the spec remain intentionally direct in v1.
+- UI labels can be Chinese to match the existing settings dialog.
+
+## Work Breakdown
+
+### 0. Prepare Workspace
+
+- [ ] Verify current docs and target branch.
+  - Run:
+    ```bash
+    git fetch upstream main
+    git rev-parse proxy-settings-design
+    git show proxy-settings-design:docs/specs/2026-07-08-network-proxy-settings-design.md >/tmp/proxy-spec-check.md
+    ```
+  - Verify: the spec exists on `proxy-settings-design` and mentions `127.0.0.1:7897`, Java-WebSocket, Socket.IO factories, and invalid config behavior.
+
+- [ ] Create or switch to a clean implementation worktree.
+  - Preferred if the partial clone can materialize files:
+    ```bash
+    git worktree add ../lizzieyzy-next-proxy proxy-settings-design
+    cd ../lizzieyzy-next-proxy
+    ```
+  - Fallback if `git worktree add` still fails because the partial clone cannot fetch blobs: coordinate with the main agent before using the existing checkout. Do not overwrite unrelated untracked files.
+  - Verify:
+    ```bash
+    git status --short
+    ```
+
+### 1. Add Proxy Config Defaults and Helper Tests First
+
+- [ ] Add focused tests for proxy config parsing and URL/URI decisions.
+  - New file: `src/test/java/featurecat/lizzie/util/NetworkProxyTest.java`
+  - Cover:
+    - missing keys -> `direct`
+    - `direct` -> `Proxy.NO_PROXY`
+    - `manual` with `127.0.0.1:7897` -> HTTP proxy address and port
+    - `manual` with blank host, non-numeric port, out-of-range port -> invalid config exception
+    - unknown mode -> invalid config exception
+    - `ws://host/path` maps to system lookup URI `http://host/path`
+    - `wss://host/path` maps to system lookup URI `https://host/path`
+    - Java `HttpClient.Builder` gets the expected `ProxySelector`
+    - OkHttp builder gets the expected `Proxy`
+  - Verification command:
+    ```bash
+    mvn -Dtest=NetworkProxyTest test
+    ```
+  - Expected before implementation: test compile fails because `NetworkProxy` does not exist.
+
+- [ ] Implement config defaults.
+  - File: `src/main/java/featurecat/lizzie/Config.java`
+  - Add default keys under `ui`:
+    - `network-proxy-mode`: `"direct"`
+    - `network-proxy-host`: `"127.0.0.1"`
+    - `network-proxy-port`: `7897`
+  - Verify by inspecting the generated/default config path used by existing tests if there is a config fixture test; otherwise this is covered by `NetworkProxyTest`.
+
+- [ ] Implement the shared helper.
+  - New file: `src/main/java/featurecat/lizzie/util/NetworkProxy.java`
+  - Public API:
+    ```java
+    public final class NetworkProxy {
+      public static final String MODE_DIRECT = "direct";
+      public static final String MODE_SYSTEM = "system";
+      public static final String MODE_MANUAL = "manual";
+
+      public static void installSystemProxyPropertyFromSavedConfig();
+      public static URLConnection openConnection(URL url) throws IOException;
+      public static HttpClient.Builder configure(HttpClient.Builder builder);
+      public static OkHttpClient.Builder configure(OkHttpClient.Builder builder);
+      public static void configure(WebSocketClient client);
+    }
+    ```
+  - Internal helpers should keep tests simple:
+    - read from `Lizzie.config.uiConfig.optString/optInt`
+    - `Proxy proxyForUrl(URL url)`
+    - `ProxySelector proxySelector()`
+    - `URI systemLookupUriForWebSocket(URI uri)`
+    - `Proxy firstHttpSystemProxy(URI uri)`
+  - Invalid stored values should throw one helper-owned unchecked exception, for example `NetworkProxy.InvalidNetworkProxyConfigException extends IllegalArgumentException`, with messages that name the bad key.
+  - `openConnection(URL)` behavior:
+    - `direct`: `url.openConnection(Proxy.NO_PROXY)`
+    - `manual`: `url.openConnection(manualProxy)`
+    - `system`: `url.openConnection()`
+  - `configure(HttpClient.Builder)` behavior:
+    - `direct`: `builder.proxy(ProxySelector.of(null))` is not valid; use a helper `ProxySelector` that always returns `Proxy.NO_PROXY`, or omit proxy only if tests prove Java will not use ambient system proxy.
+    - `manual`: `builder.proxy(ProxySelector.of(manualSocketAddress))`
+    - `system`: `builder.proxy(ProxySelector.getDefault())`
+  - `configure(OkHttpClient.Builder)` behavior:
+    - `direct`: `builder.proxy(Proxy.NO_PROXY)`
+    - `manual`: `builder.proxy(manualProxy)`
+    - `system`: `builder.proxySelector(ProxySelector.getDefault())`
+  - `configure(WebSocketClient)` behavior:
+    - `direct`: `client.setProxy(Proxy.NO_PROXY)`
+    - `manual`: `client.setProxy(manualProxy)`
+    - `system`: map `ws`/`wss` to `http`/`https`, select first HTTP proxy from `ProxySelector.getDefault()`, else `Proxy.NO_PROXY`
+  - Verify:
+    ```bash
+    mvn -Dtest=NetworkProxyTest test
+    ```
+
+- [ ] Commit helper and tests.
+  - Run:
+    ```bash
+    git status --short
+    git add src/main/java/featurecat/lizzie/Config.java src/main/java/featurecat/lizzie/util/NetworkProxy.java src/test/java/featurecat/lizzie/util/NetworkProxyTest.java
+    git commit -m "feat: add shared network proxy helper"
+    ```
+
+### 2. Add Settings UI and Startup Hook
+
+- [ ] Add proxy controls to the Advanced settings card.
+  - File: `src/main/java/featurecat/lizzie/gui/ConfigDialog2.java`
+  - Existing anchor: advanced card setup near `createModernSettingsCard(tr("Advanced Settings"))`.
+  - Add fields near other advanced network/runtime settings:
+    - `JComboBox<String> comboNetworkProxyMode`
+    - `JTextField txtNetworkProxyHost`
+    - `JTextField txtNetworkProxyPort`
+    - restart hint `JLabel`
+  - Suggested UI text:
+    - label: `网络代理`
+    - options: `不使用代理`, `使用系统代理设置`, `手动配置代理`
+    - host label: `代理主机`
+    - port label: `代理端口`
+    - hint: `切换系统代理模式后需重启程序才能完全生效。`
+  - Host and port fields are enabled only when mode is `manual`.
+  - Do not add a new settings page.
+
+- [ ] Validate UI before hiding the dialog.
+  - File: `src/main/java/featurecat/lizzie/gui/ConfigDialog2.java`
+  - Existing issue: the OK action currently hides the dialog before saving.
+  - Add a small method, for example:
+    ```java
+    private boolean validateNetworkProxyInputs()
+    ```
+  - Call it before `setVisible(false)` in the OK action.
+  - Validation rules:
+    - if mode is not manual, always pass
+    - manual host must not be blank
+    - manual port must be integer in `1..65535`
+    - on failure, show the existing message dialog helper used by this class and keep the settings dialog open
+
+- [ ] Persist UI values.
+  - File: `src/main/java/featurecat/lizzie/gui/ConfigDialog2.java`
+  - In `saveConfig()`, write:
+    - `Lizzie.config.uiConfig.put("network-proxy-mode", selectedModeValue)`
+    - `Lizzie.config.uiConfig.put("network-proxy-host", txtNetworkProxyHost.getText().trim())`
+    - `Lizzie.config.uiConfig.put("network-proxy-port", parsedPort)`
+  - Read existing values during initialization, defaulting to `direct`, `127.0.0.1`, and `7897`.
+
+- [ ] Install the system proxy property during startup.
+  - File: `src/main/java/featurecat/lizzie/Lizzie.java`
+  - Add import for `NetworkProxy`.
+  - Immediately after `config = new Config();`, call:
+    ```java
+    NetworkProxy.installSystemProxyPropertyFromSavedConfig();
+    ```
+  - Keep it before `Utils.applyMaintainedDefaultSettings()` and before any network client initialization.
+
+- [ ] Verify UI/startup compile.
+  - Run:
+    ```bash
+    mvn -DskipTests compile
+    mvn -Dtest=NetworkProxyTest test
+    ```
+
+- [ ] Commit UI and startup changes.
+  - Run:
+    ```bash
+    git status --short
+    git add src/main/java/featurecat/lizzie/Lizzie.java src/main/java/featurecat/lizzie/gui/ConfigDialog2.java
+    git commit -m "feat: add network proxy settings UI"
+    ```
+
+### 3. Migrate Existing Java Network Callers
+
+- [ ] Migrate update manifest and installer downloads.
+  - File: `src/main/java/featurecat/lizzie/update/WindowsUpdateService.java`
+  - Replace direct `url.openConnection()` calls with `NetworkProxy.openConnection(url)`.
+  - Preserve existing timeout, header, and redirect behavior.
+
+- [ ] Migrate KataGo and runtime download/probe helpers.
+  - Files:
+    - `src/main/java/featurecat/lizzie/analysis/KataGoAutoSetupHelper.java`
+    - `src/main/java/featurecat/lizzie/analysis/KataGoRuntimeHelper.java`
+  - Replace direct `openConnection()` calls with `NetworkProxy.openConnection(url)`.
+  - Preserve existing timeouts, User-Agent, progress callbacks, and file streaming logic.
+
+- [ ] Migrate Fox, Tencent, Yike, and SGF fetch URLConnection callers.
+  - Files:
+    - `src/main/java/featurecat/lizzie/rules/GetFoxRequest.java`
+    - `src/main/java/featurecat/lizzie/rules/GetTencentRequest.java`
+    - `src/main/java/featurecat/lizzie/rules/YikeApiClient.java`
+    - `src/main/java/featurecat/lizzie/gui/OnlineDialog.java`
+  - Replace `openConnection(Proxy.NO_PROXY)` and direct `url.openConnection()` with `NetworkProxy.openConnection(url)`.
+  - Preserve request headers and timeouts.
+
+- [ ] Migrate cloud/self-hosted analysis HTTP clients.
+  - Files:
+    - `src/main/java/featurecat/lizzie/analysis/remote/ZhiziApiClient.java`
+    - `src/main/java/featurecat/lizzie/analysis/remote/KataGoAnalysisWebSocketTransport.java`
+  - Replace bare `HttpClient.newBuilder()` with:
+    ```java
+    NetworkProxy.configure(HttpClient.newBuilder())
+    ```
+  - Preserve existing timeouts and executor configuration.
+
+- [ ] Migrate Socket.IO OkHttp transport.
+  - File: `src/main/java/featurecat/lizzie/analysis/remote/ZhiziGtpTransport.java`
+  - Replace `new OkHttpClient()` with a configured builder:
+    ```java
+    OkHttpClient socketHttpClient = NetworkProxy.configure(new OkHttpClient.Builder()).build();
+    ```
+  - Ensure the same `socketHttpClient` is still assigned to both:
+    - `options.callFactory`
+    - `options.webSocketFactory`
+
+- [ ] Migrate generic Ajax helper.
+  - File: `src/main/java/featurecat/lizzie/util/AjaxHttpRequest.java`
+  - Replace direct `openConnection` path with `NetworkProxy.openConnection(url)`.
+  - Remove or narrow any now-unused `Proxy` field only if this migration makes it unused.
+
+- [ ] Migrate Java-WebSocket usage.
+  - File: `src/main/java/featurecat/lizzie/gui/OnlineDialog.java`
+  - After the anonymous `new WebSocketClient(uri) { ... }` assignment and before `client.connect()`, call:
+    ```java
+    NetworkProxy.configure(client);
+    ```
+  - Preserve callbacks and reconnect behavior.
+
+- [ ] Verify targeted compile and helper tests.
+  - Run:
+    ```bash
+    mvn -DskipTests compile
+    mvn -Dtest=NetworkProxyTest test
+    ```
+
+- [ ] Commit caller migration.
+  - Run:
+    ```bash
+    git status --short
+    git add \
+      src/main/java/featurecat/lizzie/update/WindowsUpdateService.java \
+      src/main/java/featurecat/lizzie/analysis/KataGoAutoSetupHelper.java \
+      src/main/java/featurecat/lizzie/analysis/KataGoRuntimeHelper.java \
+      src/main/java/featurecat/lizzie/rules/GetFoxRequest.java \
+      src/main/java/featurecat/lizzie/rules/GetTencentRequest.java \
+      src/main/java/featurecat/lizzie/rules/YikeApiClient.java \
+      src/main/java/featurecat/lizzie/gui/OnlineDialog.java \
+      src/main/java/featurecat/lizzie/analysis/remote/ZhiziApiClient.java \
+      src/main/java/featurecat/lizzie/analysis/remote/KataGoAnalysisWebSocketTransport.java \
+      src/main/java/featurecat/lizzie/analysis/remote/ZhiziGtpTransport.java \
+      src/main/java/featurecat/lizzie/util/AjaxHttpRequest.java
+    git commit -m "feat: route Java network callers through proxy settings"
+    ```
+
+### 4. Add Inventory Guard
+
+- [ ] Add a source inventory regression test.
+  - New file: `src/test/java/featurecat/lizzie/util/NetworkProxyInventoryTest.java`
+  - Scan `src/main/java` for these patterns:
+    - `.openConnection(`
+    - `Proxy.NO_PROXY`
+    - `HttpClient.newBuilder()`
+    - `new OkHttpClient()`
+    - `new WebSocketClient(`
+  - Allowed cases:
+    - `src/main/java/featurecat/lizzie/util/NetworkProxy.java`
+    - `new WebSocketClient(` in `OnlineDialog.java` only when the same file also contains `NetworkProxy.configure(client)`
+    - local/test-only WebSocket clients if they exist outside `src/main/java`
+  - Keep the guard narrow. Do not block the raw socket exception classes unless this test explicitly scans `new Socket(`.
+
+- [ ] Add an optional raw socket inventory assertion if it is cheap.
+  - If scanning `new Socket(`, allow only:
+    - `src/main/java/featurecat/lizzie/gui/SocketLoggin.java`
+    - `src/main/java/featurecat/lizzie/gui/SocketGetFile.java`
+    - `src/main/java/featurecat/lizzie/gui/SocketKifuSearch.java`
+    - `src/main/java/featurecat/lizzie/gui/SocketUpfile.java`
+    - `src/main/java/featurecat/lizzie/gui/SocketEditFile.java`
+    - local server sockets/listeners
+  - If identifying local server sockets becomes noisy, skip the raw socket assertion and rely on the spec's explicit v1 exception list.
+
+- [ ] Verify inventory guard.
+  - Run:
+    ```bash
+    mvn -Dtest=NetworkProxyTest,NetworkProxyInventoryTest test
+    ```
+
+- [ ] Commit inventory guard.
+  - Run:
+    ```bash
+    git status --short
+    git add src/test/java/featurecat/lizzie/util/NetworkProxyInventoryTest.java
+    git commit -m "test: guard proxy-aware Java networking"
+    ```
+
+### 5. End-to-End Verification
+
+- [ ] Run focused tests.
+  - Command:
+    ```bash
+    mvn -Dtest=NetworkProxyTest,NetworkProxyInventoryTest test
+    ```
+
+- [ ] Run compile.
+  - Command:
+    ```bash
+    mvn -DskipTests compile
+    ```
+
+- [ ] Run source inventory manually once for review.
+  - Command:
+    ```bash
+    git grep -n -e "openConnection" -e "Proxy.NO_PROXY" -e "HttpClient.newBuilder" -e "new OkHttpClient" -e "new WebSocketClient" -- src/main/java
+    ```
+  - Expected: all remaining hits are either inside `NetworkProxy` or are explicitly allowed by `NetworkProxyInventoryTest`.
+
+- [ ] Optional Windows smoke check after WSL commit is ready.
+  - In Windows clone `D:\dev\weiqi\lizzieyzy-next`, run:
+    ```powershell
+    git fetch
+    git pull --ff-only
+    .\.tools\apache-maven-3.9.10\bin\mvn.cmd -DskipTests compile
+    ```
+  - Only do this after the WSL implementation branch has been pushed or otherwise synchronized to the Windows clone.
+
+### 6. Final Review Checklist
+
+- [ ] Confirm no caller parses `network-proxy-*` keys except `NetworkProxy` and `ConfigDialog2`.
+- [ ] Confirm manual default fields are `127.0.0.1` and `7897`, but default mode remains `direct`.
+- [ ] Confirm `system` mode startup hook is placed immediately after config load.
+- [ ] Confirm Socket.IO uses the same configured `OkHttpClient` for both `callFactory` and `webSocketFactory`.
+- [ ] Confirm Java-WebSocket calls `NetworkProxy.configure(client)` before `connect()`.
+- [ ] Confirm invalid manual UI input keeps the settings dialog open.
+- [ ] Confirm no unrelated files are staged.
+
+## Commit Plan
+
+Use separate commits so review can isolate risk:
+
+1. `feat: add shared network proxy helper`
+2. `feat: add network proxy settings UI`
+3. `feat: route Java network callers through proxy settings`
+4. `test: guard proxy-aware Java networking`
+
+Do not squash during implementation. Squashing can be decided only after review.

--- a/docs/specs/2026-07-08-network-proxy-settings-design.md
+++ b/docs/specs/2026-07-08-network-proxy-settings-design.md
@@ -1,0 +1,118 @@
+# Network Proxy Settings Design
+
+## Background
+
+This spec targets the current `upstream/main` networking tree used by the `proxy-settings-design` branch. Class names below refer to that tree.
+
+LizzieYzy Next has several Java-side network paths today:
+
+- Windows update manifest checks and update archive downloads.
+- KataGo weight, HumanSL model, TensorRT, and NVIDIA runtime downloads.
+- Fox, Tencent, and Yike Java API requests.
+- Zhizi and custom remote-compute connections through `HttpClient`, WebSocket, OkHttp, and Socket.IO.
+
+Some paths currently call plain `openConnection()`, while others explicitly use `Proxy.NO_PROXY`. A proxy option that only patches the updater would leave the next download or API feature with a different network policy.
+
+## Goals
+
+1. Add one saved proxy choice for Java-side app networking.
+2. Support three modes: no proxy, system proxy, and manual proxy.
+3. Make future Java HTTP/WebSocket callers reuse the same proxy decision.
+4. Keep the first version small and testable.
+
+## Non-Goals
+
+- Do not promise control over external browser windows opened through `Desktop.browse(...)`.
+- Do not promise control over external engine processes in the first version.
+- Do not include proxy authentication, PAC parsing, per-host bypass rules, or SOCKS in the first version.
+- Do not route raw `java.net.Socket` protocols in the first version. The legacy share/search socket classes (`SocketLoggin`, `SocketGetFile`, `SocketKifuSearch`, `SocketUpfile`, and `SocketEditFile`) should remain direct until SOCKS or a protocol-specific replacement is designed.
+- Do not replace existing download, update, or remote-compute business logic with a new HTTP framework.
+
+## User Settings
+
+Persist the settings under the existing `ui` config object:
+
+- `network-proxy-mode`: `direct`, `system`, or `manual`.
+- `network-proxy-host`: manual proxy host, for example `127.0.0.1`.
+- `network-proxy-port`: manual proxy port, for example `7897`.
+
+Default mode should be `direct` to avoid changing existing users' behavior on upgrade.
+
+Manual mode validates that host is non-empty and port is in `1..65535`. Invalid manual settings should be rejected when saving the settings dialog instead of silently falling back to direct.
+
+Missing keys from older configs default to `direct`. Unknown mode values or invalid stored manual settings are treated as configuration errors: show a clear settings warning and require the user to save a valid mode before applying proxy changes.
+
+Network callers must not silently fall back to direct when a saved proxy config is invalid. The helper should throw a small checked or unchecked configuration exception; UI-triggered callers show that message to the user, and background callers log it and surface the normal operation failure.
+
+## UI
+
+Add a small "Network Proxy" section to `ConfigDialog2` under Advanced:
+
+- Proxy mode combo box: no proxy, system proxy, manual proxy.
+- Host text field.
+- Port text field.
+
+Host and port are enabled only in manual mode. The visible example should use `127.0.0.1` and `7897`.
+
+Saving applies `direct` and `manual` to future requests. Switching to or from `system` during the same run should show a restart-required notice unless the implementation proves, with tests, that the JVM default `ProxySelector` can be refreshed safely. Existing long-lived remote-compute connections may need reconnecting.
+
+## Shared Proxy Helper
+
+Add a small utility in `featurecat.lizzie.util`, for example `NetworkProxy`.
+
+It should expose only the shapes the codebase needs:
+
+- Open a `URLConnection` for a `URL`.
+- Configure a `java.net.http.HttpClient.Builder`.
+- Configure an `okhttp3.OkHttpClient.Builder`.
+- Configure the existing `org.java_websocket.client.WebSocketClient` used by `OnlineDialog` through its `setProxy(Proxy)` API.
+- Return a `ProxySelector` for code that must build a client outside the helper.
+
+Mode behavior:
+
+- `direct`: use `Proxy.NO_PROXY` for `URLConnection`, a no-proxy `ProxySelector` for `HttpClient`, and direct mode for OkHttp.
+- `system`: use the JVM default `ProxySelector`. In `Lizzie.main`, immediately after `config = new Config()` and before `Utils.applyMaintainedDefaultSettings()` or any network client creation, set `java.net.useSystemProxies=true` only when the saved mode is `system`. A saved `system` setting is fully supported after restart; runtime switching into or out of `system` is restart-required unless a tested refresh path is added. `direct` and `manual` must use explicit selectors/proxies so they do not accidentally inherit JVM default proxy behavior.
+- `manual`: use `new Proxy(Proxy.Type.HTTP, new InetSocketAddress(host, port))` and equivalent selectors/builders.
+
+Java-WebSocket needs an explicit `Proxy` because it does not accept a `ProxySelector`. For `OnlineDialog`, map `direct` to `client.setProxy(Proxy.NO_PROXY)`, `manual` to the manual HTTP proxy, and `system` by converting the client URI from `ws`/`wss` to `http`/`https`, calling the default `ProxySelector.select(...)`, then applying the first usable HTTP proxy or `Proxy.NO_PROXY`.
+
+Keep this helper stateless apart from reading `Lizzie.config.uiConfig`. No background service and no global mutable client cache are needed.
+
+Required coverage should prefer the opener, builder, or selector methods. Callers should not construct a bare `Proxy` from settings because that cannot represent `system` mode.
+
+## Required Java-Side Coverage
+
+The first implementation must route these Java-side network paths through the shared helper:
+
+- `WindowsUpdateService`: manifest fetch and component downloads.
+- `KataGoAutoSetupHelper`: weight list fetches, weight downloads, and HumanSL downloads.
+- `KataGoRuntimeHelper`: NVIDIA mirror probes, runtime downloads, TensorRT downloads, and release metadata fetches.
+- `GetFoxRequest`, `GetTencentRequest`, `YikeApiClient`, and the remaining direct SGF fetch in `OnlineDialog`.
+- `ZhiziApiClient` and `KataGoAnalysisWebSocketTransport` `HttpClient` builders.
+- `ZhiziGtpTransport` OkHttp client creation for Socket.IO; the configured client must be assigned to both `options.callFactory` and `options.webSocketFactory`.
+- `AjaxHttpRequest`, so older call sites inherit the same policy if they keep using it.
+- `OnlineDialog` `org.java_websocket.client.WebSocketClient` through the `setProxy(...)` mapping described above.
+
+Any newly added Java network caller should use this helper instead of calling `openConnection()` or constructing a bare client.
+
+## Future Extensions
+
+JCEF and external process support should be tracked as separate follow-up work:
+
+- JCEF can later map manual/system proxy settings to Chromium proxy flags after checking initialization side effects.
+- External engines can later receive `HTTP_PROXY` and `HTTPS_PROXY` environment variables through their `ProcessBuilder`, but only as best effort because engines may ignore them.
+
+## Testing
+
+Add focused tests for the helper:
+
+- Direct mode returns no proxy.
+- Manual mode builds an HTTP proxy for `127.0.0.1:7897`.
+- Invalid manual host or port is rejected.
+- Missing config keys default to `direct`.
+- Unknown mode and invalid stored manual settings surface a configuration error instead of silently using direct.
+- `HttpClient` and OkHttp configuration tests assert the actual selector/proxy choice: direct must not use the default selector, and manual must use `127.0.0.1:7897`.
+- A Socket.IO test or focused seam test verifies that the configured OkHttp client is used for both `callFactory` and `webSocketFactory`.
+- Add a cheap source inventory guard for direct `openConnection()`, `Proxy.NO_PROXY`, bare `HttpClient.newBuilder()`, bare `new OkHttpClient()`, and `new WebSocketClient(...)`. The guard should allow only the helper itself, local server sockets, local/test WebSocket clients, and the listed raw share/search socket exceptions; every other outbound Java HTTP/WebSocket caller must route through the helper.
+
+For higher-level coverage, add one small test around `WindowsUpdateService` or the helper seam to prove update manifest fetches use the shared opener. Do not add real network tests.

--- a/docs/specs/2026-07-08-network-proxy-settings-design.md
+++ b/docs/specs/2026-07-08-network-proxy-settings-design.md
@@ -36,11 +36,11 @@ Persist the settings under the existing `ui` config object:
 - `network-proxy-host`: manual proxy host, for example `127.0.0.1`.
 - `network-proxy-port`: manual proxy port, for example `7897`.
 
-Default mode should be `direct` to avoid changing existing users' behavior on upgrade.
+Default mode should be `direct`, so first-time users keep the existing direct-network behavior unless they opt into a proxy.
 
 Manual mode validates that host is non-empty and port is in `1..65535`. Invalid manual settings should be rejected when saving the settings dialog instead of silently falling back to direct.
 
-Missing keys from older configs default to `direct`. Unknown mode values or invalid stored manual settings are treated as configuration errors: show a clear settings warning and require the user to save a valid mode before applying proxy changes.
+Missing keys from older configs default to `direct`. Unknown mode values or invalid stored manual settings are treated as configuration errors during actual network operations: show a clear settings warning and require the user to save a valid mode before applying proxy changes.
 
 Network callers must not silently fall back to direct when a saved proxy config is invalid. The helper should throw a small checked or unchecked configuration exception; UI-triggered callers show that message to the user, and background callers log it and surface the normal operation failure.
 
@@ -71,7 +71,7 @@ It should expose only the shapes the codebase needs:
 Mode behavior:
 
 - `direct`: use `Proxy.NO_PROXY` for `URLConnection`, a no-proxy `ProxySelector` for `HttpClient`, and direct mode for OkHttp.
-- `system`: use the JVM default `ProxySelector`. In `Lizzie.main`, immediately after `config = new Config()` and before `Utils.applyMaintainedDefaultSettings()` or any network client creation, set `java.net.useSystemProxies=true` only when the saved mode is `system`. A saved `system` setting is fully supported after restart; runtime switching into or out of `system` is restart-required unless a tested refresh path is added. `direct` and `manual` must use explicit selectors/proxies so they do not accidentally inherit JVM default proxy behavior.
+- `system`: use the JVM default `ProxySelector`. In `Lizzie.main`, immediately after `config = new Config()` and before `Utils.applyMaintainedDefaultSettings()` or any network client creation, read only the raw saved `network-proxy-mode` value and set `java.net.useSystemProxies=true` only when it is `system`. Startup must not validate manual host/port, and unknown or invalid mode values must not terminate startup. A saved `system` setting is fully supported after restart; runtime switching into or out of `system` is restart-required unless a tested refresh path is added. `direct` and `manual` must use explicit selectors/proxies so they do not accidentally inherit JVM default proxy behavior.
 - `manual`: use `new Proxy(Proxy.Type.HTTP, new InetSocketAddress(host, port))` and equivalent selectors/builders.
 
 Java-WebSocket needs an explicit `Proxy` because it does not accept a `ProxySelector`. For `OnlineDialog`, map `direct` to `client.setProxy(Proxy.NO_PROXY)`, `manual` to the manual HTTP proxy, and `system` by converting the client URI from `ws`/`wss` to `http`/`https`, calling the default `ProxySelector.select(...)`, then applying the first usable HTTP proxy or `Proxy.NO_PROXY`.

--- a/src/main/java/featurecat/lizzie/Config.java
+++ b/src/main/java/featurecat/lizzie/Config.java
@@ -2844,6 +2844,9 @@ public class Config {
     ui.put("confirm-exit", false);
     ui.put("resume-previous-game", false);
     ui.put("autosave-interval-seconds", -1);
+    ui.put("network-proxy-mode", "direct");
+    ui.put("network-proxy-host", "127.0.0.1");
+    ui.put("network-proxy-port", 7897);
     ui.put("handicap-instead-of-winrate", false);
     ui.put("board-size", 19);
     ui.put("show-dynamic-komi", false);

--- a/src/main/java/featurecat/lizzie/Config.java
+++ b/src/main/java/featurecat/lizzie/Config.java
@@ -4,6 +4,7 @@ import featurecat.lizzie.analysis.EngineManager;
 import featurecat.lizzie.gui.LizzieFrame;
 import featurecat.lizzie.theme.Theme;
 import featurecat.lizzie.util.AnalysisEngineCommandHelper;
+import featurecat.lizzie.util.NetworkProxy;
 import featurecat.lizzie.util.Utils;
 import java.awt.Color;
 import java.awt.Frame;
@@ -2844,7 +2845,7 @@ public class Config {
     ui.put("confirm-exit", false);
     ui.put("resume-previous-game", false);
     ui.put("autosave-interval-seconds", -1);
-    ui.put("network-proxy-mode", "direct");
+    ui.put("network-proxy-mode", NetworkProxy.DEFAULT_MODE);
     ui.put("network-proxy-host", "127.0.0.1");
     ui.put("network-proxy-port", 7897);
     ui.put("handicap-instead-of-winrate", false);

--- a/src/main/java/featurecat/lizzie/Lizzie.java
+++ b/src/main/java/featurecat/lizzie/Lizzie.java
@@ -21,6 +21,7 @@ import featurecat.lizzie.util.KataGoAutoSetupHelper;
 import featurecat.lizzie.util.KataGoAutoSetupHelper.SetupSnapshot;
 import featurecat.lizzie.util.KataGoRuntimeHelper;
 import featurecat.lizzie.util.MultiOutputStream;
+import featurecat.lizzie.util.NetworkProxy;
 import featurecat.lizzie.util.Utils;
 import java.awt.Font;
 import java.awt.GraphicsEnvironment;
@@ -103,6 +104,7 @@ public class Lizzie {
     }
     ensureWritableWorkingDir();
     config = new Config();
+    NetworkProxy.installSystemProxyPropertyFromSavedConfig();
     Utils.applyMaintainedDefaultSettings();
     if (config.logConsoleToFile) {
       PrintStream oldPrintStream = System.out;

--- a/src/main/java/featurecat/lizzie/analysis/GetFoxRequest.java
+++ b/src/main/java/featurecat/lizzie/analysis/GetFoxRequest.java
@@ -7,10 +7,10 @@ import featurecat.lizzie.rules.BoardHistoryList;
 import featurecat.lizzie.rules.BoardHistoryNode;
 import featurecat.lizzie.rules.SGFParser;
 import featurecat.lizzie.rules.Stone;
+import featurecat.lizzie.util.NetworkProxy;
 import featurecat.lizzie.util.Utils;
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.Proxy;
 import java.net.URI;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
@@ -221,7 +221,7 @@ public class GetFoxRequest {
     for (int attempt = 1; attempt <= HTTP_MAX_RETRIES; attempt++) {
       java.net.HttpURLConnection conn = null;
       try {
-        conn = (java.net.HttpURLConnection) URI.create(url).toURL().openConnection(Proxy.NO_PROXY);
+        conn = (java.net.HttpURLConnection) NetworkProxy.openConnection(URI.create(url).toURL());
         conn.setRequestMethod(method);
         conn.setConnectTimeout(HTTP_CONNECT_TIMEOUT_MS);
         conn.setReadTimeout(HTTP_READ_TIMEOUT_MS);

--- a/src/main/java/featurecat/lizzie/analysis/GetTencentRequest.java
+++ b/src/main/java/featurecat/lizzie/analysis/GetTencentRequest.java
@@ -1,10 +1,10 @@
 package featurecat.lizzie.analysis;
 
 import featurecat.lizzie.gui.TencentKifuDownload;
+import featurecat.lizzie.util.NetworkProxy;
 import featurecat.lizzie.util.Utils;
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.Proxy;
 import java.net.URI;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
@@ -150,7 +150,7 @@ public class GetTencentRequest {
     for (int attempt = 1; attempt <= HTTP_MAX_RETRIES; attempt++) {
       java.net.HttpURLConnection conn = null;
       try {
-        conn = (java.net.HttpURLConnection) URI.create(url).toURL().openConnection(Proxy.NO_PROXY);
+        conn = (java.net.HttpURLConnection) NetworkProxy.openConnection(URI.create(url).toURL());
         conn.setRequestMethod("GET");
         conn.setConnectTimeout(HTTP_CONNECT_TIMEOUT_MS);
         conn.setReadTimeout(HTTP_READ_TIMEOUT_MS);

--- a/src/main/java/featurecat/lizzie/analysis/remote/KataGoAnalysisWebSocketTransport.java
+++ b/src/main/java/featurecat/lizzie/analysis/remote/KataGoAnalysisWebSocketTransport.java
@@ -1,5 +1,6 @@
 package featurecat.lizzie.analysis.remote;
 
+import featurecat.lizzie.util.NetworkProxy;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -51,7 +52,9 @@ public class KataGoAnalysisWebSocketTransport implements EngineTransport {
   private String activeGtpResponseId = "";
 
   public KataGoAnalysisWebSocketTransport(String remoteUrl) throws IOException {
-    this(remoteUrl, HttpClient.newBuilder().connectTimeout(CONNECT_TIMEOUT).build());
+    this(
+        remoteUrl,
+        NetworkProxy.configure(HttpClient.newBuilder()).connectTimeout(CONNECT_TIMEOUT).build());
   }
 
   KataGoAnalysisWebSocketTransport(String remoteUrl, HttpClient httpClient) throws IOException {

--- a/src/main/java/featurecat/lizzie/analysis/remote/ZhiziApiClient.java
+++ b/src/main/java/featurecat/lizzie/analysis/remote/ZhiziApiClient.java
@@ -1,5 +1,6 @@
 package featurecat.lizzie.analysis.remote;
 
+import featurecat.lizzie.util.NetworkProxy;
 import java.io.IOException;
 import java.net.URI;
 import java.net.http.HttpClient;
@@ -17,7 +18,9 @@ public class ZhiziApiClient {
   private final HttpClient httpClient;
 
   public ZhiziApiClient() {
-    this(DEFAULT_BASE_URI, HttpClient.newBuilder().connectTimeout(REQUEST_TIMEOUT).build());
+    this(
+        DEFAULT_BASE_URI,
+        NetworkProxy.configure(HttpClient.newBuilder()).connectTimeout(REQUEST_TIMEOUT).build());
   }
 
   public ZhiziApiClient(URI baseUri, HttpClient httpClient) {

--- a/src/main/java/featurecat/lizzie/analysis/remote/ZhiziApiClient.java
+++ b/src/main/java/featurecat/lizzie/analysis/remote/ZhiziApiClient.java
@@ -17,7 +17,7 @@ public class ZhiziApiClient {
   private final URI baseUri;
   private final HttpClient httpClient;
 
-  public ZhiziApiClient() {
+  public ZhiziApiClient() throws IOException {
     this(
         DEFAULT_BASE_URI,
         NetworkProxy.configure(HttpClient.newBuilder()).connectTimeout(REQUEST_TIMEOUT).build());

--- a/src/main/java/featurecat/lizzie/analysis/remote/ZhiziGtpTransport.java
+++ b/src/main/java/featurecat/lizzie/analysis/remote/ZhiziGtpTransport.java
@@ -1,5 +1,6 @@
 package featurecat.lizzie.analysis.remote;
 
+import featurecat.lizzie.util.NetworkProxy;
 import io.socket.client.IO;
 import io.socket.client.Manager;
 import io.socket.client.Socket;
@@ -101,7 +102,7 @@ public class ZhiziGtpTransport implements EngineTransport {
               .setReconnectionDelayMax(8000)
               .setTimeout(30000)
               .build();
-      socketHttpClient = new OkHttpClient();
+      socketHttpClient = NetworkProxy.configure(new OkHttpClient.Builder()).build();
       options.callFactory = socketHttpClient;
       options.webSocketFactory = socketHttpClient;
       socket = IO.socket(socketToken.socketIOURL, options);

--- a/src/main/java/featurecat/lizzie/gui/ConfigDialog2.java
+++ b/src/main/java/featurecat/lizzie/gui/ConfigDialog2.java
@@ -337,7 +337,7 @@ public class ConfigDialog2 extends JDialog {
   private JTextField txtNetworkProxyHost;
   private JTextField txtNetworkProxyPort;
   private JLabel lblNetworkProxyRestartHint;
-  private String initialNetworkProxyMode = NetworkProxy.MODE_DIRECT;
+  private String initialNetworkProxyMode = NetworkProxy.DEFAULT_MODE;
 
   private JCheckBox chkUseScoreDiff;
   private JTextField txtPercentScoreDiff;
@@ -378,12 +378,9 @@ public class ConfigDialog2 extends JDialog {
     okButton.addActionListener(
         new ActionListener() {
           public void actionPerformed(ActionEvent e) {
-            if (!validateNetworkProxyInputs()) {
-              return;
-            }
             finalizeEditedBlunderColors();
+            if (!saveConfig()) return;
             setVisible(false);
-            saveConfig();
             LizzieFrame.menu.refreshDoubleMoveInfoStatus();
             LizzieFrame.menu.refreshLimitStatus(false);
             Lizzie.frame.resetCommentComponent();
@@ -3183,7 +3180,7 @@ public class ConfigDialog2 extends JDialog {
     card.setLayout(new javax.swing.BoxLayout(card, javax.swing.BoxLayout.Y_AXIS));
     card.setBorder(BorderFactory.createEmptyBorder(16, 20, 18, 24));
     card.setAlignmentX(Component.LEFT_ALIGNMENT);
-    card.setMaximumSize(new Dimension(Integer.MAX_VALUE, 560));
+    card.setMaximumSize(new Dimension(Integer.MAX_VALUE, Integer.MAX_VALUE));
 
     JPanel header = new JPanel(new BorderLayout(10, 0));
     header.setOpaque(false);
@@ -3234,7 +3231,7 @@ public class ConfigDialog2 extends JDialog {
   private void initNetworkProxyControls() {
     JSONObject ui = Lizzie.config.uiConfig;
     initialNetworkProxyMode =
-        normalizeNetworkProxyMode(ui.optString(NetworkProxy.KEY_PROXY_MODE, NetworkProxy.MODE_DIRECT));
+        normalizeNetworkProxyMode(ui.optString(NetworkProxy.KEY_PROXY_MODE, NetworkProxy.DEFAULT_MODE));
 
     comboNetworkProxyMode = new JComboBox<>(NETWORK_PROXY_MODE_LABELS);
     setSelectedNetworkProxyMode(initialNetworkProxyMode);
@@ -3244,6 +3241,7 @@ public class ConfigDialog2 extends JDialog {
         new JTextField(ui.optString(NetworkProxy.KEY_PROXY_HOST, "127.0.0.1").trim());
     Object savedPort = ui.opt(NetworkProxy.KEY_PROXY_PORT);
     txtNetworkProxyPort = new JTextField(savedPort == null ? "7897" : String.valueOf(savedPort));
+    styleNetworkProxyControls();
 
     lblNetworkProxyRestartHint = new JLabel("切换系统代理模式后需重启程序才能完全生效。");
     lblNetworkProxyRestartHint.putClientProperty(CLIENT_SKIP_TEXT_STYLE, Boolean.TRUE);
@@ -3252,8 +3250,33 @@ public class ConfigDialog2 extends JDialog {
     updateNetworkProxyFieldsEnabled();
   }
 
+  private void styleNetworkProxyControls() {
+    styleNetworkProxyControl(comboNetworkProxyMode, 220);
+    styleNetworkProxyControl(txtNetworkProxyHost, 150);
+    styleNetworkProxyControl(txtNetworkProxyPort, 70);
+    txtNetworkProxyHost.setDisabledTextColor(SETTINGS_MUTED);
+    txtNetworkProxyPort.setDisabledTextColor(SETTINGS_MUTED);
+  }
+
+  private void styleNetworkProxyControl(JComponent component, int width) {
+    Dimension size = new Dimension(width, 30);
+    component.setPreferredSize(size);
+    component.setMinimumSize(size);
+    component.setOpaque(true);
+    component.setBackground(SETTINGS_SURFACE_STRONG);
+    component.setForeground(SETTINGS_TEXT);
+    component.setBorder(
+        BorderFactory.createCompoundBorder(
+            BorderFactory.createLineBorder(SETTINGS_BORDER),
+            BorderFactory.createEmptyBorder(4, 8, 4, 8)));
+  }
+
   private void addNetworkProxyRows(JPanel card) {
-    addComponentRow(card, "网络代理", "控制程序自身 Java 网络请求使用的代理策略", comboNetworkProxyMode);
+    JPanel proxyMode = new JPanel(new FlowLayout(FlowLayout.LEFT, 10, 0));
+    proxyMode.setOpaque(false);
+    proxyMode.add(detachComponent(comboNetworkProxyMode));
+    proxyMode.add(lblNetworkProxyRestartHint);
+    addComponentRow(card, "网络代理", "控制程序自身 Java 网络请求使用的代理策略", proxyMode);
 
     JPanel manualProxy = new JPanel(new FlowLayout(FlowLayout.RIGHT, 8, 0));
     manualProxy.setOpaque(false);
@@ -3263,9 +3286,7 @@ public class ConfigDialog2 extends JDialog {
     manualProxy.add(proxyFieldLabel("代理端口"));
     txtNetworkProxyPort.setPreferredSize(new Dimension(70, 30));
     manualProxy.add(detachComponent(txtNetworkProxyPort));
-    addComponentRow(card, "手动代理地址", "本机代理可填写 127.0.0.1 和 7897", manualProxy);
-
-    addComponentRow(card, "系统代理提示", "系统代理设置由 JVM 启动时读取", lblNetworkProxyRestartHint);
+    addComponentRow(card, "手动代理地址", "", manualProxy);
   }
 
   private JLabel proxyFieldLabel(String text) {
@@ -3279,7 +3300,7 @@ public class ConfigDialog2 extends JDialog {
   private String selectedNetworkProxyMode() {
     int index = comboNetworkProxyMode == null ? 0 : comboNetworkProxyMode.getSelectedIndex();
     if (index < 0 || index >= NETWORK_PROXY_MODE_VALUES.length) {
-      return NetworkProxy.MODE_DIRECT;
+      return NetworkProxy.DEFAULT_MODE;
     }
     return NETWORK_PROXY_MODE_VALUES[index];
   }
@@ -3301,7 +3322,7 @@ public class ConfigDialog2 extends JDialog {
         return knownMode;
       }
     }
-    return NetworkProxy.MODE_DIRECT;
+    return NetworkProxy.DEFAULT_MODE;
   }
 
   private void updateNetworkProxyFieldsEnabled() {
@@ -3367,17 +3388,20 @@ public class ConfigDialog2 extends JDialog {
     row.setMaximumSize(new Dimension(Integer.MAX_VALUE, 58));
     JPanel text = new JPanel(new BorderLayout(0, 2));
     text.setOpaque(false);
-    text.setPreferredSize(new Dimension(330, 40));
+    boolean hasSubtitle = subtitle != null && !subtitle.isEmpty();
+    text.setPreferredSize(new Dimension(330, hasSubtitle ? 40 : 24));
     JLabel titleLabel = new JLabel(title);
     titleLabel.putClientProperty(CLIENT_SKIP_TEXT_STYLE, Boolean.TRUE);
     titleLabel.setForeground(SETTINGS_TEXT);
     titleLabel.setFont(new Font(Config.sysDefaultFontName, Font.PLAIN, 14));
-    JLabel subtitleLabel = new JLabel(subtitle);
-    subtitleLabel.putClientProperty(CLIENT_SKIP_TEXT_STYLE, Boolean.TRUE);
-    subtitleLabel.setForeground(SETTINGS_MUTED);
-    subtitleLabel.setFont(new Font(Config.sysDefaultFontName, Font.PLAIN, 12));
-    text.add(titleLabel, BorderLayout.NORTH);
-    text.add(subtitleLabel, BorderLayout.CENTER);
+    text.add(titleLabel, hasSubtitle ? BorderLayout.NORTH : BorderLayout.CENTER);
+    if (hasSubtitle) {
+      JLabel subtitleLabel = new JLabel(subtitle);
+      subtitleLabel.putClientProperty(CLIENT_SKIP_TEXT_STYLE, Boolean.TRUE);
+      subtitleLabel.setForeground(SETTINGS_MUTED);
+      subtitleLabel.setFont(new Font(Config.sysDefaultFontName, Font.PLAIN, 12));
+      text.add(subtitleLabel, BorderLayout.CENTER);
+    }
     GridBagConstraints textConstraints = new GridBagConstraints();
     textConstraints.gridx = 0;
     textConstraints.gridy = 0;
@@ -3389,7 +3413,7 @@ public class ConfigDialog2 extends JDialog {
 
     JPanel controlHost = new JPanel(new FlowLayout(FlowLayout.LEFT, 0, 0));
     controlHost.setOpaque(false);
-    controlHost.setMinimumSize(new Dimension(0, 1));
+    controlHost.setMinimumSize(new Dimension(280, 34));
     row.putClientProperty(CLIENT_DESIGN_ROW_CONTROL_HOST, controlHost);
     GridBagConstraints controlConstraints = new GridBagConstraints();
     controlConstraints.gridx = 1;
@@ -4325,7 +4349,7 @@ public class ConfigDialog2 extends JDialog {
     btnReset.addActionListener(
         new ActionListener() {
           public void actionPerformed(ActionEvent e) {
-            saveConfig();
+            if (!saveConfig()) return;
             LizzieFrame.menu.refreshDoubleMoveInfoStatus();
             LizzieFrame.menu.refreshLimitStatus(false);
             Lizzie.frame.resetCommentComponent();
@@ -5920,7 +5944,10 @@ public class ConfigDialog2 extends JDialog {
     if (model != null) model.sortData();
   }
 
-  private void saveConfig() {
+  private boolean saveConfig() {
+    if (!validateNetworkProxyInputs()) {
+      return false;
+    }
     Lizzie.config.uiConfig.put(NetworkProxy.KEY_PROXY_MODE, selectedNetworkProxyMode());
     Lizzie.config.uiConfig.put(
         NetworkProxy.KEY_PROXY_HOST, txtNetworkProxyHost.getText().trim());
@@ -6316,8 +6343,10 @@ public class ConfigDialog2 extends JDialog {
       Lizzie.config.save();
     } catch (IOException e) {
       e.printStackTrace();
+      return false;
     }
     LizzieFrame.menu.updateFastLinks();
+    return true;
   }
 
   public void switchTab(int index) {

--- a/src/main/java/featurecat/lizzie/gui/ConfigDialog2.java
+++ b/src/main/java/featurecat/lizzie/gui/ConfigDialog2.java
@@ -11,6 +11,7 @@ import featurecat.lizzie.gui.LizzieFrame.HtmlKit;
 import featurecat.lizzie.rules.Board;
 import featurecat.lizzie.theme.Theme;
 import featurecat.lizzie.util.DigitOnlyFilter;
+import featurecat.lizzie.util.NetworkProxy;
 import featurecat.lizzie.util.Utils;
 import java.awt.AlphaComposite;
 import java.awt.BasicStroke;
@@ -140,6 +141,12 @@ public class ConfigDialog2 extends JDialog {
   private static final int MODERN_NAV_ADVANCED = 4;
   private static final int MODERN_NAV_THEME = 5;
   private static final int MODERN_NAV_ABOUT = 6;
+  private static final String[] NETWORK_PROXY_MODE_VALUES = {
+    NetworkProxy.MODE_DIRECT, NetworkProxy.MODE_SYSTEM, NetworkProxy.MODE_MANUAL
+  };
+  private static final String[] NETWORK_PROXY_MODE_LABELS = {
+    "不使用代理", "使用系统代理设置", "手动配置代理"
+  };
 
   private ResourceBundle resourceBundle =
       Lizzie.resourceBundle; // ResourceBundle.getBundle("l10n.DisplayStrings");
@@ -326,6 +333,11 @@ public class ConfigDialog2 extends JDialog {
   private JCheckBox chkPonder;
   private JCheckBox chkStopAtEmpty;
   private JCheckBox chkEnableStartupBenchmark;
+  private JComboBox<String> comboNetworkProxyMode;
+  private JTextField txtNetworkProxyHost;
+  private JTextField txtNetworkProxyPort;
+  private JLabel lblNetworkProxyRestartHint;
+  private String initialNetworkProxyMode = NetworkProxy.MODE_DIRECT;
 
   private JCheckBox chkUseScoreDiff;
   private JTextField txtPercentScoreDiff;
@@ -366,6 +378,9 @@ public class ConfigDialog2 extends JDialog {
     okButton.addActionListener(
         new ActionListener() {
           public void actionPerformed(ActionEvent e) {
+            if (!validateNetworkProxyInputs()) {
+              return;
+            }
             finalizeEditedBlunderColors();
             setVisible(false);
             saveConfig();
@@ -2032,6 +2047,7 @@ public class ConfigDialog2 extends JDialog {
     if (Lizzie.config.enableClickReview) chkEnableClickReview.setSelected(true);
     if (Lizzie.config.noRefreshOnSub) chkNoRefreshSub.setSelected(true);
     if (Lizzie.config.enableLizzieCache) chkLizzieCache.setSelected(true);
+    initNetworkProxyControls();
 
     tabbedPane.addChangeListener(
         new ChangeListener() {
@@ -2509,7 +2525,8 @@ public class ConfigDialog2 extends JDialog {
               {
                 "首次启动智能测速",
                 toggleText(chkEnableStartupBenchmark, Lizzie.config.enableStartupBenchmark)
-              }
+              },
+              {"网络代理", comboText(comboNetworkProxyMode, "不使用代理")}
             });
         addSummaryTip(modernSummaryBody, "<html><b>谨慎修改</b><br>这些选项更偏性能和调试，建议一次只改一两项再观察效果。</html>");
         break;
@@ -3124,6 +3141,7 @@ public class ConfigDialog2 extends JDialog {
         addToggleRow(advanced, "空棋盘停止计算", "空棋盘时自动暂停分析", chkStopAtEmpty);
         addToggleRow(advanced, "首次启动智能测速", "首次启动时引导运行智能测速优化", chkEnableStartupBenchmark);
         addToggleRow(advanced, "五子棋无提子规则", "五子棋模式下禁用提子逻辑", chkNoCapture);
+        addNetworkProxyRows(advanced);
         return advanced;
       case MODERN_NAV_DISPLAY:
       default:
@@ -3211,6 +3229,135 @@ public class ConfigDialog2 extends JDialog {
     input.add(suffix);
     addDesignRowControl(row, input);
     card.add(row);
+  }
+
+  private void initNetworkProxyControls() {
+    JSONObject ui = Lizzie.config.uiConfig;
+    initialNetworkProxyMode =
+        normalizeNetworkProxyMode(ui.optString(NetworkProxy.KEY_PROXY_MODE, NetworkProxy.MODE_DIRECT));
+
+    comboNetworkProxyMode = new JComboBox<>(NETWORK_PROXY_MODE_LABELS);
+    setSelectedNetworkProxyMode(initialNetworkProxyMode);
+    comboNetworkProxyMode.addActionListener(e -> updateNetworkProxyFieldsEnabled());
+
+    txtNetworkProxyHost =
+        new JTextField(ui.optString(NetworkProxy.KEY_PROXY_HOST, "127.0.0.1").trim());
+    Object savedPort = ui.opt(NetworkProxy.KEY_PROXY_PORT);
+    txtNetworkProxyPort = new JTextField(savedPort == null ? "7897" : String.valueOf(savedPort));
+
+    lblNetworkProxyRestartHint = new JLabel("切换系统代理模式后需重启程序才能完全生效。");
+    lblNetworkProxyRestartHint.putClientProperty(CLIENT_SKIP_TEXT_STYLE, Boolean.TRUE);
+    lblNetworkProxyRestartHint.setForeground(SETTINGS_MUTED);
+    lblNetworkProxyRestartHint.setFont(new Font(Config.sysDefaultFontName, Font.PLAIN, 12));
+    updateNetworkProxyFieldsEnabled();
+  }
+
+  private void addNetworkProxyRows(JPanel card) {
+    addComponentRow(card, "网络代理", "控制程序自身 Java 网络请求使用的代理策略", comboNetworkProxyMode);
+
+    JPanel manualProxy = new JPanel(new FlowLayout(FlowLayout.RIGHT, 8, 0));
+    manualProxy.setOpaque(false);
+    manualProxy.add(proxyFieldLabel("代理主机"));
+    txtNetworkProxyHost.setPreferredSize(new Dimension(150, 30));
+    manualProxy.add(detachComponent(txtNetworkProxyHost));
+    manualProxy.add(proxyFieldLabel("代理端口"));
+    txtNetworkProxyPort.setPreferredSize(new Dimension(70, 30));
+    manualProxy.add(detachComponent(txtNetworkProxyPort));
+    addComponentRow(card, "手动代理地址", "本机代理可填写 127.0.0.1 和 7897", manualProxy);
+
+    addComponentRow(card, "系统代理提示", "系统代理设置由 JVM 启动时读取", lblNetworkProxyRestartHint);
+  }
+
+  private JLabel proxyFieldLabel(String text) {
+    JLabel label = new JLabel(text);
+    label.putClientProperty(CLIENT_SKIP_TEXT_STYLE, Boolean.TRUE);
+    label.setForeground(SETTINGS_MUTED);
+    label.setFont(new Font(Config.sysDefaultFontName, Font.PLAIN, 12));
+    return label;
+  }
+
+  private String selectedNetworkProxyMode() {
+    int index = comboNetworkProxyMode == null ? 0 : comboNetworkProxyMode.getSelectedIndex();
+    if (index < 0 || index >= NETWORK_PROXY_MODE_VALUES.length) {
+      return NetworkProxy.MODE_DIRECT;
+    }
+    return NETWORK_PROXY_MODE_VALUES[index];
+  }
+
+  private void setSelectedNetworkProxyMode(String mode) {
+    for (int i = 0; i < NETWORK_PROXY_MODE_VALUES.length; i++) {
+      if (NETWORK_PROXY_MODE_VALUES[i].equals(mode)) {
+        comboNetworkProxyMode.setSelectedIndex(i);
+        return;
+      }
+    }
+    comboNetworkProxyMode.setSelectedIndex(0);
+  }
+
+  private String normalizeNetworkProxyMode(String mode) {
+    String value = mode == null ? "" : mode.trim();
+    for (String knownMode : NETWORK_PROXY_MODE_VALUES) {
+      if (knownMode.equals(value)) {
+        return knownMode;
+      }
+    }
+    return NetworkProxy.MODE_DIRECT;
+  }
+
+  private void updateNetworkProxyFieldsEnabled() {
+    boolean manualMode = NetworkProxy.MODE_MANUAL.equals(selectedNetworkProxyMode());
+    if (txtNetworkProxyHost != null) {
+      txtNetworkProxyHost.setEnabled(manualMode);
+    }
+    if (txtNetworkProxyPort != null) {
+      txtNetworkProxyPort.setEnabled(manualMode);
+    }
+    if (lblNetworkProxyRestartHint != null) {
+      boolean systemModeInvolved =
+          NetworkProxy.MODE_SYSTEM.equals(initialNetworkProxyMode)
+              || NetworkProxy.MODE_SYSTEM.equals(selectedNetworkProxyMode());
+      lblNetworkProxyRestartHint.setVisible(systemModeInvolved);
+    }
+  }
+
+  private boolean validateNetworkProxyInputs() {
+    if (!NetworkProxy.MODE_MANUAL.equals(selectedNetworkProxyMode())) {
+      return true;
+    }
+    if (txtNetworkProxyHost.getText().trim().isEmpty()) {
+      showNetworkProxyWarning("手动代理主机不能为空。");
+      txtNetworkProxyHost.requestFocusInWindow();
+      return false;
+    }
+    try {
+      parseNetworkProxyPort();
+    } catch (NumberFormatException e) {
+      showNetworkProxyWarning("代理端口必须是 1 到 65535 的整数。");
+      txtNetworkProxyPort.requestFocusInWindow();
+      txtNetworkProxyPort.selectAll();
+      return false;
+    }
+    return true;
+  }
+
+  private void showNetworkProxyWarning(String message) {
+    JOptionPane.showMessageDialog(this, message, "网络代理设置", JOptionPane.WARNING_MESSAGE);
+  }
+
+  private int parseNetworkProxyPort() {
+    int port = Integer.parseInt(txtNetworkProxyPort.getText().trim());
+    if (port < 1 || port > 65535) {
+      throw new NumberFormatException(String.valueOf(port));
+    }
+    return port;
+  }
+
+  private int savedNetworkProxyPort() {
+    try {
+      return parseNetworkProxyPort();
+    } catch (NumberFormatException e) {
+      return 7897;
+    }
   }
 
   private JPanel createDesignRow(String title, String subtitle) {
@@ -5774,6 +5921,10 @@ public class ConfigDialog2 extends JDialog {
   }
 
   private void saveConfig() {
+    Lizzie.config.uiConfig.put(NetworkProxy.KEY_PROXY_MODE, selectedNetworkProxyMode());
+    Lizzie.config.uiConfig.put(
+        NetworkProxy.KEY_PROXY_HOST, txtNetworkProxyHost.getText().trim());
+    Lizzie.config.uiConfig.put(NetworkProxy.KEY_PROXY_PORT, savedNetworkProxyPort());
     Lizzie.config.showScoreAsDiff = chkShowScoreAsLead.isSelected();
     Lizzie.config.uiConfig.put("show-score-as-diff", Lizzie.config.showScoreAsDiff);
     Lizzie.config.logConsoleToFile = chkLogConsoleToFile.isSelected();

--- a/src/main/java/featurecat/lizzie/gui/KataGoAutoSetupDialog.java
+++ b/src/main/java/featurecat/lizzie/gui/KataGoAutoSetupDialog.java
@@ -455,7 +455,13 @@ public class KataGoAutoSetupDialog extends JDialog {
       Lizzie.frame.openRemoteComputeCenter();
       return;
     }
-    RemoteComputeDialog dialog = new RemoteComputeDialog(JOptionPane.getFrameForComponent(this));
+    RemoteComputeDialog dialog;
+    try {
+      dialog = new RemoteComputeDialog(JOptionPane.getFrameForComponent(this));
+    } catch (IOException e) {
+      JOptionPane.showMessageDialog(this, e.getMessage(), "网络代理设置", JOptionPane.WARNING_MESSAGE);
+      return;
+    }
     dialog.setVisible(true);
     dialog.toFront();
   }

--- a/src/main/java/featurecat/lizzie/gui/LizzieFrame.java
+++ b/src/main/java/featurecat/lizzie/gui/LizzieFrame.java
@@ -17034,7 +17034,13 @@ public class LizzieFrame extends JFrame {
   }
 
   public void openRemoteComputeCenter() {
-    RemoteComputeDialog dialog = new RemoteComputeDialog(this);
+    RemoteComputeDialog dialog;
+    try {
+      dialog = new RemoteComputeDialog(this);
+    } catch (IOException e) {
+      JOptionPane.showMessageDialog(this, e.getMessage(), "网络代理设置", JOptionPane.WARNING_MESSAGE);
+      return;
+    }
     dialog.setVisible(true);
     dialog.toFront();
   }

--- a/src/main/java/featurecat/lizzie/gui/OnlineDialog.java
+++ b/src/main/java/featurecat/lizzie/gui/OnlineDialog.java
@@ -56,6 +56,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -64,6 +65,7 @@ import javax.swing.JButton;
 import javax.swing.JDialog;
 import javax.swing.JFormattedTextField;
 import javax.swing.JLabel;
+import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 import javax.swing.JTextField;
 import javax.swing.SwingConstants;
@@ -430,6 +432,9 @@ public class OnlineDialog extends JDialog {
         proc();
       } catch (IOException | URISyntaxException e) {
         e.printStackTrace();
+        if (e instanceof IOException) {
+          showNetworkProxyConfigWarning((IOException) e);
+        }
       }
     } else {
       error(true);
@@ -464,6 +469,17 @@ public class OnlineDialog extends JDialog {
       lblError.setVisible(e);
       setVisible(true);
     }
+  }
+
+  private boolean showNetworkProxyConfigWarning(IOException e) {
+    if (!(e.getCause() instanceof NetworkProxy.InvalidNetworkProxyConfigException)) {
+      return false;
+    }
+    SwingUtilities.invokeLater(
+        () ->
+            JOptionPane.showMessageDialog(
+                this, e.getMessage(), "网络代理设置", JOptionPane.WARNING_MESSAGE));
+    return true;
   }
 
   private boolean isYikeSyncType() {
@@ -1400,6 +1416,7 @@ public class OnlineDialog extends JDialog {
         } catch (IOException e) {
           // TODO Auto-generated catch block
           e.printStackTrace();
+          showNetworkProxyConfigWarning(e);
         }
       }
     }.start();
@@ -1433,10 +1450,14 @@ public class OnlineDialog extends JDialog {
     if (clear) Lizzie.board.clearForOnline();
     ensureOnlineExecutor();
     final int refreshSeconds = normalizeYikeRefreshSeconds(requestRefreshTime);
+    AtomicBoolean invalidProxyConfig = new AtomicBoolean();
     Runnable fetch =
         new Runnable() {
           @Override
           public void run() {
+            if (invalidProxyConfig.get()) {
+              return;
+            }
             if (!shouldAcceptYikeLiveFetchResult(
                 isStoped,
                 LizzieFrame.urlSgf,
@@ -1522,6 +1543,10 @@ public class OnlineDialog extends JDialog {
             } catch (IOException | JSONException e) {
               YikeSyncDebugLog.log("OnlineDialog.reqNewYikeRoom error: " + e.toString());
               e.printStackTrace();
+              if (e instanceof IOException
+                  && showNetworkProxyConfigWarning((IOException) e)) {
+                invalidProxyConfig.set(true);
+              }
               SwingUtilities.invokeLater(
                   new Runnable() {
                     @Override
@@ -1577,6 +1602,9 @@ public class OnlineDialog extends JDialog {
                       ajax.send(params);
                     } catch (IOException e) {
                       e.printStackTrace();
+                      if (showNetworkProxyConfigWarning(e)) {
+                        timer.stop();
+                      }
                     }
                   }
                 }
@@ -1588,6 +1616,7 @@ public class OnlineDialog extends JDialog {
         ajax.send(params);
       } catch (IOException e) {
         e.printStackTrace();
+        showNetworkProxyConfigWarning(e);
       }
     }
   }
@@ -1599,6 +1628,7 @@ public class OnlineDialog extends JDialog {
         refresh("(jQuery1\\(\\\")([^\\\"]+)(?s).*", 2, false, true);
       } catch (IOException e) {
         e.printStackTrace();
+        showNetworkProxyConfigWarning(e);
       }
     }
   }
@@ -1636,8 +1666,11 @@ public class OnlineDialog extends JDialog {
 
                 try {
                   req(true);
-                } catch (URISyntaxException e) {
+                } catch (IOException | URISyntaxException e) {
                   e.printStackTrace();
+                  if (e instanceof IOException) {
+                    showNetworkProxyConfigWarning((IOException) e);
+                  }
                 }
               }
             }
@@ -1649,18 +1682,22 @@ public class OnlineDialog extends JDialog {
       ajax.send(params);
     } catch (IOException e) {
       e.printStackTrace();
+      showNetworkProxyConfigWarning(e);
     }
   }
 
   private void reReq() {
     try {
       req(true);
-    } catch (URISyntaxException e) {
+    } catch (IOException | URISyntaxException e) {
       e.printStackTrace();
+      if (e instanceof IOException) {
+        showNetworkProxyConfigWarning((IOException) e);
+      }
     }
   }
 
-  private void req(boolean clear) throws URISyntaxException {
+  private void req(boolean clear) throws IOException, URISyntaxException {
     seqs = 0;
     URI uri = new URI(new String(type == 3 ? b : b2));
 
@@ -3259,6 +3296,7 @@ public class OnlineDialog extends JDialog {
           refresh("(?s).*?(\\\"Content\\\":\\\")(.+)(\\\",\\\")(?s).*", 2, false, false);
         } catch (IOException e) {
           e.printStackTrace();
+          showNetworkProxyConfigWarning(e);
         }
       }
     }
@@ -4310,6 +4348,9 @@ public class OnlineDialog extends JDialog {
         proc();
       } catch (IOException | URISyntaxException e) {
         e.printStackTrace();
+        if (e instanceof IOException) {
+          showNetworkProxyConfigWarning((IOException) e);
+        }
       }
     } else {
       error(true);
@@ -4449,6 +4490,9 @@ public class OnlineDialog extends JDialog {
       } catch (IOException | URISyntaxException e) {
         yikeDebugLog("applyChangeWeb proc error: " + e.toString());
         e.printStackTrace();
+        if (e instanceof IOException) {
+          showNetworkProxyConfigWarning((IOException) e);
+        }
         reportSyncStatus("同步启动失败: " + e.getMessage());
       } catch (RuntimeException e) {
         yikeDebugLog("applyChangeWeb proc runtime error: " + e.toString());

--- a/src/main/java/featurecat/lizzie/gui/OnlineDialog.java
+++ b/src/main/java/featurecat/lizzie/gui/OnlineDialog.java
@@ -11,6 +11,7 @@ import featurecat.lizzie.rules.BoardHistoryNode;
 import featurecat.lizzie.rules.SGFParser;
 import featurecat.lizzie.rules.Stone;
 import featurecat.lizzie.util.AjaxHttpRequest;
+import featurecat.lizzie.util.NetworkProxy;
 import featurecat.lizzie.util.Utils;
 import featurecat.lizzie.util.YikeSyncDebugLog;
 import io.socket.client.Ack;
@@ -1375,7 +1376,7 @@ public class OnlineDialog extends JDialog {
       public void run() {
         try {
           URL url = URI.create(ajaxUrl).toURL();
-          HttpURLConnection con = (HttpURLConnection) url.openConnection();
+          HttpURLConnection con = (HttpURLConnection) NetworkProxy.openConnection(url);
 
           con.setRequestMethod("GET");
           con.setRequestProperty(
@@ -1703,6 +1704,7 @@ public class OnlineDialog extends JDialog {
           }
         };
 
+    NetworkProxy.configure(client);
     client.connect();
   }
 

--- a/src/main/java/featurecat/lizzie/gui/RemoteComputeDialog.java
+++ b/src/main/java/featurecat/lizzie/gui/RemoteComputeDialog.java
@@ -32,6 +32,7 @@ import java.awt.Toolkit;
 import java.awt.datatransfer.StringSelection;
 import java.awt.image.BufferedImage;
 import java.io.File;
+import java.io.IOException;
 import java.net.URI;
 import javax.imageio.ImageIO;
 import javax.swing.BorderFactory;
@@ -70,7 +71,7 @@ public class RemoteComputeDialog extends JDialog {
   private static final Color GOLD = new Color(193, 132, 42);
   private static final Color ERROR = new Color(190, 69, 56);
 
-  private final ZhiziApiClient apiClient = new ZhiziApiClient();
+  private final ZhiziApiClient apiClient;
   private final CardLayout pageLayout = new CardLayout();
   private final JPanel pageCards = transparent(pageLayout);
   private final JButton zhiziTab = tabButton("智子云算力");
@@ -111,8 +112,9 @@ public class RemoteComputeDialog extends JDialog {
   private char passwordEchoChar;
   private boolean busy;
 
-  public RemoteComputeDialog(Frame owner) {
+  public RemoteComputeDialog(Frame owner) throws IOException {
     super(owner, "远程算力", false);
+    apiClient = new ZhiziApiClient();
     setDefaultCloseOperation(DISPOSE_ON_CLOSE);
     setMinimumSize(new Dimension(1040, 660));
     setPreferredSize(new Dimension(1120, 700));

--- a/src/main/java/featurecat/lizzie/gui/YikeApiClient.java
+++ b/src/main/java/featurecat/lizzie/gui/YikeApiClient.java
@@ -1,12 +1,12 @@
 package featurecat.lizzie.gui;
 
+import featurecat.lizzie.util.NetworkProxy;
 import featurecat.lizzie.util.Utils;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
-import java.net.Proxy;
 import java.net.URI;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
@@ -49,7 +49,7 @@ public class YikeApiClient {
 
   public String fetch(String url) throws IOException {
     HttpURLConnection connection =
-        (HttpURLConnection) URI.create(url).toURL().openConnection(Proxy.NO_PROXY);
+        (HttpURLConnection) NetworkProxy.openConnection(URI.create(url).toURL());
     connection.setConnectTimeout(HTTP_TIMEOUT_MS);
     connection.setReadTimeout(HTTP_TIMEOUT_MS);
     connection.setRequestMethod("GET");

--- a/src/main/java/featurecat/lizzie/update/WindowsUpdateService.java
+++ b/src/main/java/featurecat/lizzie/update/WindowsUpdateService.java
@@ -1,6 +1,7 @@
 package featurecat.lizzie.update;
 
 import featurecat.lizzie.Lizzie;
+import featurecat.lizzie.util.NetworkProxy;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -51,7 +52,7 @@ public final class WindowsUpdateService {
     String manifestUrl = System.getProperty(MANIFEST_URL_PROPERTY, DEFAULT_MANIFEST_URL);
     HttpURLConnection conn = null;
     try {
-      conn = (HttpURLConnection) URI.create(manifestUrl).toURL().openConnection();
+      conn = (HttpURLConnection) NetworkProxy.openConnection(URI.create(manifestUrl).toURL());
       conn.setConnectTimeout(CONNECT_TIMEOUT_MS);
       conn.setReadTimeout(READ_TIMEOUT_MS);
       conn.setRequestProperty("Accept", "application/json");
@@ -186,7 +187,8 @@ public final class WindowsUpdateService {
     Files.deleteIfExists(part);
     HttpURLConnection conn = null;
     try {
-      conn = (HttpURLConnection) URI.create(component.downloadUrl).toURL().openConnection();
+      conn =
+          (HttpURLConnection) NetworkProxy.openConnection(URI.create(component.downloadUrl).toURL());
       conn.setConnectTimeout(CONNECT_TIMEOUT_MS);
       conn.setReadTimeout(READ_TIMEOUT_MS);
       conn.setRequestProperty("User-Agent", "LizzieYzy-Next-Updater");

--- a/src/main/java/featurecat/lizzie/util/AjaxHttpRequest.java
+++ b/src/main/java/featurecat/lizzie/util/AjaxHttpRequest.java
@@ -5,7 +5,6 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.UnsupportedEncodingException;
 import java.net.HttpURLConnection;
-import java.net.Proxy;
 import java.net.URI;
 import java.net.URL;
 import java.net.URLConnection;
@@ -38,7 +37,6 @@ public class AjaxHttpRequest {
   private URLConnection connection;
   private String userAgent;
   private String postCharset = DEFAULT_AJAX_CHARSET;
-  private Proxy proxy;
 
   private URL requestURL;
   protected String requestMethod;
@@ -87,9 +85,7 @@ public class AjaxHttpRequest {
       final String password)
       throws IOException {
     this.abort();
-    Proxy proxy = this.proxy;
-    URLConnection c =
-        proxy == null || proxy == Proxy.NO_PROXY ? url.openConnection() : url.openConnection(proxy);
+    URLConnection c = NetworkProxy.openConnection(url);
     synchronized (this) {
       this.connection = c;
       this.async = async;

--- a/src/main/java/featurecat/lizzie/util/KataGoAutoSetupHelper.java
+++ b/src/main/java/featurecat/lizzie/util/KataGoAutoSetupHelper.java
@@ -503,7 +503,9 @@ public final class KataGoAutoSetupHelper {
     Path temp = modelsDir.resolve(HUMAN_SL_MODEL_FILE_NAME + ".part");
     HttpURLConnection conn = null;
     try {
-      conn = (HttpURLConnection) URI.create(humanSlModelDownloadUrl()).toURL().openConnection();
+      conn =
+          (HttpURLConnection)
+              NetworkProxy.openConnection(URI.create(humanSlModelDownloadUrl()).toURL());
       activeSession.attach(conn);
       activeSession.throwIfCancelled();
       conn.setInstanceFollowRedirects(true);
@@ -598,7 +600,7 @@ public final class KataGoAutoSetupHelper {
     Path temp = weightsDir.resolve(info.fileName() + ".part");
     HttpURLConnection conn = null;
     try {
-      conn = (HttpURLConnection) URI.create(info.downloadUrl).toURL().openConnection();
+      conn = (HttpURLConnection) NetworkProxy.openConnection(URI.create(info.downloadUrl).toURL());
       activeSession.attach(conn);
       activeSession.throwIfCancelled();
       conn.setInstanceFollowRedirects(true);
@@ -1031,7 +1033,7 @@ public final class KataGoAutoSetupHelper {
   private static String httpGet(String url) throws IOException {
     HttpURLConnection conn = null;
     try {
-      conn = (HttpURLConnection) URI.create(url).toURL().openConnection();
+      conn = (HttpURLConnection) NetworkProxy.openConnection(URI.create(url).toURL());
       conn.setInstanceFollowRedirects(true);
       conn.setRequestMethod("GET");
       conn.setConnectTimeout(15000);

--- a/src/main/java/featurecat/lizzie/util/KataGoRuntimeHelper.java
+++ b/src/main/java/featurecat/lizzie/util/KataGoRuntimeHelper.java
@@ -3030,7 +3030,7 @@ public final class KataGoRuntimeHelper {
     long startedAt = System.nanoTime();
     long bytesRead = 0L;
     try {
-      conn = (HttpURLConnection) URI.create(probeUrl).toURL().openConnection();
+      conn = (HttpURLConnection) NetworkProxy.openConnection(URI.create(probeUrl).toURL());
       session.attach(conn);
       session.throwIfCancelled();
       conn.setInstanceFollowRedirects(true);
@@ -3256,7 +3256,7 @@ public final class KataGoRuntimeHelper {
         session.throwIfCancelled();
         long existingBytes = resumeBytes;
         boolean appendToPartial = existingBytes > 0;
-        conn = URI.create(spec.url).toURL().openConnection();
+        conn = NetworkProxy.openConnection(URI.create(spec.url).toURL());
         conn.setConnectTimeout(15000);
         conn.setReadTimeout(30000);
         conn.setRequestProperty("User-Agent", USER_AGENT);
@@ -3621,7 +3621,7 @@ public final class KataGoRuntimeHelper {
   private static String httpGet(String url) throws IOException {
     HttpURLConnection conn = null;
     try {
-      conn = (HttpURLConnection) URI.create(url).toURL().openConnection();
+      conn = (HttpURLConnection) NetworkProxy.openConnection(URI.create(url).toURL());
       conn.setInstanceFollowRedirects(true);
       conn.setRequestMethod("GET");
       conn.setConnectTimeout(15000);

--- a/src/main/java/featurecat/lizzie/util/NetworkProxy.java
+++ b/src/main/java/featurecat/lizzie/util/NetworkProxy.java
@@ -24,45 +24,55 @@ public final class NetworkProxy {
   public static final String MODE_DIRECT = "direct";
   public static final String MODE_SYSTEM = "system";
   public static final String MODE_MANUAL = "manual";
-
-  private static final ProxySelector DIRECT_SELECTOR =
-      new ProxySelector() {
-        @Override
-        public List<Proxy> select(URI uri) {
-          return List.of(Proxy.NO_PROXY);
-        }
-
-        @Override
-        public void connectFailed(URI uri, SocketAddress sa, IOException ioe) {}
-      };
+  public static final String DEFAULT_MODE = MODE_DIRECT;
 
   private NetworkProxy() {}
 
   public static void installSystemProxyPropertyFromSavedConfig() {
-    if (settings(currentUiConfig()).mode.equals(MODE_SYSTEM)) {
+    if (MODE_SYSTEM.equals(currentUiConfig().optString(KEY_PROXY_MODE, DEFAULT_MODE).trim())) {
       System.setProperty("java.net.useSystemProxies", "true");
     }
   }
 
   public static URLConnection openConnection(URL url) throws IOException {
-    Proxy proxy = proxyForUrl(url, currentUiConfig());
-    return proxy == null ? url.openConnection() : url.openConnection(proxy);
+    try {
+      Proxy proxy = proxyForUrl(url, currentUiConfig());
+      return proxy == null ? url.openConnection() : url.openConnection(proxy);
+    } catch (InvalidNetworkProxyConfigException e) {
+      throw invalidSettings(e);
+    }
   }
 
-  public static ProxySelector proxySelector() {
-    return proxySelector(currentUiConfig());
+  public static ProxySelector proxySelector() throws IOException {
+    try {
+      return proxySelector(currentUiConfig());
+    } catch (InvalidNetworkProxyConfigException e) {
+      throw invalidSettings(e);
+    }
   }
 
-  public static HttpClient.Builder configure(HttpClient.Builder builder) {
-    return configure(builder, currentUiConfig());
+  public static HttpClient.Builder configure(HttpClient.Builder builder) throws IOException {
+    try {
+      return configure(builder, currentUiConfig());
+    } catch (InvalidNetworkProxyConfigException e) {
+      throw invalidSettings(e);
+    }
   }
 
-  public static OkHttpClient.Builder configure(OkHttpClient.Builder builder) {
-    return configure(builder, currentUiConfig());
+  public static OkHttpClient.Builder configure(OkHttpClient.Builder builder) throws IOException {
+    try {
+      return configure(builder, currentUiConfig());
+    } catch (InvalidNetworkProxyConfigException e) {
+      throw invalidSettings(e);
+    }
   }
 
-  public static void configure(WebSocketClient client) {
-    client.setProxy(proxyForWebSocket(client.getURI(), currentUiConfig()));
+  public static void configure(WebSocketClient client) throws IOException {
+    try {
+      client.setProxy(proxyForWebSocket(client.getURI(), currentUiConfig()));
+    } catch (InvalidNetworkProxyConfigException e) {
+      throw invalidSettings(e);
+    }
   }
 
   static HttpClient.Builder configure(HttpClient.Builder builder, JSONObject uiConfig) {
@@ -102,7 +112,7 @@ public final class NetworkProxy {
     Settings settings = settings(uiConfig);
     switch (settings.mode) {
       case MODE_DIRECT:
-        return DIRECT_SELECTOR;
+        return directSelector();
       case MODE_MANUAL:
         return ProxySelector.of(settings.address());
       case MODE_SYSTEM:
@@ -151,7 +161,11 @@ public final class NetworkProxy {
 
   private static ProxySelector defaultProxySelector() {
     ProxySelector selector = ProxySelector.getDefault();
-    return selector == null ? DIRECT_SELECTOR : selector;
+    return selector == null ? directSelector() : selector;
+  }
+
+  private static ProxySelector directSelector() {
+    return DirectSelectorHolder.INSTANCE;
   }
 
   private static JSONObject currentUiConfig() {
@@ -163,10 +177,8 @@ public final class NetworkProxy {
 
   private static Settings settings(JSONObject uiConfig) {
     JSONObject ui = uiConfig == null ? new JSONObject() : uiConfig;
-    String mode = ui.optString(KEY_PROXY_MODE, MODE_DIRECT).trim();
-    if (mode.isEmpty()) {
-      mode = MODE_DIRECT;
-    }
+    String mode =
+        ui.has(KEY_PROXY_MODE) ? ui.optString(KEY_PROXY_MODE, "").trim() : DEFAULT_MODE;
     switch (mode) {
       case MODE_DIRECT:
       case MODE_SYSTEM:
@@ -191,12 +203,9 @@ public final class NetworkProxy {
   }
 
   private static int parsePort(Object rawPort) {
-    if (rawPort instanceof Number) {
-      return ((Number) rawPort).intValue();
-    }
-    if (rawPort instanceof String) {
+    if (rawPort instanceof Number || rawPort instanceof String) {
       try {
-        return Integer.parseInt(((String) rawPort).trim());
+        return Integer.parseInt(String.valueOf(rawPort).trim());
       } catch (NumberFormatException e) {
         throw new InvalidNetworkProxyConfigException(KEY_PROXY_PORT, String.valueOf(rawPort));
       }
@@ -204,10 +213,30 @@ public final class NetworkProxy {
     throw new InvalidNetworkProxyConfigException(KEY_PROXY_PORT, String.valueOf(rawPort));
   }
 
+  private static IOException invalidSettings(InvalidNetworkProxyConfigException e) {
+    return new IOException(
+        "Network proxy settings are invalid. Open Settings > Advanced > Network Proxy and fix "
+            + e.getMessage(),
+        e);
+  }
+
   public static final class InvalidNetworkProxyConfigException extends IllegalArgumentException {
     InvalidNetworkProxyConfigException(String key, String value) {
       super("Invalid " + key + ": " + value);
     }
+  }
+
+  private static final class DirectSelectorHolder {
+    private static final ProxySelector INSTANCE =
+        new ProxySelector() {
+          @Override
+          public List<Proxy> select(URI uri) {
+            return List.of(Proxy.NO_PROXY);
+          }
+
+          @Override
+          public void connectFailed(URI uri, SocketAddress sa, IOException ioe) {}
+        };
   }
 
   private static final class Settings {

--- a/src/main/java/featurecat/lizzie/util/NetworkProxy.java
+++ b/src/main/java/featurecat/lizzie/util/NetworkProxy.java
@@ -1,0 +1,232 @@
+package featurecat.lizzie.util;
+
+import featurecat.lizzie.Lizzie;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.Proxy;
+import java.net.ProxySelector;
+import java.net.SocketAddress;
+import java.net.URI;
+import java.net.URL;
+import java.net.URLConnection;
+import java.net.http.HttpClient;
+import java.util.List;
+import java.util.Objects;
+import okhttp3.OkHttpClient;
+import org.java_websocket.client.WebSocketClient;
+import org.json.JSONObject;
+
+public final class NetworkProxy {
+  public static final String KEY_PROXY_MODE = "network-proxy-mode";
+  public static final String KEY_PROXY_HOST = "network-proxy-host";
+  public static final String KEY_PROXY_PORT = "network-proxy-port";
+
+  public static final String MODE_DIRECT = "direct";
+  public static final String MODE_SYSTEM = "system";
+  public static final String MODE_MANUAL = "manual";
+
+  private static final ProxySelector DIRECT_SELECTOR =
+      new ProxySelector() {
+        @Override
+        public List<Proxy> select(URI uri) {
+          return List.of(Proxy.NO_PROXY);
+        }
+
+        @Override
+        public void connectFailed(URI uri, SocketAddress sa, IOException ioe) {}
+      };
+
+  private NetworkProxy() {}
+
+  public static void installSystemProxyPropertyFromSavedConfig() {
+    if (settings(currentUiConfig()).mode.equals(MODE_SYSTEM)) {
+      System.setProperty("java.net.useSystemProxies", "true");
+    }
+  }
+
+  public static URLConnection openConnection(URL url) throws IOException {
+    Proxy proxy = proxyForUrl(url, currentUiConfig());
+    return proxy == null ? url.openConnection() : url.openConnection(proxy);
+  }
+
+  public static ProxySelector proxySelector() {
+    return proxySelector(currentUiConfig());
+  }
+
+  public static HttpClient.Builder configure(HttpClient.Builder builder) {
+    return configure(builder, currentUiConfig());
+  }
+
+  public static OkHttpClient.Builder configure(OkHttpClient.Builder builder) {
+    return configure(builder, currentUiConfig());
+  }
+
+  public static void configure(WebSocketClient client) {
+    client.setProxy(proxyForWebSocket(client.getURI(), currentUiConfig()));
+  }
+
+  static HttpClient.Builder configure(HttpClient.Builder builder, JSONObject uiConfig) {
+    return builder.proxy(proxySelector(uiConfig));
+  }
+
+  static OkHttpClient.Builder configure(OkHttpClient.Builder builder, JSONObject uiConfig) {
+    Settings settings = settings(uiConfig);
+    switch (settings.mode) {
+      case MODE_DIRECT:
+        return builder.proxy(Proxy.NO_PROXY);
+      case MODE_MANUAL:
+        return builder.proxy(settings.manualProxy());
+      case MODE_SYSTEM:
+        return builder.proxySelector(defaultProxySelector());
+      default:
+        throw new InvalidNetworkProxyConfigException(KEY_PROXY_MODE, settings.mode);
+    }
+  }
+
+  static Proxy proxyForUrl(URL url, JSONObject uiConfig) {
+    Objects.requireNonNull(url, "url");
+    Settings settings = settings(uiConfig);
+    switch (settings.mode) {
+      case MODE_DIRECT:
+        return Proxy.NO_PROXY;
+      case MODE_MANUAL:
+        return settings.manualProxy();
+      case MODE_SYSTEM:
+        return null;
+      default:
+        throw new InvalidNetworkProxyConfigException(KEY_PROXY_MODE, settings.mode);
+    }
+  }
+
+  static ProxySelector proxySelector(JSONObject uiConfig) {
+    Settings settings = settings(uiConfig);
+    switch (settings.mode) {
+      case MODE_DIRECT:
+        return DIRECT_SELECTOR;
+      case MODE_MANUAL:
+        return ProxySelector.of(settings.address());
+      case MODE_SYSTEM:
+        return defaultProxySelector();
+      default:
+        throw new InvalidNetworkProxyConfigException(KEY_PROXY_MODE, settings.mode);
+    }
+  }
+
+  static Proxy proxyForWebSocket(URI uri, JSONObject uiConfig) {
+    Settings settings = settings(uiConfig);
+    switch (settings.mode) {
+      case MODE_DIRECT:
+        return Proxy.NO_PROXY;
+      case MODE_MANUAL:
+        return settings.manualProxy();
+      case MODE_SYSTEM:
+        return firstHttpSystemProxy(systemLookupUriForWebSocket(uri));
+      default:
+        throw new InvalidNetworkProxyConfigException(KEY_PROXY_MODE, settings.mode);
+    }
+  }
+
+  static URI systemLookupUriForWebSocket(URI uri) {
+    String scheme = uri.getScheme();
+    if ("ws".equalsIgnoreCase(scheme)) {
+      return URI.create("http" + uri.toString().substring(scheme.length()));
+    }
+    if ("wss".equalsIgnoreCase(scheme)) {
+      return URI.create("https" + uri.toString().substring(scheme.length()));
+    }
+    return uri;
+  }
+
+  static Proxy firstHttpSystemProxy(URI uri) {
+    List<Proxy> proxies = defaultProxySelector().select(uri);
+    if (proxies != null) {
+      for (Proxy proxy : proxies) {
+        if (proxy.type() == Proxy.Type.HTTP) {
+          return proxy;
+        }
+      }
+    }
+    return Proxy.NO_PROXY;
+  }
+
+  private static ProxySelector defaultProxySelector() {
+    ProxySelector selector = ProxySelector.getDefault();
+    return selector == null ? DIRECT_SELECTOR : selector;
+  }
+
+  private static JSONObject currentUiConfig() {
+    if (Lizzie.config == null || Lizzie.config.uiConfig == null) {
+      return new JSONObject();
+    }
+    return Lizzie.config.uiConfig;
+  }
+
+  private static Settings settings(JSONObject uiConfig) {
+    JSONObject ui = uiConfig == null ? new JSONObject() : uiConfig;
+    String mode = ui.optString(KEY_PROXY_MODE, MODE_DIRECT).trim();
+    if (mode.isEmpty()) {
+      mode = MODE_DIRECT;
+    }
+    switch (mode) {
+      case MODE_DIRECT:
+      case MODE_SYSTEM:
+        return new Settings(mode, "", 0);
+      case MODE_MANUAL:
+        return manualSettings(ui);
+      default:
+        throw new InvalidNetworkProxyConfigException(KEY_PROXY_MODE, mode);
+    }
+  }
+
+  private static Settings manualSettings(JSONObject ui) {
+    String host = ui.optString(KEY_PROXY_HOST, "").trim();
+    if (host.isEmpty()) {
+      throw new InvalidNetworkProxyConfigException(KEY_PROXY_HOST, host);
+    }
+    int port = parsePort(ui.opt(KEY_PROXY_PORT));
+    if (port < 1 || port > 65535) {
+      throw new InvalidNetworkProxyConfigException(KEY_PROXY_PORT, String.valueOf(port));
+    }
+    return new Settings(MODE_MANUAL, host, port);
+  }
+
+  private static int parsePort(Object rawPort) {
+    if (rawPort instanceof Number) {
+      return ((Number) rawPort).intValue();
+    }
+    if (rawPort instanceof String) {
+      try {
+        return Integer.parseInt(((String) rawPort).trim());
+      } catch (NumberFormatException e) {
+        throw new InvalidNetworkProxyConfigException(KEY_PROXY_PORT, String.valueOf(rawPort));
+      }
+    }
+    throw new InvalidNetworkProxyConfigException(KEY_PROXY_PORT, String.valueOf(rawPort));
+  }
+
+  public static final class InvalidNetworkProxyConfigException extends IllegalArgumentException {
+    InvalidNetworkProxyConfigException(String key, String value) {
+      super("Invalid " + key + ": " + value);
+    }
+  }
+
+  private static final class Settings {
+    final String mode;
+    final String host;
+    final int port;
+
+    Settings(String mode, String host, int port) {
+      this.mode = mode;
+      this.host = host;
+      this.port = port;
+    }
+
+    InetSocketAddress address() {
+      return InetSocketAddress.createUnresolved(host, port);
+    }
+
+    Proxy manualProxy() {
+      return new Proxy(Proxy.Type.HTTP, address());
+    }
+  }
+}

--- a/src/test/java/featurecat/lizzie/ConfigNetworkProxyDefaultsTest.java
+++ b/src/test/java/featurecat/lizzie/ConfigNetworkProxyDefaultsTest.java
@@ -1,0 +1,26 @@
+package featurecat.lizzie;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import featurecat.lizzie.util.NetworkProxy;
+import java.lang.reflect.Method;
+import java.nio.file.Path;
+import org.json.JSONObject;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class ConfigNetworkProxyDefaultsTest {
+  @TempDir Path tempRoot;
+
+  @Test
+  void defaultConfigUsesDirectProxy() throws Exception {
+    Config config = ConfigTestHelper.createForTests(tempRoot);
+    Method createDefaultConfig = Config.class.getDeclaredMethod("createDefaultConfig");
+    createDefaultConfig.setAccessible(true);
+    JSONObject defaults = (JSONObject) createDefaultConfig.invoke(config);
+
+    assertEquals(
+        NetworkProxy.MODE_DIRECT,
+        defaults.getJSONObject("ui").getString(NetworkProxy.KEY_PROXY_MODE));
+  }
+}

--- a/src/test/java/featurecat/lizzie/update/WindowsUpdateServiceTest.java
+++ b/src/test/java/featurecat/lizzie/update/WindowsUpdateServiceTest.java
@@ -1,0 +1,187 @@
+package featurecat.lizzie.update;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import featurecat.lizzie.ConfigTestHelper;
+import featurecat.lizzie.Lizzie;
+import featurecat.lizzie.util.NetworkProxy;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.net.InetAddress;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.MessageDigest;
+import java.util.HexFormat;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.json.JSONObject;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class WindowsUpdateServiceTest {
+  @TempDir Path tempDir;
+
+  @AfterEach
+  void tearDown() {
+    System.clearProperty(WindowsUpdateService.MANIFEST_URL_PROPERTY);
+    System.clearProperty(WindowsUpdatePaths.APP_ROOT_PROPERTY);
+    System.clearProperty(WindowsUpdatePaths.APP_DIR_PROPERTY);
+    System.clearProperty(WindowsUpdatePaths.WORK_DIR_PROPERTY);
+    System.clearProperty(WindowsUpdatePaths.CURRENT_JAR_PROPERTY);
+    Lizzie.config = null;
+  }
+
+  @Test
+  void fetchLatestManifestUsesConfiguredProxy() throws Exception {
+    try (OneShotHttp proxy = new OneShotHttp(UpdateManifestTest.validManifest().toString())) {
+      useManualProxy(proxy.port());
+      System.setProperty(
+          WindowsUpdateService.MANIFEST_URL_PROPERTY, "http://example.invalid/update.json");
+
+      UpdateManifest manifest = new WindowsUpdateService().fetchLatestManifest();
+
+      assertEquals("next-2026-06-12.1", manifest.releaseTag);
+      assertEquals(1, proxy.requests.get());
+      assertTrue(proxy.lastRequestLine.contains("http://example.invalid/update.json"));
+    }
+  }
+
+  @Test
+  void downloadAndPrepareUsesConfiguredProxy() throws Exception {
+    byte[] archive = "downloaded archive".getBytes(StandardCharsets.UTF_8);
+    try (OneShotHttp proxy = new OneShotHttp(archive)) {
+      useManualProxy(proxy.port());
+      WindowsUpdatePlan plan = updatePlan("http://example.invalid/core.zip", archive);
+      configureUpdatePaths();
+
+      Path requestPath = new WindowsUpdateService().downloadAndPrepare(plan, null);
+
+      Path archivePath = requestPath.getParent().resolve("2026-06-12-windows64.core-update.zip");
+      assertEquals("downloaded archive", Files.readString(archivePath));
+      assertEquals(1, proxy.requests.get());
+      assertTrue(proxy.lastRequestLine.contains("http://example.invalid/core.zip"));
+    }
+  }
+
+  @Test
+  void fetchLatestManifestReportsInvalidProxyConfigAsNetworkFailure() {
+    Lizzie.config = ConfigTestHelper.createForTests(tempDir.resolve("config"));
+    Lizzie.config.uiConfig =
+        new JSONObject()
+            .put(NetworkProxy.KEY_PROXY_MODE, NetworkProxy.MODE_MANUAL)
+            .put(NetworkProxy.KEY_PROXY_HOST, " ")
+            .put(NetworkProxy.KEY_PROXY_PORT, 7897);
+    System.setProperty(
+        WindowsUpdateService.MANIFEST_URL_PROPERTY, "http://example.invalid/update.json");
+
+    IOException error =
+        assertThrows(IOException.class, () -> new WindowsUpdateService().fetchLatestManifest());
+
+    assertFalse(error.getMessage().contains("Invalid update manifest"));
+    assertTrue(error.getMessage().contains(NetworkProxy.KEY_PROXY_HOST));
+    assertTrue(error.getMessage().contains("Settings"));
+  }
+
+  private void useManualProxy(int port) {
+    Lizzie.config = ConfigTestHelper.createForTests(tempDir.resolve("config"));
+    Lizzie.config.uiConfig = new JSONObject();
+    Lizzie.config.uiConfig.put(NetworkProxy.KEY_PROXY_MODE, NetworkProxy.MODE_MANUAL);
+    Lizzie.config.uiConfig.put(NetworkProxy.KEY_PROXY_HOST, "127.0.0.1");
+    Lizzie.config.uiConfig.put(NetworkProxy.KEY_PROXY_PORT, port);
+  }
+
+  private WindowsUpdatePlan updatePlan(String downloadUrl, byte[] archive) throws Exception {
+    JSONObject manifest = UpdateManifestTest.validManifest();
+    JSONObject component = manifest.getJSONArray("components").getJSONObject(0);
+    component.put("downloadUrl", downloadUrl);
+    component.put("sizeBytes", archive.length);
+    component.put("sha256", sha256(archive));
+    return WindowsUpdatePlan.create(
+        UpdateManifest.parse(manifest),
+        InstalledUpdateState.empty("next-2026-06-01.1", "windows", "opencl"),
+        "next-2026-06-01.1",
+        "opencl");
+  }
+
+  private void configureUpdatePaths() throws IOException {
+    Path appRoot = Files.createDirectories(tempDir.resolve("app-root"));
+    Path appDir = Files.createDirectories(appRoot.resolve("app"));
+    Path workDir = Files.createDirectories(tempDir.resolve("work"));
+    Path currentJar = appDir.resolve("lizzie-yzy2.5.3-shaded.jar");
+    Files.writeString(currentJar, "old jar");
+    System.setProperty(WindowsUpdatePaths.APP_ROOT_PROPERTY, appRoot.toString());
+    System.setProperty(WindowsUpdatePaths.APP_DIR_PROPERTY, appDir.toString());
+    System.setProperty(WindowsUpdatePaths.WORK_DIR_PROPERTY, workDir.toString());
+    System.setProperty(WindowsUpdatePaths.CURRENT_JAR_PROPERTY, currentJar.toString());
+  }
+
+  private String sha256(byte[] bytes) throws Exception {
+    return HexFormat.of().formatHex(MessageDigest.getInstance("SHA-256").digest(bytes));
+  }
+
+  private static final class OneShotHttp implements AutoCloseable {
+    final AtomicInteger requests = new AtomicInteger();
+    final ServerSocket server;
+    final ExecutorService executor = Executors.newSingleThreadExecutor();
+    final byte[] body;
+    volatile String lastRequestLine = "";
+
+    OneShotHttp(String body) throws IOException {
+      this(body.getBytes(StandardCharsets.UTF_8));
+    }
+
+    OneShotHttp(byte[] body) throws IOException {
+      this.body = body;
+      this.server = new ServerSocket(0, 50, InetAddress.getLoopbackAddress());
+      executor.submit(this::serve);
+    }
+
+    int port() {
+      return server.getLocalPort();
+    }
+
+    private void serve() {
+      try {
+        while (!server.isClosed()) {
+          handle(server.accept());
+        }
+      } catch (IOException ignored) {
+      }
+    }
+
+    private void handle(Socket socket) throws IOException {
+      requests.incrementAndGet();
+      try (socket) {
+        BufferedReader reader =
+            new BufferedReader(
+                new InputStreamReader(socket.getInputStream(), StandardCharsets.US_ASCII));
+        lastRequestLine = reader.readLine();
+        String line;
+        while ((line = reader.readLine()) != null && !line.isEmpty()) {}
+        OutputStream out = socket.getOutputStream();
+        out.write(
+            ("HTTP/1.1 200 OK\r\nContent-Length: "
+                    + body.length
+                    + "\r\nConnection: close\r\n\r\n")
+                .getBytes(StandardCharsets.US_ASCII));
+        out.write(body);
+      }
+    }
+
+    @Override
+    public void close() throws IOException {
+      server.close();
+      executor.shutdownNow();
+    }
+  }
+}

--- a/src/test/java/featurecat/lizzie/util/NetworkProxyInventoryTest.java
+++ b/src/test/java/featurecat/lizzie/util/NetworkProxyInventoryTest.java
@@ -1,0 +1,81 @@
+package featurecat.lizzie.util;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class NetworkProxyInventoryTest {
+  private static final Path MAIN_SOURCES = Path.of("src/main/java");
+  private static final String HELPER = "featurecat/lizzie/util/NetworkProxy.java";
+  private static final String UPDATER = "featurecat/lizzie/update/WindowsUpdateService.java";
+  private static final String ONLINE_DIALOG = "featurecat/lizzie/gui/OnlineDialog.java";
+
+  @Test
+  void outboundJavaNetworkCallersUseNetworkProxyHelper() throws IOException {
+    List<String> violations = new ArrayList<>();
+    try (var paths = Files.walk(MAIN_SOURCES)) {
+      paths
+          .filter(path -> path.toString().endsWith(".java"))
+          .forEach(path -> collectNetworkViolations(path, violations));
+    }
+
+    assertTrue(
+        violations.isEmpty(),
+        "Outbound Java HTTP/WebSocket callers must use NetworkProxy:\n"
+            + String.join("\n", violations));
+  }
+
+  @Test
+  void windowsUpdaterUsesSharedProxyOpener() throws IOException {
+    String source = Files.readString(MAIN_SOURCES.resolve(UPDATER));
+
+    assertTrue(source.contains("NetworkProxy.openConnection("));
+    assertTrue(!source.contains(".toURL().openConnection("));
+  }
+
+  private static void collectNetworkViolations(Path path, List<String> violations) {
+    String relative = MAIN_SOURCES.relativize(path).toString().replace('\\', '/');
+    try {
+      String source = Files.readString(path);
+      boolean onlineDialogConfiguresWebSocket =
+          ONLINE_DIALOG.equals(relative) && source.contains("NetworkProxy.configure(client)");
+      String[] lines = source.split("\\R", -1);
+      for (int i = 0; i < lines.length; i++) {
+        String line = lines[i];
+        if (isNetworkPattern(line)
+            && !isAllowedNetworkPattern(relative, line, onlineDialogConfiguresWebSocket)) {
+          violations.add(relative + ":" + (i + 1) + ": " + line.trim());
+        }
+      }
+    } catch (IOException e) {
+      throw new AssertionError("Failed to read " + path, e);
+    }
+  }
+
+  private static boolean isNetworkPattern(String line) {
+    return line.contains(".openConnection(")
+        || line.contains("Proxy.NO_PROXY")
+        || line.contains("HttpClient.newBuilder()")
+        || line.contains("new OkHttpClient()")
+        || line.contains("new OkHttpClient.Builder()")
+        || line.contains("new WebSocketClient(");
+  }
+
+  private static boolean isAllowedNetworkPattern(
+      String relative, String line, boolean onlineDialogConfiguresWebSocket) {
+    if (HELPER.equals(relative)) {
+      return true;
+    }
+    if (line.contains("NetworkProxy.openConnection(")
+        || line.contains("NetworkProxy.configure(HttpClient.newBuilder())")
+        || line.contains("NetworkProxy.configure(new OkHttpClient.Builder())")) {
+      return true;
+    }
+    return onlineDialogConfiguresWebSocket && line.contains("new WebSocketClient(");
+  }
+}

--- a/src/test/java/featurecat/lizzie/util/NetworkProxyTest.java
+++ b/src/test/java/featurecat/lizzie/util/NetworkProxyTest.java
@@ -1,0 +1,119 @@
+package featurecat.lizzie.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.net.InetSocketAddress;
+import java.net.Proxy;
+import java.net.ProxySelector;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.util.List;
+import okhttp3.OkHttpClient;
+import org.json.JSONObject;
+import org.junit.jupiter.api.Test;
+
+class NetworkProxyTest {
+  @Test
+  void missingKeysDefaultToDirect() {
+    ProxySelector selector = NetworkProxy.proxySelector(new JSONObject());
+
+    assertEquals(List.of(Proxy.NO_PROXY), selector.select(URI.create("https://example.test")));
+  }
+
+  @Test
+  void directModeDoesNotUseDefaultProxySelector() {
+    ProxySelector defaultSelector = ProxySelector.getDefault();
+    ProxySelector selector = NetworkProxy.proxySelector(ui(NetworkProxy.MODE_DIRECT));
+
+    assertNotSame(defaultSelector, selector);
+    assertEquals(List.of(Proxy.NO_PROXY), selector.select(URI.create("https://example.test")));
+  }
+
+  @Test
+  void manualModeUsesConfiguredHttpProxy() throws Exception {
+    Proxy proxy = NetworkProxy.proxyForUrl(URI.create("https://example.test").toURL(), manualUi());
+
+    assertEquals(Proxy.Type.HTTP, proxy.type());
+    assertAddress(proxy, "127.0.0.1", 7897);
+  }
+
+  @Test
+  void rejectsInvalidManualSettings() {
+    assertThrows(
+        NetworkProxy.InvalidNetworkProxyConfigException.class,
+        () ->
+            NetworkProxy.proxySelector(
+                ui(NetworkProxy.MODE_MANUAL).put(NetworkProxy.KEY_PROXY_HOST, " ")));
+    assertThrows(
+        NetworkProxy.InvalidNetworkProxyConfigException.class,
+        () ->
+            NetworkProxy.proxySelector(
+                ui(NetworkProxy.MODE_MANUAL).put(NetworkProxy.KEY_PROXY_PORT, "abc")));
+    assertThrows(
+        NetworkProxy.InvalidNetworkProxyConfigException.class,
+        () ->
+            NetworkProxy.proxySelector(
+                ui(NetworkProxy.MODE_MANUAL).put(NetworkProxy.KEY_PROXY_PORT, 70000)));
+  }
+
+  @Test
+  void rejectsUnknownMode() {
+    assertThrows(
+        NetworkProxy.InvalidNetworkProxyConfigException.class,
+        () -> NetworkProxy.proxySelector(ui("surprise")));
+  }
+
+  @Test
+  void mapsWebSocketUrisForSystemProxyLookup() {
+    assertEquals(
+        URI.create("http://example.test/socket?token=1"),
+        NetworkProxy.systemLookupUriForWebSocket(URI.create("ws://example.test/socket?token=1")));
+    assertEquals(
+        URI.create("https://example.test/socket"),
+        NetworkProxy.systemLookupUriForWebSocket(URI.create("wss://example.test/socket")));
+  }
+
+  @Test
+  void configuresHttpClientBuilder() {
+    HttpClient manualClient = NetworkProxy.configure(HttpClient.newBuilder(), manualUi()).build();
+    Proxy manualProxy =
+        manualClient.proxy().orElseThrow().select(URI.create("https://example.test")).get(0);
+
+    assertAddress(manualProxy, "127.0.0.1", 7897);
+
+    HttpClient directClient =
+        NetworkProxy.configure(HttpClient.newBuilder(), ui(NetworkProxy.MODE_DIRECT)).build();
+    assertEquals(
+        List.of(Proxy.NO_PROXY),
+        directClient.proxy().orElseThrow().select(URI.create("https://example.test")));
+  }
+
+  @Test
+  void configuresOkHttpBuilder() {
+    OkHttpClient manualClient =
+        NetworkProxy.configure(new OkHttpClient.Builder(), manualUi()).build();
+    assertAddress(manualClient.proxy(), "127.0.0.1", 7897);
+
+    OkHttpClient directClient =
+        NetworkProxy.configure(new OkHttpClient.Builder(), ui(NetworkProxy.MODE_DIRECT)).build();
+    assertEquals(Proxy.NO_PROXY, directClient.proxy());
+  }
+
+  private static JSONObject manualUi() {
+    return ui(NetworkProxy.MODE_MANUAL)
+        .put(NetworkProxy.KEY_PROXY_HOST, "127.0.0.1")
+        .put(NetworkProxy.KEY_PROXY_PORT, 7897);
+  }
+
+  private static JSONObject ui(String mode) {
+    return new JSONObject().put(NetworkProxy.KEY_PROXY_MODE, mode);
+  }
+
+  private static void assertAddress(Proxy proxy, String host, int port) {
+    InetSocketAddress address = (InetSocketAddress) proxy.address();
+    assertEquals(host, address.getHostString());
+    assertEquals(port, address.getPort());
+  }
+}

--- a/src/test/java/featurecat/lizzie/util/NetworkProxyTest.java
+++ b/src/test/java/featurecat/lizzie/util/NetworkProxyTest.java
@@ -1,24 +1,50 @@
 package featurecat.lizzie.util;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import featurecat.lizzie.ConfigTestHelper;
+import featurecat.lizzie.Lizzie;
+import java.io.IOException;
+import java.lang.reflect.Field;
 import java.net.InetSocketAddress;
 import java.net.Proxy;
 import java.net.ProxySelector;
 import java.net.URI;
+import java.net.URL;
 import java.net.http.HttpClient;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
 import java.util.List;
 import okhttp3.OkHttpClient;
+import org.java_websocket.client.WebSocketClient;
+import org.java_websocket.handshake.ServerHandshake;
 import org.json.JSONObject;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import sun.misc.Unsafe;
 
 class NetworkProxyTest {
+  @TempDir Path tempDir;
+
+  @AfterEach
+  void tearDown() {
+    Lizzie.config = null;
+    System.clearProperty("java.net.useSystemProxies");
+  }
+
   @Test
-  void missingKeysDefaultToDirect() {
+  void missingKeysDefaultToDirectProxy() {
+    ProxySelector defaultSelector = ProxySelector.getDefault();
     ProxySelector selector = NetworkProxy.proxySelector(new JSONObject());
 
+    assertNotSame(defaultSelector, selector);
     assertEquals(List.of(Proxy.NO_PROXY), selector.select(URI.create("https://example.test")));
   }
 
@@ -50,12 +76,22 @@ class NetworkProxyTest {
         NetworkProxy.InvalidNetworkProxyConfigException.class,
         () ->
             NetworkProxy.proxySelector(
-                ui(NetworkProxy.MODE_MANUAL).put(NetworkProxy.KEY_PROXY_PORT, "abc")));
+                manualUi().put(NetworkProxy.KEY_PROXY_PORT, "abc")));
     assertThrows(
         NetworkProxy.InvalidNetworkProxyConfigException.class,
         () ->
             NetworkProxy.proxySelector(
-                ui(NetworkProxy.MODE_MANUAL).put(NetworkProxy.KEY_PROXY_PORT, 70000)));
+                manualUi().put(NetworkProxy.KEY_PROXY_PORT, 70000)));
+    assertThrows(
+        NetworkProxy.InvalidNetworkProxyConfigException.class,
+        () ->
+            NetworkProxy.proxySelector(
+                manualUi().put(NetworkProxy.KEY_PROXY_PORT, 7897.5)));
+    assertThrows(
+        NetworkProxy.InvalidNetworkProxyConfigException.class,
+        () ->
+            NetworkProxy.proxySelector(
+                manualUi().put(NetworkProxy.KEY_PROXY_PORT, 4294975193L)));
   }
 
   @Test
@@ -63,6 +99,56 @@ class NetworkProxyTest {
     assertThrows(
         NetworkProxy.InvalidNetworkProxyConfigException.class,
         () -> NetworkProxy.proxySelector(ui("surprise")));
+    assertThrows(
+        NetworkProxy.InvalidNetworkProxyConfigException.class,
+        () -> NetworkProxy.proxySelector(ui(" ")));
+  }
+
+  @Test
+  void startupSystemProxyHookIgnoresInvalidManualSettings() {
+    Lizzie.config = ConfigTestHelper.createForTests(tempDir.resolve("config"));
+    Lizzie.config.uiConfig =
+        ui(NetworkProxy.MODE_MANUAL).put(NetworkProxy.KEY_PROXY_HOST, " ");
+
+    assertDoesNotThrow(NetworkProxy::installSystemProxyPropertyFromSavedConfig);
+  }
+
+  @Test
+  void startupSystemProxyHookDefersDirectSelectorInitialization() throws Exception {
+    String javaExecutable =
+        Path.of(
+                System.getProperty("java.home"),
+                "bin",
+                System.getProperty("os.name", "").startsWith("Windows") ? "java.exe" : "java")
+            .toString();
+    String classPath =
+        System.getProperty(
+            "surefire.test.class.path", System.getProperty("java.class.path", ""));
+    Process process =
+        new ProcessBuilder(
+                javaExecutable,
+                "-cp",
+                classPath,
+                StartupProbe.class.getName(),
+                tempDir.resolve("startup-probe").toString())
+            .redirectErrorStream(true)
+            .start();
+    String output = new String(process.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+
+    assertEquals(0, process.waitFor(), output);
+  }
+
+  @Test
+  void publicEntrypointsWrapInvalidStoredConfigAsIOException() throws Exception {
+    Lizzie.config = ConfigTestHelper.createForTests(tempDir.resolve("config"));
+    Lizzie.config.uiConfig =
+        ui(NetworkProxy.MODE_MANUAL).put(NetworkProxy.KEY_PROXY_HOST, " ");
+
+    assertInvalidStoredConfig(() -> NetworkProxy.openConnection(new URL("https://example.test")));
+    assertInvalidStoredConfig(NetworkProxy::proxySelector);
+    assertInvalidStoredConfig(() -> NetworkProxy.configure(HttpClient.newBuilder()));
+    assertInvalidStoredConfig(() -> NetworkProxy.configure(new OkHttpClient.Builder()));
+    assertInvalidStoredConfig(() -> NetworkProxy.configure(testWebSocketClient()));
   }
 
   @Test
@@ -111,9 +197,84 @@ class NetworkProxyTest {
     return new JSONObject().put(NetworkProxy.KEY_PROXY_MODE, mode);
   }
 
+  private static void assertInvalidStoredConfig(IoCallable callable) {
+    IOException error = assertThrows(IOException.class, callable::call);
+
+    assertEquals(NetworkProxy.InvalidNetworkProxyConfigException.class, error.getCause().getClass());
+    assertTrue(error.getMessage().contains(NetworkProxy.KEY_PROXY_HOST));
+    assertTrue(error.getMessage().contains("Settings"));
+  }
+
+  private static WebSocketClient testWebSocketClient() {
+    return new WebSocketClient(URI.create("ws://example.test/socket")) {
+      @Override
+      public void onOpen(ServerHandshake handshake) {}
+
+      @Override
+      public void onMessage(String message) {}
+
+      @Override
+      public void onMessage(ByteBuffer bytes) {}
+
+      @Override
+      public void onClose(int code, String reason, boolean remote) {}
+
+      @Override
+      public void onError(Exception ex) {}
+    };
+  }
+
   private static void assertAddress(Proxy proxy, String host, int port) {
     InetSocketAddress address = (InetSocketAddress) proxy.address();
     assertEquals(host, address.getHostString());
     assertEquals(port, address.getPort());
+  }
+
+  private static Unsafe unsafe() throws ReflectiveOperationException {
+    Field field = Unsafe.class.getDeclaredField("theUnsafe");
+    field.setAccessible(true);
+    return (Unsafe) field.get(null);
+  }
+
+  public static final class StartupProbe {
+    public static void main(String[] args) throws Exception {
+      for (Field field : NetworkProxy.class.getDeclaredFields()) {
+        if (ProxySelector.class.isAssignableFrom(field.getType())) {
+          throw new AssertionError(
+              "NetworkProxy eagerly declares a ProxySelector field: " + field.getName());
+        }
+      }
+
+      Class<?> holder =
+          Class.forName(
+              NetworkProxy.class.getName() + "$DirectSelectorHolder",
+              false,
+              NetworkProxy.class.getClassLoader());
+      Unsafe unsafe = unsafe();
+      if (!unsafe.shouldBeInitialized(holder)) {
+        throw new AssertionError("Direct selector holder initialized before startup hook");
+      }
+
+      Lizzie.config = ConfigTestHelper.createForTests(Path.of(args[0]));
+      Lizzie.config.uiConfig = ui(NetworkProxy.MODE_SYSTEM);
+      NetworkProxy.installSystemProxyPropertyFromSavedConfig();
+
+      if (!"true".equals(System.getProperty("java.net.useSystemProxies"))) {
+        throw new AssertionError("System proxy property was not installed");
+      }
+      if (!unsafe.shouldBeInitialized(holder)) {
+        throw new AssertionError("Startup hook initialized the direct selector holder");
+      }
+
+      Lizzie.config.uiConfig.put(NetworkProxy.KEY_PROXY_MODE, NetworkProxy.MODE_DIRECT);
+      NetworkProxy.proxySelector();
+      if (unsafe.shouldBeInitialized(holder)) {
+        throw new AssertionError("Direct selector holder was not initialized on first use");
+      }
+    }
+  }
+
+  private interface IoCallable {
+    void call() throws IOException;
   }
 }


### PR DESCRIPTION
## Summary

- Add application-level proxy settings with `direct`, `system`, and `manual` modes. The default remains direct connections.
- Route Java-side update checks/downloads, model/runtime downloads, API requests, `HttpClient`, OkHttp, and Java-WebSocket connections through a shared `NetworkProxy` helper.
- Reject invalid saved proxy configurations during network operations instead of silently falling back to direct connections.
- Initialize JVM system-proxy support before the default `ProxySelector` is created, so Windows system proxy settings work after restart.
- Add settings UI, validation, design documentation, implementation notes, and source-inventory regression coverage.

## Where Proxy Settings Apply

The selected proxy mode applies to Java-side HTTP and WebSocket traffic created by the application, including:

- Windows update manifest checks and update package downloads.
- KataGo weight downloads, HumanSL models, TensorRT packages, NVIDIA runtime packages, mirror probes, and release metadata.
- Fox, Tencent, and Yike Java API requests and SGF downloads.
- Zhizi cloud compute and self-hosted remote compute connections using Java `HttpClient`, Java-WebSocket, OkHttp, and Socket.IO.
- Existing requests through `AjaxHttpRequest`.
- Future Java HTTP/WebSocket features that use the shared `NetworkProxy` helper.

Mode behavior:

- `direct`: explicitly bypasses system and manual proxies.
- `system`: uses the JVM system proxy selector. Switching to or from this mode requires restarting the application.
- `manual`: routes supported traffic through the configured HTTP proxy host and port.
- Invalid proxy configuration causes the network operation to fail with a configuration error; it does not silently retry with a direct connection.
- Existing long-lived remote-compute connections may need to be reconnected after changing the proxy mode.

The setting does not currently control:

- External browser windows opened by the application.
- External KataGo or other engine processes.
- JCEF/Chromium traffic.
- Legacy raw `java.net.Socket` protocols.
- SOCKS, PAC, proxy authentication, or per-host bypass rules.

## Type Of Change

- [ ] Bug fix
- [x] Feature
- [ ] Packaging / release update
- [x] Docs / translation
- [ ] Refactor

## Testing

- [x] Tested locally
- [ ] Verified package contents if packaging changed
- [ ] Verified Fox sync flow if related
- [ ] Added screenshots if UI changed
- [x] Updated README / docs if user-facing behavior changed
- [x] Noted affected platforms if the change is platform-specific

Validation performed:

- Windows full build: `mvn -Dfmt.skip=true package`
  - 1081 tests, 0 failures, 0 errors, 1 skipped
  - Shaded JAR built successfully with JDK 21
- Focused proxy/update suite:
  - `NetworkProxyTest`
  - `NetworkProxyInventoryTest`
  - `ConfigNetworkProxyDefaultsTest`
  - `WindowsUpdateServiceTest`
  - 17 tests, 0 failures
- Windows real-machine system proxy test with `127.0.0.1:7897` confirmed update-manifest traffic passed through the configured proxy.
- `git diff --check upstream/main` passed.

## Notes

- System proxy mode requires an application restart because the JVM system-proxy property must be installed before the default `ProxySelector` is initialized.
- This does not add proxy authentication, PAC parsing, SOCKS support, per-host bypass rules, or proxy support for external engine processes.
- Raw legacy socket protocols remain direct as documented in the design specification.
- The settings UI was validated locally, but screenshots are not embedded in this PR.
