### PR TITLE
修复草稿发布构建与 macOS 签名重试

### DIFF
--- a/.github/workflows/build-macos-amd64-release.yml
+++ b/.github/workflows/build-macos-amd64-release.yml
@@ -106,7 +106,7 @@ jobs:
           APPLE_APP_PASSWORD: ${{ secrets.APPLE_APP_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
           APPLE_SIGN_IDENTITY: ${{ secrets.APPLE_SIGN_IDENTITY }}
-        run: bash ./scripts/sign_macos_release.sh dist/release mac-amd64
+        run: bash ./scripts/sign_macos_release_with_retry.sh dist/release mac-amd64
 
       - name: Validate public macOS amd64 assets
         run: bash ./scripts/validate_release_assets.sh mac-amd64 dist/release "${{ inputs.date_tag }}"

--- a/.github/workflows/build-macos-arm64-release.yml
+++ b/.github/workflows/build-macos-arm64-release.yml
@@ -106,7 +106,7 @@ jobs:
           APPLE_APP_PASSWORD: ${{ secrets.APPLE_APP_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
           APPLE_SIGN_IDENTITY: ${{ secrets.APPLE_SIGN_IDENTITY }}
-        run: bash ./scripts/sign_macos_release.sh dist/release mac-arm64
+        run: bash ./scripts/sign_macos_release_with_retry.sh dist/release mac-arm64
 
       - name: Validate public macOS arm64 assets
         run: bash ./scripts/validate_release_assets.sh mac-arm64 dist/release "${{ inputs.date_tag }}"

--- a/.github/workflows/build-windows-release.yml
+++ b/.github/workflows/build-windows-release.yml
@@ -11,6 +11,11 @@ on:
         description: Existing GitHub release tag to upload into
         required: true
         default: next-2026-05-06.1
+      release_prerelease:
+        description: Optional explicit pre-release state for draft release publishing
+        required: false
+        default: ''
+        type: string
 
 permissions:
   contents: write
@@ -70,15 +75,37 @@ jobs:
         shell: bash
         env:
           GITHUB_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ inputs.release_tag }}
+          RELEASE_PRERELEASE: ${{ inputs.release_prerelease }}
         run: |
-          release_prerelease="$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${{ inputs.release_tag }}" --jq '.prerelease')"
-          serial="${{ inputs.release_tag }}"
+          set -euo pipefail
+          if [[ ! "$RELEASE_TAG" =~ ^next-[0-9]{4}-[0-9]{2}-[0-9]{2}\.[1-9][0-9]*$ ]]; then
+            echo "Invalid release tag: $RELEASE_TAG" >&2
+            exit 1
+          fi
+
+          release_prerelease="$RELEASE_PRERELEASE"
+          if [[ -z "$release_prerelease" ]]; then
+            # Draft releases are intentionally omitted by the releases/tags endpoint.
+            # The authenticated release listing includes both drafts and public releases.
+            release_prerelease="$(
+              gh api --paginate "repos/${GITHUB_REPOSITORY}/releases?per_page=100" |
+                jq -r --arg tag "$RELEASE_TAG" \
+                  'first(.[] | select(.tag_name == $tag)) | .prerelease'
+            )"
+          fi
+          if [[ "$release_prerelease" != "true" && "$release_prerelease" != "false" ]]; then
+            echo "Unable to determine pre-release state for $RELEASE_TAG" >&2
+            exit 1
+          fi
+
+          serial="$RELEASE_TAG"
           serial="${serial##*.}"
           if [[ ! "$serial" =~ ^[0-9]+$ ]]; then
             serial="${GITHUB_RUN_ATTEMPT:-0}"
           fi
           WINDOWS_BUILD_SERIAL="$serial" LIZZIE_RELEASE_PRERELEASE="$release_prerelease" \
