### PR TITLE
发布 Windows 验收通过的多平台预览版

### DIFF
--- a/.github/release-notes/next-2026-07-22.1.md
+++ b/.github/release-notes/next-2026-07-22.1.md
@@ -1,0 +1,305 @@
+# LizzieYzy Next next-2026-07-22.1
+
+## 中文
+
+这是 `next-2026-07-13.2` 之后面向分析可靠性与普通用户操作的预览版：整盘精析变成一键入口，智子云断线恢复更稳，让子棋谱、形势判断、本地引擎修复和 Windows 启动链路也完成了系统加固。
+
+### 本版主要更新
+
+- “自动分析”第一项现在是“整盘精析（推荐）”：先用 32 visits 快速补齐整盘胜率曲线，再以至少 500 visits 逐手深入分析；支持真实进度、剩余时间、隐藏后恢复、停止后保留结果。
+- 修复智子云点击“继续分析”后偶发停住：watchdog 只在 visits 确实增长时续期，断线、排队和重复旧进度会自动恢复；超时后的迟到响应也不会阻止引擎重启。
+- 修复让子棋 SGF 初始目差沿用错误贴目或旧分析数据。加载 `KM[0] / HA[2]` 棋谱后会直接按 0 贴目重新分析，实测开局黑方约领先 21 目，不再需要手动加减贴目。
+- 完善本地 KataGo 自动发现与修复，统一识别发布包内置、绝对/相对路径、中文及空格路径，并保留默认、上次退出、手动选择和无引擎等既有启动方式。
+- 形势判断优先复用已就绪的主 KataGo，不再为每次点击重复加载大权重；TensorRT 环境实测约 300 ms 出结果，完成或取消后会恢复原棋盘分析。
+- 更新检查改为只在用户点击“帮助 → 检查更新”时执行，并忽略 GitHub pre-release；同时加固 Windows 启动器、Alt+O 内置 readboard、配置恢复和 smoke 子进程清理。
+- 本轮整合 PR #127–#133，并在 Windows 11、150% 缩放、OpenCL portable 与包内 KataGo 1.16.5 上完成真实 EXE 验收。
+
+### 下载前先看这几句
+
+- 主推荐整合包继续内置 KataGo `v1.16.5` 和默认智子 28B 权重。
+- Windows 普通用户优先下载 OpenCL 免安装版；NVIDIA 用户按显卡代际选择普通 NVIDIA 或 RTX 50 CUDA 包。
+- 已有免安装版可保留原目录中的 `user-data`、自定义权重和 TensorRT；覆盖升级前仍建议先备份。
+- 这是 pre-release，适合提前验证整盘精析、智子云恢复和多平台打包；稳定后再转为正式 release。
+
+### 下载建议
+
+| 你的电脑 | 直接下载这个 |
+| --- | --- |
+| Windows 64 位，OpenCL 推荐版，免安装 | [windows64.opencl.portable.zip][win-opencl-portable] |
+| 已有 Windows 免安装版，日常小更新 | [windows64.core-update.zip][win-core-update] |
+| Windows 64 位，OpenCL 推荐版，安装器 | [windows64.opencl.installer.exe][win-opencl-installer] |
+| Windows 64 位，CPU 兼容版，免安装 | [windows64.with-katago.portable.zip][win-cpu-portable] |
+| Windows 64 位，CPU 兼容版，安装器 | [windows64.with-katago.installer.exe][win-cpu-installer] |
+| Windows 64 位，NVIDIA 20/30/40 系，免安装 | [windows64.nvidia.portable.zip][win-nvidia-portable] |
+| Windows 64 位，NVIDIA 20/30/40 系，安装器 | [windows64.nvidia.installer.exe][win-nvidia-installer] |
+| Windows 64 位，RTX 5070/5080/5090，免安装 | [windows64.nvidia50.cuda.portable.zip][win-nvidia50-portable] |
+| Windows 64 位，RTX 5070/5080/5090，安装器 | [windows64.nvidia50.cuda.installer.exe][win-nvidia50-installer] |
+| 高级可选 TensorRT 分卷包说明 | [TensorRT README][win-tensorrt-readme] |
+| Windows 64 位，自己配置引擎，免安装 | [windows64.without.engine.portable.zip][win-no-engine-portable] |
+| Windows 64 位，自己配置引擎，安装器 | [windows64.without.engine.installer.exe][win-no-engine-installer] |
+| macOS Apple Silicon | [mac-apple-silicon.with-katago.dmg][mac-arm64] |
+| macOS Intel | [mac-intel.with-katago.dmg][mac-intel] |
+| Linux 64 位，CPU 兼容版 | [linux64.with-katago.zip][linux-cpu] |
+| Linux 64 位，OpenCL 版 | [linux64.opencl.zip][linux-opencl] |
+| Linux 64 位，NVIDIA CUDA 版 | [linux64.nvidia.zip][linux-nvidia] |
+
+### 这一版为什么值得测试
+
+- 普通用户只需打开“自动分析”并点击第一项，即可完成先补曲线、再深入的整盘分析。
+- 本地与远程算力的暂停、恢复、切换棋谱和异常重连路径都有明确状态和自动恢复。
+- 发布前通过 162 个测试套件、1484 项测试（0 failure / 0 error / 2 skipped）、完整打包和 Windows 真机验收。
+
+### 交流
+
+- QQ 群：`299419120`
+
+---
+
+## 繁體中文
+
+這是 `next-2026-07-13.2` 之後針對分析可靠性與一般使用者操作的預覽版：整盤精析成為一鍵入口，智子雲斷線恢復更穩，讓子棋譜、形勢判斷、本機引擎修復與 Windows 啟動流程也完成系統加固。
+
+### 本版主要更新
+
+- 「自動分析」第一項現在是「整盤精析（推薦）」：先以 32 visits 快速補齊整盤勝率曲線，再以至少 500 visits 逐手深入分析；支援真實進度、剩餘時間、隱藏後恢復與停止後保留結果。
+- 修正智子雲點擊「繼續分析」後偶爾停住：watchdog 只在 visits 確實增加時續期，斷線、排隊與重複舊進度會自動恢復；逾時後的遲到回應也不會阻止引擎重啟。
+- 修正讓子棋 SGF 初始目差沿用錯誤貼目或舊分析資料。載入 `KM[0] / HA[2]` 後會直接按 0 貼目重新分析，實測開局黑方約領先 21 目。
+- 完善本機 KataGo 自動探索與修復，統一識別內建、絕對/相對、中文與空格路徑，同時保留預設、上次退出、手動選擇及無引擎等啟動方式。
+- 形勢判斷優先重用已就緒的主 KataGo；TensorRT 環境實測約 300 ms 顯示結果，完成或取消後會恢復原棋盤分析。
+- 更新檢查只在使用者點擊「說明 → 檢查更新」時執行，並忽略 GitHub pre-release；Windows launcher、Alt+O readboard、設定復原與 smoke 子程序清理也同步加固。
+- 本輪整合 PR #127–#133，並以 Windows 11、150% 縮放、OpenCL portable 與內建 KataGo 1.16.5 完成真實 EXE 驗收。
+
+### 下載前先看這幾句
+
+- 推薦整合包繼續內建 KataGo `v1.16.5` 與預設智子 28B 權重。
+- Windows 一般使用者優先選 OpenCL 免安裝版；NVIDIA 使用者依顯示卡世代選擇一般 NVIDIA 或 RTX 50 CUDA 套件。
+- 既有免安裝版可保留 `user-data`、自訂權重與 TensorRT；覆蓋升級前仍建議先備份。
+- 這是 pre-release，適合提前驗證整盤精析、智子雲恢復與多平台套件。
+
+### 下載建議
+
+| 你的電腦 | 直接下載這個 |
+| --- | --- |
+| Windows OpenCL 推薦版，免安裝 | [windows64.opencl.portable.zip][win-opencl-portable] |
+| 既有 Windows 免安裝版，小更新 | [windows64.core-update.zip][win-core-update] |
+| Windows OpenCL 推薦版，安裝器 | [windows64.opencl.installer.exe][win-opencl-installer] |
+| Windows CPU 相容版，免安裝 / 安裝器 | [portable][win-cpu-portable] / [installer][win-cpu-installer] |
+| Windows NVIDIA 20/30/40 系，免安裝 / 安裝器 | [portable][win-nvidia-portable] / [installer][win-nvidia-installer] |
+| Windows RTX 50 CUDA，免安裝 / 安裝器 | [portable][win-nvidia50-portable] / [installer][win-nvidia50-installer] |
+| 進階 TensorRT 分卷包說明 | [TensorRT README][win-tensorrt-readme] |
+| Windows 自行配置引擎，免安裝 / 安裝器 | [portable][win-no-engine-portable] / [installer][win-no-engine-installer] |
+| macOS Apple Silicon / Intel | [Apple Silicon][mac-arm64] / [Intel][mac-intel] |
+| Linux CPU / OpenCL / NVIDIA CUDA | [CPU][linux-cpu] / [OpenCL][linux-opencl] / [NVIDIA][linux-nvidia] |
+
+### 這一版為什麼值得測試
+
+- 一般使用者只要開啟「自動分析」並點第一項，即可先補曲線再進行整盤深入分析。
+- 本機與遠端算力的暫停、恢復、切換棋譜及異常重連都有明確狀態與自動復原。
+- 發布前通過 162 個測試套件、1484 項測試（0 failure / 0 error / 2 skipped）、完整打包與 Windows 真機驗收。
+
+### 交流
+
+- QQ 群：`299419120`
+
+---
+
+## English
+
+This pre-release builds on `next-2026-07-13.2` with a more dependable analysis workflow for everyday users: one-click whole-game deep analysis, resilient Zhizi Cloud recovery, correct handicap scoring, faster position estimates, safer local-engine repair, and a hardened Windows launch path.
+
+### Release Highlights
+
+- Whole-game Deep Analysis is now the recommended first item under Auto Analyze. Stage 1 fills the complete win-rate curve at 32 visits, then Stage 2 deepens every position to at least 500 visits, with real progress, ETA, hide/restore, and retained partial results.
+- Fixed Zhizi Cloud sessions that could stop after Continue Analysis. The watchdog now renews only when visits actually grow, recovers queued or disconnected requests, and prevents late stale packets from suppressing a required restart.
+- Fixed handicap SGFs reusing the wrong komi or stale embedded analysis. A `KM[0] / HA[2]` game is analyzed immediately at zero komi and was verified around Black +21 at the opening.
+- Unified local KataGo discovery and repair across bundled, absolute, relative, non-ASCII, and space-containing paths while preserving Default, Last Used, Manual, and No Engine startup choices.
+- Position Estimate now reuses the ready foreground KataGo instead of loading another large model on every click. A TensorRT test returned in about 300 ms and restored normal board analysis afterward.
+- Update checks now run only from Help → Check for Updates and ignore GitHub pre-releases. Windows launcher, bundled readboard Alt+O, configuration restoration, and smoke-process cleanup were also hardened.
+- This build integrates PRs #127–#133 and was accepted through the real OpenCL portable EXE on Windows 11 at 150% scaling with bundled KataGo 1.16.5.
+
+### Read Before Downloading
+
+- Recommended bundles include KataGo `v1.16.5` and the default Zhizi 28B model.
+- Most Windows users should choose the OpenCL portable. NVIDIA users should select the standard NVIDIA or RTX 50 CUDA build for their GPU generation.
+- Existing portable users can keep `user-data`, custom weights, and TensorRT in place, but should still back up before overwriting an installation.
+- This is a pre-release for early validation of whole-game analysis, Zhizi recovery, and all platform packages.
+
+### Download Guide
+
+| Your computer | Download |
+| --- | --- |
+| Windows OpenCL recommended, portable / installer | [portable][win-opencl-portable] / [installer][win-opencl-installer] |
+| Existing Windows portable, small core update | [core update][win-core-update] |
+| Windows CPU compatible, portable / installer | [portable][win-cpu-portable] / [installer][win-cpu-installer] |
+| Windows NVIDIA RTX 20/30/40, portable / installer | [portable][win-nvidia-portable] / [installer][win-nvidia-installer] |
+| Windows RTX 5070/5080/5090 CUDA, portable / installer | [portable][win-nvidia50-portable] / [installer][win-nvidia50-installer] |
+| Advanced optional TensorRT split package | [TensorRT README][win-tensorrt-readme] |
+| Windows, configure your own engine, portable / installer | [portable][win-no-engine-portable] / [installer][win-no-engine-installer] |
+| macOS Apple Silicon / Intel | [Apple Silicon][mac-arm64] / [Intel][mac-intel] |
+| Linux CPU / OpenCL / NVIDIA CUDA | [CPU][linux-cpu] / [OpenCL][linux-opencl] / [NVIDIA][linux-nvidia] |
+
+### Why Test This Release
+
+- Auto Analyze now takes a user from a fast complete curve to deep whole-game analysis through one recommended action.
+- Local and remote pause, resume, game switching, and reconnect paths expose clear state and recover automatically.
+- Verification covered 162 test suites and 1484 tests (0 failures, 0 errors, 2 skipped), full packaging, and real Windows acceptance.
+
+### Contact
+
+- QQ group: `299419120`
+
+---
+
+## 日本語
+
+`next-2026-07-13.2` 以降の分析信頼性と一般ユーザー操作を改善した pre-release です。ワンクリックの全局精密分析、Zhizi Cloud の復旧、handicap score、形勢判断、local engine 修復、Windows 起動経路を強化しました。
+
+### 主な更新
+
+- Auto Analyze の先頭を推奨の Whole-game Deep Analysis にしました。Stage 1 は 32 visits で全局 curve を埋め、Stage 2 は各局面を 500 visits 以上まで深掘りします。進捗、残り時間、非表示からの復帰、途中結果の保持に対応します。
+- Continue Analysis 後に Zhizi Cloud が停止する問題を修正しました。watchdog は visits が実際に増えた時だけ延長され、切断、queue、重複した古い進捗を復旧し、遅延 packet が再起動を妨げません。
+- handicap SGF が誤った komi や古い analysis を使う問題を修正しました。`KM[0] / HA[2]` は komi 0 で直ちに再解析され、序盤は黒約 21 目リードを確認しました。
+- bundle、絶対/相対 path、非 ASCII path、空白を含む path から local KataGo を一貫して検出・修復し、既存の engine 起動設定を保持します。
+- 形勢判断は起動済み foreground KataGo を再利用します。TensorRT 環境では約 300 ms で結果を確認し、その後通常分析へ復帰します。
+- 更新確認は Help メニューからの手動操作だけに変更し、GitHub pre-release を通知対象外にしました。Windows launcher、Alt+O readboard、設定復元、process cleanup も強化しました。
+- PR #127–#133 を統合し、Windows 11、150% scale、OpenCL portable、内蔵 KataGo 1.16.5 の実 EXE で受入試験を行いました。
+
+### ダウンロード前に
+
+- 推奨 bundle は KataGo `v1.16.5` と既定 Zhizi 28B model を同梱します。
+- 多くの Windows ユーザーは OpenCL portable、NVIDIA ユーザーは GPU 世代に合う NVIDIA または RTX 50 CUDA build を選んでください。
+- portable 版は `user-data`、custom weight、TensorRT を保持できますが、上書き前の backup を推奨します。
+- whole-game analysis、Zhizi 復旧、全 platform package を正式版前に確認する pre-release です。
+
+### ダウンロード案内
+
+| 環境 | ダウンロード |
+| --- | --- |
+| Windows OpenCL portable / installer | [portable][win-opencl-portable] / [installer][win-opencl-installer] |
+| Windows portable 小型更新 | [core update][win-core-update] |
+| Windows CPU portable / installer | [portable][win-cpu-portable] / [installer][win-cpu-installer] |
+| Windows NVIDIA portable / installer | [portable][win-nvidia-portable] / [installer][win-nvidia-installer] |
+| Windows RTX 50 CUDA portable / installer | [portable][win-nvidia50-portable] / [installer][win-nvidia50-installer] |
+| TensorRT 分割 package | [README][win-tensorrt-readme] |
+| macOS Apple Silicon / Intel | [Apple Silicon][mac-arm64] / [Intel][mac-intel] |
+| Linux CPU / OpenCL / NVIDIA | [CPU][linux-cpu] / [OpenCL][linux-opencl] / [NVIDIA][linux-nvidia] |
+
+### このリリースを試す理由
+
+- Auto Analyze の先頭項目だけで curve の高速補完から全局の深い解析まで実行できます。
+- local/remote の一時停止、再開、棋譜切替、再接続に明確な状態と自動復旧があります。
+- 162 suites、1484 tests（failure 0 / error 0 / skipped 2）、full package、Windows 実機試験を完了しました。
+
+### 連絡先
+
+- QQ group: `299419120`
+
+---
+
+## 한국어
+
+`next-2026-07-13.2` 이후 분석 신뢰성과 일반 사용자 흐름을 개선한 pre-release입니다. 원클릭 전체 기보 정밀 분석, Zhizi Cloud 복구, handicap 점수, 형세 판단, local engine 복구, Windows 실행 경로를 강화했습니다.
+
+### 주요 업데이트
+
+- Auto Analyze 첫 항목을 권장 Whole-game Deep Analysis로 변경했습니다. Stage 1은 32 visits로 전체 win-rate curve를 채우고 Stage 2는 각 국면을 최소 500 visits까지 심화하며 실제 진행률, 남은 시간, 숨김/복원, 부분 결과 보존을 지원합니다.
+- Continue Analysis 뒤 Zhizi Cloud가 멈추는 문제를 수정했습니다. watchdog은 visits가 실제 증가할 때만 갱신되고, 연결 끊김, queue, 반복된 이전 진행을 복구하며 늦은 packet이 필요한 재시작을 막지 않습니다.
+- handicap SGF가 잘못된 komi 또는 오래된 analysis를 재사용하는 문제를 수정했습니다. `KM[0] / HA[2]`는 komi 0으로 즉시 다시 분석되며 초반 흑 약 21집 우세를 확인했습니다.
+- bundle, 절대/상대 path, 비 ASCII 및 공백 path의 local KataGo 탐색과 복구를 통합하고 기존 engine 시작 설정을 유지합니다.
+- 형세 판단은 준비된 foreground KataGo를 재사용합니다. TensorRT 환경에서 약 300 ms 결과를 확인했고 완료 또는 취소 뒤 기존 바둑판 분석을 복원합니다.
+- 업데이트 확인은 Help 메뉴에서 사용자가 직접 실행할 때만 동작하며 GitHub pre-release는 알리지 않습니다. Windows launcher, Alt+O readboard, 설정 복원, process 정리도 강화했습니다.
+- PR #127–#133을 통합하고 Windows 11, 150% scale, OpenCL portable, 내장 KataGo 1.16.5 실제 EXE로 사용자 검수를 완료했습니다.
+
+### 다운로드 전 확인
+
+- 추천 bundle은 KataGo `v1.16.5`와 기본 Zhizi 28B model을 포함합니다.
+- 대부분의 Windows 사용자는 OpenCL portable, NVIDIA 사용자는 GPU 세대에 맞는 NVIDIA 또는 RTX 50 CUDA build를 선택하세요.
+- portable 사용자는 `user-data`, custom weight, TensorRT를 유지할 수 있지만 덮어쓰기 전 backup을 권장합니다.
+- whole-game analysis, Zhizi 복구, 전체 platform package를 안정판 전 미리 확인하는 pre-release입니다.
+
+### 다운로드 안내
+
+| 환경 | 다운로드 |
+| --- | --- |
+| Windows OpenCL portable / installer | [portable][win-opencl-portable] / [installer][win-opencl-installer] |
+| Windows portable 소형 업데이트 | [core update][win-core-update] |
+| Windows CPU portable / installer | [portable][win-cpu-portable] / [installer][win-cpu-installer] |
+| Windows NVIDIA portable / installer | [portable][win-nvidia-portable] / [installer][win-nvidia-installer] |
+| Windows RTX 50 CUDA portable / installer | [portable][win-nvidia50-portable] / [installer][win-nvidia50-installer] |
+| TensorRT 분할 package | [README][win-tensorrt-readme] |
+| macOS Apple Silicon / Intel | [Apple Silicon][mac-arm64] / [Intel][mac-intel] |
+| Linux CPU / OpenCL / NVIDIA | [CPU][linux-cpu] / [OpenCL][linux-opencl] / [NVIDIA][linux-nvidia] |
+
+### 이 릴리스를 테스트할 이유
+
+- Auto Analyze 첫 항목만으로 curve 빠른 완성과 전체 기보 심층 분석을 연속 실행할 수 있습니다.
+- local/remote 일시정지, 재개, 기보 전환, 재연결 경로에 명확한 상태와 자동 복구가 있습니다.
+- 162 suites, 1484 tests(실패 0 / 오류 0 / skipped 2), 전체 package, Windows 실기 검수를 완료했습니다.
+
+### 연락처
+
+- QQ 그룹: `299419120`
+
+---
+
+## ภาษาไทย
+
+pre-release นี้ต่อยอดจาก `next-2026-07-13.2` เพื่อให้การวิเคราะห์น่าเชื่อถือและใช้ง่ายขึ้น: วิเคราะห์ทั้งเกมด้วยคลิกเดียว, กู้คืน Zhizi Cloud, แก้คะแนน handicap, เร่ง Position Estimate, ซ่อม local engine และเพิ่มความเสถียรของการเปิดโปรแกรมบน Windows
+
+### ไฮไลต์ของเวอร์ชันนี้
+
+- Whole-game Deep Analysis เป็นรายการแนะนำอันดับแรกใน Auto Analyze: Stage 1 เติม win-rate curve ทั้งเกมที่ 32 visits แล้ว Stage 2 วิเคราะห์ทุกตำแหน่งอย่างน้อย 500 visits พร้อม progress จริง, เวลาคงเหลือ, ซ่อน/เรียกคืน และเก็บผลที่ทำเสร็จแล้ว
+- แก้ Zhizi Cloud หยุดหลัง Continue Analysis โดย watchdog จะต่อเวลาเมื่อ visits เพิ่มจริงเท่านั้น กู้คำสั่งที่ค้างหรือหลุดการเชื่อมต่อ และไม่ให้ packet เก่าที่มาช้าขัดขวางการ restart
+- แก้ SGF แบบ handicap ใช้ komi ผิดหรือ analysis เก่า เกม `KM[0] / HA[2]` จะวิเคราะห์ใหม่ด้วย komi 0 ทันที และทดสอบได้ว่าช่วงต้นดำได้นำประมาณ 21 แต้ม
+- รวมการค้นหาและซ่อม local KataGo สำหรับ engine ใน bundle, path แบบ absolute/relative, path ที่มีอักษร non-ASCII หรือเว้นวรรค และคงค่าเริ่ม engine เดิมของผู้ใช้
+- Position Estimate reuse foreground KataGo ที่พร้อมอยู่ ทดสอบ TensorRT ได้ผลประมาณ 300 ms และคืนการวิเคราะห์กระดานเดิมหลังเสร็จหรือยกเลิก
+- ตรวจอัปเดตเฉพาะเมื่อผู้ใช้กด Help → Check for Updates และไม่แจ้ง GitHub pre-release พร้อมเพิ่มความทนทานของ Windows launcher, Alt+O readboard, การคืน config และการเก็บ process
+- รวม PR #127–#133 และทดสอบ EXE จริงบน Windows 11, scale 150%, OpenCL portable และ KataGo 1.16.5 ที่มากับแพ็กเกจ
+
+### ก่อนดาวน์โหลด
+
+- แพ็กเกจแนะนำรวม KataGo `v1.16.5` และ Zhizi 28B model เริ่มต้น
+- ผู้ใช้ Windows ส่วนใหญ่เลือก OpenCL portable; ผู้ใช้ NVIDIA เลือก NVIDIA หรือ RTX 50 CUDA build ตามรุ่น GPU
+- portable เดิมเก็บ `user-data`, custom weight และ TensorRT ได้ แต่ควร backup ก่อนเขียนทับ
+- นี่คือ pre-release สำหรับทดสอบ whole-game analysis, การกู้คืน Zhizi และ package ทุก platform ก่อนเลื่อนเป็น stable release
+
+### คำแนะนำดาวน์โหลด
+
+| ระบบ | ดาวน์โหลด |
+| --- | --- |
+| Windows OpenCL portable / installer | [portable][win-opencl-portable] / [installer][win-opencl-installer] |
+| อัปเดตเล็กสำหรับ Windows portable เดิม | [core update][win-core-update] |
+| Windows CPU portable / installer | [portable][win-cpu-portable] / [installer][win-cpu-installer] |
+| Windows NVIDIA portable / installer | [portable][win-nvidia-portable] / [installer][win-nvidia-installer] |
+| Windows RTX 50 CUDA portable / installer | [portable][win-nvidia50-portable] / [installer][win-nvidia50-installer] |
+| TensorRT split package | [README][win-tensorrt-readme] |
+| macOS Apple Silicon / Intel | [Apple Silicon][mac-arm64] / [Intel][mac-intel] |
+| Linux CPU / OpenCL / NVIDIA | [CPU][linux-cpu] / [OpenCL][linux-opencl] / [NVIDIA][linux-nvidia] |
+
+### ทำไมควรทดสอบเวอร์ชันนี้
+
+- ผู้ใช้เปิด Auto Analyze แล้วเลือกรายการแรกเพื่อเติม curve อย่างรวดเร็วและวิเคราะห์ทั้งเกมต่อได้ทันที
+- เส้นทาง pause, resume, เปลี่ยน SGF และ reconnect ของ local/remote แสดงสถานะชัดเจนและกู้คืนอัตโนมัติ
+- ก่อนเผยแพร่ผ่าน 162 test suites และ 1484 tests (failure 0 / error 0 / skipped 2), full packaging และ Windows real-device acceptance
+
+### ติดต่อ
+
+- QQ group: `299419120`
+
+[win-opencl-portable]: https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-22.1/2026-07-22-windows64.opencl.portable.zip
+[win-core-update]: https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-22.1/2026-07-22-windows64.core-update.zip
+[win-opencl-installer]: https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-22.1/2026-07-22-windows64.opencl.installer.exe
+[win-cpu-portable]: https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-22.1/2026-07-22-windows64.with-katago.portable.zip
+[win-cpu-installer]: https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-22.1/2026-07-22-windows64.with-katago.installer.exe
+[win-nvidia-portable]: https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-22.1/2026-07-22-windows64.nvidia.portable.zip
+[win-nvidia-installer]: https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-22.1/2026-07-22-windows64.nvidia.installer.exe
+[win-nvidia50-portable]: https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-22.1/2026-07-22-windows64.nvidia50.cuda.portable.zip
+[win-nvidia50-installer]: https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-22.1/2026-07-22-windows64.nvidia50.cuda.installer.exe
+[win-tensorrt-readme]: https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-22.1/2026-07-22-windows64.nvidia.tensorrt.portable.README.txt
+[win-no-engine-portable]: https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-22.1/2026-07-22-windows64.without.engine.portable.zip
+[win-no-engine-installer]: https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-22.1/2026-07-22-windows64.without.engine.installer.exe
+[mac-arm64]: https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-22.1/2026-07-22-mac-apple-silicon.with-katago.dmg
+[mac-intel]: https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-22.1/2026-07-22-mac-intel.with-katago.dmg
+[linux-cpu]: https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-22.1/2026-07-22-linux64.with-katago.zip
+[linux-opencl]: https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-22.1/2026-07-22-linux64.opencl.zip
+[linux-nvidia]: https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-22.1/2026-07-22-linux64.nvidia.zip

