### PR TITLE
Fix engine menu refresh and legacy Windows updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@
 
 Windows `portable.zip` 是真正的免安装模式：配置、日志、保存棋谱、下载权重和软件内安装的 TensorRT 加速文件都会保存在解压出来的同一个文件夹里，主要位置是 `user-data/`。如果想彻底清理这个免安装版，删除整个解压文件夹即可；如果想保留设置，升级前把旧文件夹里的 `user-data/` 复制到新文件夹。
 
-已有 Windows 免安装版时，日常小版本升级不用重新下载完整大包。下载 `*windows64.core-update.zip`，关闭软件，把 zip 里的内容解压到旧的免安装目录覆盖即可。这个小包只替换 `app/lizzie-yzy2.5.3-shaded.jar` 和 `app/LizzieYzy Next*.cfg`，用来同步标题栏版本号和必要 JVM 参数；不会重复下载或覆盖 `weights/`、`engines/`、`runtime/`、`jcef-bundle/`、`readboard/`、`user-data/`。如果某次 release 明确写了 KataGo、权重或运行环境升级，再按说明下载完整包或对应资源包。
+已有 Windows 免安装版时，日常小版本升级不用重新下载完整大包。下载 `*windows64.core-update.zip`，关闭软件，把 zip 里的内容解压到旧的免安装目录覆盖即可。这个小包更新 `app/lizzie-yzy2.5.3-shaded.jar` 和 `app/LizzieYzy Next*.cfg`，并保留一个供旧版自动更新器识别的兼容文件；不会重复下载或覆盖 `weights/`、`engines/`、`runtime/`、`jcef-bundle/`、`readboard/`、`user-data/`。如果某次 release 明确写了 KataGo、权重或运行环境升级，再按说明下载完整包或对应资源包。
 
 如果你懒得分辨：
 

--- a/docs/PACKAGES.md
+++ b/docs/PACKAGES.md
@@ -57,7 +57,7 @@
 - TensorRT 分卷包是高级可选资产，不计入普通用户主推荐路径；只下载 `.7z.001` 没用，必须下载全部 `.7z.00N`。
 - Windows 64 位现在优先推荐免安装包，安装器作为可选路径保留。
 - Windows 免安装包会在解压目录内启用便携模式，配置、日志、保存棋谱、下载权重和软件内安装的 TensorRT 文件都随这个文件夹保存，主要位于 `user-data/`。
-- 已有 Windows 免安装版时，关闭软件后把 `<date>-windows64.core-update.zip` 解压到旧目录覆盖即可；它只替换 `app/lizzie-yzy2.5.3-shaded.jar` 和 `app/LizzieYzy Next*.cfg`，用于同步标题栏版本号和必要 JVM 参数，不会覆盖权重、引擎、运行环境、JCEF、readboard、TensorRT 或 `user-data/`。
+- 已有 Windows 免安装版时，关闭软件后把 `<date>-windows64.core-update.zip` 解压到旧目录覆盖即可；它更新 `app/lizzie-yzy2.5.3-shaded.jar` 和 `app/LizzieYzy Next*.cfg`，并携带 `lizzieyzy-next-core.jar` 兼容旧版自动更新请求。这个兼容文件与主 jar 内容、校验值相同，不会覆盖权重、引擎、运行环境、JCEF、readboard、TensorRT 或 `user-data/`。
 - 远程算力不属于发布包资产：`设置 -> 远程算力中心` 只保存连接配置和可选 token，不把智子云算力、KaTrain/SWHub 自建远程服务或任何云端模型打进安装包。
 - 旧 tag 里如果还看到兼容 zip 或历史包，那属于历史发布格式。
 