-            ./scripts/package_windows_exe.sh "${{ inputs.date_tag }}" 1.0.0 target/lizzie-yzy2.5.3-shaded.jar "${{ inputs.release_tag }}"
+            ./scripts/package_windows_exe.sh "${{ inputs.date_tag }}" 1.0.0 target/lizzie-yzy2.5.3-shaded.jar "$RELEASE_TAG"
 
       - name: Validate public Windows assets
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,17 +38,21 @@ jobs:
             scripts/generate_release_notes.py \
             scripts/package_runtime_tools.py \
             scripts/prepare_bundled_jcef.py \
+            scripts/publish_release_request.py \
             scripts/summarize_jfr.py \
             scripts/test_generate_release_notes.py \
+            scripts/test_publish_release_request.py \
             scripts/test_windows_launcher_packaging.py
           python3 scripts/test_generate_release_notes.py
           python3 scripts/test_prepare_bundled_jcef.py
+          python3 scripts/test_publish_release_request.py
           python3 scripts/test_windows_launcher_packaging.py
           bash -n \
             scripts/package_macos_dmg.sh \
             scripts/package_release.sh \
             scripts/package_windows_exe.sh \
             scripts/run_jfr_benchmark.sh \
+            scripts/sign_macos_release_with_retry.sh \
             scripts/validate_release_assets.sh
 
       - name: Run unit tests

--- a/scripts/publish_release_request.py
+++ b/scripts/publish_release_request.py
@@ -93,6 +93,7 @@ class WorkflowSpec:
     workflow_file: str
     exact_suffixes: tuple[str, ...]
     required_patterns: tuple[re.Pattern[str], ...] = ()
+    dispatch_inputs: tuple[tuple[str, str], ...] = ()
 
     def missing_assets(self, asset_names: Iterable[str], date_tag: str) -> list[str]:
         names = set(asset_names)
@@ -129,6 +130,7 @@ WORKFLOWS = (
             "windows64.nvidia.tensorrt.portable.sha256.txt",
         ),
         (re.compile(r"^{date}-windows64\.nvidia\.tensorrt\.portable\.7z\.\d{{3}}$"),),
