### PR TITLE
feat(readboard): support v2 update package protocol

### DIFF
--- a/src/main/java/featurecat/lizzie/analysis/ReadBoard.java
+++ b/src/main/java/featurecat/lizzie/analysis/ReadBoard.java
@@ -60,6 +60,8 @@ public class ReadBoard {
       System.getProperty("lizzie.localMoveSyncLog", "runtime/readboard-local-move-debug.log");
   private static final long LOCAL_MOVE_SYNC_LOG_MAX_BYTES = 2_000_000L;
   private static final String READBOARD_UPDATE_SUPPORTED_COMMAND = "readboardUpdateSupported";
+  private static final String READBOARD_UPDATE_PACKAGE_V2_SUPPORTED_COMMAND =
+      "readboardUpdatePackageV2Supported";
   private static final String YIKE_SYNC_START_COMMAND = "yikeSyncStart";
   private static final String YIKE_SYNC_STOP_COMMAND = "yikeSyncStop";
   private static final String READBOARD_GMA_TOKEN = "gma";
@@ -5128,6 +5130,7 @@ public class ReadBoard {
   public void announceHostedUpdateSupport() {
     if (shouldAnnounceHostedUpdateSupport()) {
       sendCommand(READBOARD_UPDATE_SUPPORTED_COMMAND);
+      sendCommand(READBOARD_UPDATE_PACKAGE_V2_SUPPORTED_COMMAND);
     }
   }
 

--- a/src/main/java/featurecat/lizzie/analysis/ReadBoardUpdateInstaller.java
+++ b/src/main/java/featurecat/lizzie/analysis/ReadBoardUpdateInstaller.java
@@ -17,7 +17,8 @@ import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 
 public final class ReadBoardUpdateInstaller {
-  private static final String PACKAGE_PREFIX = "readboard-github-release-";
+  private static final String LEGACY_PACKAGE_PREFIX = "readboard-github-release-";
+  private static final String WEBVIEW2_PACKAGE_PREFIX = "readboard-webview2-";
   private static final String PACKAGE_SUFFIX = ".zip";
   private static final DateTimeFormatter OPERATION_SUFFIX_FORMAT =
       DateTimeFormatter.ofPattern("yyyyMMdd-HHmmss-SSS");
@@ -76,7 +77,7 @@ public final class ReadBoardUpdateInstaller {
     if (!Files.isRegularFile(zipPath)) {
       throw new IOException("ReadBoard update package does not exist.");
     }
-    if (!expectedPackageFileName(request.versionTag()).equals(zipPath.getFileName().toString())) {
+    if (!isExpectedPackageFileName(request.versionTag(), zipPath.getFileName().toString())) {
       throw new IOException(
           "ReadBoard update package filename does not match the requested version.");
     }
@@ -217,8 +218,9 @@ public final class ReadBoardUpdateInstaller {
     return relativePath;
   }
 
-  private static String expectedPackageFileName(String versionTag) {
-    return PACKAGE_PREFIX + versionTag + PACKAGE_SUFFIX;
+  private static boolean isExpectedPackageFileName(String versionTag, String fileName) {
+    return (LEGACY_PACKAGE_PREFIX + versionTag + PACKAGE_SUFFIX).equals(fileName)
+        || (WEBVIEW2_PACKAGE_PREFIX + versionTag + PACKAGE_SUFFIX).equals(fileName);
   }
 
   private static void deleteRecursively(Path directory) throws IOException {

--- a/src/test/java/featurecat/lizzie/analysis/ReadBoardUpdateInstallerTest.java
+++ b/src/test/java/featurecat/lizzie/analysis/ReadBoardUpdateInstallerTest.java
@@ -60,6 +60,38 @@ class ReadBoardUpdateInstallerTest {
   }
 
   @Test
+  void validateRequestAcceptsWebView2PackageName() throws Exception {
+    ReadBoardUpdateRequest request =
+        createRequest(
+            "readboard-webview2-",
+            "v3.1.0",
+            Map.of(
+                "readboard.exe", "new-exe",
+                "readboard.dll", "new-dll",
+                "readboard.runtimeconfig.json", "{}",
+                "readboard.deps.json", "{}",
+                "language_cn.txt", "cn"));
+
+    assertDoesNotThrow(() -> installer.validateRequest(request));
+  }
+
+  @Test
+  void validateRequestRejectsUnapprovedZipName() throws Exception {
+    ReadBoardUpdateRequest request =
+        createRequest(
+            "readboard-custom-",
+            "v3.1.0",
+            Map.of(
+                "readboard.exe", "new-exe",
+                "readboard.dll", "new-dll",
+                "readboard.runtimeconfig.json", "{}",
+                "readboard.deps.json", "{}",
+                "language_cn.txt", "cn"));
+
+    assertThrows(IOException.class, () -> installer.validateRequest(request));
+  }
+
+  @Test
   void validateRequestRejectsNestedRequiredFilesBelowInstallRoot() throws Exception {
     ReadBoardUpdateRequest request =
         createRequest(
@@ -127,8 +159,12 @@ class ReadBoardUpdateInstallerTest {
 
   private ReadBoardUpdateRequest createRequest(String versionTag, Map<String, String> entries)
       throws Exception {
-    Path zipPath =
-        createZip(tempDir.resolve("readboard-github-release-" + versionTag + ".zip"), entries);
+    return createRequest("readboard-github-release-", versionTag, entries);
+  }
+
+  private ReadBoardUpdateRequest createRequest(
+      String packagePrefix, String versionTag, Map<String, String> entries) throws Exception {
+    Path zipPath = createZip(tempDir.resolve(packagePrefix + versionTag + ".zip"), entries);
     ReadBoardUpdateRequest request =
         ReadBoardUpdateRequest.tryParse(
             "readboardUpdateReady\t" + versionTag + "\t" + zipPath.toAbsolutePath());

--- a/src/test/java/featurecat/lizzie/analysis/ReadBoardUpdateProtocolTest.java
+++ b/src/test/java/featurecat/lizzie/analysis/ReadBoardUpdateProtocolTest.java
@@ -60,7 +60,9 @@ class ReadBoardUpdateProtocolTest {
     nativePipeReadBoard.announceHostedUpdateSupport();
     socketReadBoard.announceHostedUpdateSupport();
 
-    assertEquals("readboardUpdateSupported\n", nativePipeOutput.writtenText());
+    assertEquals(
+        "readboardUpdateSupported\nreadboardUpdatePackageV2Supported\n",
+        nativePipeOutput.writtenText());
     assertEquals("", socketOutput.writtenText());
     assertTrue(nativePipeReadBoard.shouldAnnounceHostedUpdateSupport());
     assertFalse(socketReadBoard.shouldAnnounceHostedUpdateSupport());
@@ -82,7 +84,8 @@ class ReadBoardUpdateProtocolTest {
       readBoard.handleReady();
 
       assertEquals(
-          "version\nreadboardUpdateSupported\nanalysisState running\n", output.writtenText());
+          "version\nreadboardUpdateSupported\nreadboardUpdatePackageV2Supported\nanalysisState running\n",
+          output.writtenText());
     } finally {
       Lizzie.leelaz = previousLeelaz;
     }
@@ -101,7 +104,8 @@ class ReadBoardUpdateProtocolTest {
       readBoard.handleReady();
 
       assertEquals(
-          "version\nreadboardUpdateSupported\nanalysisState paused\n", output.writtenText());
+          "version\nreadboardUpdateSupported\nreadboardUpdatePackageV2Supported\nanalysisState paused\n",
+          output.writtenText());
     } finally {
       Lizzie.leelaz = previousLeelaz;
     }


### PR DESCRIPTION
## Summary

- Advertise the additive `readboardUpdatePackageV2Supported` capability after the existing `readboardUpdateSupported` capability for native-pipe ReadBoard sessions.
- Accept both the legacy `readboard-github-release-<tag>.zip` package and the new `readboard-webview2-<tag>.zip` package while rejecting arbitrary ZIP names and version mismatches.
- Add regression coverage for capability ordering, socket behavior, ready-state analysis reporting, and installer package-name validation.

This allows newer ReadBoard versions to negotiate hosted WebView2 update packages without breaking the existing v1 package contract.

## Type Of Change

- [ ] Bug fix
- [x] Feature
- [ ] Packaging / release update
- [ ] Docs / translation
- [ ] Refactor

## Testing

- [x] Tested locally
- [ ] Verified package contents if packaging changed
- [ ] Verified Fox sync flow if related
- [ ] Added screenshots if UI changed
- [ ] Updated README / docs if user-facing behavior changed
- [x] Noted affected platforms if the change is platform-specific

Validation performed:

- `mvn -B -Dfmt.skip=true test`
  - 1,163 tests run
  - 0 failures
  - 0 errors
  - 0 skipped
- `git diff --check upstream/main..HEAD`

## Notes

The capability is additive: native-pipe hosts continue to announce the existing v1 capability first, followed by v2. Socket sessions do not announce hosted-update capabilities.

The `readboardUpdateReady\t<tag>\t<absolute-path>` request format is unchanged. The installer only accepts the two exact package-name conventions matching the requested version tag.

This change targets the maintained Windows native ReadBoard integration.
