### PR TITLE
fix(gui): preserve positive move numbers in branch previews

### DIFF
--- a/src/main/java/featurecat/lizzie/gui/BoardRenderer.java
+++ b/src/main/java/featurecat/lizzie/gui/BoardRenderer.java
@@ -2027,6 +2027,7 @@ public class BoardRenderer {
           }
           String moveNumberString = String.valueOf(mvNum);
           if (!showAllinBranch
+              && !branchOpt.isPresent()
               && Lizzie.config.showMoveNumberFromOne
               && Lizzie.config.allowMoveNumber > 0) {
             if (lastMoveNumber > Lizzie.config.allowMoveNumber) {

--- a/src/test/java/featurecat/lizzie/gui/SnapshotNodeRenderGateTest.java
+++ b/src/test/java/featurecat/lizzie/gui/SnapshotNodeRenderGateTest.java
@@ -1,5 +1,7 @@
 package featurecat.lizzie.gui;
 
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -109,6 +111,28 @@ class SnapshotNodeRenderGateTest {
   }
 
   @Test
+  void branchPreviewMoveNumbersIgnoreMainBoardRenumberingFromOne() throws Exception {
+    TestEnvironment env = TestEnvironment.open();
+    try {
+      Board board = boardWithRoot(BoardData.empty(BOARD_SIZE, BOARD_SIZE));
+      Lizzie.board = board;
+      Branch branch = branchWith(sevenMoveBranchPreview());
+
+      BoardRenderer renderer = new BoardRenderer(false);
+      renderer.branchOpt = Optional.of(branch);
+      renderer.setDisplayedBranchLength(branch.length);
+      configureOverlayRenderer(renderer);
+
+      assertAll(
+          "candidate previews should keep their positive local move numbers",
+          () -> assertBranchPreviewMoveNumbersUnchanged(renderer, 1),
+          () -> assertBranchPreviewMoveNumbersUnchanged(renderer, 5));
+    } finally {
+      env.close();
+    }
+  }
+
+  @Test
   void floatBoardBranchSnapshotWithMarkerDrawsNoOverlay() throws Exception {
     TestEnvironment env = TestEnvironment.open();
     try {
@@ -140,6 +164,27 @@ class SnapshotNodeRenderGateTest {
     } finally {
       graphics.dispose();
     }
+  }
+
+  private static void assertBranchPreviewMoveNumbersUnchanged(
+      BoardRenderer renderer, int allowMoveNumber) throws Exception {
+    Lizzie.config.allowMoveNumber = allowMoveNumber;
+    Lizzie.config.showMoveNumberFromOne = false;
+    int[] expected = pixels(renderOverlay(renderer, BoardRenderer.class, "drawMoveNumbers"));
+
+    Lizzie.config.showMoveNumberFromOne = true;
+    int[] actual = pixels(renderOverlay(renderer, BoardRenderer.class, "drawMoveNumbers"));
+
+    assertArrayEquals(
+        expected,
+        actual,
+        "last "
+            + allowMoveNumber
+            + " should not renumber the complete candidate preview sequence");
+  }
+
+  private static int[] pixels(BufferedImage image) {
+    return image.getRGB(0, 0, image.getWidth(), image.getHeight(), null, 0, image.getWidth());
   }
 
   private static boolean hasVisiblePaint(BufferedImage image) {
@@ -204,6 +249,31 @@ class SnapshotNodeRenderGateTest {
     moveNumberList[Board.getIndex(1, 0)] = 2;
     return BoardData.move(
         stones, new int[] {1, 0}, Stone.WHITE, true, new Zobrist(), 2, moveNumberList, 0, 0, 50, 0);
+  }
+
+  private static BoardData sevenMoveBranchPreview() {
+    Stone[] stones = emptyStones();
+    stones[Board.getIndex(0, 0)] = Stone.BLACK;
+    stones[Board.getIndex(1, 0)] = Stone.WHITE;
+    stones[Board.getIndex(0, 1)] = Stone.WHITE;
+    stones[Board.getIndex(1, 1)] = Stone.BLACK;
+    int[] moveNumberList = new int[BOARD_AREA];
+    moveNumberList[Board.getIndex(0, 0)] = 1;
+    moveNumberList[Board.getIndex(1, 0)] = 2;
+    moveNumberList[Board.getIndex(0, 1)] = 6;
+    moveNumberList[Board.getIndex(1, 1)] = 7;
+    return BoardData.move(
+        stones,
+        new int[] {1, 1},
+        Stone.BLACK,
+        false,
+        new Zobrist(),
+        7,
+        moveNumberList,
+        0,
+        0,
+        50,
+        0);
   }
 
   private static Board boardWithRoot(BoardData root) throws Exception {


### PR DESCRIPTION
## Summary

- Prevent the main-board "start move numbers from 1" offset from being reapplied to branch preview move numbers.
- Preserve the complete positive local `1..L` sequence when candidate previews are shown with the "last 1 move" or "last 5 moves" setting.
- Add pixel-level regression coverage for both reported configurations.

The branch preview already uses local variation move numbers and intentionally bypasses the main-board last-N filtering. Applying the main-board renumbering offset a second time changed early preview moves into zero or negative values.

## Type Of Change

- [x] Bug fix
- [ ] Feature
- [ ] Packaging / release update
- [ ] Docs / translation
- [ ] Refactor

## Testing

- [x] Tested locally
- [ ] Verified package contents if packaging changed
- [ ] Verified Fox sync flow if related
- [ ] Added screenshots if UI changed
- [ ] Updated README / docs if user-facing behavior changed
- [x] Noted affected platforms if the change is platform-specific

Validation performed:

- Confirmed the new regression test fails on the unmodified `upstream/main` baseline for both last-1 and last-5 configurations.
- `mvn -B -Dfmt.skip=true -Dtest=SnapshotNodeRenderGateTest,PassPreviewGateTest,SnapshotMoveUiGateTest,MoveOnlyUiGateTest test`
  - 30 tests run
  - 0 failures
  - 0 errors
- `mvn -B -Dfmt.skip=true test`
  - 1,162 tests run
  - 0 failures
  - 0 errors
  - 0 skipped
- Windows focused tests and `-DskipTests package`: passed.
- `git diff --check upstream/main..HEAD`: passed.

## Notes

This is a rendering-only fix. It does not change ReadBoard, synchronization protocols, configuration persistence, or SNAPSHOT/PASS/history behavior.

Normal main-board last-N renumbering remains unchanged. Only active branch previews skip that main-board-specific offset.