+        (("release_prerelease", "true"),),
     ),
     WorkflowSpec(
         "Linux",
@@ -380,16 +382,19 @@ class ReleasePublisher:
             self.sleep(min(self.poll_seconds, 10))
         raise PublishError(f"Timed out locating dispatched workflow run for {workflow_file}")
 
-    def _dispatch(self, workflow_file: str) -> int:
+    def _dispatch(self, spec: WorkflowSpec) -> int:
+        workflow_file = spec.workflow_file
         existing = self.client.list_workflow_runs(workflow_file, self.request.release_tag)
         previous_ids = {int(run["id"]) for run in existing if run.get("id") is not None}
+        inputs = {
+            "date_tag": self.request.date_tag,
+            "release_tag": self.request.release_tag,
+        }
+        inputs.update(spec.dispatch_inputs)
         run_id = self.client.dispatch_workflow(
             workflow_file,
             self.request.release_tag,
-            {
-                "date_tag": self.request.date_tag,
-                "release_tag": self.request.release_tag,
-            },
+            inputs,
         )
         if run_id is None:
             run_id = self._discover_new_run(workflow_file, previous_ids)
@@ -492,7 +497,7 @@ class ReleasePublisher:
                 run_id = int(active["id"])
                 print(f"{spec.platform}: waiting for existing run {run_id}", flush=True)
             else:
-                run_id = self._dispatch(spec.workflow_file)
+                run_id = self._dispatch(spec)
             runs[spec.platform] = run_id
 
         self._wait_for_runs(runs)

--- a/scripts/sign_macos_release_with_retry.sh
+++ b/scripts/sign_macos_release_with_retry.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Retry the complete macOS signing transaction when Apple's timestamp or
+# notarization services are temporarily unavailable. The underlying script
+# replaces the public DMG only after signing and notarization both succeed.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+sign_script="${MACOS_SIGN_SCRIPT:-$ROOT_DIR/scripts/sign_macos_release.sh}"
+max_attempts="${MACOS_SIGN_MAX_ATTEMPTS:-3}"
+retry_delay_seconds="${MACOS_SIGN_RETRY_DELAY_SECONDS:-30}"
+
+if [[ ! "$max_attempts" =~ ^[1-9][0-9]*$ ]]; then
+  echo "MACOS_SIGN_MAX_ATTEMPTS must be a positive integer" >&2
+  exit 2
+fi
+if [[ ! "$retry_delay_seconds" =~ ^[0-9]+$ ]]; then
+  echo "MACOS_SIGN_RETRY_DELAY_SECONDS must be a non-negative integer" >&2
+  exit 2
+fi
+
+for ((attempt = 1; attempt <= max_attempts; attempt++)); do
+  if bash "$sign_script" "$@"; then
+    exit 0
+  fi
+
+  if ((attempt == max_attempts)); then
+    echo "macOS signing/notarization failed after $attempt attempts" >&2
+    exit 1
+  fi
+
+  delay=$((attempt * retry_delay_seconds))
+  echo "macOS signing/notarization attempt $attempt/$max_attempts failed; retrying in ${delay}s..." >&2
+  sleep "$delay"
+done

--- a/scripts/test_publish_release_request.py
+++ b/scripts/test_publish_release_request.py
@@ -5,7 +5,10 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import os
 from pathlib import Path
+import shutil
+import subprocess
 import sys
 import tempfile
 import unittest
@@ -60,6 +63,7 @@ class FakeClient:
         self.next_run_id = 100
         self.failed_workflow = failed_workflow
         self.dispatched: list[str] = []
+        self.dispatched_inputs: dict[str, dict[str, str]] = {}
 
     def get_tag_sha(self, _tag: str) -> str | None:
         return self.tag_sha
@@ -99,7 +103,7 @@ class FakeClient:
         return list(self.workflow_runs.get(workflow_file, []))
 
     def dispatch_workflow(
-        self, workflow_file: str, _tag: str, _inputs: dict[str, str]
+        self, workflow_file: str, _tag: str, inputs: dict[str, str]
     ) -> int:
         self.next_run_id += 1
         run_id = self.next_run_id
@@ -114,6 +118,7 @@ class FakeClient:
         self.runs[run_id] = run
         self.workflow_runs.setdefault(workflow_file, []).insert(0, run)
         self.dispatched.append(workflow_file)
+        self.dispatched_inputs[workflow_file] = dict(inputs)
 
         if conclusion == "success":
             for spec in PUBLISH.WORKFLOWS:
@@ -208,6 +213,61 @@ class ReviewedReleaseNotesTest(unittest.TestCase):
         self.assertNotIn("}}", notes)
 
 
+class ReleaseWorkflowResilienceTest(unittest.TestCase):
+    def test_windows_draft_release_metadata_has_an_explicit_input_and_safe_fallback(self) -> None:
+        workflow = (
+            SCRIPT_PATH.parents[1] / ".github" / "workflows" / "build-windows-release.yml"
+        ).read_text(encoding="utf-8")
+
+        self.assertIn("release_prerelease:", workflow)
+        self.assertIn("releases?per_page=100", workflow)
+        self.assertNotIn("releases/tags/", workflow)
+        self.assertIn('LIZZIE_RELEASE_PRERELEASE="$release_prerelease"', workflow)
+
+    @unittest.skipIf(os.name == "nt", "behavior test runs with native bash in CI")
+    def test_macos_signing_retries_transient_failures(self) -> None:
+        bash = shutil.which("bash")
+        if bash is None:
+            self.skipTest("bash is unavailable")
+
+        helper = SCRIPT_PATH.with_name("sign_macos_release_with_retry.sh")
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            attempts = root / "attempts.txt"
+            fake_signer = root / "fake-sign.sh"
+            fake_signer.write_text(
+                "#!/usr/bin/env bash\n"
+                "set -euo pipefail\n"
+                "count=0\n"
+                '[[ ! -f "$ATTEMPT_FILE" ]] || count="$(cat "$ATTEMPT_FILE")"\n'
+                "count=$((count + 1))\n"
+                'printf \'%s\' "$count" > "$ATTEMPT_FILE"\n'
+                '[[ "$count" -ge 3 ]]\n',
+                encoding="utf-8",
+            )
+            env = os.environ.copy()
+            env.update(
+                {
+                    "ATTEMPT_FILE": str(attempts),
+                    "MACOS_SIGN_SCRIPT": str(fake_signer),
+                    "MACOS_SIGN_MAX_ATTEMPTS": "3",
+                    "MACOS_SIGN_RETRY_DELAY_SECONDS": "0",
+                }
+            )
+
+            completed = subprocess.run(
+                [bash, str(helper), "unused", "mac-arm64"],
+                check=False,
+                capture_output=True,
+                text=True,
+                env=env,
+            )
+
+            self.assertEqual(0, completed.returncode, completed.stderr)
+            self.assertEqual("3", attempts.read_text(encoding="utf-8"))
+            self.assertEqual(2, completed.stderr.count("retrying"))
+
+
 class ReleasePublisherTest(unittest.TestCase):
     def request(self) -> PUBLISH.ReleaseRequest:
         return PUBLISH.ReleaseRequest(
@@ -244,6 +304,13 @@ class ReleasePublisherTest(unittest.TestCase):
             [spec.workflow_file for spec in PUBLISH.WORKFLOWS],
             client.dispatched,
         )
+        self.assertEqual(
+            "true",
+            client.dispatched_inputs["build-windows-release.yml"]["release_prerelease"],
+        )
+        for workflow_file, inputs in client.dispatched_inputs.items():
+            if workflow_file != "build-windows-release.yml":
+                self.assertNotIn("release_prerelease", inputs)
         self.assertCountEqual(all_asset_names(), client.assets)
 
     def test_failed_platform_keeps_release_as_draft(self) -> None:

--- a/scripts/test_windows_launcher_packaging.py
+++ b/scripts/test_windows_launcher_packaging.py
@@ -80,7 +80,19 @@ def main() -> None:
         '"prerelease": prerelease == "true"',
         "package_windows_exe.sh",
     )
