### PR TITLE
Fix settings font initialization crash

### DIFF
--- a/src/main/java/featurecat/lizzie/util/Utils.java
+++ b/src/main/java/featurecat/lizzie/util/Utils.java
@@ -1443,8 +1443,15 @@ public class Utils {
   }
 
   public static void changeFontRecursive(Container root, String fontName) {
+    String resolvedFontName =
+        fontName == null || fontName.isBlank() ? Font.DIALOG : fontName;
+    Font inheritedFont = root.getFont();
     for (Component c : root.getComponents()) {
-      c.setFont(new Font(fontName, c.getFont().getStyle(), c.getFont().getSize()));
+      Font currentFont = c.getFont();
+      Font referenceFont = currentFont != null ? currentFont : inheritedFont;
+      int style = referenceFont == null ? Font.PLAIN : referenceFont.getStyle();
+      int size = referenceFont == null ? 12 : Math.max(1, referenceFont.getSize());
+      c.setFont(new Font(resolvedFontName, style, size));
       if (c instanceof Container) {
         changeFontRecursive((Container) c, fontName);
       }

--- a/src/test/java/featurecat/lizzie/util/UtilsFontTest.java
+++ b/src/test/java/featurecat/lizzie/util/UtilsFontTest.java
@@ -1,0 +1,32 @@
+package featurecat.lizzie.util;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.awt.Component;
+import java.awt.Container;
+import java.awt.Font;
+import org.junit.jupiter.api.Test;
+
+class UtilsFontTest {
+  @Test
+  void changesFontWhenNestedComponentsDoNotHaveAnInheritedFont() {
+    Container root = new Container();
+    Container nested = new Container();
+    Component leaf = new Component() {};
+    root.add(nested);
+    nested.add(leaf);
+
+    assertNull(nested.getFont());
+    assertNull(leaf.getFont());
+
+    assertDoesNotThrow(() -> Utils.changeFontRecursive(root, Font.DIALOG));
+
+    assertNotNull(nested.getFont());
+    assertNotNull(leaf.getFont());
+    assertEquals(Font.DIALOG, nested.getFont().getName());
+    assertEquals(Font.DIALOG, leaf.getFont().getName());
+  }
+}


### PR DESCRIPTION
## Summary

- make recursive UI font application tolerate components without an inherited font
- preserve each component style and size when available, with a safe Swing fallback
- add a regression test for nested AWT components whose font is initially null

## Why

A real packaged-app smoke test after PR #97 found that opening **综合设置** with `Shift+X` could throw an EDT `NullPointerException` in `Utils.changeFontRecursive()` before the dialog became visible. Newly added controls exposed a long-standing assumption that every child component has a non-null font.

## Validation

- `mvn -B -Dfmt.skip=true -Dtest=UtilsFontTest,NetworkProxyTest,ConfigNetworkProxyDefaultsTest test` (13 passed)
- `mvn -B -Dfmt.skip=true test` (1082 passed)
- `mvn -B -Dfmt.skip=true -DskipTests package`
- `python3 scripts/check_markdown_links.py`
- `git diff --check`
- rebuilt and launched a temporary macOS app image; `Shift+X` opens 综合设置 without an EDT exception
