### PR TITLE
Replace current winrate guide with a red marker

### DIFF
--- a/src/main/java/featurecat/lizzie/gui/WinrateGraph.java
+++ b/src/main/java/featurecat/lizzie/gui/WinrateGraph.java
@@ -121,6 +121,10 @@ public class WinrateGraph {
 
   private int DOT_RADIUS = 3;
   private static final int GRAPH_ANCHOR_HIT_HALF_SIZE = 2;
+  private static final int CURRENT_MOVE_MARKER_RADIUS = 4;
+  private static final Color CURRENT_MOVE_MARKER_COLOR = new Color(244, 67, 72);
+  private static final Color CURRENT_MOVE_MARKER_BORDER = new Color(112, 24, 28, 230);
+  private static final Color CURRENT_MOVE_MARKER_HALO = new Color(255, 250, 240, 225);
   private int[] origParams = {0, 0, 0, 0};
   private int[] params = {0, 0, 0, 0, 0};
   public BoardHistoryNode mouseOverNode;
@@ -164,7 +168,35 @@ public class WinrateGraph {
   }
 
   private Color winrateGuideColor(int alpha) {
-    return withAlpha(winrateLineColor(), alpha);
+    return new Color(232, 225, 210, clamp(alpha, 0, 255));
+  }
+
+  private void drawCurrentMoveMarker(Graphics2D g, int centerX, int centerY, int radius) {
+    int markerRadius = Math.max(3, radius);
+    int haloRadius = markerRadius + 2;
+    Paint previousPaint = g.getPaint();
+    Stroke previousStroke = g.getStroke();
+    g.setColor(CURRENT_MOVE_MARKER_HALO);
+    g.fillOval(
+        centerX - haloRadius,
+        centerY - haloRadius,
+        haloRadius * 2,
+        haloRadius * 2);
+    g.setColor(CURRENT_MOVE_MARKER_COLOR);
+    g.fillOval(
+        centerX - markerRadius,
+        centerY - markerRadius,
+        markerRadius * 2,
+        markerRadius * 2);
+    g.setColor(CURRENT_MOVE_MARKER_BORDER);
+    g.setStroke(new BasicStroke(1f));
+    g.drawOval(
+        centerX - markerRadius,
+        centerY - markerRadius,
+        markerRadius * 2,
+        markerRadius * 2);
+    g.setPaint(previousPaint);
+    g.setStroke(previousStroke);
   }
 
   private static Color withAlpha(Color color, int alpha) {
@@ -380,45 +412,6 @@ public class WinrateGraph {
       int saveCurMovenum = 0;
       double saveCurWr = 0;
       if (numMoves < 2) return;
-      Stroke previousStroke = g.getStroke();
-      int x =
-          posx
-              + ((Lizzie.board.getHistory().getCurrentHistoryNode().getData().moveNumber - 1)
-                  * width
-                  / numMoves);
-      g.setStroke(new BasicStroke(2));
-      g.setColor(winrateGuideColor(200));
-      // if (Lizzie.board.getHistory().getCurrentHistoryNode() !=
-      // Lizzie.board.getHistory().getEnd())
-      g.drawLine(x, posy, x, posy + height);
-      g.setStroke(previousStroke);
-      String moveNumString =
-          String.valueOf(Lizzie.board.getHistory().getCurrentHistoryNode().getData().moveNumber);
-      //  int mw = g.getFontMetrics().stringWidth(moveNumString);
-      int margin = strokeRadius;
-      //      int mx = x - posx < width / 2 ? x + margin : x - mw - margin;
-      //      if (node.getData().blackToPlay) {
-      //
-      //      } else {
-      //        g.setColor(Color.BLACK);
-      //      }
-      g.setColor(Color.WHITE);
-      if (Lizzie.board.getHistory().getCurrentHistoryNode() != Lizzie.board.getHistory().getEnd()) {
-        Font f =
-            new Font(Config.sysDefaultFontName, Font.BOLD, largeEnough ? Utils.zoomOut(12) : 12);
-        g.setFont(f);
-        g.setColor(Color.WHITE);
-        int moveNum = Lizzie.board.getHistory().getCurrentHistoryNode().getData().moveNumber;
-        if (moveNum < 10)
-          g.drawString(
-              moveNumString, moveNum < numMoves / 2 ? x + 3 : x - 10, posy + height - margin);
-        else if (Lizzie.board.getHistory().getCurrentHistoryNode().getData().moveNumber > 99)
-          g.drawString(
-              moveNumString, moveNum < numMoves / 2 ? x + 3 : x - 22, posy + height - margin);
-        else
-          g.drawString(
-              moveNumString, moveNum < numMoves / 2 ? x + 3 : x - 16, posy + height - margin);
-      }
       while (node.previous().isPresent() && node.previous().get().previous().isPresent()) {
         BoardHistoryNode twoBackNode = node.previous().get().previous().get();
         int currentMoveIndex = node.getData().moveNumber - 1;
@@ -666,65 +659,6 @@ public class WinrateGraph {
             } else {
               score = lastScore;
             }
-            if (node == curMove) {
-              // Draw a vertical line at the current move
-              Stroke previousStroke = g.getStroke();
-              int x = posx + (movenum * width / numMoves);
-              g.setStroke(new BasicStroke(2));
-              g.setColor(winrateGuideColor(200));
-              g.drawLine(x, posy, x, posy + height);
-              // Show move number
-              String moveNumString = String.valueOf(node.getData().moveNumber);
-              //    int mw = g.getFontMetrics().stringWidth(moveNumString);
-              int margin = strokeRadius;
-              // int mx = x - posx < width / 2 ? x + margin : x - mw - margin;
-              if (!noC) {
-                Font f =
-                    new Font(
-                        Config.sysDefaultFontName, Font.BOLD, largeEnough ? Utils.zoomOut(12) : 12);
-                g.setFont(f);
-                g.setColor(Color.WHITE);
-                int moveNum = node.getData().moveNumber;
-                if (wr < 3) {
-                  int fontHeight = g.getFontMetrics().getAscent() - g.getFontMetrics().getDescent();
-                  if (moveNum < 10)
-                    g.drawString(
-                        moveNumString,
-                        moveNum < numMoves / 2 ? x + 3 : x - 10,
-                        posy + fontHeight - margin);
-                  else if (Lizzie.board.getHistory().getCurrentHistoryNode().getData().moveNumber
-                      > 99)
-                    g.drawString(
-                        moveNumString,
-                        moveNum < numMoves / 2 ? x + 3 : x - 22,
-                        posy + fontHeight - margin);
-                  else
-                    g.drawString(
-                        moveNumString,
-                        moveNum < numMoves / 2 ? x + 3 : x - 16,
-                        posy + fontHeight - margin);
-                } else {
-                  if (moveNum < 10)
-                    g.drawString(
-                        moveNumString,
-                        moveNum < numMoves / 2 ? x + 3 : x - 10,
-                        posy + height - margin);
-                  else if (Lizzie.board.getHistory().getCurrentHistoryNode().getData().moveNumber
-                      > 99)
-                    g.drawString(
-                        moveNumString,
-                        moveNum < numMoves / 2 ? x + 3 : x - 22,
-                        posy + height - margin);
-                  else
-                    g.drawString(
-                        moveNumString,
-                        moveNum < numMoves / 2 ? x + 3 : x - 16,
-                        posy + height - margin);
-                }
-              }
-              g.setStroke(previousStroke);
-            }
-
             // if (Lizzie.frame.isPlayingAgainstLeelaz
             // && Lizzie.frame.playerIsBlack == !node.getData().blackToPlay) {
             // wr = lastWr;
@@ -808,42 +742,6 @@ public class WinrateGraph {
             lastOkMove = lastNodeOk ? movenum : -1;
           } else {
             lastNodeOk = false;
-            if (node == curMove) {
-              // Draw a vertical line at the current move
-              Stroke previousStroke = g.getStroke();
-              int x = posx + (movenum * width / numMoves);
-              g.setStroke(new BasicStroke(2));
-              g.setColor(winrateGuideColor(200));
-              g.drawLine(x, posy, x, posy + height);
-              // Show move number
-              if (!noC) {
-                String moveNumString = "" + node.getData().moveNumber;
-                g.setFont(
-                    new Font(
-                        Config.sysDefaultFontName,
-                        Font.BOLD,
-                        largeEnough ? Utils.zoomOut(12) : 12));
-                g.setColor(Color.WHITE);
-                int moveNum = node.getData().moveNumber;
-                if (moveNum < 10)
-                  g.drawString(
-                      moveNumString,
-                      moveNum < numMoves / 2 ? x + 3 : x - 10,
-                      posy + height - strokeRadius);
-                else if (Lizzie.board.getHistory().getCurrentHistoryNode().getData().moveNumber
-                    > 99)
-                  g.drawString(
-                      moveNumString,
-                      moveNum < numMoves / 2 ? x + 3 : x - 22,
-                      posy + height - strokeRadius);
-                else
-                  g.drawString(
-                      moveNumString,
-                      moveNum < numMoves / 2 ? x + 3 : x - 16,
-                      posy + height - strokeRadius);
-              }
-              g.setStroke(previousStroke);
-            }
           }
 
           if (mouseOverNode != null && node == mouseOverNode) {
@@ -914,51 +812,6 @@ public class WinrateGraph {
           double wr = node.getData().winrate;
           double score = node.getData().scoreMean;
           int playouts = node.getData().getPlayouts();
-          if (node == curMove) {
-            //            if (Lizzie.config.dynamicWinrateGraphWidth
-            //                && node.getData().moveNumber - 1 > this.numMovesOfPlayed) {
-            //              this.numMovesOfPlayed = node.getData().moveNumber - 1;
-            //              numMoves = this.numMovesOfPlayed;
-            //            }
-            // Draw a vertical line at the current move
-            // Stroke previousStroke = g.getStroke();
-            Stroke previousStroke = g.getStroke();
-            int x = posx + (currentMoveIndex * width / numMoves);
-            g.setStroke(new BasicStroke(2));
-            g.setColor(winrateGuideColor(200));
-            if (curMove != Lizzie.board.getHistory().getEnd())
-              g.drawLine(x, posy, x, posy + height);
-
-            // Show move number
-            String moveNumString = "" + node.getData().moveNumber;
-            //   int mw = g.getFontMetrics().stringWidth(moveNumString);
-            int margin = strokeRadius;
-            //       int mx = x - posx < width / 2 ? x + margin : x - mw - margin;
-            //            if (node.getData().blackToPlay) {
-            //              g.setColor(Color.WHITE);
-            //            } else {
-            //              g.setColor(Color.BLACK);
-            //            }
-            if (Lizzie.board.getHistory().getCurrentHistoryNode()
-                != Lizzie.board.getHistory().getEnd()) {
-              Font f =
-                  new Font(
-                      Config.sysDefaultFontName, Font.BOLD, largeEnough ? Utils.zoomOut(12) : 12);
-              g.setFont(f);
-              g.setColor(Color.WHITE);
-              int moveNum = Lizzie.board.getHistory().getCurrentHistoryNode().getData().moveNumber;
-              if (moveNum < 10)
-                g.drawString(
-                    moveNumString, moveNum < numMoves / 2 ? x + 3 : x - 10, posy + height - margin);
-              else if (Lizzie.board.getHistory().getCurrentHistoryNode().getData().moveNumber > 99)
-                g.drawString(
-                    moveNumString, moveNum < numMoves / 2 ? x + 3 : x - 22, posy + height - margin);
-              else
-                g.drawString(
-                    moveNumString, moveNum < numMoves / 2 ? x + 3 : x - 16, posy + height - margin);
-            }
-            g.setStroke(previousStroke);
-          }
           if (playouts > 0) {
             if (wr < 0) {
               wr = 100 - lastWr;
@@ -1578,6 +1431,7 @@ public class WinrateGraph {
     BoardHistoryNode graphBaseNode = curMove;
     List<GraphPoint> renderedAnchors = buildGraphAnchorPoints(graphBaseNode);
     drawGraphAnchors(g, renderedAnchors);
+    drawMainCurrentMoveMarker(g, renderedAnchors, graphBaseNode);
     QuickOverviewLayout quickOverviewLayout =
         drawQuickOverview(g, gBlunder, gBackground, curMove, posx, width, numMoves);
     rememberRenderedPointSources(quickOverviewLayout, renderedAnchors);
@@ -1726,18 +1580,8 @@ public class WinrateGraph {
     QuickOverviewPoint currentPoint = findQuickOverviewPoint(layout.points, curMove);
     QuickOverviewPoint hoverPoint = findQuickOverviewPoint(layout.points, mouseOverNode);
 
-    if (currentPoint != null) {
-      g.setColor(new Color(255, 255, 255, 170));
-      g.drawLine(currentPoint.x, layout.innerY, currentPoint.x, layout.innerY + layout.innerHeight);
-      g.fillOval(
-          currentPoint.x - layout.dotSize / 2,
-          currentPoint.y - layout.dotSize / 2,
-          layout.dotSize,
-          layout.dotSize);
-    }
-
     if (hoverPoint != null) {
-      g.setColor(new Color(61, 204, 255, 230));
+      g.setColor(winrateGuideColor(210));
       g.drawLine(hoverPoint.x, layout.innerY, hoverPoint.x, layout.innerY + layout.innerHeight);
       g.fillOval(
           hoverPoint.x - layout.dotSize / 2,
@@ -1751,6 +1595,13 @@ public class WinrateGraph {
           layout.overviewY,
           layout.innerX,
           layout.innerX + layout.innerWidth);
+    }
+    if (currentPoint != null) {
+      drawCurrentMoveMarker(
+          g,
+          currentPoint.x,
+          currentPoint.y,
+          Math.max(3, layout.dotSize / 2 + 1));
     }
     return layout;
   }
@@ -2105,13 +1956,29 @@ public class WinrateGraph {
     if (params[2] <= 0 || params[3] <= 0 || params[4] <= 0 || currentNode == null) {
       return Collections.emptyList();
     }
+    List<GraphPoint> points;
     if (isEngineOrPkGraphMode()) {
-      return buildEngineGraphAnchorPoints(currentNode);
+      points = buildEngineGraphAnchorPoints(currentNode);
+    } else if (mode == 1) {
+      points = buildDualCurveGraphAnchorPoints(currentNode);
+    } else {
+      points = buildDefaultGraphAnchorPoints(currentNode);
     }
-    if (mode == 1) {
-      return buildDualCurveGraphAnchorPoints(currentNode);
+    return includeCurrentMoveMarkerPoint(points, currentNode);
+  }
+
+  private List<GraphPoint> includeCurrentMoveMarkerPoint(
+      List<GraphPoint> points, BoardHistoryNode currentNode) {
+    if (findGraphPoint(points, currentNode) != null) {
+      return points;
     }
-    return buildDefaultGraphAnchorPoints(currentNode);
+    GraphPoint markerPoint = currentMoveMarkerPoint(points, currentNode);
+    if (markerPoint == null) {
+      return points;
+    }
+    ArrayList<GraphPoint> pointsWithMarker = new ArrayList<>(points);
+    pointsWithMarker.add(markerPoint);
+    return pointsWithMarker;
   }
 
   private List<GraphPoint> buildDefaultGraphAnchorPoints(BoardHistoryNode currentNode) {
@@ -2807,6 +2674,37 @@ public class WinrateGraph {
     if (targetNode == null) return null;
     for (GraphPoint point : points) {
       if (point.node == targetNode) return point;
+    }
+    return null;
+  }
+
+  private void drawMainCurrentMoveMarker(
+      Graphics2D g, List<GraphPoint> points, BoardHistoryNode currentNode) {
+    GraphPoint point = currentMoveMarkerPoint(points, currentNode);
+    if (point != null) {
+      drawCurrentMoveMarker(g, point.x, point.y, CURRENT_MOVE_MARKER_RADIUS);
+    }
+  }
+
+  private GraphPoint currentMoveMarkerPoint(
+      List<GraphPoint> points, BoardHistoryNode currentNode) {
+    GraphPoint exactPoint = findGraphPoint(points, currentNode);
+    if (exactPoint != null) {
+      return exactPoint;
+    }
+    if (currentNode == null || currentNode.getData() == null) {
+      return null;
+    }
+    BoardHistoryNode fallbackNode = currentNode;
+    while (fallbackNode.previous().isPresent()) {
+      fallbackNode = fallbackNode.previous().get();
+      GraphPoint fallbackPoint = findGraphPoint(points, fallbackNode);
+      if (fallbackPoint != null) {
+        return new GraphPoint(
+            currentNode,
+            graphPointX(currentNode.getData().moveNumber),
+            fallbackPoint.y);
+      }
     }
     return null;
   }

--- a/src/test/java/featurecat/lizzie/gui/WinrateGraphEnginePkModeHitTest.java
+++ b/src/test/java/featurecat/lizzie/gui/WinrateGraphEnginePkModeHitTest.java
@@ -35,6 +35,50 @@ class WinrateGraphEnginePkModeHitTest {
   private static final Color CUSTOM_WINRATE_COLOR = new Color(20, 210, 95);
   private static final Color CUSTOM_MISS_COLOR = new Color(220, 90, 30);
   private static final Color CUSTOM_BLUNDER_COLOR = new Color(180, 30, 220, 255);
+  private static final Color CURRENT_MOVE_MARKER_COLOR = new Color(244, 67, 72);
+
+  @Test
+  void currentMoveUsesRedPointWithoutVerticalGuideInDefaultMode() throws Exception {
+    TestEnvironment env = TestEnvironment.open();
+    try {
+      RenderFixture fixture = modeZeroFixture();
+      fixture.board.isPkBoard = false;
+      EngineManager.isEngineGame = false;
+
+      assertCurrentMoveUsesPointOnly(fixture, false);
+    } finally {
+      env.close();
+    }
+  }
+
+  @Test
+  void currentMoveUsesRedPointWithoutVerticalGuideInEngineGame() throws Exception {
+    TestEnvironment env = TestEnvironment.open();
+    try {
+      RenderFixture fixture = modeZeroFixture();
+      fixture.board.isPkBoard = false;
+      EngineManager.isEngineGame = true;
+
+      assertCurrentMoveUsesPointOnly(fixture, false);
+    } finally {
+      env.close();
+    }
+  }
+
+  @Test
+  void pendingCurrentMoveUsesItsOwnColumnWithoutVerticalGuideInDualCurveMode()
+      throws Exception {
+    TestEnvironment env = TestEnvironment.open();
+    try {
+      RenderFixture fixture = modeOneFixture();
+      fixture.board.isPkBoard = false;
+      EngineManager.isEngineGame = false;
+
+      assertCurrentMoveUsesPointOnly(fixture, true);
+    } finally {
+      env.close();
+    }
+  }
 
   @Test
   void engineGameClickAndDragUseRenderedDotPixel() throws Exception {
@@ -533,6 +577,28 @@ class WinrateGraphEnginePkModeHitTest {
         "drag should follow the rendered pixel to the exact target node.");
   }
 
+  private static void assertCurrentMoveUsesPointOnly(
+      RenderFixture fixture, boolean assertCurrentColumn) throws Exception {
+    RenderLayers layers = renderLayers(fixture.graph);
+    int[] marker = renderedCurrentMoveMarkerPoint(fixture.graph, fixture.current);
+
+    assertNotNull(marker, "the current move should have a visible marker point.");
+    assertColorNear(layers.winrate, marker, CURRENT_MOVE_MARKER_COLOR, 2);
+    assertTrue(
+        longestOpaqueRunOutsideMarker(layers.winrate, marker[0], marker[1], 8) < 15,
+        "the current move column should not contain a full-height guide line.");
+    assertSame(
+        fixture.current,
+        fixture.graph.resolveMoveTargetNode(marker[0], marker[1]),
+        "the visible current marker should resolve to the current node.");
+    if (assertCurrentColumn) {
+      assertEquals(
+          graphPointX(fixture.graph, fixture.current.getData().moveNumber),
+          marker[0],
+          "a pending current move should stay on its own move column.");
+    }
+  }
+
   private static RenderFixture modeZeroFixture() throws Exception {
     TrackingBoard board = allocate(TrackingBoard.class);
     board.startStonelist = new ArrayList<>();
@@ -697,6 +763,34 @@ class WinrateGraphEnginePkModeHitTest {
     return (int[]) method.invoke(graph, node);
   }
 
+  @SuppressWarnings("unchecked")
+  private static int[] renderedCurrentMoveMarkerPoint(
+      WinrateGraph graph, BoardHistoryNode currentNode) throws Exception {
+    Method method =
+        WinrateGraph.class.getDeclaredMethod(
+            "currentMoveMarkerPoint", java.util.List.class, BoardHistoryNode.class);
+    method.setAccessible(true);
+    Object point =
+        method.invoke(
+            graph,
+            (java.util.List<Object>) getField(graph, "renderedGraphPoints"),
+            currentNode);
+    if (point == null) {
+      return null;
+    }
+    Field xField = point.getClass().getDeclaredField("x");
+    Field yField = point.getClass().getDeclaredField("y");
+    xField.setAccessible(true);
+    yField.setAccessible(true);
+    return new int[] {xField.getInt(point), yField.getInt(point)};
+  }
+
+  private static int graphPointX(WinrateGraph graph, int moveNumber) throws Exception {
+    Method method = WinrateGraph.class.getDeclaredMethod("graphPointX", int.class);
+    method.setAccessible(true);
+    return (int) method.invoke(graph, moveNumber);
+  }
+
   private static BufferedImage renderGraphLayer(WinrateGraph graph) {
     return renderLayers(graph).winrate;
   }
@@ -736,6 +830,25 @@ class WinrateGraphEnginePkModeHitTest {
       }
     }
     throw new AssertionError("expected color near point: " + expected);
+  }
+
+  private static int longestOpaqueRunOutsideMarker(
+      BufferedImage image, int x, int markerY, int markerClearance) {
+    int longest = 0;
+    int current = 0;
+    for (int y = 0; y < image.getHeight(); y++) {
+      if (Math.abs(y - markerY) <= markerClearance) {
+        current = 0;
+        continue;
+      }
+      if (new Color(image.getRGB(x, y), true).getAlpha() > 0) {
+        current++;
+        longest = Math.max(longest, current);
+      } else {
+        current = 0;
+      }
+    }
+    return longest;
   }
 
   private static void assertColorPresent(BufferedImage image, Color expected) {

--- a/src/test/java/featurecat/lizzie/gui/WinrateGraphVariationHitTest.java
+++ b/src/test/java/featurecat/lizzie/gui/WinrateGraphVariationHitTest.java
@@ -34,7 +34,6 @@ class WinrateGraphVariationHitTest {
   private static final int GRAPH_NUM_MOVES = 4;
   private static final int RENDER_WIDTH = 240;
   private static final int RENDER_HEIGHT = 120;
-  private static final double FALLBACK_CURRENT_WINRATE = 50.0;
 
   @Test
   void hoverKeepsVariationCurrentNodeReachable() throws Exception {
@@ -408,7 +407,7 @@ class WinrateGraphVariationHitTest {
   }
 
   @Test
-  void hoverIgnoresRenderedVariationFallbackPixelWhenNoAnchorExists() throws Exception {
+  void hoverIgnoresVariationCurrentColumnWhenWinrateLineIsHidden() throws Exception {
     TestEnvironment env = TestEnvironment.open();
     try {
       VariationFixture fixture = boardWithFallbackVariationCurrent();
@@ -419,8 +418,21 @@ class WinrateGraphVariationHitTest {
       LizzieFrame.winrateGraph = graph;
       Lizzie.config.showWinrateLine = false;
 
+      BufferedImage winrateLayer = renderGraph(graph);
+      int[] graphParams = (int[]) getField(graph, "params");
       int[] point =
-          renderedCurrentDotLeftPixel(graph, fixture.variationCurrent, FALLBACK_CURRENT_WINRATE);
+          new int[] {
+            graphParams[0]
+                + (fixture.variationCurrent.getData().moveNumber - 1)
+                    * graphParams[2]
+                    / graphParams[4],
+            graphParams[1] + graphParams[3] / 2
+          };
+
+      assertEquals(
+          0,
+          new Color(winrateLayer.getRGB(point[0], point[1]), true).getAlpha(),
+          "hiding the winrate line should leave the current column free of marker pixels.");
 
       graph.clearMouseOverNode();
       boolean handled = frame.processMouseMoveOnWinrateGraph(point[0], point[1]);
@@ -614,16 +626,6 @@ class WinrateGraphVariationHitTest {
     method.invoke(graph, new Object[] {null});
   }
 
-  private static int[] renderedCurrentDotLeftPixel(
-      WinrateGraph graph, BoardHistoryNode node, double displayedWinrate) throws Exception {
-    BufferedImage winrateLayer = renderGraph(graph);
-    int[] graphParams = (int[]) getField(graph, "params");
-    int centerX =
-        graphParams[0] + (node.getData().moveNumber - 1) * graphParams[2] / graphParams[4];
-    int centerY = graphParams[1] + graphParams[3] - (int) (displayedWinrate * graphParams[3] / 100);
-    return opaquePixelInsideLeftHalf(winrateLayer, centerX, centerY);
-  }
-
   private static int[] renderedVisiblePixelNearNode(WinrateGraph graph, BoardHistoryNode node)
       throws Exception {
     graph.setMouseOverNode(node);
@@ -744,30 +746,6 @@ class WinrateGraphVariationHitTest {
         start,
         fixture.board.getHistory().getCurrentHistoryNode(),
         label + " pixel should miss drag.");
-  }
-
-  private static int[] opaquePixelInsideLeftHalf(BufferedImage image, int centerX, int centerY) {
-    for (int radius = 0; radius <= 4; radius++) {
-      int up = centerY - radius;
-      if (up >= 0) {
-        for (int x = Math.max(0, centerX - 3); x <= centerX; x++) {
-          Color pixel = new Color(image.getRGB(x, up), true);
-          if (pixel.getAlpha() > 0) {
-            return new int[] {x, up};
-          }
-        }
-      }
-      int down = centerY + radius;
-      if (down < image.getHeight()) {
-        for (int x = Math.max(0, centerX - 3); x <= centerX; x++) {
-          Color pixel = new Color(image.getRGB(x, down), true);
-          if (pixel.getAlpha() > 0) {
-            return new int[] {x, down};
-          }
-        }
-      }
-    }
-    throw new AssertionError("expected the rendered current point to paint an opaque pixel.");
   }
 
   private static int[] foregroundPixelResolvingToNode(


### PR DESCRIPTION
## Summary

- replaces the full-height blue current-move guide with a compact red point inspired by KaTrain
- applies the marker consistently to the normal graph, dual-curve mode, engine/PK mode, and quick overview
- keeps pending current moves on their own move column and makes the visible marker clickable/hoverable
- changes the temporary hover guide to a neutral warm gray so it cannot be mistaken for the winrate curve

## Validation

- `mvn -B -Dfmt.skip=true -Dtest='WinrateGraph*Test' test` (69 tests passed)
- `mvn -B -Dfmt.skip=true test` (1106 tests passed)
- `mvn -B -Dfmt.skip=true -DskipTests package` (passed)
- `git diff --check` (passed)
- offscreen Swing render verified the red point and absence of a full-height current-move guide