-    require(workflow, "--jq '.prerelease'", "build-windows-release.yml")
+    require(
+        workflow,
+        "RELEASE_PRERELEASE: ${{ inputs.release_prerelease }}",
+        "build-windows-release.yml",
+    )
+    require(workflow, "releases?per_page=100", "build-windows-release.yml")
+    require(
+        workflow,
+        'if [[ "$release_prerelease" != "true" && "$release_prerelease" != "false" ]]',
+        "build-windows-release.yml",
+    )
+    if "releases/tags/" in workflow:
+        raise AssertionError("draft release metadata must not use the tag endpoint")
     if "scheduleAutomaticCheck" in lizzie_source or "auto-check" in update_controller:
         raise AssertionError("Windows updates must only run after an explicit user action")
 


### PR DESCRIPTION
## 背景

`next-2026-07-22.1` 的自动预发布门禁正确阻止了残缺发布，但暴露出两个发布基础设施问题：Windows 构建访问草稿不可见的 `releases/tags/{tag}` 而收到 404；macOS Apple Silicon 在 Developer ID 签名时遇到 Apple 时间戳服务短暂不可用。

## 修复

- 发布器只向 Windows 工作流显式传入 `release_prerelease=true`；手工触发仍可通过认证 release 列表读取草稿状态。
- Windows 工作流验证 tag 和 pre-release 值域，不再依赖草稿不可见的 tag endpoint。
- macOS Intel/Apple Silicon 统一使用完整签名事务三次重试；底层脚本仅在签名和公证全部成功后替换公开 DMG。
- CI 增加发布器、草稿查询守卫和 macOS 重试行为测试，并更新 Windows launcher packaging 守卫。

## 验证

- 发布器专项：13 tests, 0 failures（Windows 本机跳过 1 个仅限原生 Bash 的行为测试；CI 会执行）
- Windows launcher packaging guards：PASS
- release notes tests：2 tests, 0 failures
- Bash syntax：PASS
- Maven：162 suites / 1484 tests / 0 failures / 0 errors / 2 skipped
- `mvn -DskipTests package`：BUILD SUCCESS
- `git diff --check`：PASS

合并后将另开 reviewed release-request PR 发布 `next-2026-07-22.2`，不会移动失败的 `.1` 标签。