### PR TITLE
Fix handicap SGF komi regression on main

### DIFF
--- a/src/main/java/featurecat/lizzie/analysis/Leelaz.java
+++ b/src/main/java/featurecat/lizzie/analysis/Leelaz.java
@@ -722,7 +722,9 @@ public class Leelaz {
       Thread thread = new Thread(runnable);
       thread.start();
     }
-    if (this == Lizzie.leelaz) Lizzie.board.getHistory().getGameInfo().setKomi(komi);
+    if (this == Lizzie.leelaz && shouldApplyInitialEngineKomiToCurrentGame()) {
+      Lizzie.board.getHistory().getGameInfo().setKomi(komi);
+    }
     if (isSSH) {
       Runnable runnable =
           new Runnable() {
@@ -2648,11 +2650,38 @@ public class Leelaz {
     this.height = height;
     if (reopenMainBoard) Lizzie.board.reopen(width, height);
     if (firstLoad) {
-      Lizzie.board.getHistory().getGameInfo().setKomi(komi);
-      Lizzie.board.getHistory().getGameInfo();
+      if (shouldApplyInitialEngineKomiToCurrentGame()) {
+        Lizzie.board.getHistory().getGameInfo().setKomi(komi);
+      }
       GameInfo.DEFAULT_KOMI = (double) komi;
       firstLoad = false;
     }
+  }
+
+  private boolean shouldApplyInitialEngineKomiToCurrentGame() {
+    if (Lizzie.board == null || Lizzie.board.getHistory() == null) {
+      return false;
+    }
+    BoardHistoryList history = Lizzie.board.getHistory();
+    BoardHistoryNode start = history.getStart();
+    if (start == null || start.getData() == null) {
+      return false;
+    }
+    if (start.next(true).isPresent()) {
+      return false;
+    }
+    BoardData data = start.getData();
+    if (!data.getProperties().isEmpty()) {
+      return false;
+    }
+    if (data.stones != null) {
+      for (Stone stone : data.stones) {
+        if (stone != null && (stone.isBlack() || stone.isWhite())) {
+          return false;
+        }
+      }
+    }
+    return true;
   }
 
   public void komi(double komi) {
@@ -3773,8 +3802,11 @@ public class Leelaz {
             oriEnginename,
             EngineManager.engineGameInfo.isBlackEngine(currentEngineN()));
 
-      } else if (Lizzie.config.alwaysGtp || Lizzie.gtpConsole.isVisible())
+      } else if (Lizzie.gtpConsole != null
+          && ((Lizzie.config != null && Lizzie.config.alwaysGtp)
+              || Lizzie.gtpConsole.isVisible())) {
         Lizzie.gtpConsole.addCommand(command, cmdNumber, oriEnginename);
+      }
     } else {
       String detail = "outputStream unavailable";
       rememberRecentLine(

--- a/src/main/java/featurecat/lizzie/rules/Board.java
+++ b/src/main/java/featurecat/lizzie/rules/Board.java
@@ -1302,10 +1302,27 @@ public class Board {
 
   private void syncPrimaryEngineKomiToCurrentGame() {
     BoardHistoryList currentHistory = getHistory();
-    if (currentHistory == null || currentHistory.getGameInfo() == null) {
+    if (Lizzie.leelaz == null
+        || currentHistory == null
+        || currentHistory.getGameInfo() == null) {
       return;
     }
     Lizzie.leelaz.syncKomiForCurrentGame(currentHistory.getGameInfo().getKomi());
+  }
+
+  private void syncEngineKomiToNonDefaultCurrentGame(Leelaz engine) {
+    BoardHistoryList currentHistory = getHistory();
+    if (engine == null
+        || Float.isNaN(engine.komi)
+        || currentHistory == null
+        || currentHistory.getGameInfo() == null) {
+      return;
+    }
+    double gameKomi = currentHistory.getGameInfo().getKomi();
+    if (Double.compare(gameKomi, GameInfo.DEFAULT_KOMI) == 0) {
+      return;
+    }
+    engine.syncKomiForCurrentGame(gameKomi);
   }
 
   private boolean isPrimaryEngineReady() {
@@ -2945,6 +2962,7 @@ public class Board {
   }
 
   private void restoreEnginePosition(Leelaz engine, ArrayList<Movelist> fallbackMoves) {
+    syncEngineKomiToNonDefaultCurrentGame(engine);
     boolean wasPondering = engine.isPondering();
     engine.sendCommand("clear_board");
     BoardHistoryNode currentNode = getHistory().getCurrentHistoryNode();

--- a/src/main/java/featurecat/lizzie/rules/SGFParser.java
+++ b/src/main/java/featurecat/lizzie/rules/SGFParser.java
@@ -12,6 +12,7 @@ import featurecat.lizzie.util.Utils;
 import java.io.*;
 import java.lang.reflect.Field;
 import java.text.SimpleDateFormat;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -70,6 +71,10 @@ public class SGFParser {
     }
 
     boolean returnValue = parse(value);
+    if (returnValue) {
+      applySgfKomiForSetupGameWhenReadKomiDisabled();
+      discardImportedAnalysisIfGameKomiDiffersFromEngineDefault();
+    }
     Lizzie.board.isLoadingFile = false;
     SwingUtilities.invokeLater(
         new Runnable() {
@@ -105,6 +110,10 @@ public class SGFParser {
     isExtraMode2 = false;
     Lizzie.board.isLoadingFile = true;
     boolean result = parse(sgfString);
+    if (result) {
+      applySgfKomiForSetupGameWhenReadKomiDisabled();
+      discardImportedAnalysisIfGameKomiDiffersFromEngineDefault();
+    }
     if (Lizzie.config.loadSgfLast)
       while (Lizzie.board.nextMove(false))
         ;
@@ -127,6 +136,124 @@ public class SGFParser {
   private static void syncPrimaryEngineAfterSgfLoad() {
     if (Lizzie.board != null) {
       Lizzie.board.resendCurrentPositionToPrimaryEngine();
+    }
+  }
+
+  private static void applySgfKomiForSetupGameWhenReadKomiDisabled() {
+    if (Lizzie.config == null || Lizzie.config.readKomi) {
+      return;
+    }
+    BoardHistoryList history = currentHistory();
+    if (history == null || !isSetupOrHandicapGame(history)) {
+      return;
+    }
+    parsedRootKomi(history.getStart()).ifPresent(komi -> history.getGameInfo().setKomi(komi));
+  }
+
+  private static void discardImportedAnalysisIfGameKomiDiffersFromEngineDefault() {
+    BoardHistoryList history = currentHistory();
+    if (history == null) {
+      return;
+    }
+    double gameKomi =
+        parsedRootKomi(history.getStart()).orElse(history.getGameInfo().getKomi());
+    if (!isSetupOrHandicapGame(history)) {
+      return;
+    }
+    if (Math.abs(gameKomi - GameInfo.DEFAULT_KOMI) < 0.0001) {
+      return;
+    }
+    clearImportedAnalysisPayloads(history.getStart());
+  }
+
+  private static BoardHistoryList currentHistory() {
+    if (Lizzie.board == null || Lizzie.board.getHistory() == null) {
+      return null;
+    }
+    BoardHistoryList history = Lizzie.board.getHistory();
+    return history.getGameInfo() == null ? null : history;
+  }
+
+  private static boolean isSetupOrHandicapGame(BoardHistoryList history) {
+    if (history == null || history.getStart() == null || history.getStart().getData() == null) {
+      return false;
+    }
+    int handicap = history.getGameInfo().getHandicap();
+    if (handicap <= 0) {
+      handicap = parseHandicapProperty(history.getStart().getData().getProperty("HA"));
+    }
+    return handicap > 0 || hasRootSetupStones(history.getStart());
+  }
+
+  private static boolean hasRootSetupStones(BoardHistoryNode start) {
+    if (start == null || start.getData() == null) {
+      return false;
+    }
+    return start.getData().getProperties().containsKey("AB")
+        || start.getData().getProperties().containsKey("AW")
+        || start.getData().getProperties().containsKey("AE");
+  }
+
+  private static Optional<Double> parsedRootKomi(BoardHistoryNode start) {
+    if (start == null || start.getData() == null) {
+      return Optional.empty();
+    }
+    String rawKomi = start.getData().getProperty("KM");
+    if (Utils.isBlank(rawKomi)) {
+      rawKomi = start.getData().getProperty("KO");
+    }
+    return parseSgfKomi(rawKomi);
+  }
+
+  private static Optional<Double> parseSgfKomi(String rawKomi) {
+    if (Utils.isBlank(rawKomi)) {
+      return Optional.empty();
+    }
+    try {
+      Double komi = Double.parseDouble(rawKomi.trim());
+      return normalizeSgfKomi(komi);
+    } catch (NumberFormatException ignored) {
+      return Optional.empty();
+    }
+  }
+
+  private static Optional<Double> normalizeSgfKomi(Double komi) {
+    if (komi == null) {
+      return Optional.empty();
+    }
+    if (komi >= 200) {
+      komi = komi / 100;
+      if (komi <= 4 && komi >= -4) {
+        komi = komi * 2;
+      }
+    }
+    if (komi.toString().endsWith(".75") || komi.toString().endsWith(".25")) {
+      komi = komi * 2;
+    }
+    return Math.abs(komi) < Board.boardWidth * Board.boardHeight
+        ? Optional.of(komi)
+        : Optional.empty();
+  }
+
+  private static void clearImportedAnalysisPayloads(BoardHistoryNode start) {
+    if (start == null) {
+      return;
+    }
+    ArrayDeque<BoardHistoryNode> pending = new ArrayDeque<>();
+    pending.push(start);
+    while (!pending.isEmpty()) {
+      BoardHistoryNode node = pending.pop();
+      if (node.getData().hasAnyAnalysisPayload()) {
+        clearPrimaryAnalysisPayload(node.getData());
+        clearSecondaryAnalysisPayload(node.getData());
+        node.nodeInfo = new NodeInfo();
+        node.nodeInfoMain = new NodeInfo();
+        node.nodeInfo2 = new NodeInfo();
+        node.nodeInfoMain2 = new NodeInfo();
+      }
+      for (int i = node.numberOfChildren() - 1; i >= 0; i--) {
+        pending.push(node.getVariations().get(i));
+      }
     }
   }
 
@@ -249,6 +376,7 @@ public class SGFParser {
     // boolean isChineseRule = true;
     // boolean hasHandicap = false;
     Double komi = Lizzie.board.getHistory().getGameInfo().getKomi();
+    boolean parsedKomiTag = false;
     // Support unicode characters (UTF-8)
     int len = value.length();
     boolean shouldProcessDummy = false;
@@ -496,6 +624,7 @@ public class SGFParser {
             try {
               if (!tagContent.trim().isEmpty()) {
                 komi = Double.parseDouble(tagContent);
+                parsedKomiTag = true;
               }
             } catch (NumberFormatException e) {
               e.printStackTrace();
@@ -640,19 +769,16 @@ public class SGFParser {
       }
     }
     flushPendingSetupMetadataToCurrentNode(Lizzie.board.getHistory(), pendingSetupMetadata);
-    if (Lizzie.config.readKomi) {
+    Optional<Double> parsedKomi = parsedKomiTag ? normalizeSgfKomi(komi) : Optional.empty();
+    if (parsedKomi.isPresent()
+        && (Lizzie.config.readKomi
+            || isSetupOrHandicapGame(Lizzie.board.getHistory())
+            || parseHandicapProperty(gameProperties.get("HA")) > 0)) {
       //      if (!hasHandicap && komi == 0) {
       //        if (isChineseRule) komi = 7.5;
       //        else komi = 6.5;
       //      }
-      if (komi >= 200) {
-        komi = komi / 100;
-        if (komi <= 4 && komi >= -4) komi = komi * 2;
-      }
-      if (komi.toString().endsWith(".75") || komi.toString().endsWith(".25")) komi = komi * 2;
-      if (Math.abs(komi) < Board.boardWidth * Board.boardHeight) {
-        Lizzie.board.getHistory().getGameInfo().setKomi(komi);
-      }
+      Lizzie.board.getHistory().getGameInfo().setKomi(parsedKomi.get());
     }
     Lizzie.frame.setPlayers(whitePlayer, blackPlayer);
     Lizzie.frame.setResult(result);
@@ -3605,6 +3731,7 @@ public class SGFParser {
     }
 
     String blackPlayer = "", whitePlayer = "";
+    Optional<Double> parsedKomi = Optional.empty();
 
     // Support unicode characters (UTF-8)
     for (int i = 0; i < value.length(); i++) {
@@ -3765,19 +3892,13 @@ public class SGFParser {
           } else if (tag.equals("PW")) {
             whitePlayer = tagContent;
             history.getGameInfo().setPlayerWhite(whitePlayer);
-          } else if (tag.equals("KM") && Lizzie.config.readKomi) {
+          } else if (tag.equals("KM")) {
             if (firstTime) {
               try {
                 if (!tagContent.trim().isEmpty()) {
-                  Double komi = Double.parseDouble(tagContent);
-                  if (komi >= 200) {
-                    komi = komi / 100;
-                    if (komi <= 4 && komi >= -4) komi = komi * 2;
-                  }
-                  if (komi.toString().endsWith(".75") || komi.toString().endsWith(".25"))
-                    komi = komi * 2;
-                  if (Math.abs(komi) < Board.boardWidth * Board.boardHeight) {
-                    history.getGameInfo().setKomiNoMenu(komi);
+                  parsedKomi = normalizeSgfKomi(Double.parseDouble(tagContent));
+                  if (Lizzie.config.readKomi && parsedKomi.isPresent()) {
+                    history.getGameInfo().setKomiNoMenu(parsedKomi.get());
                   }
                 }
               } catch (NumberFormatException e) {
@@ -3915,6 +4036,11 @@ public class SGFParser {
         history.getData().addProperties(gameProperties);
       }
       stabilizeRootSetupSideToPlay(history);
+      if (!Lizzie.config.readKomi
+          && parsedKomi.isPresent()
+          && (isSetupOrHandicapGame(history) || parseHandicapProperty(gameProperties.get("HA")) > 0)) {
+        history.getGameInfo().setKomiNoMenu(parsedKomi.get());
+      }
     }
     return history;
   }

--- a/src/test/java/featurecat/lizzie/rules/BoardMovelistExportTest.java
+++ b/src/test/java/featurecat/lizzie/rules/BoardMovelistExportTest.java
@@ -9,6 +9,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import featurecat.lizzie.Config;
 import featurecat.lizzie.Lizzie;
+import featurecat.lizzie.analysis.GameInfo;
 import featurecat.lizzie.analysis.Leelaz;
 import featurecat.lizzie.gui.LizzieFrame;
 import featurecat.lizzie.gui.Menu;
@@ -713,33 +714,38 @@ class BoardMovelistExportTest {
   }
 
   @Test
-  void resendMoveToEngineSnapshotRestoreUsesCurrentEngineKomiNotLoadedGameInfoKomi()
-      throws Exception {
+  void resendMoveToEngineSnapshotRestoreSyncsLoadedGameKomiBeforeLoadsgf() throws Exception {
     TestEnvironment env = TestEnvironment.open();
     Board previousBoard = Lizzie.board;
+    double previousDefaultKomi = GameInfo.DEFAULT_KOMI;
     try {
+      GameInfo.DEFAULT_KOMI = 7.5;
       Board board = allocate(Board.class);
       board.startStonelist = new ArrayList<>();
       board.hasStartStone = false;
       BoardData snapshot = capturedCenterSnapshotAnchor();
-      snapshot.komi = 7.5;
+      snapshot.komi = 0.0;
       BoardHistoryList history = new BoardHistoryList(snapshot);
-      history.getGameInfo().setKomiNoMenu(7.5);
+      history.getGameInfo().setKomiNoMenu(0.0);
       board.setHistory(history);
       Lizzie.board = board;
 
       SnapshotSgfAwareFakeLeelaz engine = allocate(SnapshotSgfAwareFakeLeelaz.class);
-      engine.komi = 6.5f;
-      engine.orikomi = 6.5f;
+      engine.komi = 7.5f;
+      engine.orikomi = 7.5f;
       board.resendMoveToEngine(engine, false);
 
       assertTrue(
-          engine.loadedSgf().contains("KM[6.5]"),
-          "snapshot restore should keep the current engine komi in KataGo loadsgf.");
+          engine.recordedCommands().contains("komi 0"),
+          "engine replay should sync to the loaded game's komi before clear/loadsgf.");
       assertFalse(
           engine.loadedSgf().contains("KM[7.5]"),
-          "loaded SGF/game-info komi must not overwrite the current engine komi.");
+          "stale engine komi must not leak into KataGo loadsgf.");
+      assertTrue(
+          engine.loadedSgf().contains("KM[0.0]"),
+          "snapshot restore should load the displayed game's komi.");
     } finally {
+      GameInfo.DEFAULT_KOMI = previousDefaultKomi;
       Lizzie.board = previousBoard;
       env.close();
     }

--- a/src/test/java/featurecat/lizzie/rules/BoardNodeKindHistoryPipelineTest.java
+++ b/src/test/java/featurecat/lizzie/rules/BoardNodeKindHistoryPipelineTest.java
@@ -964,6 +964,150 @@ class BoardNodeKindHistoryPipelineTest {
   }
 
   @Test
+  void loadFromStringHandicapKomiDiscardsImportedAnalysisBeforeEngineDefaultKomiInitializes()
+      throws Exception {
+    TestEnvironment env = TestEnvironment.open();
+    int previousCurrentEngineNo = EngineManager.currentEngineNo;
+    try {
+      Lizzie.config.readKomi = true;
+      EngineManager.currentEngineNo = 0;
+      EngineManager.isEmpty = false;
+      TrackingLeelaz leelaz = (TrackingLeelaz) Lizzie.leelaz;
+      leelaz.komi = 7.5f;
+      leelaz.orikomi = 7.5f;
+      leelaz.isLoaded = true;
+      leelaz.notPondering();
+      setStarted(leelaz, true);
+      String staleAnalysis =
+          "zhizi28Bmuonfd2 0.8 536 13.8015 14.4396\n"
+              + "move B2 visits 211 winrate 9918 prior 1764 scoreMean 13.80 pv B2 C2";
+      String sgf =
+          "(;SZ[3]KM[0]HA[2]AB[aa]AB[ca]PL[W]LZOP["
+              + staleAnalysis
+              + "]LZ["
+              + staleAnalysis
+              + "];W[ba])";
+
+      assertTrue(SGFParser.loadFromString(sgf));
+
+      BoardData root = Lizzie.board.getHistory().getStart().getData();
+      assertFalse(
+          root.hasAnyAnalysisPayload(),
+          "stale imported analysis must not hide fresh analysis for non-default-komi handicap SGFs.");
+      assertEquals(0, root.getPlayouts(), "root playouts should wait for fresh engine analysis.");
+      assertEquals(0.0, root.scoreMean, 0.0001, "stale 13.7-point score must be cleared.");
+      assertTrue(
+          leelaz.recordedCommands().contains("komi 0"),
+          "fresh analysis should still be requested with the loaded SGF komi.");
+      assertEquals(7.5, leelaz.orikomi, 0.0001);
+    } finally {
+      EngineManager.currentEngineNo = previousCurrentEngineNo;
+      env.close();
+    }
+  }
+
+  @Test
+  void loadFromStringHandicapKomiUsesSgfKomiAndClearsStaleAnalysisWhenReadKomiDisabled()
+      throws Exception {
+    TestEnvironment env = TestEnvironment.open();
+    int previousCurrentEngineNo = EngineManager.currentEngineNo;
+    try {
+      Lizzie.config.readKomi = false;
+      EngineManager.currentEngineNo = 0;
+      EngineManager.isEmpty = false;
+      TrackingLeelaz leelaz = (TrackingLeelaz) Lizzie.leelaz;
+      leelaz.komi = 7.5f;
+      leelaz.orikomi = 0.0f;
+      leelaz.isLoaded = true;
+      leelaz.notPondering();
+      setStarted(leelaz, true);
+      String staleAnalysis =
+          "zhizi28Bmuonfd2 0.8 536 13.8015 14.4396\n"
+              + "move B2 visits 211 winrate 9918 prior 1764 scoreMean 13.80 pv B2 C2";
+      String sgf =
+          "(;SZ[3]KM[0.0]HA[2]AB[aa][ca]PL[W]LZOP["
+              + staleAnalysis
+              + "]LZ["
+              + staleAnalysis
+              + "];W[ba])";
+
+      assertTrue(SGFParser.loadFromString(sgf));
+
+      BoardData root = Lizzie.board.getHistory().getStart().getData();
+      assertEquals(
+          0.0,
+          Lizzie.board.getHistory().getGameInfo().getKomi(),
+          0.0001,
+          "handicap/root-setup SGFs must use their own KM even when general SGF-komi import is off.");
+      assertFalse(
+          root.hasAnyAnalysisPayload(),
+          "stale embedded analysis must be discarded after forcing the setup SGF komi.");
+      assertEquals(0.0, root.scoreMean, 0.0001);
+      assertTrue(
+          leelaz.recordedCommands().contains("komi 0"),
+          "fresh analysis should be requested with the setup SGF komi, not the engine default.");
+      assertEquals(
+          0.0,
+          leelaz.orikomi,
+          0.0001,
+          "clearing stale SGF analysis must not depend on a fully initialized engine default komi.");
+    } finally {
+      EngineManager.currentEngineNo = previousCurrentEngineNo;
+      env.close();
+    }
+  }
+
+  @Test
+  void loadFromStringYikeHandicapHeaderOrderUsesSgfKomiWhenReadKomiDisabled()
+      throws Exception {
+    TestEnvironment env = TestEnvironment.open();
+    int previousCurrentEngineNo = EngineManager.currentEngineNo;
+    try {
+      Lizzie.config.readKomi = false;
+      EngineManager.currentEngineNo = 0;
+      EngineManager.isEmpty = false;
+      TrackingLeelaz leelaz = (TrackingLeelaz) Lizzie.leelaz;
+      leelaz.komi = 7.5f;
+      leelaz.orikomi = 7.5f;
+      leelaz.isLoaded = true;
+      leelaz.notPondering();
+      setStarted(leelaz, true);
+      String staleAnalysis =
+          "zhizi28Bmuonfd2 0.8 536 13.8015 14.4396\n"
+              + "move Q4 visits 211 winrate 9918 prior 1764 scoreMean 13.80 pv Q4 R4";
+      String sgf =
+          "(;CA[UTF-8]AB[aa][ca]PL[W]FF[4]RU[jp]GM[1]SZ[3]SO[弈客直播员]"
+              + "AP[LizzieYzy Next: next-2026-07-13.2]HA[2]KM[0.0]"
+              + "PW[KataGo]PB[申真谞]LZOP["
+              + staleAnalysis
+              + "]LZ["
+              + staleAnalysis
+              + "];W[ba])";
+
+      assertTrue(SGFParser.loadFromString(sgf));
+
+      BoardHistoryList history = Lizzie.board.getHistory();
+      assertEquals(0.0, history.getGameInfo().getKomi(), 0.0001);
+      assertFalse(history.getStart().getData().hasAnyAnalysisPayload());
+      assertTrue(leelaz.recordedCommands().contains("komi 0"));
+      assertFalse(
+          (boolean) requireMethod(Leelaz.class, "shouldApplyInitialEngineKomiToCurrentGame")
+              .invoke(leelaz),
+          "engine startup must not overwrite a loaded handicap SGF komi after parsing.");
+
+      leelaz.boardSizeForEngine(3, 3);
+      assertEquals(
+          0.0,
+          history.getGameInfo().getKomi(),
+          0.0001,
+          "late engine first-load board-size initialization must not overwrite a loaded SGF komi.");
+    } finally {
+      EngineManager.currentEngineNo = previousCurrentEngineNo;
+      env.close();
+    }
+  }
+
+  @Test
   void parseSgfDetachedLzopRoundTripKeepsSingleEngineAnalysisPayload() throws Exception {
     TestEnvironment env = TestEnvironment.open();
     try {


### PR DESCRIPTION
## Summary
- Restore the handicap/setup SGF komi handling that was missing from latest `main`.
- Discard stale imported `LZ/LZOP` analysis for non-default-komi handicap/setup SGFs so fresh engine analysis can replace old score data.
- Prevent late engine startup initialization from overwriting an already-loaded SGF komi.
- Add a small null guard around GTP console command recording so recovery/early-start paths do not interrupt engine queue progress when UI config is absent.

## Windows QA
- `mvn -B -Dfmt.skip=true -Dtest=BoardNodeKindHistoryPipelineTest,BoardMovelistExportTest,LeelazGtpConfigurationTest test`: 141 tests, 0 failures.
- `mvn -B -Dfmt.skip=true -Dtest=LeelazReadBoardGmaTest test`: 56 tests, 0 failures.
- `mvn -B -Dfmt.skip=true test`: 1438 tests, 0 failures, 0 errors, 1 skipped.
- `mvn -B -Dfmt.skip=true -DskipTests package`: BUILD SUCCESS.
- `python scripts/test_windows_launcher_packaging.py`: passed.
- `git diff --check`: passed.
- Windows EXE smoke: `scripts/windows_smoke_test.ps1 -LauncherOnly` passed.

## Real Windows EXE retest
Test package: `C:\ailearn3\lizzie-main-fullqa-20260720-2007\LizzieYzy Next OpenCL\LizzieYzy Next OpenCL.exe`

- Fresh launch showed normal main UI, `first-time-load=false`, and bundled OpenCL KataGo started analysis.
- Before the fix, loading `C:\Users\kk\Downloads\申真谞_Vs_KataGo_20260717155430.sgf` showed 13.7 points.
- After the fix, the same SGF shows `贴目 0.0` and about `黑领先 21.1`, matching the expected handicap score range.
- Alt+O launched bundled `app\readboard\readboard.exe`; confirmed `readboard.exe` process and visible sync window.

Screenshots are saved locally under:
`C:\ailearn3\lizzie-main-fullqa-20260720-2007\screenshots\`