### PR TITLE
fix(readboard): integrate clear-board and analysis-state protocols

### DIFF
--- a/src/main/java/featurecat/lizzie/analysis/ReadBoard.java
+++ b/src/main/java/featurecat/lizzie/analysis/ReadBoard.java
@@ -545,10 +545,8 @@ public class ReadBoard {
             String rawLine = line.toString();
             logReadBoardOutputLine(rawLine);
             parseLine(rawLine);
-            if (!isLoaded) {
-              isLoaded = true;
-              checkVersion();
-              announceHostedUpdateSupport();
+            if ("ready".equals(rawLine.trim())) {
+              handleReady();
             }
           } catch (Exception ex) {
             ex.printStackTrace();
@@ -714,11 +712,14 @@ public class ReadBoard {
       tempcount = new ArrayList<Integer>();
       publishCurrentReadBoardDiagnosticsSnapshot();
     }
-    if (line.startsWith("clear")) {
+    if (line.trim().equals("clear")) {
       resetActiveSyncStateForReadBoardControlLine();
       clearPendingRemoteContext();
       tempcount = new ArrayList<Integer>();
       publishCurrentReadBoardDiagnosticsSnapshot();
+    }
+    if (line.trim().equals("clearBoard")) {
+      runOnEdtAndWait(() -> Lizzie.board.clear(false));
     }
     if (line.startsWith("start")) {
       clearPendingRemoteContext();
@@ -922,7 +923,7 @@ public class ReadBoard {
       }
     }
 
-    if (line.startsWith("noponder")) {
+    if (line.trim().equals("noponder")) {
       clearReadBoardGmaAutoPlay("noponder");
       if (Lizzie.frame.isPlayingAgainstLeelaz) {
         Lizzie.frame.isPlayingAgainstLeelaz = false;
@@ -932,6 +933,16 @@ public class ReadBoard {
         Lizzie.frame.stopAiPlayingAndPolicy();
       }
       stopPonderingIfActive();
+      sendAnalysisState();
+    }
+    if (line.trim().equals("resumeponder")) {
+      runOnEdtAndWait(
+          () -> {
+            if (isReadBoardAnalysisEngineAvailable() && !Lizzie.leelaz.isPondering()) {
+              Lizzie.frame.togglePonderMannul();
+            }
+          });
+      sendAnalysisState();
     }
     if (line.startsWith("noinboard")) {
       if (Lizzie.frame.floatBoard != null && Lizzie.frame.floatBoard.isVisible()) {
@@ -2793,6 +2804,18 @@ public class ReadBoard {
 
   private void clearBoardWithoutInvalidatingResumeState(boolean isEngineGame) {
     runWithSuppressedHistoryOverwriteInvalidation(() -> Lizzie.board.clear(isEngineGame));
+  }
+
+  private void runOnEdtAndWait(Runnable action) {
+    if (SwingUtilities.isEventDispatchThread()) {
+      action.run();
+      return;
+    }
+    try {
+      SwingUtilities.invokeAndWait(action);
+    } catch (Exception e) {
+      throw new IllegalStateException("ReadBoard EDT command failed", e);
+    }
   }
 
   private void setHistoryWithoutInvalidatingResumeState(BoardHistoryList history) {
@@ -5081,6 +5104,21 @@ public class ReadBoard {
 
   public void checkVersion() {
     sendCommand("version");
+  }
+
+  void handleReady() {
+    if (isLoaded) {
+      return;
+    }
+    isLoaded = true;
+    checkVersion();
+    announceHostedUpdateSupport();
+    sendAnalysisState();
+  }
+
+  private void sendAnalysisState() {
+    boolean running = Lizzie.leelaz != null && Lizzie.leelaz.isPondering();
+    sendCommand("analysisState " + (running ? "running" : "paused"));
   }
 
   public boolean shouldAnnounceHostedUpdateSupport() {

--- a/src/main/java/featurecat/lizzie/analysis/ReadBoardStream.java
+++ b/src/main/java/featurecat/lizzie/analysis/ReadBoardStream.java
@@ -38,11 +38,7 @@ public class ReadBoardStream extends Thread implements Closeable {
         }
         //  System.out.println(line);
         owner.parseLine(line);
-        if (line.equals("ready"))
-          if (!owner.isLoaded) {
-            owner.isLoaded = true;
-            checkVersion();
-          }
+        if (line.equals("ready")) owner.handleReady();
       }
     } catch (NumberFormatException e) {
       // TODO Auto-generated catch block
@@ -67,10 +63,6 @@ public class ReadBoardStream extends Thread implements Closeable {
       // TODO Auto-generated catch block
       //  e.printStackTrace();
     }
-  }
-
-  public void checkVersion() {
-    sendCommand("version");
   }
 
   @Override

--- a/src/test/java/featurecat/lizzie/analysis/ReadBoardEngineResumeTest.java
+++ b/src/test/java/featurecat/lizzie/analysis/ReadBoardEngineResumeTest.java
@@ -31,6 +31,7 @@ import java.util.List;
 import java.util.Optional;
 import javax.swing.JCheckBox;
 import javax.swing.JTextField;
+import javax.swing.SwingUtilities;
 import org.json.JSONObject;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -746,6 +747,7 @@ class ReadBoardEngineResumeTest {
       assertEquals(0, harness.leelaz.togglePonderCount);
       assertEquals(0, harness.leelaz.ponderCount);
       assertFalse(harness.leelaz.isPondering());
+      assertEquals("analysisState paused\n", harness.protocolOutput());
     }
   }
 
@@ -762,6 +764,7 @@ class ReadBoardEngineResumeTest {
       assertEquals(0, harness.leelaz.togglePonderCount);
       assertEquals(0, harness.leelaz.ponderCount);
       assertFalse(harness.leelaz.isPondering());
+      assertEquals("analysisState paused\n", harness.protocolOutput());
     }
   }
 
@@ -777,6 +780,37 @@ class ReadBoardEngineResumeTest {
       assertEquals(1, harness.leelaz.nameCmdCount);
       assertEquals(0, harness.leelaz.ponderCount);
       assertFalse(harness.leelaz.isPondering());
+      assertEquals("analysisState paused\n", harness.protocolOutput());
+    }
+  }
+
+  @Test
+  void resumeponderUsesManualToggleOnceAndReportsRunningState() throws Exception {
+    try (EngineResumeHarness harness =
+        EngineResumeHarness.create(rootHistory(emptyStones(), true))) {
+      harness.leelaz.notPondering();
+
+      harness.readBoard.parseLine("resumeponder");
+      harness.readBoard.parseLine("resumeponder");
+
+      assertEquals(1, harness.frame.togglePonderMannulCount);
+      assertEquals(1, harness.leelaz.togglePonderCount);
+      assertEquals("analysisState running\nanalysisState running\n", harness.protocolOutput());
+    }
+  }
+
+  @Test
+  void clearBoardClearsOnEdtWithoutMatchingLegacyClear() throws Exception {
+    try (EngineResumeHarness harness =
+        EngineResumeHarness.create(rootHistory(emptyStones(), true))) {
+      ArrayList<Integer> pendingSnapshot = new ArrayList<>(List.of(1));
+      setField(harness.readBoard, "tempcount", pendingSnapshot);
+
+      harness.readBoard.parseLine("clearBoard");
+
+      assertEquals(1, harness.board.clearCount);
+      assertEquals(true, harness.board.clearCalledOnEdt);
+      assertEquals(pendingSnapshot, getField(harness.readBoard, "tempcount"));
     }
   }
 
@@ -1595,6 +1629,12 @@ class ReadBoardEngineResumeTest {
     return field.getBoolean(target);
   }
 
+  private static Object getField(Object target, String name) throws Exception {
+    Field field = findField(target.getClass(), name);
+    field.setAccessible(true);
+    return field.get(target);
+  }
+
   private static Field findField(Class<?> type, String name) throws NoSuchFieldException {
     Class<?> current = type;
     while (current != null) {
@@ -1682,6 +1722,7 @@ class ReadBoardEngineResumeTest {
     private final TrackingFrame frame;
     private final SnapshotTrackingLeelaz leelaz;
     private final ReadBoard readBoard;
+    private final ByteArrayOutputStream protocolCapture;
 
     private EngineResumeHarness(
         Config previousConfig,
@@ -1693,7 +1734,8 @@ class ReadBoardEngineResumeTest {
         TrackingBoard board,
         TrackingFrame frame,
         SnapshotTrackingLeelaz leelaz,
-        ReadBoard readBoard) {
+        ReadBoard readBoard,
+        ByteArrayOutputStream protocolCapture) {
       this.previousConfig = previousConfig;
       this.previousBoard = previousBoard;
       this.previousLeelaz = previousLeelaz;
@@ -1704,6 +1746,7 @@ class ReadBoardEngineResumeTest {
       this.frame = frame;
       this.leelaz = leelaz;
       this.readBoard = readBoard;
+      this.protocolCapture = protocolCapture;
     }
 
     private static EngineResumeHarness create(BoardHistoryList history) throws Exception {
@@ -1744,6 +1787,9 @@ class ReadBoardEngineResumeTest {
       setField(readBoard, "localNavigationTracker", new SyncLocalNavigationTracker());
       setField(readBoard, "tempcount", new ArrayList<Integer>());
       readBoard.firstSync = false;
+      setField(readBoard, "usePipe", true);
+      ByteArrayOutputStream protocolCapture = new ByteArrayOutputStream();
+      setField(readBoard, "outputStream", new BufferedOutputStream(protocolCapture));
       frame.readBoard = readBoard;
 
       return new EngineResumeHarness(
@@ -1756,7 +1802,8 @@ class ReadBoardEngineResumeTest {
           board,
           frame,
           leelaz,
-          readBoard);
+          readBoard,
+          protocolCapture);
     }
 
     private void sync(int[] snapshotCodes) throws Exception {
@@ -1766,6 +1813,10 @@ class ReadBoardEngineResumeTest {
       }
       setField(readBoard, "tempcount", counts);
       invokeSyncBoardStones(readBoard);
+    }
+
+    private String protocolOutput() {
+      return protocolCapture.toString(StandardCharsets.UTF_8);
     }
 
     @Override
@@ -1780,6 +1831,9 @@ class ReadBoardEngineResumeTest {
   }
 
   private static final class TrackingBoard extends Board {
+    private int clearCount;
+    private boolean clearCalledOnEdt;
+
     private void initialize(BoardHistoryList history) {
       setHistory(history);
       hasStartStone = false;
@@ -1790,6 +1844,8 @@ class ReadBoardEngineResumeTest {
 
     @Override
     public void clear(boolean isEngineGame) {
+      clearCount++;
+      clearCalledOnEdt = SwingUtilities.isEventDispatchThread();
       setHistory(rootHistory(emptyStones(), true));
       hasStartStone = false;
       if (Lizzie.frame != null && Lizzie.frame.readBoard != null) {
@@ -1828,6 +1884,7 @@ class ReadBoardEngineResumeTest {
     private int stopAiPlayingAndPolicyCount;
     private int flashAnalyzeGameCount;
     private Runnable lastScheduledResumeAction;
+    private int togglePonderMannulCount;
     private TrackingBoard board;
 
     private void initialize(TrackingBoard board) {
@@ -1840,6 +1897,12 @@ class ReadBoardEngineResumeTest {
 
     @Override
     public void refresh() {}
+
+    @Override
+    public void togglePonderMannul() {
+      togglePonderMannulCount++;
+      super.togglePonderMannul();
+    }
 
     @Override
     public void flashAnalyzeGame(boolean isAllGame, boolean isAllBranches, boolean silentAnalyze) {

--- a/src/test/java/featurecat/lizzie/analysis/ReadBoardStreamTest.java
+++ b/src/test/java/featurecat/lizzie/analysis/ReadBoardStreamTest.java
@@ -7,6 +7,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import featurecat.lizzie.Lizzie;
 import featurecat.lizzie.gui.LizzieFrame;
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
 import java.lang.reflect.Field;
 import java.net.ServerSocket;
 import java.net.Socket;
@@ -55,9 +57,77 @@ class ReadBoardStreamTest {
     }
   }
 
+  @Test
+  void tcpReadySendsInitialAnalysisState() throws Exception {
+    Leelaz previousLeelaz = Lizzie.leelaz;
+    ReadBoard readBoard = allocate(ReadBoard.class);
+    setField(readBoard, "usePipe", false);
+    SnapshotTrackingLeelaz leelaz = SnapshotTrackingLeelaz.create();
+    leelaz.notPondering();
+    Lizzie.leelaz = leelaz;
+
+    try (ServerSocket serverSocket = new ServerSocket(0);
+        Socket clientSocket = new Socket("127.0.0.1", serverSocket.getLocalPort());
+        Socket streamSocket = serverSocket.accept()) {
+      ReadBoardStream stream = new ReadBoardStream(readBoard, streamSocket);
+      setField(readBoard, "readBoardStream", stream);
+      try {
+        clientSocket.getOutputStream().write("ready\n".getBytes(StandardCharsets.UTF_8));
+        clientSocket.getOutputStream().flush();
+        BufferedReader response =
+            new BufferedReader(
+                new InputStreamReader(clientSocket.getInputStream(), StandardCharsets.UTF_8));
+
+        assertEquals("version", response.readLine());
+        assertEquals("analysisState paused", response.readLine());
+      } finally {
+        stream.close();
+        stream.join(1000L);
+      }
+    } finally {
+      Lizzie.leelaz = previousLeelaz;
+    }
+  }
+
+  @Test
+  void tcpReadyReportsPausedWithoutAnInitializedEngine() throws Exception {
+    Leelaz previousLeelaz = Lizzie.leelaz;
+    ReadBoard readBoard = allocate(ReadBoard.class);
+    setField(readBoard, "usePipe", false);
+    Lizzie.leelaz = null;
+
+    try (ServerSocket serverSocket = new ServerSocket(0);
+        Socket clientSocket = new Socket("127.0.0.1", serverSocket.getLocalPort());
+        Socket streamSocket = serverSocket.accept()) {
+      ReadBoardStream stream = new ReadBoardStream(readBoard, streamSocket);
+      setField(readBoard, "readBoardStream", stream);
+      try {
+        clientSocket.getOutputStream().write("ready\n".getBytes(StandardCharsets.UTF_8));
+        clientSocket.getOutputStream().flush();
+        BufferedReader response =
+            new BufferedReader(
+                new InputStreamReader(clientSocket.getInputStream(), StandardCharsets.UTF_8));
+
+        assertEquals("version", response.readLine());
+        assertEquals("analysisState paused", response.readLine());
+      } finally {
+        stream.close();
+        stream.join(1000L);
+      }
+    } finally {
+      Lizzie.leelaz = previousLeelaz;
+    }
+  }
+
   @SuppressWarnings("unchecked")
   private static <T> T allocate(Class<T> type) throws Exception {
     return (T) UnsafeHolder.UNSAFE.allocateInstance(type);
+  }
+
+  private static void setField(Object target, String name, Object value) throws Exception {
+    Field field = ReadBoard.class.getDeclaredField(name);
+    field.setAccessible(true);
+    field.set(target, value);
   }
 
   private static final class UnsafeHolder {

--- a/src/test/java/featurecat/lizzie/analysis/ReadBoardUpdateProtocolTest.java
+++ b/src/test/java/featurecat/lizzie/analysis/ReadBoardUpdateProtocolTest.java
@@ -67,6 +67,47 @@ class ReadBoardUpdateProtocolTest {
   }
 
   @Test
+  void nativePipeReadySendsInitialAnalysisStateOnce() throws Exception {
+    Leelaz previousLeelaz = Lizzie.leelaz;
+    try {
+      SnapshotTrackingLeelaz leelaz = SnapshotTrackingLeelaz.create();
+      leelaz.Pondering();
+      Lizzie.leelaz = leelaz;
+      ReadBoard readBoard = allocate(ReadBoard.class);
+      TrackingBufferedOutputStream output = new TrackingBufferedOutputStream();
+      setField(readBoard, "usePipe", true);
+      setField(readBoard, "outputStream", output);
+
+      readBoard.handleReady();
+      readBoard.handleReady();
+
+      assertEquals(
+          "version\nreadboardUpdateSupported\nanalysisState running\n", output.writtenText());
+    } finally {
+      Lizzie.leelaz = previousLeelaz;
+    }
+  }
+
+  @Test
+  void nativePipeReadyReportsPausedWhenEngineIsNotInitialized() throws Exception {
+    Leelaz previousLeelaz = Lizzie.leelaz;
+    try {
+      Lizzie.leelaz = null;
+      ReadBoard readBoard = allocate(ReadBoard.class);
+      TrackingBufferedOutputStream output = new TrackingBufferedOutputStream();
+      setField(readBoard, "usePipe", true);
+      setField(readBoard, "outputStream", output);
+
+      readBoard.handleReady();
+
+      assertEquals(
+          "version\nreadboardUpdateSupported\nanalysisState paused\n", output.writtenText());
+    } finally {
+      Lizzie.leelaz = previousLeelaz;
+    }
+  }
+
+  @Test
   void parseLineRoutesHostedUpdateRequestToFrameHandler() throws Exception {
     LizzieFrame previousFrame = Lizzie.frame;
     try {


### PR DESCRIPTION
## Summary

- Handle the exact `clearBoard` command on the Swing EDT while preserving the legacy `clear` behavior.
- Report `analysisState running|paused` after the ReadBoard `ready` handshake and analysis-state changes.
- Support the exact `resumeponder` command and report state changes after `noponder`.
- Add regression coverage for pipe/socket readiness, null-engine state, EDT board clearing, and ponder resumption.

This allows ReadBoard to clear the Lizzie board reliably and keep its analysis controls synchronized with the host application.

## Type Of Change

- [x] Bug fix
- [ ] Feature
- [ ] Packaging / release update
- [ ] Docs / translation
- [ ] Refactor

## Testing

- [x] Tested locally
- [ ] Verified package contents if packaging changed
- [ ] Verified Fox sync flow if related
- [ ] Added screenshots if UI changed
- [ ] Updated README / docs if user-facing behavior changed
- [x] Noted affected platforms if the change is platform-specific

Validation performed:

- `mvn -B -Dfmt.skip=true test`
  - 1161 tests run
  - 0 failures
  - 0 errors
  - 1 skipped
- `git diff --check upstream/main..HEAD`

## Notes

This change targets the native ReadBoard integration used on Windows. Existing legacy `clear`, GMA cleanup, and active synchronization reset behavior are preserved.

Reviewers may want to pay particular attention to exact command matching and Swing EDT dispatch for `clearBoard` and `resumeponder`.