--- a/.github/release-requests/next-2026-07-22.1.json
+++ b/.github/release-requests/next-2026-07-22.1.json
@@ -1,0 +1,7 @@
+{
+  "date_tag": "2026-07-22",
+  "release_tag": "next-2026-07-22.1",
+  "title": "LizzieYzy Next next-2026-07-22.1",
+  "prerelease": true,
+  "notes_file": ".github/release-notes/next-2026-07-22.1.md"
+}

--- a/.github/workflows/publish-requested-pre-release.yml
+++ b/.github/workflows/publish-requested-pre-release.yml
@@ -1,0 +1,88 @@
+name: Publish Requested Pre-release
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - .github/release-requests/*.json
+  workflow_dispatch:
+    inputs:
+      request_file:
+        description: Reviewed request file under .github/release-requests
+        required: true
+        type: string
+
+permissions:
+  actions: write
+  contents: write
+
+concurrency:
+  group: publish-requested-pre-release
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+
+    steps:
+      - name: Checkout exact release source
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.x'
+
+      - name: Locate the reviewed release request
+        id: request
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BEFORE_SHA: ${{ github.event.before }}
+          TARGET_SHA: ${{ github.sha }}
+          MANUAL_REQUEST: ${{ inputs.request_file }}
+        run: |
+          set -euo pipefail
+          if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
+            request_file="$MANUAL_REQUEST"
+          else
+            mapfile -t requests < <(
+              git diff --name-only "$BEFORE_SHA" "$TARGET_SHA" -- \
+                '.github/release-requests/*.json'
+            )
+            if [[ "${#requests[@]}" -ne 1 ]]; then
+              printf 'Expected exactly one changed release request, found %s\n' "${#requests[@]}" >&2
+              printf '%s\n' "${requests[@]}" >&2
+              exit 1
+            fi
+            request_file="${requests[0]}"
+          fi
+
+          case "$request_file" in
+            .github/release-requests/*.json) ;;
+            *)
+              echo "Request must be a JSON file under .github/release-requests" >&2
+              exit 1
+              ;;
+          esac
+          test -f "$request_file"
+          echo "request_file=$request_file" >> "$GITHUB_OUTPUT"
+
+      - name: Test release metadata and fail-closed publishing
+        run: |
+          python3 -m unittest \
+            scripts.test_publish_release_request \
+            scripts.test_generate_release_notes
+
+      - name: Build, verify, and publish the pre-release
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          python3 scripts/publish_release_request.py \
+            --request "${{ steps.request.outputs.request_file }}" \
+            --repository "${{ github.repository }}" \
+            --target-sha "${{ github.sha }}"

--- a/scripts/publish_release_request.py
+++ b/scripts/publish_release_request.py
@@ -1,0 +1,563 @@
+#!/usr/bin/env python3
+"""Publish an audited multi-platform pre-release request.
+
+The release remains a draft until every platform workflow succeeds, all expected
+assets are present, and the localized release notes have been generated.
+"""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+import json
+import os
+from pathlib import Path
+import re
+import sys
+import time
+from typing import Callable, Iterable
+from urllib.error import HTTPError
+from urllib.parse import quote, urlencode
+from urllib.request import Request, urlopen
+
+
+API_VERSION = "2026-03-10"
+TAG_PATTERN = re.compile(r"^next-(\d{4}-\d{2}-\d{2})\.(\d+)$")
+LOCALIZED_NOTE_HEADINGS = (
+    "## 中文",
+    "## 繁體中文",
+    "## English",
+    "## 日本語",
+    "## 한국어",
+    "## ภาษาไทย",
+)
+ACTIVE_RUN_STATUSES = {"queued", "in_progress", "waiting", "requested", "pending"}
+
+
+class PublishError(RuntimeError):
+    """A release invariant or GitHub API operation failed."""
+
+
+@dataclass(frozen=True)
+class ReleaseRequest:
+    date_tag: str
+    release_tag: str
+    title: str
+    prerelease: bool
+    notes_file: str
+
+    @classmethod
+    def load(cls, path: Path) -> "ReleaseRequest":
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            raise PublishError(f"Unable to read release request {path}: {exc}") from exc
+
+        required = {"date_tag", "release_tag", "title", "prerelease", "notes_file"}
+        missing = sorted(required.difference(payload))
+        if missing:
+            raise PublishError(f"Release request is missing: {', '.join(missing)}")
+
+        request = cls(
+            date_tag=str(payload["date_tag"]).strip(),
+            release_tag=str(payload["release_tag"]).strip(),
+            title=str(payload["title"]).strip(),
+            prerelease=payload["prerelease"],
+            notes_file=str(payload["notes_file"]).strip(),
+        )
+        request.validate()
+        return request
+
+    def validate(self) -> None:
+        match = TAG_PATTERN.fullmatch(self.release_tag)
+        if not match:
+            raise PublishError(
+                "release_tag must use next-YYYY-MM-DD.N, for example next-2026-07-22.1"
+            )
+        if match.group(1) != self.date_tag:
+            raise PublishError("date_tag must match the date embedded in release_tag")
+        if match.group(2).startswith("0"):
+            raise PublishError("release serial must be a positive integer without leading zeros")
+        if self.prerelease is not True:
+            raise PublishError("Automated release requests must explicitly set prerelease to true")
+        if self.title != f"LizzieYzy Next {self.release_tag}":
+            raise PublishError("title must be exactly 'LizzieYzy Next <release_tag>'")
+        expected_notes = f".github/release-notes/{self.release_tag}.md"
+        if self.notes_file != expected_notes:
+            raise PublishError(f"notes_file must be exactly {expected_notes}")
+
+
+@dataclass(frozen=True)
+class WorkflowSpec:
+    platform: str
+    workflow_file: str
+    exact_suffixes: tuple[str, ...]
+    required_patterns: tuple[re.Pattern[str], ...] = ()
+
+    def missing_assets(self, asset_names: Iterable[str], date_tag: str) -> list[str]:
+        names = set(asset_names)
+        missing = [
+            f"{date_tag}-{suffix}"
+            for suffix in self.exact_suffixes
+            if f"{date_tag}-{suffix}" not in names
+        ]
+        for pattern in self.required_patterns:
+            rendered = re.compile(pattern.pattern.format(date=re.escape(date_tag)))
+            if not any(rendered.fullmatch(name) for name in names):
+                missing.append(pattern.pattern.format(date=date_tag))
+        return missing
+
+
+WORKFLOWS = (
+    WorkflowSpec(
+        "Windows",
+        "build-windows-release.yml",
+        (
+            "windows64.opencl.installer.exe",
+            "windows64.opencl.portable.zip",
+            "windows64.nvidia.installer.exe",
+            "windows64.nvidia.portable.zip",
+            "windows64.nvidia50.cuda.installer.exe",
+            "windows64.nvidia50.cuda.portable.zip",
+            "windows64.with-katago.installer.exe",
+            "windows64.with-katago.portable.zip",
+            "windows64.without.engine.installer.exe",
+            "windows64.without.engine.portable.zip",
+            "windows64.core-update.zip",
+            "windows64.nvidia.tensorrt.portable.README.txt",
+            "windows64.nvidia.tensorrt.portable.manifest.json",
+            "windows64.nvidia.tensorrt.portable.sha256.txt",
+        ),
+        (re.compile(r"^{date}-windows64\.nvidia\.tensorrt\.portable\.7z\.\d{{3}}$"),),
+    ),
+    WorkflowSpec(
+        "Linux",
+        "build-linux-release.yml",
+        ("linux64.with-katago.zip", "linux64.opencl.zip", "linux64.nvidia.zip"),
+    ),
+    WorkflowSpec(
+        "macOS Intel",
+        "build-macos-amd64-release.yml",
+        ("mac-intel.with-katago.dmg",),
+    ),
+    WorkflowSpec(
+        "macOS Apple Silicon",
+        "build-macos-arm64-release.yml",
+        ("mac-apple-silicon.with-katago.dmg",),
+    ),
+)
+
+
+class GitHubClient:
+    def __init__(self, repository: str, token: str, api_url: str | None = None) -> None:
+        if not token:
+            raise PublishError("GITHUB_TOKEN is required")
+        if not re.fullmatch(r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+", repository):
+            raise PublishError("repository must use owner/name format")
+        self.repository = repository
+        self.token = token
+        self.api_url = (api_url or "https://api.github.com").rstrip("/")
+
+    def _request(
+        self,
+        method: str,
+        path: str,
+        payload: dict[str, object] | None = None,
+        expected: tuple[int, ...] = (200,),
+        allow_not_found: bool = False,
+    ) -> tuple[int, dict[str, object] | list[object] | None]:
+        body = json.dumps(payload).encode("utf-8") if payload is not None else None
+        request = Request(
+            f"{self.api_url}{path}",
+            data=body,
+            method=method,
+            headers={
+                "Accept": "application/vnd.github+json",
+                "Authorization": f"Bearer {self.token}",
+                "Content-Type": "application/json",
+                "User-Agent": "lizzieyzy-next-release-publisher",
+                "X-GitHub-Api-Version": API_VERSION,
+            },
+        )
+        try:
+            with urlopen(request, timeout=60) as response:
+                status = response.status
+                raw = response.read()
+        except HTTPError as exc:
+            if allow_not_found and exc.code == 404:
+                return 404, None
+            detail = exc.read().decode("utf-8", errors="replace")[:2000]
+            raise PublishError(f"GitHub API {method} {path} failed ({exc.code}): {detail}") from exc
+        except OSError as exc:
+            raise PublishError(f"GitHub API {method} {path} failed: {exc}") from exc
+
+        if status not in expected:
+            raise PublishError(
+                f"GitHub API {method} {path} returned {status}; expected {expected}"
+            )
+        if not raw:
+            return status, None
+        try:
+            return status, json.loads(raw.decode("utf-8"))
+        except json.JSONDecodeError as exc:
+            raise PublishError(f"GitHub API {method} {path} returned invalid JSON") from exc
+
+    def get_tag_sha(self, tag: str) -> str | None:
+        path = f"/repos/{self.repository}/git/ref/tags/{quote(tag, safe='')}"
+        _status, payload = self._request("GET", path, allow_not_found=True)
+        if payload is None:
+            return None
+        assert isinstance(payload, dict)
+        obj = payload.get("object")
+        if not isinstance(obj, dict) or obj.get("type") != "commit" or not obj.get("sha"):
+            raise PublishError(f"Existing tag {tag} is not a lightweight commit tag")
+        return str(obj["sha"])
+
+    def create_tag(self, tag: str, target_sha: str) -> None:
+        self._request(
+            "POST",
+            f"/repos/{self.repository}/git/refs",
+            {"ref": f"refs/tags/{tag}", "sha": target_sha},
+            expected=(201,),
+        )
+
+    def get_release(self, tag: str) -> dict[str, object] | None:
+        path = f"/repos/{self.repository}/releases/tags/{quote(tag, safe='')}"
+        _status, payload = self._request("GET", path, allow_not_found=True)
+        if payload is not None:
+            assert isinstance(payload, dict)
+            return payload
+
+        # The tag endpoint can omit drafts. The authenticated release listing includes them.
+        _status, listing = self._request(
+            "GET", f"/repos/{self.repository}/releases?per_page=100"
+        )
+        assert isinstance(listing, list)
+        for release in listing:
+            if isinstance(release, dict) and release.get("tag_name") == tag:
+                return release
+        return None
+
+    def create_draft_release(
+        self, request: ReleaseRequest, target_sha: str
+    ) -> dict[str, object]:
+        _status, payload = self._request(
+            "POST",
+            f"/repos/{self.repository}/releases",
+            {
+                "tag_name": request.release_tag,
+                "target_commitish": target_sha,
+                "name": request.title,
+                "body": "Multi-platform packages are being built and verified.",
+                "draft": True,
+                "prerelease": True,
+                "generate_release_notes": False,
+                "make_latest": "false",
+            },
+            expected=(201,),
+        )
+        assert isinstance(payload, dict)
+        return payload
+
+    def update_release(self, release_id: int, payload: dict[str, object]) -> dict[str, object]:
+        _status, response = self._request(
+            "PATCH",
+            f"/repos/{self.repository}/releases/{release_id}",
+            payload,
+        )
+        assert isinstance(response, dict)
+        return response
+
+    def list_release_assets(self, release_id: int) -> list[str]:
+        _status, payload = self._request(
+            "GET",
+            f"/repos/{self.repository}/releases/{release_id}/assets?per_page=100",
+        )
+        assert isinstance(payload, list)
+        return [str(asset["name"]) for asset in payload if isinstance(asset, dict)]
+
+    def list_workflow_runs(self, workflow_file: str, tag: str) -> list[dict[str, object]]:
+        workflow = quote(workflow_file, safe="")
+        query = urlencode({"event": "workflow_dispatch", "branch": tag, "per_page": 50})
+        _status, payload = self._request(
+            "GET",
+            f"/repos/{self.repository}/actions/workflows/{workflow}/runs?{query}",
+        )
+        assert isinstance(payload, dict)
+        runs = payload.get("workflow_runs", [])
+        return [run for run in runs if isinstance(run, dict)]
+
+    def dispatch_workflow(
+        self, workflow_file: str, tag: str, inputs: dict[str, str]
+    ) -> int | None:
+        workflow = quote(workflow_file, safe="")
+        _status, payload = self._request(
+            "POST",
+            f"/repos/{self.repository}/actions/workflows/{workflow}/dispatches",
+            {"ref": tag, "inputs": inputs},
+            expected=(200, 204),
+        )
+        if isinstance(payload, dict) and payload.get("workflow_run_id") is not None:
+            return int(payload["workflow_run_id"])
+        return None
+
+    def get_workflow_run(self, run_id: int) -> dict[str, object]:
+        _status, payload = self._request(
+            "GET", f"/repos/{self.repository}/actions/runs/{run_id}"
+        )
+        assert isinstance(payload, dict)
+        return payload
+
+
+class ReleasePublisher:
+    def __init__(
+        self,
+        client: GitHubClient,
+        request: ReleaseRequest,
+        target_sha: str,
+        release_notes: str,
+        sleep: Callable[[float], None] = time.sleep,
+        poll_seconds: float = 30,
+        run_timeout_seconds: float = 5 * 60 * 60 + 30 * 60,
+    ) -> None:
+        if not re.fullmatch(r"[0-9a-f]{40}", target_sha):
+            raise PublishError("target_sha must be a full 40-character commit SHA")
+        self.client = client
+        self.request = request
+        self.target_sha = target_sha
+        self.release_notes = release_notes
+        self.sleep = sleep
+        self.poll_seconds = poll_seconds
+        self.run_timeout_seconds = run_timeout_seconds
+        self.run_urls: dict[str, str] = {}
+        if not self._notes_text_complete(release_notes):
+            raise PublishError("Reviewed release notes are missing the tag or a language section")
+        if "{{" in release_notes or "}}" in release_notes:
+            raise PublishError("Reviewed release notes contain an unresolved template token")
+
+    def _ensure_tag(self) -> None:
+        existing = self.client.get_tag_sha(self.request.release_tag)
+        if existing is None:
+            self.client.create_tag(self.request.release_tag, self.target_sha)
+            print(f"Created tag {self.request.release_tag} at {self.target_sha}", flush=True)
+            return
+        if existing != self.target_sha:
+            raise PublishError(
+                f"Tag {self.request.release_tag} points to {existing}, expected {self.target_sha}"
+            )
+        print(f"Reusing tag {self.request.release_tag} at {existing}", flush=True)
+
+    def _ensure_draft_release(self) -> tuple[dict[str, object], bool]:
+        release = self.client.get_release(self.request.release_tag)
+        if release is None:
+            release = self.client.create_draft_release(self.request, self.target_sha)
+            print(f"Created draft pre-release {self.request.release_tag}", flush=True)
+            return release, False
+        if release.get("prerelease") is not True:
+            raise PublishError("Existing release is not marked as a pre-release")
+        if release.get("draft") is False:
+            return release, True
+        print(f"Reusing draft pre-release {self.request.release_tag}", flush=True)
+        return release, False
+
+    def _matching_active_run(self, workflow_file: str) -> dict[str, object] | None:
+        for run in self.client.list_workflow_runs(workflow_file, self.request.release_tag):
+            if run.get("head_sha") != self.target_sha:
+                continue
+            if str(run.get("status")) in ACTIVE_RUN_STATUSES:
+                return run
+        return None
+
+    def _discover_new_run(
+        self, workflow_file: str, previous_ids: set[int], timeout_seconds: float = 180
+    ) -> int:
+        deadline = time.monotonic() + timeout_seconds
+        while time.monotonic() < deadline:
+            for run in self.client.list_workflow_runs(workflow_file, self.request.release_tag):
+                run_id = int(run["id"])
+                if run_id not in previous_ids and run.get("head_sha") == self.target_sha:
+                    return run_id
+            self.sleep(min(self.poll_seconds, 10))
+        raise PublishError(f"Timed out locating dispatched workflow run for {workflow_file}")
+
+    def _dispatch(self, workflow_file: str) -> int:
+        existing = self.client.list_workflow_runs(workflow_file, self.request.release_tag)
+        previous_ids = {int(run["id"]) for run in existing if run.get("id") is not None}
+        run_id = self.client.dispatch_workflow(
+            workflow_file,
+            self.request.release_tag,
+            {
+                "date_tag": self.request.date_tag,
+                "release_tag": self.request.release_tag,
+            },
+        )
+        if run_id is None:
+            run_id = self._discover_new_run(workflow_file, previous_ids)
+        print(f"Dispatched {workflow_file}: run {run_id}", flush=True)
+        return run_id
+
+    def _wait_for_runs(self, runs: dict[str, int]) -> None:
+        if not runs:
+            return
+        deadline = time.monotonic() + self.run_timeout_seconds
+        pending = dict(runs)
+        last_state: dict[int, tuple[str, object]] = {}
+        while pending:
+            if time.monotonic() >= deadline:
+                names = ", ".join(sorted(pending))
+                raise PublishError(f"Timed out waiting for workflows: {names}")
+            for name, run_id in list(pending.items()):
+                run = self.client.get_workflow_run(run_id)
+                status = str(run.get("status", "unknown"))
+                conclusion = run.get("conclusion")
+                state = (status, conclusion)
+                if last_state.get(run_id) != state:
+                    print(f"{name}: {status} ({conclusion or 'pending'})", flush=True)
+                    last_state[run_id] = state
+                if run.get("html_url"):
+                    self.run_urls[name] = str(run["html_url"])
+                if status == "completed":
+                    if conclusion != "success":
+                        raise PublishError(
+                            f"{name} workflow run {run_id} completed with {conclusion}"
+                        )
+                    del pending[name]
+            if pending:
+                self.sleep(self.poll_seconds)
+
+    def _verify_platform_assets(self, release_id: int) -> list[str]:
+        missing: list[str] = []
+        for attempt in range(7):
+            assets = self.client.list_release_assets(release_id)
+            missing = []
+            for spec in WORKFLOWS:
+                missing.extend(spec.missing_assets(assets, self.request.date_tag))
+            if "lizzieyzy-next-update-manifest.json" not in assets:
+                missing.append("lizzieyzy-next-update-manifest.json")
+            if not missing:
+                return assets
+            if attempt < 6:
+                self.sleep(min(self.poll_seconds, 10))
+        raise PublishError("Release is missing assets: " + ", ".join(missing))
+
+    def _notes_complete(self, release: dict[str, object]) -> bool:
+        return self._notes_text_complete(str(release.get("body") or ""))
+
+    def _notes_text_complete(self, body: str) -> bool:
+        return self.request.release_tag in body and all(
+            heading in body for heading in LOCALIZED_NOTE_HEADINGS
+        )
+
+    def _publish_summary(self, release: dict[str, object], assets: list[str]) -> None:
+        summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+        if not summary_path:
+            return
+        lines = [
+            f"## Published {self.request.release_tag}",
+            "",
+            f"- Target: `{self.target_sha}`",
+            f"- Assets verified: {len(assets)}",
+            f"- Pre-release: `{str(release.get('prerelease')).lower()}`",
+            f"- URL: {release.get('html_url', '')}",
+            "",
+            "### Workflow runs",
+        ]
+        lines.extend(f"- {name}: {url}" for name, url in sorted(self.run_urls.items()))
+        with Path(summary_path).open("a", encoding="utf-8") as handle:
+            handle.write("\n".join(lines) + "\n")
+
+    def publish(self) -> dict[str, object]:
+        self._ensure_tag()
+        release, already_published = self._ensure_draft_release()
+        release_id = int(release["id"])
+        if already_published:
+            assets = self._verify_platform_assets(release_id)
+            if not self._notes_complete(release):
+                raise PublishError("Published pre-release does not contain all six language sections")
+            print(f"{self.request.release_tag} is already complete", flush=True)
+            self._publish_summary(release, assets)
+            return release
+
+        current_assets = self.client.list_release_assets(release_id)
+        runs: dict[str, int] = {}
+        for spec in WORKFLOWS:
+            missing = spec.missing_assets(current_assets, self.request.date_tag)
+            if not missing and (
+                spec.platform != "Windows" or "lizzieyzy-next-update-manifest.json" in current_assets
+            ):
+                print(f"{spec.platform}: required assets already present", flush=True)
+                continue
+            active = self._matching_active_run(spec.workflow_file)
+            if active is not None:
+                run_id = int(active["id"])
+                print(f"{spec.platform}: waiting for existing run {run_id}", flush=True)
+            else:
+                run_id = self._dispatch(spec.workflow_file)
+            runs[spec.platform] = run_id
+
+        self._wait_for_runs(runs)
+        assets = self._verify_platform_assets(release_id)
+
+        release = self.client.update_release(
+            release_id,
+            {
+                "name": self.request.title,
+                "body": self.release_notes,
+                "draft": True,
+                "prerelease": True,
+                "make_latest": "false",
+            },
+        )
+        if not self._notes_complete(release):
+            raise PublishError("GitHub did not retain the reviewed six-language release notes")
+
+        release = self.client.update_release(
+            release_id,
+            {
+                "name": self.request.title,
+                "draft": False,
+                "prerelease": True,
+                "make_latest": "false",
+            },
+        )
+        if release.get("draft") is not False or release.get("prerelease") is not True:
+            raise PublishError("GitHub did not publish the release as a pre-release")
+        assets = self._verify_platform_assets(release_id)
+        self._publish_summary(release, assets)
+        print(f"Published pre-release: {release.get('html_url', '')}", flush=True)
+        return release
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--request", required=True, type=Path)
+    parser.add_argument("--repository", required=True)
+    parser.add_argument("--target-sha", required=True)
+    parser.add_argument("--api-url", default=os.environ.get("GITHUB_API_URL"))
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        request = ReleaseRequest.load(args.request)
+        repository_root = Path(__file__).resolve().parents[1]
+        notes_path = repository_root / request.notes_file
+        try:
+            release_notes = notes_path.read_text(encoding="utf-8")
+        except OSError as exc:
+            raise PublishError(f"Unable to read reviewed release notes {notes_path}: {exc}") from exc
+        client = GitHubClient(
+            args.repository,
+            os.environ.get("GITHUB_TOKEN", ""),
+            api_url=args.api_url,
+        )
+        ReleasePublisher(client, request, args.target_sha, release_notes).publish()
+    except PublishError as exc:
+        print(f"release publishing failed: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_publish_release_request.py
+++ b/scripts/test_publish_release_request.py
@@ -1,0 +1,291 @@
+#!/usr/bin/env python3
+"""Regression tests for the audited pre-release publisher."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+import sys
+import tempfile
+import unittest
+
+
+SCRIPT_PATH = Path(__file__).with_name("publish_release_request.py")
+SPEC = importlib.util.spec_from_file_location("publish_release_request", SCRIPT_PATH)
+if SPEC is None or SPEC.loader is None:
+    raise RuntimeError(f"Unable to load {SCRIPT_PATH}")
+PUBLISH = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = PUBLISH
+SPEC.loader.exec_module(PUBLISH)
+
+
+DATE_TAG = "2026-07-22"
+RELEASE_TAG = f"next-{DATE_TAG}.1"
+TARGET_SHA = "a" * 40
+
+
+def request_payload(**overrides: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "date_tag": DATE_TAG,
+        "release_tag": RELEASE_TAG,
+        "title": f"LizzieYzy Next {RELEASE_TAG}",
+        "prerelease": True,
+        "notes_file": f".github/release-notes/{RELEASE_TAG}.md",
+    }
+    payload.update(overrides)
+    return payload
+
+
+def all_asset_names() -> list[str]:
+    names: list[str] = []
+    for spec in PUBLISH.WORKFLOWS:
+        names.extend(f"{DATE_TAG}-{suffix}" for suffix in spec.exact_suffixes)
+    names.extend(
+        [
+            f"{DATE_TAG}-windows64.nvidia.tensorrt.portable.7z.001",
+            "lizzieyzy-next-update-manifest.json",
+        ]
+    )
+    return names
+
+
+class FakeClient:
+    def __init__(self, failed_workflow: str | None = None) -> None:
+        self.tag_sha: str | None = None
+        self.release: dict[str, object] | None = None
+        self.assets: list[str] = []
+        self.runs: dict[int, dict[str, object]] = {}
+        self.workflow_runs: dict[str, list[dict[str, object]]] = {}
+        self.next_run_id = 100
+        self.failed_workflow = failed_workflow
+        self.dispatched: list[str] = []
+
+    def get_tag_sha(self, _tag: str) -> str | None:
+        return self.tag_sha
+
+    def create_tag(self, _tag: str, target_sha: str) -> None:
+        self.tag_sha = target_sha
+
+    def get_release(self, _tag: str) -> dict[str, object] | None:
+        return dict(self.release) if self.release is not None else None
+
+    def create_draft_release(
+        self, request: PUBLISH.ReleaseRequest, _target_sha: str
+    ) -> dict[str, object]:
+        self.release = {
+            "id": 7,
+            "tag_name": request.release_tag,
+            "name": request.title,
+            "body": "building",
+            "draft": True,
+            "prerelease": True,
+            "html_url": "https://example.invalid/draft",
+        }
+        return dict(self.release)
+
+    def update_release(
+        self, _release_id: int, payload: dict[str, object]
+    ) -> dict[str, object]:
+        assert self.release is not None
+        self.release.update(payload)
+        self.release["html_url"] = "https://example.invalid/release"
+        return dict(self.release)
+
+    def list_release_assets(self, _release_id: int) -> list[str]:
+        return list(self.assets)
+
+    def list_workflow_runs(self, workflow_file: str, _tag: str) -> list[dict[str, object]]:
+        return list(self.workflow_runs.get(workflow_file, []))
+
+    def dispatch_workflow(
+        self, workflow_file: str, _tag: str, _inputs: dict[str, str]
+    ) -> int:
+        self.next_run_id += 1
+        run_id = self.next_run_id
+        conclusion = "failure" if workflow_file == self.failed_workflow else "success"
+        run = {
+            "id": run_id,
+            "head_sha": TARGET_SHA,
+            "status": "completed",
+            "conclusion": conclusion,
+            "html_url": f"https://example.invalid/runs/{run_id}",
+        }
+        self.runs[run_id] = run
+        self.workflow_runs.setdefault(workflow_file, []).insert(0, run)
+        self.dispatched.append(workflow_file)
+
+        if conclusion == "success":
+            for spec in PUBLISH.WORKFLOWS:
+                if spec.workflow_file == workflow_file:
+                    self.assets.extend(
+                        f"{DATE_TAG}-{suffix}" for suffix in spec.exact_suffixes
+                    )
+                    if spec.platform == "Windows":
+                        self.assets.extend(
+                            [
+                                f"{DATE_TAG}-windows64.nvidia.tensorrt.portable.7z.001",
+                                "lizzieyzy-next-update-manifest.json",
+                            ]
+                        )
+        return run_id
+
+    def get_workflow_run(self, run_id: int) -> dict[str, object]:
+        return dict(self.runs[run_id])
+
+
+class ReleaseRequestTest(unittest.TestCase):
+    def load(self, payload: dict[str, object]) -> PUBLISH.ReleaseRequest:
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "request.json"
+            path.write_text(json.dumps(payload), encoding="utf-8")
+            return PUBLISH.ReleaseRequest.load(path)
+
+    def test_loads_valid_pre_release_request(self) -> None:
+        request = self.load(request_payload())
+
+        self.assertEqual(DATE_TAG, request.date_tag)
+        self.assertEqual(RELEASE_TAG, request.release_tag)
+        self.assertTrue(request.prerelease)
+
+    def test_rejects_mismatched_date(self) -> None:
+        with self.assertRaisesRegex(PUBLISH.PublishError, "date_tag must match"):
+            self.load(request_payload(date_tag="2026-07-21"))
+
+    def test_rejects_non_pre_release(self) -> None:
+        with self.assertRaisesRegex(PUBLISH.PublishError, "prerelease"):
+            self.load(request_payload(prerelease=False))
+
+    def test_rejects_unreviewable_title(self) -> None:
+        with self.assertRaisesRegex(PUBLISH.PublishError, "title must be exactly"):
+            self.load(request_payload(title="Surprise release"))
+
+
+class WorkflowSpecTest(unittest.TestCase):
+    def test_complete_asset_set_satisfies_every_platform(self) -> None:
+        assets = all_asset_names()
+
+        for spec in PUBLISH.WORKFLOWS:
+            self.assertEqual([], spec.missing_assets(assets, DATE_TAG), spec.platform)
+
+    def test_windows_requires_a_tensorrt_volume(self) -> None:
+        assets = [
+            name
+            for name in all_asset_names()
+            if "nvidia.tensorrt.portable.7z.001" not in name
+        ]
+
+        missing = PUBLISH.WORKFLOWS[0].missing_assets(assets, DATE_TAG)
+
+        self.assertEqual(1, len(missing))
+        self.assertIn("nvidia", missing[0])
+        self.assertIn("7z", missing[0])
+
+
+class ReviewedReleaseNotesTest(unittest.TestCase):
+    def test_notes_are_complete_localized_and_link_to_all_platforms(self) -> None:
+        path = SCRIPT_PATH.parents[1] / ".github" / "release-notes" / f"{RELEASE_TAG}.md"
+        notes = path.read_text(encoding="utf-8")
+
+        for heading in PUBLISH.LOCALIZED_NOTE_HEADINGS:
+            self.assertEqual(1, notes.count(heading), heading)
+        for marker in (
+            "windows64.opencl.portable.zip",
+            "windows64.nvidia50.cuda.portable.zip",
+            "windows64.nvidia.tensorrt.portable.README.txt",
+            "mac-apple-silicon.with-katago.dmg",
+            "mac-intel.with-katago.dmg",
+            "linux64.with-katago.zip",
+            "linux64.opencl.zip",
+            "linux64.nvidia.zip",
+        ):
+            self.assertIn(marker, notes)
+        self.assertIn(RELEASE_TAG, notes)
+        self.assertIn("PR #127–#133", notes)
+        self.assertIn("1484", notes)
+        self.assertNotIn("知子", notes)
+        self.assertNotIn("{{", notes)
+        self.assertNotIn("}}", notes)
+
+
+class ReleasePublisherTest(unittest.TestCase):
+    def request(self) -> PUBLISH.ReleaseRequest:
+        return PUBLISH.ReleaseRequest(
+            DATE_TAG,
+            RELEASE_TAG,
+            f"LizzieYzy Next {RELEASE_TAG}",
+            True,
+            f".github/release-notes/{RELEASE_TAG}.md",
+        )
+
+    def release_notes(self) -> str:
+        return RELEASE_TAG + "\n" + "\n".join(PUBLISH.LOCALIZED_NOTE_HEADINGS)
+
+    def publisher(self, client: FakeClient) -> PUBLISH.ReleasePublisher:
+        return PUBLISH.ReleasePublisher(
+            client,
+            self.request(),
+            TARGET_SHA,
+            self.release_notes(),
+            sleep=lambda _seconds: None,
+            poll_seconds=0,
+            run_timeout_seconds=30,
+        )
+
+    def test_publishes_only_after_platforms_assets_and_notes_succeed(self) -> None:
+        client = FakeClient()
+
+        release = self.publisher(client).publish()
+
+        self.assertEqual(TARGET_SHA, client.tag_sha)
+        self.assertFalse(release["draft"])
+        self.assertTrue(release["prerelease"])
+        self.assertEqual(
+            [spec.workflow_file for spec in PUBLISH.WORKFLOWS],
+            client.dispatched,
+        )
+        self.assertCountEqual(all_asset_names(), client.assets)
+
+    def test_failed_platform_keeps_release_as_draft(self) -> None:
+        client = FakeClient(failed_workflow="build-linux-release.yml")
+
+        with self.assertRaisesRegex(PUBLISH.PublishError, "Linux workflow.*failure"):
+            self.publisher(client).publish()
+
+        assert client.release is not None
+        self.assertTrue(client.release["draft"])
+        self.assertTrue(client.release["prerelease"])
+
+    def test_already_published_complete_release_is_idempotent(self) -> None:
+        client = FakeClient()
+        client.tag_sha = TARGET_SHA
+        client.assets = all_asset_names()
+        client.release = {
+            "id": 7,
+            "body": self.release_notes(),
+            "draft": False,
+            "prerelease": True,
+            "html_url": "https://example.invalid/release",
+        }
+
+        release = self.publisher(client).publish()
+
+        self.assertFalse(release["draft"])
+        self.assertEqual([], client.dispatched)
+
+    def test_rejects_incomplete_notes_before_creating_a_tag(self) -> None:
+        client = FakeClient()
+
+        with self.assertRaisesRegex(PUBLISH.PublishError, "missing the tag or a language"):
+            PUBLISH.ReleasePublisher(
+                client,
+                self.request(),
+                TARGET_SHA,
+                "## 中文\nIncomplete",
+            )
+
+        self.assertIsNone(client.tag_sha)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 概要

为已通过 Windows 真机验收的 PR #127–#133 创建可审计的多平台预发布请求。

- 新增 `next-2026-07-22.1` 六语更新说明与明确的全平台下载指引。
- 合并本 PR 后先创建 **draft pre-release**，再并行触发 Windows、Linux、macOS Intel、macOS Apple Silicon 四条既有发布工作流。
- 只有四条工作流全部成功、预期资产完整、六语说明写入成功后，才将草稿公开为 Pre-release。
- 任一平台失败时保持草稿，不向普通用户暴露半成品；重跑具有幂等性，可复用已完成资产和正在运行的任务。
- 每次发布由 `.github/release-requests/*.json` 经 PR 审核触发，后续发布不再依赖人工逐项点工作流。

## 本轮功能内容

发布说明覆盖本轮已经集成并验收的改动：

- 两阶段整盘精析及统一的“自动分析”入口。
- 智子云“继续分析”停滞恢复与进度感知 watchdog。
- 让子棋 SGF 贴目、旧分析 payload 与初始目差修复。
- 本地 KataGo 自动发现与修复。
- 复用主引擎加速形势判断。
- 手动更新检查及忽略 pre-release。
- Windows launcher、Alt+O readboard 与 smoke 清理加固。

## 验证

- 完整 Maven：162 suites，1484 tests，0 failures，0 errors，2 skipped
- `mvn -B -Dfmt.skip=true -DskipTests package`：BUILD SUCCESS
- 发布器与说明回归：13 tests，0 failures
- `python scripts/test_windows_launcher_packaging.py`：PASS
- PowerShell parser：PASS
- Bash packaging syntax：PASS
- SnakeYAML workflow parse：PASS
- `git diff --check`：PASS

## Windows 用户验收

Windows 11、150% 缩放、OpenCL portable、包内 JRE 与 KataGo 1.16.5：

- 全新 EXE 启动、持续分析和完整胜率曲线通过。
- 用户让二子 SGF 直接显示贴目 0.0、开局黑领先约 21 目。
- 物理 Alt+O 启动内置 readboard v3.0.6。
- 两阶段整盘精析 1/2 阶段完成，窗口保持响应。
- 智子云真实账号登录、切换、暂停、继续及停滞恢复通过。
- 最终 launcher/readboard smoke 通过，退出后包内残留进程与 smoke JVM 参数均为 0。

合并本 PR 会自动开始构建 `next-2026-07-22.1`，在全部资产通过验证前不会公开发布。