### PR TITLE
修复加载让子棋谱后初始目差使用错误贴目

### DIFF
--- a/src/main/java/featurecat/lizzie/analysis/Leelaz.java
+++ b/src/main/java/featurecat/lizzie/analysis/Leelaz.java
@@ -2459,6 +2459,22 @@ public class Leelaz {
     }
   }
 
+  /**
+   * Aligns the running engine with the displayed game's komi without changing the engine default or
+   * discarding analysis embedded in a loaded SGF.
+   */
+  public boolean syncKomiForCurrentGame(double komi) {
+    float normalizedKomi = (float) (komi == 0.0 ? 0.0 : komi);
+    synchronized (this) {
+      if (Float.compare(this.komi, normalizedKomi) == 0) {
+        return false;
+      }
+      this.komi = normalizedKomi;
+      sendCommand("komi " + (komi == 0.0 ? "0" : komi));
+      return true;
+    }
+  }
+
   public void nameCmdfornoponder() {
     YikeSyncDebugLog.log(
         "Leelaz nameCmdfornoponder isKatago="

--- a/src/main/java/featurecat/lizzie/rules/Board.java
+++ b/src/main/java/featurecat/lizzie/rules/Board.java
@@ -1267,6 +1267,7 @@ public class Board {
     if (!isPrimaryEngineReady()) {
       return false;
     }
+    syncPrimaryEngineKomiToCurrentGame();
     if (Lizzie.leelaz.width != boardWidth || Lizzie.leelaz.height != boardHeight) {
       Lizzie.leelaz.boardSizeForEngine(boardWidth, boardHeight);
     }
@@ -1288,13 +1289,23 @@ public class Board {
     }
     BoardData currentPosition = currentHistory.getData();
     if (matchesEnginePosition(previousPosition, currentPosition)) {
+      syncPrimaryEngineKomiToCurrentGame();
       return true;
     }
     BoardHistoryNode previousNode = currentHistory.getCurrentHistoryNode().previous().orElse(null);
     if (previousNode == null || !matchesEnginePosition(previousPosition, previousNode.getData())) {
       return false;
     }
+    syncPrimaryEngineKomiToCurrentGame();
     return playHistoryActionToPrimaryEngine(currentPosition);
+  }
+
+  private void syncPrimaryEngineKomiToCurrentGame() {
+    BoardHistoryList currentHistory = getHistory();
+    if (currentHistory == null || currentHistory.getGameInfo() == null) {
+      return;
+    }
+    Lizzie.leelaz.syncKomiForCurrentGame(currentHistory.getGameInfo().getKomi());
   }
 
   private boolean isPrimaryEngineReady() {

--- a/src/test/java/featurecat/lizzie/gui/LizzieFrameRegressionTest.java
+++ b/src/test/java/featurecat/lizzie/gui/LizzieFrameRegressionTest.java
@@ -680,9 +680,9 @@ class LizzieFrameRegressionTest {
 
       assertEquals(0, frame.flashAnalyzeGameCount);
       assertEquals(
-          List.of("boardsize 2", "clear_board", "play B A2", "ponder"),
+          List.of("komi 7.5", "boardsize 2", "clear_board", "play B A2", "ponder"),
           leelaz.commands(),
-          "foreground analysis should replay the loaded SGF position before starting ponder.");
+          "foreground analysis should replay the loaded SGF komi and position before pondering.");
     } finally {
       env.close();
     }
@@ -705,9 +705,9 @@ class LizzieFrameRegressionTest {
       frame.togglePonderMannul();
 
       assertEquals(
-          List.of("boardsize 2", "clear_board", "play B A2", "ponder"),
+          List.of("komi 7.5", "boardsize 2", "clear_board", "play B A2", "ponder"),
           leelaz.commands(),
-          "manual resume should also align the engine to the current SGF before analysis.");
+          "manual resume should align the engine to the current SGF komi and position.");
     } finally {
       env.close();
     }

--- a/src/test/java/featurecat/lizzie/rules/BoardNodeKindHistoryPipelineTest.java
+++ b/src/test/java/featurecat/lizzie/rules/BoardNodeKindHistoryPipelineTest.java
@@ -917,7 +917,8 @@ class BoardNodeKindHistoryPipelineTest {
   }
 
   @Test
-  void loadFromStringWithKomiDoesNotOverwriteCurrentEngineKomi() throws Exception {
+  void loadFromStringHandicapKomiSynchronizesCurrentEngineWithoutChangingDefault()
+      throws Exception {
     TestEnvironment env = TestEnvironment.open();
     int previousCurrentEngineNo = EngineManager.currentEngineNo;
     try {
@@ -925,29 +926,37 @@ class BoardNodeKindHistoryPipelineTest {
       EngineManager.currentEngineNo = 0;
       EngineManager.isEmpty = false;
       TrackingLeelaz leelaz = (TrackingLeelaz) Lizzie.leelaz;
-      leelaz.komi = 6.5f;
-      leelaz.orikomi = 6.5f;
+      leelaz.komi = 7.5f;
+      leelaz.orikomi = 7.5f;
       leelaz.isLoaded = true;
       setStarted(leelaz, true);
 
-      assertTrue(SGFParser.loadFromString("(;SZ[3]KM[7.5];B[aa])"));
+      assertTrue(SGFParser.loadFromString("(;SZ[3]KM[0]HA[2]AB[aa]AB[ca]PL[W];W[ba])"));
 
-      assertFalse(
-          leelaz.recordedCommands().contains("komi 7.5"),
-          "loading SGF KM should not send a komi command that overwrites the current engine.");
+      assertTrue(
+          leelaz.recordedCommands().contains("komi 0"),
+          "the running engine must analyze with the komi displayed from the loaded SGF.");
       assertEquals(
-          6.5,
+          0.0,
           leelaz.komi,
           0.0001,
-          "current engine komi field should keep the engine/default komi after loading SGF.");
+          "the engine's current-game komi should match the loaded handicap game.");
       assertEquals(
           7.5,
+          leelaz.orikomi,
+          0.0001,
+          "loading a game must not rewrite the engine profile's default komi.");
+      assertEquals(
+          0.0,
           Lizzie.board.getHistory().getGameInfo().getKomi(),
           0.0001,
-          "SGF KM should still be visible as loaded game information.");
+          "SGF KM should remain the displayed game komi.");
       assertFalse(
           Lizzie.board.getHistory().getGameInfo().changedKomi,
           "loaded SGF KM should not be treated as a manual engine-komi change.");
+      assertTrue(
+          leelaz.lastLoadedSgfContent().contains("KM[0.0]"),
+          "the root setup snapshot passed to KataGo must carry the loaded SGF komi.");
     } finally {
       EngineManager.currentEngineNo = previousCurrentEngineNo;
       env.close();
@@ -4438,6 +4447,7 @@ class BoardNodeKindHistoryPipelineTest {
     private Stone[] stones;
     private boolean blackToPlay = true;
     private Path lastLoadedSgf;
+    private String lastLoadedSgfContent = "";
 
     private TrackingLeelaz() throws IOException {
       super("");
@@ -4510,6 +4520,10 @@ class BoardNodeKindHistoryPipelineTest {
       return lastLoadedSgf;
     }
 
+    private String lastLoadedSgfContent() {
+      return lastLoadedSgfContent;
+    }
+
     private List<String> recordedCommands() {
       if (commands == null) {
         commands = new ArrayList<>();
@@ -4536,6 +4550,7 @@ class BoardNodeKindHistoryPipelineTest {
       resetBoardState();
       try {
         String content = Files.readString(path);
+        lastLoadedSgfContent = content;
         Matcher matcher = PROPERTY_PATTERN.matcher(content);
         while (matcher.find()) {
           String tag = matcher.group(1);

--- a/src/test/java/featurecat/lizzie/rules/BoardPrimaryEngineSyncTest.java
+++ b/src/test/java/featurecat/lizzie/rules/BoardPrimaryEngineSyncTest.java
@@ -108,6 +108,38 @@ class BoardPrimaryEngineSyncTest {
   }
 
   @Test
+  void trySyncCurrentPositionToPrimaryEngineSynchronizesChangedGameKomiWithoutReset()
+      throws Exception {
+    try (TestHarness harness = TestHarness.open()) {
+      Board board = allocate(Board.class);
+      board.startStonelist = new ArrayList<>();
+      board.hasStartStone = false;
+      BoardHistoryList history = new BoardHistoryList(BoardData.empty(BOARD_SIZE, BOARD_SIZE));
+      history.getGameInfo().setKomiNoMenu(0.0);
+      BoardData previousPosition = history.getData().clone();
+      board.setHistory(history);
+      Lizzie.board = board;
+
+      Leelaz engine = new Leelaz("");
+      engine.komi = 7.5f;
+      engine.orikomi = 7.5f;
+      engine.isLoaded = true;
+      setStarted(engine, true);
+      RecordingOutputStream output = new RecordingOutputStream();
+      setOutputStream(engine, output);
+      Lizzie.leelaz = engine;
+
+      assertTrue(
+          board.trySyncCurrentPositionToPrimaryEngineIncrementally(
+              previousPosition, BOARD_SIZE, BOARD_SIZE));
+
+      assertEquals(List.of("komi 0"), output.commands());
+      assertEquals(0.0, engine.komi, 0.0001);
+      assertEquals(7.5, engine.orikomi, 0.0001);
+    }
+  }
+
+  @Test
   void trySyncCurrentPositionToPrimaryEngineIncrementallyRejectsMultipleAppendedMoves()
       throws Exception {
     try (TestHarness harness = TestHarness.open()) {


### PR DESCRIPTION
## 问题

加载带 `KM[0]` 的让二子 SGF 后，界面显示贴目 0，但运行中的 KataGo 仍沿用引擎默认贴目 7.5，导致初始目差约为 13.7 目。手动把贴目 +0.5 再 -0.5 会重新发送贴目，所以结果才恢复正常。

根因是棋谱贴目已写入 `GameInfo`，但主引擎在恢复/同步棋盘位置前没有同步当前棋局贴目；快照恢复又会优先保留引擎当前贴目。

## 修复

- 新增“仅同步当前棋局贴目”的引擎入口，更新运行中 KataGo，但不改写引擎配置默认贴目 `orikomi`。
- 主引擎完整恢复和增量位置同步前，统一从当前棋局 `GameInfo` 同步贴目。
- 不清除棋谱内已有分析，也不把加载 SGF 误记为用户手动修改贴目。
- 增加让二子 `KM[0] / HA[2] / AB / PL[W]`、增量同步、前台恢复顺序等回归测试。

## 验证

- 完整测试：1189 tests，0 failures，0 errors，1 skipped。
- 最终定向回归：164 tests，0 failures，0 errors，0 skipped。
- `mvn -B -Dfmt.skip=true -DskipTests package`：BUILD SUCCESS。
- `python scripts/test_windows_launcher_packaging.py`：passed。
- `git diff --check`：passed。
- Windows 11、150% 缩放、OpenCL portable 真机启动 EXE，使用打包内 KataGo 1.16.5 和 RTX 3070 Laptop GPU。
- 真实打开用户棋谱 `申真谞_Vs_KataGo_20260717155430.sgf`，未进行任何贴目加减操作：
  - 界面贴目立即为 0.0；
  - 初始黑领先稳定在约 21.0 目（用户预期约 20.8 目）；
  - GTP 日志确认在 `loadsgf` 和重新分析前发送 `komi 0`；
  - 新建普通棋局后恢复默认贴目 7.5，证明没有污染引擎默认配置。

## 用户影响

带非默认贴目的让子棋、无贴目棋及其他 SGF 会直接按棋谱贴目分析，不再需要通过加减贴目的变通操作。