--- a/scripts/package_windows_exe.sh
+++ b/scripts/package_windows_exe.sh
@@ -1089,6 +1089,8 @@ create_core_update_asset() {
   rm -rf "$core_dir" "$core_zip"
   mkdir -p "$core_dir/app"
   cp "$JAR_PATH" "$core_dir/app/$MAIN_JAR"
+  # Clients released before the component-path migration still request this root-level alias.
+  cp "$JAR_PATH" "$core_dir/lizzieyzy-next-core.jar"
   shopt -s nullglob
   for launcher_cfg in "$DIST_DIR"/app-image-*/*/app/*.cfg; do
     cp "$launcher_cfg" "$core_dir/app/$(basename "$launcher_cfg")"
@@ -1157,6 +1159,12 @@ files = [
     {
         "path": f"app/{main_jar}",
         "purpose": "in-app-updater-and-manual-overlay-target",
+        "sizeBytes": jar.stat().st_size,
+        "sha256": jar_sha256,
+    },
+    {
+        "path": "lizzieyzy-next-core.jar",
+        "purpose": "legacy-in-app-updater-source",
         "sizeBytes": jar.stat().st_size,
         "sha256": jar_sha256,
     },

--- a/scripts/validate_release_assets.sh
+++ b/scripts/validate_release_assets.sh
@@ -168,6 +168,7 @@ with zipfile.ZipFile(core_path) as archive:
         if name and not name.endswith("/")
     }
 assert "app/lizzie-yzy2.5.3-shaded.jar" in entries
+assert "lizzieyzy-next-core.jar" in entries, "core update must retain the legacy updater source alias"
 assert any(entry.startswith("app/LizzieYzy Next") and entry.endswith(".cfg") for entry in entries), "core update must include launcher cfg files so title-bar version and JVM options are refreshed"
 assert "README.txt" in entries
 assert "lizzieyzy-next-core-update-manifest.json" in entries

--- a/src/main/java/featurecat/lizzie/gui/Menu.java
+++ b/src/main/java/featurecat/lizzie/gui/Menu.java
@@ -9935,23 +9935,23 @@ public class Menu extends JMenuBar {
   }
 
   public void updateEngineMenu() {
+    if (!SwingUtilities.isEventDispatchThread()) {
+      SwingUtilities.invokeLater(this::updateEngineMenu);
+      return;
+    }
 
-    this.remove(engineMenu);
-    this.remove(engineMenu2);
-    engineMenu = new JFontMenu(resourceBundle.getString("Menu.noEngine"));
+    engineMenu.removeAll();
+    engineMenu2.removeAll();
     engineMenu.setText(resourceBundle.getString("Menu.noEngine"));
+    engineMenu.setIcon(null);
     engineMenu.setForeground(MorandiPalette.MENU_ITEM_TEXT);
     engineMenu.setFont(
         new Font(Config.sysDefaultFontName, Font.BOLD, Math.max(Config.frameFontSize, 15)));
-    this.add(engineMenu);
-    //   if (Lizzie.config.Lizzie.config.isDoubleEngineMode()) {
-    engineMenu2 = new JFontMenu(resourceBundle.getString("Menu.noEngine"));
     engineMenu2.setText(resourceBundle.getString("Menu.noEngine"));
+    engineMenu2.setIcon(null);
     engineMenu2.setForeground(MorandiPalette.MENU_ITEM_TEXT);
     engineMenu2.setFont(
         new Font(Config.sysDefaultFontName, Font.BOLD, Math.max(Config.frameFontSize, 15)));
-    this.add(engineMenu2);
-    //    }
     if (!Lizzie.config.showDoubleMenu) {
       if (Lizzie.config.isFrameFontSmall() && komiContentPanel != null) {
         this.remove(komiContentPanel);
@@ -10075,6 +10075,12 @@ public class Menu extends JMenuBar {
     engineMenu2.add(restartCurrentEngine2);
     engineMenu2.add(shutdownCurrentEngine2);
     if (!Lizzie.config.isDoubleEngineMode()) engineMenu2.setVisible(false);
+    engineMenu.revalidate();
+    engineMenu.repaint();
+    engineMenu2.revalidate();
+    engineMenu2.repaint();
+    revalidate();
+    repaint();
   }
 
   public void changeEngineIcon(int index, int mode) {

--- a/src/main/java/featurecat/lizzie/gui/WindowMenuStrip.java
+++ b/src/main/java/featurecat/lizzie/gui/WindowMenuStrip.java
@@ -13,6 +13,8 @@ import java.awt.Insets;
 import java.awt.RenderingHints;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
 import java.util.ArrayList;
 import java.util.List;
 import javax.swing.JButton;
@@ -20,6 +22,7 @@ import javax.swing.JMenu;
 import javax.swing.JMenuBar;
 import javax.swing.JPanel;
 import javax.swing.JPopupMenu;
+import javax.swing.SwingUtilities;
 import javax.swing.border.EmptyBorder;
 import javax.swing.event.MenuEvent;
 import javax.swing.event.MenuListener;
@@ -43,6 +46,9 @@ public class WindowMenuStrip extends JPanel {
   }
 
   public void rebuild() {
+    for (MenuButton button : menuButtons) {
+      button.detach();
+    }
     removeAll();
     menuButtons.clear();
     if (sourceMenuBar == null) {
@@ -212,14 +218,15 @@ public class WindowMenuStrip extends JPanel {
 
   private final class MenuButton extends JButton {
     private final JMenu menu;
+    private final PropertyChangeListener menuPropertyListener = this::menuPropertyChanged;
     private boolean suppressNextAction;
 
     private MenuButton(JMenu menu) {
       super(menu.getText());
       this.menu = menu;
       ensurePopupListener(menu);
-      setFont(menu.getFont().deriveFont(Font.BOLD, Math.max(Config.frameFontSize, 12)));
-      setForeground(AppleStyleSupport.dialogTextColor());
+      syncFromMenu();
+      menu.addPropertyChangeListener(menuPropertyListener);
       setOpaque(false);
       setContentAreaFilled(false);
       setBorderPainted(false);
@@ -262,6 +269,40 @@ public class WindowMenuStrip extends JPanel {
               repaint();
             }
           });
+    }
+
+    private void menuPropertyChanged(PropertyChangeEvent event) {
+      String property = event.getPropertyName();
+      if ("visible".equals(property)) {
+        SwingUtilities.invokeLater(WindowMenuStrip.this::rebuild);
+        return;
+      }
+      if ("text".equals(property)
+          || "enabled".equals(property)
+          || "font".equals(property)
+          || "foreground".equals(property)) {
+        syncFromMenu();
+      }
+    }
+
+    private void syncFromMenu() {
+      setText(menu.getText());
+      setEnabled(menu.isEnabled());
+      Font menuFont = menu.getFont();
+      if (menuFont != null) {
+        setFont(menuFont.deriveFont(Font.BOLD, Math.max(Config.frameFontSize, 12)));
+      }
+      setForeground(AppleStyleSupport.dialogTextColor());
+      if (getAccessibleContext() != null) {
+        getAccessibleContext().setAccessibleName(menu.getText());
+        getAccessibleContext().setAccessibleDescription(menu.getText());
+      }
+      revalidate();
+      repaint();
+    }
+
+    private void detach() {
+      menu.removePropertyChangeListener(menuPropertyListener);
     }
 
     @Override

--- a/src/main/java/featurecat/lizzie/update/WindowsUpdateApplier.java
+++ b/src/main/java/featurecat/lizzie/update/WindowsUpdateApplier.java
@@ -90,12 +90,43 @@ public final class WindowsUpdateApplier {
       Path backupRoot,
       List<BackupEntry> backups)
       throws IOException {
-    Path newJar = extracted.resolve(component.optString("sourcePath", currentJar.getFileName().toString()));
-    if (!Files.isRegularFile(newJar)) {
-      throw new IOException("Core update jar not found: " + newJar);
-    }
+    Path newJar = resolveCoreUpdateJar(component, extracted, currentJar);
     replaceFile(newJar, currentJar, backupRoot, appDir, backups);
     replaceBundledLauncherConfigsIfPresent(extracted, appDir, backupRoot, backups);
+  }
+
+  private static Path resolveCoreUpdateJar(
+      JSONObject component, Path extracted, Path currentJar) throws IOException {
+    String requested = component.optString("sourcePath", currentJar.getFileName().toString());
+    List<String> candidates = new ArrayList<>();
+    candidates.add(requested);
+    candidates.add("app/" + currentJar.getFileName());
+    candidates.add(currentJar.getFileName().toString());
+    candidates.add("lizzieyzy-next-core.jar");
+    List<Path> attempted = new ArrayList<>();
+    for (String candidate : candidates) {
+      if (candidate == null || candidate.isBlank()) {
+        continue;
+      }
+      Path path = safeExtractedSource(extracted, candidate);
+      if (attempted.contains(path)) {
+        continue;
+      }
+      attempted.add(path);
+      if (Files.isRegularFile(path)) {
+        return path;
+      }
+    }
+    throw new IOException("Core update jar not found. Tried: " + attempted);
+  }
+
+  private static Path safeExtractedSource(Path extracted, String relativePath) throws IOException {
+    Path normalizedRoot = extracted.toAbsolutePath().normalize();
+    Path source = normalizedRoot.resolve(relativePath).normalize();
+    if (!source.startsWith(normalizedRoot)) {
+      throw new IOException("Update source escapes extracted archive: " + relativePath);
+    }
+    return source;
   }
 
   private static void replaceBundledLauncherConfigsIfPresent(

--- a/src/test/java/featurecat/lizzie/gui/WindowMenuStripTest.java
+++ b/src/test/java/featurecat/lizzie/gui/WindowMenuStripTest.java
@@ -1,5 +1,6 @@
 package featurecat.lizzie.gui;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -14,6 +15,23 @@ import javax.swing.JPopupMenu;
 import org.junit.jupiter.api.Test;
 
 class WindowMenuStripTest {
+  @Test
+  void mirrorsSourceMenuTextAndEnabledStateWithoutRebuild() {
+    JMenuBar menuBar = new JMenuBar();
+    JMenu engine = new JMenu("[1] KataGo");
+    menuBar.add(engine);
+
+    WindowMenuStrip strip = new WindowMenuStrip(menuBar);
+    JButton button = (JButton) strip.getComponent(0);
+
+    engine.setText("[2] ZenGTPX");
+    engine.setEnabled(false);
+
+    assertEquals("[2] ZenGTPX", button.getText());
+    assertEquals("[2] ZenGTPX", button.getAccessibleContext().getAccessibleName());
+    assertFalse(button.isEnabled());
+  }
+
   @Test
   void secondPressOnOpenTopMenuClosesInsteadOfReopening() {
     JMenuBar menuBar = new JMenuBar();

--- a/src/test/java/featurecat/lizzie/update/WindowsUpdateApplierTest.java
+++ b/src/test/java/featurecat/lizzie/update/WindowsUpdateApplierTest.java
@@ -44,6 +44,37 @@ class WindowsUpdateApplierTest {
   }
 
   @Test
+  void fallsBackToCurrentAppJarForLegacyUpdateRequest() throws Exception {
+    Fixture fixture = fixture();
+    Path coreZip = tempDir.resolve("core.zip");
+    writeZip(coreZip, entry("app/lizzie-yzy2.5.3-shaded.jar", "new-core"));
+    Path request =
+        request(
+            fixture,
+            component("core", "replace-core", coreZip, "lizzieyzy-next-core.jar", null),
+            installedManifest());
+
+    WindowsUpdateApplier.apply(request);
+
+    assertEquals("new-core", Files.readString(fixture.currentJar));
+  }
+
+  @Test
+  void rejectsCoreSourceThatEscapesTheExtractedArchive() throws Exception {
+    Fixture fixture = fixture();
+    Path coreZip = tempDir.resolve("core.zip");
+    writeZip(coreZip, entry("app/lizzie-yzy2.5.3-shaded.jar", "new-core"));
+    Path request =
+        request(
+            fixture,
+            component("core", "replace-core", coreZip, "../../outside.jar", null),
+            installedManifest());
+
+    assertThrows(IOException.class, () -> WindowsUpdateApplier.apply(request));
+    assertEquals("old-core", Files.readString(fixture.currentJar));
+  }
+
+  @Test
   void replacesMappedResourceDirectory() throws Exception {
     Fixture fixture = fixture();
     Path engineDir = fixture.appDir.resolve("engines/katago/windows-x64");


### PR DESCRIPTION
## Summary

- keeps the existing engine menu objects alive so the custom window menu strip updates immediately after adding or removing engines
- preserves restart and shutdown actions instead of reparenting them into a replacement menu that the visible strip no longer references
- makes Windows core updates tolerant of old and new archive layouts
- adds the legacy root-level core jar alias to future Windows small-update packages

## Validation

- `mvn -B -Dfmt.skip=true test`: 1415 tests passed
- `mvn -B -Dfmt.skip=true -DskipTests package`: passed
- `bash -n scripts/package_windows_exe.sh`: passed
- `bash -n scripts/validate_release_assets.sh`: passed
- `python3 scripts/check_markdown_links.py`: passed
- `git diff --check`: passed

## Issue handling

Fixes #121.
Addresses #114; the already-published package cannot be changed by this merge, so the user-facing updater fix becomes available in the next Windows release asset.

感谢 @semanym 和 @FengmingGo 报告并复现引擎菜单刷新问题，也感谢 @qiyi71w 精确定位旧版更新器与新小更新包目录不兼容的根因。
