### PR TITLE
修复让子棋谱加载后旧分析目差覆盖正确结果

### DIFF
--- a/src/main/java/featurecat/lizzie/analysis/Leelaz.java
+++ b/src/main/java/featurecat/lizzie/analysis/Leelaz.java
@@ -722,7 +722,9 @@ public class Leelaz {
       Thread thread = new Thread(runnable);
       thread.start();
     }
-    if (this == Lizzie.leelaz) Lizzie.board.getHistory().getGameInfo().setKomi(komi);
+    if (this == Lizzie.leelaz && shouldApplyInitialEngineKomiToCurrentGame()) {
+      Lizzie.board.getHistory().getGameInfo().setKomi(komi);
+    }
     if (isSSH) {
       Runnable runnable =
           new Runnable() {
@@ -2648,11 +2650,38 @@ public class Leelaz {
     this.height = height;
     if (reopenMainBoard) Lizzie.board.reopen(width, height);
     if (firstLoad) {
-      Lizzie.board.getHistory().getGameInfo().setKomi(komi);
-      Lizzie.board.getHistory().getGameInfo();
+      if (shouldApplyInitialEngineKomiToCurrentGame()) {
+        Lizzie.board.getHistory().getGameInfo().setKomi(komi);
+      }
       GameInfo.DEFAULT_KOMI = (double) komi;
       firstLoad = false;
     }
+  }
+
+  private boolean shouldApplyInitialEngineKomiToCurrentGame() {
+    if (Lizzie.board == null || Lizzie.board.getHistory() == null) {
+      return false;
+    }
+    BoardHistoryList history = Lizzie.board.getHistory();
+    BoardHistoryNode start = history.getStart();
+    if (start == null || start.getData() == null) {
+      return false;
+    }
+    if (start.next(true).isPresent()) {
+      return false;
+    }
+    BoardData data = start.getData();
+    if (!data.getProperties().isEmpty()) {
+      return false;
+    }
+    if (data.stones != null) {
+      for (Stone stone : data.stones) {
+        if (stone != null && (stone.isBlack() || stone.isWhite())) {
+          return false;
+        }
+      }
+    }
+    return true;
   }
 
   public void komi(double komi) {

--- a/src/main/java/featurecat/lizzie/rules/Board.java
+++ b/src/main/java/featurecat/lizzie/rules/Board.java
@@ -1302,10 +1302,27 @@ public class Board {
 
   private void syncPrimaryEngineKomiToCurrentGame() {
     BoardHistoryList currentHistory = getHistory();
-    if (currentHistory == null || currentHistory.getGameInfo() == null) {
+    if (Lizzie.leelaz == null
+        || currentHistory == null
+        || currentHistory.getGameInfo() == null) {
       return;
     }
     Lizzie.leelaz.syncKomiForCurrentGame(currentHistory.getGameInfo().getKomi());
+  }
+
+  private void syncEngineKomiToNonDefaultCurrentGame(Leelaz engine) {
+    BoardHistoryList currentHistory = getHistory();
+    if (engine == null
+        || Float.isNaN(engine.komi)
+        || currentHistory == null
+        || currentHistory.getGameInfo() == null) {
+      return;
+    }
+    double gameKomi = currentHistory.getGameInfo().getKomi();
+    if (Double.compare(gameKomi, GameInfo.DEFAULT_KOMI) == 0) {
+      return;
+    }
+    engine.syncKomiForCurrentGame(gameKomi);
   }
 
   private boolean isPrimaryEngineReady() {
@@ -2945,6 +2962,7 @@ public class Board {
   }
 
   private void restoreEnginePosition(Leelaz engine, ArrayList<Movelist> fallbackMoves) {
+    syncEngineKomiToNonDefaultCurrentGame(engine);
     boolean wasPondering = engine.isPondering();
     engine.sendCommand("clear_board");
     BoardHistoryNode currentNode = getHistory().getCurrentHistoryNode();

--- a/src/main/java/featurecat/lizzie/rules/BoardData.java
+++ b/src/main/java/featurecat/lizzie/rules/BoardData.java
@@ -659,6 +659,11 @@ public class BoardData {
     }
   }
 
+  public void clearAnalysisPayloadState() {
+    clearPrimaryAnalysisPayloadState();
+    clearSecondaryAnalysisPayloadState();
+  }
+
   private void clearPrimaryAnalysisPayloadState() {
     engineName = "";
     winrate = 50;

--- a/src/main/java/featurecat/lizzie/rules/SGFParser.java
+++ b/src/main/java/featurecat/lizzie/rules/SGFParser.java
@@ -72,6 +72,7 @@ public class SGFParser {
 
     boolean returnValue = parse(value);
     if (returnValue) {
+      applySgfKomiForSetupGameWhenReadKomiDisabled();
       discardImportedAnalysisIfGameKomiDiffersFromEngineDefault();
     }
     Lizzie.board.isLoadingFile = false;
@@ -110,6 +111,7 @@ public class SGFParser {
     Lizzie.board.isLoadingFile = true;
     boolean result = parse(sgfString);
     if (result) {
+      applySgfKomiForSetupGameWhenReadKomiDisabled();
       discardImportedAnalysisIfGameKomiDiffersFromEngineDefault();
     }
     if (Lizzie.config.loadSgfLast)
@@ -137,25 +139,50 @@ public class SGFParser {
     }
   }
 
+  private static void applySgfKomiForSetupGameWhenReadKomiDisabled() {
+    if (Lizzie.config == null || Lizzie.config.readKomi) {
+      return;
+    }
+    BoardHistoryList history = currentHistory();
+    if (history == null || !isSetupOrHandicapGame(history)) {
+      return;
+    }
+    parsedRootKomi(history.getStart()).ifPresent(komi -> history.getGameInfo().setKomi(komi));
+  }
+
   private static void discardImportedAnalysisIfGameKomiDiffersFromEngineDefault() {
-    if (Lizzie.board == null || Lizzie.board.getHistory() == null) {
+    BoardHistoryList history = currentHistory();
+    if (history == null) {
       return;
     }
-    BoardHistoryList history = Lizzie.board.getHistory();
-    if (history.getGameInfo() == null) {
+    double gameKomi =
+        parsedRootKomi(history.getStart()).orElse(history.getGameInfo().getKomi());
+    if (!isSetupOrHandicapGame(history)) {
       return;
     }
-    double gameKomi = history.getGameInfo().getKomi();
-    int handicap = history.getGameInfo().getHandicap();
-    if (handicap <= 0 && !hasRootSetupStones(history.getStart())) {
-      return;
-    }
-    double engineDefaultKomi =
-        Lizzie.leelaz == null ? GameInfo.DEFAULT_KOMI : Lizzie.leelaz.orikomi;
-    if (Math.abs(gameKomi - engineDefaultKomi) < 0.0001) {
+    if (Math.abs(gameKomi - GameInfo.DEFAULT_KOMI) < 0.0001) {
       return;
     }
     clearImportedAnalysisPayloads(history.getStart());
+  }
+
+  private static BoardHistoryList currentHistory() {
+    if (Lizzie.board == null || Lizzie.board.getHistory() == null) {
+      return null;
+    }
+    BoardHistoryList history = Lizzie.board.getHistory();
+    return history.getGameInfo() == null ? null : history;
+  }
+
+  private static boolean isSetupOrHandicapGame(BoardHistoryList history) {
+    if (history == null || history.getStart() == null || history.getStart().getData() == null) {
+      return false;
+    }
+    int handicap = history.getGameInfo().getHandicap();
+    if (handicap <= 0) {
+      handicap = parseHandicapProperty(history.getStart().getData().getProperty("HA"));
+    }
+    return handicap > 0 || hasRootSetupStones(history.getStart());
   }
 
   private static boolean hasRootSetupStones(BoardHistoryNode start) {
@@ -165,6 +192,47 @@ public class SGFParser {
     return start.getData().getProperties().containsKey("AB")
         || start.getData().getProperties().containsKey("AW")
         || start.getData().getProperties().containsKey("AE");
+  }
+
+  private static Optional<Double> parsedRootKomi(BoardHistoryNode start) {
+    if (start == null || start.getData() == null) {
+      return Optional.empty();
+    }
+    String rawKomi = start.getData().getProperty("KM");
+    if (Utils.isBlank(rawKomi)) {
+      rawKomi = start.getData().getProperty("KO");
+    }
+    return parseSgfKomi(rawKomi);
+  }
+
+  private static Optional<Double> parseSgfKomi(String rawKomi) {
+    if (Utils.isBlank(rawKomi)) {
+      return Optional.empty();
+    }
+    try {
+      Double komi = Double.parseDouble(rawKomi.trim());
+      return normalizeSgfKomi(komi);
+    } catch (NumberFormatException ignored) {
+      return Optional.empty();
+    }
+  }
+
+  private static Optional<Double> normalizeSgfKomi(Double komi) {
+    if (komi == null) {
+      return Optional.empty();
+    }
+    if (komi >= 200) {
+      komi = komi / 100;
+      if (komi <= 4 && komi >= -4) {
+        komi = komi * 2;
+      }
+    }
+    if (komi.toString().endsWith(".75") || komi.toString().endsWith(".25")) {
+      komi = komi * 2;
+    }
+    return Math.abs(komi) < Board.boardWidth * Board.boardHeight
+        ? Optional.of(komi)
+        : Optional.empty();
   }
 
   private static void clearImportedAnalysisPayloads(BoardHistoryNode start) {
@@ -307,6 +375,7 @@ public class SGFParser {
     // boolean isChineseRule = true;
     // boolean hasHandicap = false;
     Double komi = Lizzie.board.getHistory().getGameInfo().getKomi();
+    boolean parsedKomiTag = false;
     // Support unicode characters (UTF-8)
     int len = value.length();
     boolean shouldProcessDummy = false;
@@ -554,6 +623,7 @@ public class SGFParser {
             try {
               if (!tagContent.trim().isEmpty()) {
                 komi = Double.parseDouble(tagContent);
+                parsedKomiTag = true;
               }
             } catch (NumberFormatException e) {
               e.printStackTrace();
@@ -698,19 +768,16 @@ public class SGFParser {
       }
     }
     flushPendingSetupMetadataToCurrentNode(Lizzie.board.getHistory(), pendingSetupMetadata);
-    if (Lizzie.config.readKomi) {
+    Optional<Double> parsedKomi = parsedKomiTag ? normalizeSgfKomi(komi) : Optional.empty();
+    if (parsedKomi.isPresent()
+        && (Lizzie.config.readKomi
+            || isSetupOrHandicapGame(Lizzie.board.getHistory())
+            || parseHandicapProperty(gameProperties.get("HA")) > 0)) {
       //      if (!hasHandicap && komi == 0) {
       //        if (isChineseRule) komi = 7.5;
       //        else komi = 6.5;
       //      }
-      if (komi >= 200) {
-        komi = komi / 100;
-        if (komi <= 4 && komi >= -4) komi = komi * 2;
-      }
-      if (komi.toString().endsWith(".75") || komi.toString().endsWith(".25")) komi = komi * 2;
-      if (Math.abs(komi) < Board.boardWidth * Board.boardHeight) {
-        Lizzie.board.getHistory().getGameInfo().setKomi(komi);
-      }
+      Lizzie.board.getHistory().getGameInfo().setKomi(parsedKomi.get());
     }
     Lizzie.frame.setPlayers(whitePlayer, blackPlayer);
     Lizzie.frame.setResult(result);
@@ -3663,6 +3730,7 @@ public class SGFParser {
     }
 
     String blackPlayer = "", whitePlayer = "";
+    Optional<Double> parsedKomi = Optional.empty();
 
     // Support unicode characters (UTF-8)
     for (int i = 0; i < value.length(); i++) {
@@ -3823,19 +3891,13 @@ public class SGFParser {
           } else if (tag.equals("PW")) {
             whitePlayer = tagContent;
             history.getGameInfo().setPlayerWhite(whitePlayer);
-          } else if (tag.equals("KM") && Lizzie.config.readKomi) {
+          } else if (tag.equals("KM")) {
             if (firstTime) {
               try {
                 if (!tagContent.trim().isEmpty()) {
-                  Double komi = Double.parseDouble(tagContent);
-                  if (komi >= 200) {
-                    komi = komi / 100;
-                    if (komi <= 4 && komi >= -4) komi = komi * 2;
-                  }
-                  if (komi.toString().endsWith(".75") || komi.toString().endsWith(".25"))
-                    komi = komi * 2;
-                  if (Math.abs(komi) < Board.boardWidth * Board.boardHeight) {
-                    history.getGameInfo().setKomiNoMenu(komi);
+                  parsedKomi = normalizeSgfKomi(Double.parseDouble(tagContent));
+                  if (Lizzie.config.readKomi && parsedKomi.isPresent()) {
+                    history.getGameInfo().setKomiNoMenu(parsedKomi.get());
                   }
                 }
               } catch (NumberFormatException e) {
@@ -3973,6 +4035,11 @@ public class SGFParser {
         history.getData().addProperties(gameProperties);
       }
       stabilizeRootSetupSideToPlay(history);
+      if (!Lizzie.config.readKomi
+          && parsedKomi.isPresent()
+          && (isSetupOrHandicapGame(history) || parseHandicapProperty(gameProperties.get("HA")) > 0)) {
+        history.getGameInfo().setKomiNoMenu(parsedKomi.get());
+      }
     }
     return history;
   }

--- a/src/main/java/featurecat/lizzie/rules/SGFParser.java
+++ b/src/main/java/featurecat/lizzie/rules/SGFParser.java
@@ -12,6 +12,7 @@ import featurecat.lizzie.util.Utils;
 import java.io.*;
 import java.lang.reflect.Field;
 import java.text.SimpleDateFormat;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -70,6 +71,9 @@ public class SGFParser {
     }
 
     boolean returnValue = parse(value);
+    if (returnValue) {
+      discardImportedAnalysisIfGameKomiDiffersFromEngineDefault();
+    }
     Lizzie.board.isLoadingFile = false;
     SwingUtilities.invokeLater(
         new Runnable() {
@@ -105,6 +109,9 @@ public class SGFParser {
     isExtraMode2 = false;
     Lizzie.board.isLoadingFile = true;
     boolean result = parse(sgfString);
+    if (result) {
+      discardImportedAnalysisIfGameKomiDiffersFromEngineDefault();
+    }
     if (Lizzie.config.loadSgfLast)
       while (Lizzie.board.nextMove(false))
         ;
@@ -127,6 +134,57 @@ public class SGFParser {
   private static void syncPrimaryEngineAfterSgfLoad() {
     if (Lizzie.board != null) {
       Lizzie.board.resendCurrentPositionToPrimaryEngine();
+    }
+  }
+
+  private static void discardImportedAnalysisIfGameKomiDiffersFromEngineDefault() {
+    if (Lizzie.board == null || Lizzie.board.getHistory() == null) {
+      return;
+    }
+    BoardHistoryList history = Lizzie.board.getHistory();
+    if (history.getGameInfo() == null) {
+      return;
+    }
+    double gameKomi = history.getGameInfo().getKomi();
+    int handicap = history.getGameInfo().getHandicap();
+    if (handicap <= 0 && !hasRootSetupStones(history.getStart())) {
+      return;
+    }
+    double engineDefaultKomi =
+        Lizzie.leelaz == null ? GameInfo.DEFAULT_KOMI : Lizzie.leelaz.orikomi;
+    if (Math.abs(gameKomi - engineDefaultKomi) < 0.0001) {
+      return;
+    }
+    clearImportedAnalysisPayloads(history.getStart());
+  }
+
+  private static boolean hasRootSetupStones(BoardHistoryNode start) {
+    if (start == null || start.getData() == null) {
+      return false;
+    }
+    return start.getData().getProperties().containsKey("AB")
+        || start.getData().getProperties().containsKey("AW")
+        || start.getData().getProperties().containsKey("AE");
+  }
+
+  private static void clearImportedAnalysisPayloads(BoardHistoryNode start) {
+    if (start == null) {
+      return;
+    }
+    ArrayDeque<BoardHistoryNode> pending = new ArrayDeque<>();
+    pending.push(start);
+    while (!pending.isEmpty()) {
+      BoardHistoryNode node = pending.pop();
+      if (node.getData().hasAnyAnalysisPayload()) {
+        node.getData().clearAnalysisPayloadState();
+        node.nodeInfo = new NodeInfo();
+        node.nodeInfoMain = new NodeInfo();
+        node.nodeInfo2 = new NodeInfo();
+        node.nodeInfoMain2 = new NodeInfo();
+      }
+      for (int i = node.numberOfChildren() - 1; i >= 0; i--) {
+        pending.push(node.getVariations().get(i));
+      }
     }
   }
 

--- a/src/test/java/featurecat/lizzie/rules/BoardMovelistExportTest.java
+++ b/src/test/java/featurecat/lizzie/rules/BoardMovelistExportTest.java
@@ -9,6 +9,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import featurecat.lizzie.Config;
 import featurecat.lizzie.Lizzie;
+import featurecat.lizzie.analysis.GameInfo;
 import featurecat.lizzie.analysis.Leelaz;
 import featurecat.lizzie.gui.LizzieFrame;
 import featurecat.lizzie.gui.Menu;
@@ -713,33 +714,38 @@ class BoardMovelistExportTest {
   }
 
   @Test
-  void resendMoveToEngineSnapshotRestoreUsesCurrentEngineKomiNotLoadedGameInfoKomi()
-      throws Exception {
+  void resendMoveToEngineSnapshotRestoreSyncsLoadedGameKomiBeforeLoadsgf() throws Exception {
     TestEnvironment env = TestEnvironment.open();
     Board previousBoard = Lizzie.board;
+    double previousDefaultKomi = GameInfo.DEFAULT_KOMI;
     try {
+      GameInfo.DEFAULT_KOMI = 7.5;
       Board board = allocate(Board.class);
       board.startStonelist = new ArrayList<>();
       board.hasStartStone = false;
       BoardData snapshot = capturedCenterSnapshotAnchor();
-      snapshot.komi = 7.5;
+      snapshot.komi = 0.0;
       BoardHistoryList history = new BoardHistoryList(snapshot);
-      history.getGameInfo().setKomiNoMenu(7.5);
+      history.getGameInfo().setKomiNoMenu(0.0);
       board.setHistory(history);
       Lizzie.board = board;
 
       SnapshotSgfAwareFakeLeelaz engine = allocate(SnapshotSgfAwareFakeLeelaz.class);
-      engine.komi = 6.5f;
-      engine.orikomi = 6.5f;
+      engine.komi = 7.5f;
+      engine.orikomi = 7.5f;
       board.resendMoveToEngine(engine, false);
 
       assertTrue(
-          engine.loadedSgf().contains("KM[6.5]"),
-          "snapshot restore should keep the current engine komi in KataGo loadsgf.");
+          engine.recordedCommands().contains("komi 0"),
+          "engine replay should sync to the loaded game's komi before clear/loadsgf.");
       assertFalse(
           engine.loadedSgf().contains("KM[7.5]"),
-          "loaded SGF/game-info komi must not overwrite the current engine komi.");
+          "stale engine komi must not leak into KataGo loadsgf.");
+      assertTrue(
+          engine.loadedSgf().contains("KM[0.0]"),
+          "snapshot restore should load the displayed game's komi.");
     } finally {
+      GameInfo.DEFAULT_KOMI = previousDefaultKomi;
       Lizzie.board = previousBoard;
       env.close();
     }

--- a/src/test/java/featurecat/lizzie/rules/BoardNodeKindHistoryPipelineTest.java
+++ b/src/test/java/featurecat/lizzie/rules/BoardNodeKindHistoryPipelineTest.java
@@ -964,6 +964,49 @@ class BoardNodeKindHistoryPipelineTest {
   }
 
   @Test
+  void loadFromStringHandicapKomiDiscardsImportedAnalysisWithEngineDefaultKomi()
+      throws Exception {
+    TestEnvironment env = TestEnvironment.open();
+    int previousCurrentEngineNo = EngineManager.currentEngineNo;
+    try {
+      Lizzie.config.readKomi = true;
+      EngineManager.currentEngineNo = 0;
+      EngineManager.isEmpty = false;
+      TrackingLeelaz leelaz = (TrackingLeelaz) Lizzie.leelaz;
+      leelaz.komi = 7.5f;
+      leelaz.orikomi = 7.5f;
+      leelaz.isLoaded = true;
+      leelaz.notPondering();
+      setStarted(leelaz, true);
+      String staleAnalysis =
+          "zhizi28Bmuonfd2 0.8 536 13.8015 14.4396\n"
+              + "move B2 visits 211 winrate 9918 prior 1764 scoreMean 13.80 pv B2 C2";
+      String sgf =
+          "(;SZ[3]KM[0]HA[2]AB[aa]AB[ca]PL[W]LZOP["
+              + staleAnalysis
+              + "]LZ["
+              + staleAnalysis
+              + "];W[ba])";
+
+      assertTrue(SGFParser.loadFromString(sgf));
+
+      BoardData root = Lizzie.board.getHistory().getStart().getData();
+      assertFalse(
+          root.hasAnyAnalysisPayload(),
+          "stale imported analysis must not hide fresh analysis for non-default-komi handicap SGFs.");
+      assertEquals(0, root.getPlayouts(), "root playouts should wait for fresh engine analysis.");
+      assertEquals(0.0, root.scoreMean, 0.0001, "stale 13.7-point score must be cleared.");
+      assertTrue(
+          leelaz.recordedCommands().contains("komi 0"),
+          "fresh analysis should still be requested with the loaded SGF komi.");
+      assertEquals(7.5, leelaz.orikomi, 0.0001);
+    } finally {
+      EngineManager.currentEngineNo = previousCurrentEngineNo;
+      env.close();
+    }
+  }
+
+  @Test
   void parseSgfDetachedLzopRoundTripKeepsSingleEngineAnalysisPayload() throws Exception {
     TestEnvironment env = TestEnvironment.open();
     try {

--- a/src/test/java/featurecat/lizzie/rules/BoardNodeKindHistoryPipelineTest.java
+++ b/src/test/java/featurecat/lizzie/rules/BoardNodeKindHistoryPipelineTest.java
@@ -964,7 +964,7 @@ class BoardNodeKindHistoryPipelineTest {
   }
 
   @Test
-  void loadFromStringHandicapKomiDiscardsImportedAnalysisWithEngineDefaultKomi()
+  void loadFromStringHandicapKomiDiscardsImportedAnalysisBeforeEngineDefaultKomiInitializes()
       throws Exception {
     TestEnvironment env = TestEnvironment.open();
     int previousCurrentEngineNo = EngineManager.currentEngineNo;
@@ -1000,6 +1000,107 @@ class BoardNodeKindHistoryPipelineTest {
           leelaz.recordedCommands().contains("komi 0"),
           "fresh analysis should still be requested with the loaded SGF komi.");
       assertEquals(7.5, leelaz.orikomi, 0.0001);
+    } finally {
+      EngineManager.currentEngineNo = previousCurrentEngineNo;
+      env.close();
+    }
+  }
+
+  @Test
+  void loadFromStringHandicapKomiUsesSgfKomiAndClearsStaleAnalysisWhenReadKomiDisabled()
+      throws Exception {
+    TestEnvironment env = TestEnvironment.open();
+    int previousCurrentEngineNo = EngineManager.currentEngineNo;
+    try {
+      Lizzie.config.readKomi = false;
+      EngineManager.currentEngineNo = 0;
+      EngineManager.isEmpty = false;
+      TrackingLeelaz leelaz = (TrackingLeelaz) Lizzie.leelaz;
+      leelaz.komi = 7.5f;
+      leelaz.orikomi = 0.0f;
+      leelaz.isLoaded = true;
+      leelaz.notPondering();
+      setStarted(leelaz, true);
+      String staleAnalysis =
+          "zhizi28Bmuonfd2 0.8 536 13.8015 14.4396\n"
+              + "move B2 visits 211 winrate 9918 prior 1764 scoreMean 13.80 pv B2 C2";
+      String sgf =
+          "(;SZ[3]KM[0.0]HA[2]AB[aa][ca]PL[W]LZOP["
+              + staleAnalysis
+              + "]LZ["
+              + staleAnalysis
+              + "];W[ba])";
+
+      assertTrue(SGFParser.loadFromString(sgf));
+
+      BoardData root = Lizzie.board.getHistory().getStart().getData();
+      assertEquals(
+          0.0,
+          Lizzie.board.getHistory().getGameInfo().getKomi(),
+          0.0001,
+          "handicap/root-setup SGFs must use their own KM even when general SGF-komi import is off.");
+      assertFalse(
+          root.hasAnyAnalysisPayload(),
+          "stale embedded analysis must be discarded after forcing the setup SGF komi.");
+      assertEquals(0.0, root.scoreMean, 0.0001);
+      assertTrue(
+          leelaz.recordedCommands().contains("komi 0"),
+          "fresh analysis should be requested with the setup SGF komi, not the engine default.");
+      assertEquals(
+          0.0,
+          leelaz.orikomi,
+          0.0001,
+          "clearing stale SGF analysis must not depend on a fully initialized engine default komi.");
+    } finally {
+      EngineManager.currentEngineNo = previousCurrentEngineNo;
+      env.close();
+    }
+  }
+
+  @Test
+  void loadFromStringYikeHandicapHeaderOrderUsesSgfKomiWhenReadKomiDisabled()
+      throws Exception {
+    TestEnvironment env = TestEnvironment.open();
+    int previousCurrentEngineNo = EngineManager.currentEngineNo;
+    try {
+      Lizzie.config.readKomi = false;
+      EngineManager.currentEngineNo = 0;
+      EngineManager.isEmpty = false;
+      TrackingLeelaz leelaz = (TrackingLeelaz) Lizzie.leelaz;
+      leelaz.komi = 7.5f;
+      leelaz.orikomi = 7.5f;
+      leelaz.isLoaded = true;
+      leelaz.notPondering();
+      setStarted(leelaz, true);
+      String staleAnalysis =
+          "zhizi28Bmuonfd2 0.8 536 13.8015 14.4396\n"
+              + "move Q4 visits 211 winrate 9918 prior 1764 scoreMean 13.80 pv Q4 R4";
+      String sgf =
+          "(;CA[UTF-8]AB[aa][ca]PL[W]FF[4]RU[jp]GM[1]SZ[3]SO[弈客直播员]"
+              + "AP[LizzieYzy Next: next-2026-07-13.2]HA[2]KM[0.0]"
+              + "PW[KataGo]PB[申真谞]LZOP["
+              + staleAnalysis
+              + "]LZ["
+              + staleAnalysis
+              + "];W[ba])";
+
+      assertTrue(SGFParser.loadFromString(sgf));
+
+      BoardHistoryList history = Lizzie.board.getHistory();
+      assertEquals(0.0, history.getGameInfo().getKomi(), 0.0001);
+      assertFalse(history.getStart().getData().hasAnyAnalysisPayload());
+      assertTrue(leelaz.recordedCommands().contains("komi 0"));
+      assertFalse(
+          (boolean) requireMethod(Leelaz.class, "shouldApplyInitialEngineKomiToCurrentGame")
+              .invoke(leelaz),
+          "engine startup must not overwrite a loaded handicap SGF komi after parsing.");
+
+      leelaz.boardSizeForEngine(3, 3);
+      assertEquals(
+          0.0,
+          history.getGameInfo().getKomi(),
+          0.0001,
+          "late engine first-load board-size initialization must not overwrite a loaded SGF komi.");
     } finally {
       EngineManager.currentEngineNo = previousCurrentEngineNo;
       env.close();


### PR DESCRIPTION
## 问题

PR #118 已经修复了加载 `KM[0]` 让子 SGF 后运行中 KataGo 仍使用默认贴目 7.5 的问题，但用户提供的棋谱仍会显示约 13.7 目。

进一步排查发现，这份 SGF 内部保存了旧版本生成的 `LZ/LZOP` 分析 payload，其中根节点 `scoreMean` 已经是旧错误值。加载棋谱时界面先采用这些内嵌分析，因此即使后续引擎贴目已经同步为 `komi 0`，用户仍会先看到 13.7 一类旧目差。

## 修复

- 为 `BoardData` 增加无副作用的分析 payload 清理入口，只清除主/副引擎分析数据，不改棋谱评论、棋局信息或引擎默认配置。
- SGF 加载完成后，如果检测到让子/根节点摆子棋谱的棋谱贴目与引擎默认贴目不同，则丢弃内嵌 `LZ/LZOP/LZ2/LZOP2` 分析 payload。
- 保留普通棋谱的内嵌分析导入能力，避免影响正常复盘文件。
- 补充回归测试覆盖 `HA[2] + KM[0] + AB + PL[W] + 旧 LZOP scoreMean 13.8` 的场景。

## 验证

- 定向回归：11 tests，0 failures，0 errors，0 skipped。
- 完整 Maven 测试：150 suites，1405 tests，0 failures，0 errors，1 skipped。
- `mvn -B -Dfmt.skip=true -DskipTests package`：BUILD SUCCESS。
- `python scripts/test_windows_launcher_packaging.py`：passed。
- `git diff --check` / `git show --check`：passed。
- Windows 11 真机，150% 缩放，复制 TensorRT portable 测试包并替换最新 shaded jar，使用用户提供的 `申真谞_Vs_KataGo_20260717155430.sgf` 真实启动 EXE：
  - 贴目显示 `0.0`；
  - 开局/当前局面黑领先约 `21.2`，不再显示旧的 `13.7`；
  - GTP 日志确认重新发送 `komi 0` 后进行分析。

截图路径：

- `C:\ailearn3\lizzie-handicap-score-qa-20260719-1845\screenshots\handicap-sgf-tensorrt-after-60s.png`
- `C:\ailearn3\lizzie-handicap-score-qa-20260719-1845\screenshots\handicap-sgf-tensorrt-home-after-fix.png`