### PR TITLE
发布 next-2026-07-22.2 多平台预览版

### DIFF
--- a/.github/release-notes/next-2026-07-22.2.md
+++ b/.github/release-notes/next-2026-07-22.2.md
@@ -1,0 +1,305 @@
+# LizzieYzy Next next-2026-07-22.2
+
+## 中文
+
+这是 `next-2026-07-13.2` 之后面向分析可靠性与普通用户操作的预览版：整盘精析变成一键入口，智子云断线恢复更稳，让子棋谱、形势判断、本地引擎修复和 Windows 启动链路也完成了系统加固。
+
+### 本版主要更新
+
+- “自动分析”第一项现在是“整盘精析（推荐）”：先用 32 visits 快速补齐整盘胜率曲线，再以至少 500 visits 逐手深入分析；支持真实进度、剩余时间、隐藏后恢复、停止后保留结果。
+- 修复智子云点击“继续分析”后偶发停住：watchdog 只在 visits 确实增长时续期，断线、排队和重复旧进度会自动恢复；超时后的迟到响应也不会阻止引擎重启。
+- 修复让子棋 SGF 初始目差沿用错误贴目或旧分析数据。加载 `KM[0] / HA[2]` 棋谱后会直接按 0 贴目重新分析，实测开局黑方约领先 21 目，不再需要手动加减贴目。
+- 完善本地 KataGo 自动发现与修复，统一识别发布包内置、绝对/相对路径、中文及空格路径，并保留默认、上次退出、手动选择和无引擎等既有启动方式。
+- 形势判断优先复用已就绪的主 KataGo，不再为每次点击重复加载大权重；TensorRT 环境实测约 300 ms 出结果，完成或取消后会恢复原棋盘分析。
+- 更新检查改为只在用户点击“帮助 → 检查更新”时执行，并忽略 GitHub pre-release；同时加固 Windows 启动器、Alt+O 内置 readboard、配置恢复和 smoke 子进程清理。
+- 本轮整合 PR #127–#133，并在 Windows 11、150% 缩放、OpenCL portable 与包内 KataGo 1.16.5 上完成真实 EXE 验收。
+
+### 下载前先看这几句
+
+- 主推荐整合包继续内置 KataGo `v1.16.5` 和默认智子 28B 权重。
+- Windows 普通用户优先下载 OpenCL 免安装版；NVIDIA 用户按显卡代际选择普通 NVIDIA 或 RTX 50 CUDA 包。
+- 已有免安装版可保留原目录中的 `user-data`、自定义权重和 TensorRT；覆盖升级前仍建议先备份。
+- 这是 pre-release，适合提前验证整盘精析、智子云恢复和多平台打包；稳定后再转为正式 release。
+
+### 下载建议
+
+| 你的电脑 | 直接下载这个 |
+| --- | --- |
+| Windows 64 位，OpenCL 推荐版，免安装 | [windows64.opencl.portable.zip][win-opencl-portable] |
+| 已有 Windows 免安装版，日常小更新 | [windows64.core-update.zip][win-core-update] |
+| Windows 64 位，OpenCL 推荐版，安装器 | [windows64.opencl.installer.exe][win-opencl-installer] |
+| Windows 64 位，CPU 兼容版，免安装 | [windows64.with-katago.portable.zip][win-cpu-portable] |
+| Windows 64 位，CPU 兼容版，安装器 | [windows64.with-katago.installer.exe][win-cpu-installer] |
+| Windows 64 位，NVIDIA 20/30/40 系，免安装 | [windows64.nvidia.portable.zip][win-nvidia-portable] |
+| Windows 64 位，NVIDIA 20/30/40 系，安装器 | [windows64.nvidia.installer.exe][win-nvidia-installer] |
+| Windows 64 位，RTX 5070/5080/5090，免安装 | [windows64.nvidia50.cuda.portable.zip][win-nvidia50-portable] |
+| Windows 64 位，RTX 5070/5080/5090，安装器 | [windows64.nvidia50.cuda.installer.exe][win-nvidia50-installer] |
+| 高级可选 TensorRT 分卷包说明 | [TensorRT README][win-tensorrt-readme] |
+| Windows 64 位，自己配置引擎，免安装 | [windows64.without.engine.portable.zip][win-no-engine-portable] |
+| Windows 64 位，自己配置引擎，安装器 | [windows64.without.engine.installer.exe][win-no-engine-installer] |
+| macOS Apple Silicon | [mac-apple-silicon.with-katago.dmg][mac-arm64] |
+| macOS Intel | [mac-intel.with-katago.dmg][mac-intel] |
+| Linux 64 位，CPU 兼容版 | [linux64.with-katago.zip][linux-cpu] |
+| Linux 64 位，OpenCL 版 | [linux64.opencl.zip][linux-opencl] |
+| Linux 64 位，NVIDIA CUDA 版 | [linux64.nvidia.zip][linux-nvidia] |
+
+### 这一版为什么值得测试
+
+- 普通用户只需打开“自动分析”并点击第一项，即可完成先补曲线、再深入的整盘分析。
+- 本地与远程算力的暂停、恢复、切换棋谱和异常重连路径都有明确状态和自动恢复。
+- 发布前通过 162 个测试套件、1484 项测试（0 failure / 0 error / 2 skipped）、完整打包和 Windows 真机验收。
+
+### 交流
+
+- QQ 群：`299419120`
+
+---
+
+## 繁體中文
+
+這是 `next-2026-07-13.2` 之後針對分析可靠性與一般使用者操作的預覽版：整盤精析成為一鍵入口，智子雲斷線恢復更穩，讓子棋譜、形勢判斷、本機引擎修復與 Windows 啟動流程也完成系統加固。
+
+### 本版主要更新
+
+- 「自動分析」第一項現在是「整盤精析（推薦）」：先以 32 visits 快速補齊整盤勝率曲線，再以至少 500 visits 逐手深入分析；支援真實進度、剩餘時間、隱藏後恢復與停止後保留結果。
+- 修正智子雲點擊「繼續分析」後偶爾停住：watchdog 只在 visits 確實增加時續期，斷線、排隊與重複舊進度會自動恢復；逾時後的遲到回應也不會阻止引擎重啟。
+- 修正讓子棋 SGF 初始目差沿用錯誤貼目或舊分析資料。載入 `KM[0] / HA[2]` 後會直接按 0 貼目重新分析，實測開局黑方約領先 21 目。
+- 完善本機 KataGo 自動探索與修復，統一識別內建、絕對/相對、中文與空格路徑，同時保留預設、上次退出、手動選擇及無引擎等啟動方式。
+- 形勢判斷優先重用已就緒的主 KataGo；TensorRT 環境實測約 300 ms 顯示結果，完成或取消後會恢復原棋盤分析。
+- 更新檢查只在使用者點擊「說明 → 檢查更新」時執行，並忽略 GitHub pre-release；Windows launcher、Alt+O readboard、設定復原與 smoke 子程序清理也同步加固。
+- 本輪整合 PR #127–#133，並以 Windows 11、150% 縮放、OpenCL portable 與內建 KataGo 1.16.5 完成真實 EXE 驗收。
+
+### 下載前先看這幾句
+
+- 推薦整合包繼續內建 KataGo `v1.16.5` 與預設智子 28B 權重。
+- Windows 一般使用者優先選 OpenCL 免安裝版；NVIDIA 使用者依顯示卡世代選擇一般 NVIDIA 或 RTX 50 CUDA 套件。
+- 既有免安裝版可保留 `user-data`、自訂權重與 TensorRT；覆蓋升級前仍建議先備份。
+- 這是 pre-release，適合提前驗證整盤精析、智子雲恢復與多平台套件。
+
+### 下載建議
+
+| 你的電腦 | 直接下載這個 |
+| --- | --- |
+| Windows OpenCL 推薦版，免安裝 | [windows64.opencl.portable.zip][win-opencl-portable] |
+| 既有 Windows 免安裝版，小更新 | [windows64.core-update.zip][win-core-update] |
+| Windows OpenCL 推薦版，安裝器 | [windows64.opencl.installer.exe][win-opencl-installer] |
+| Windows CPU 相容版，免安裝 / 安裝器 | [portable][win-cpu-portable] / [installer][win-cpu-installer] |
+| Windows NVIDIA 20/30/40 系，免安裝 / 安裝器 | [portable][win-nvidia-portable] / [installer][win-nvidia-installer] |
+| Windows RTX 50 CUDA，免安裝 / 安裝器 | [portable][win-nvidia50-portable] / [installer][win-nvidia50-installer] |
+| 進階 TensorRT 分卷包說明 | [TensorRT README][win-tensorrt-readme] |
+| Windows 自行配置引擎，免安裝 / 安裝器 | [portable][win-no-engine-portable] / [installer][win-no-engine-installer] |
+| macOS Apple Silicon / Intel | [Apple Silicon][mac-arm64] / [Intel][mac-intel] |
+| Linux CPU / OpenCL / NVIDIA CUDA | [CPU][linux-cpu] / [OpenCL][linux-opencl] / [NVIDIA][linux-nvidia] |
+
+### 這一版為什麼值得測試
+
+- 一般使用者只要開啟「自動分析」並點第一項，即可先補曲線再進行整盤深入分析。
+- 本機與遠端算力的暫停、恢復、切換棋譜及異常重連都有明確狀態與自動復原。
+- 發布前通過 162 個測試套件、1484 項測試（0 failure / 0 error / 2 skipped）、完整打包與 Windows 真機驗收。
+
+### 交流
+
+- QQ 群：`299419120`
+
+---
+
+## English
+
+This pre-release builds on `next-2026-07-13.2` with a more dependable analysis workflow for everyday users: one-click whole-game deep analysis, resilient Zhizi Cloud recovery, correct handicap scoring, faster position estimates, safer local-engine repair, and a hardened Windows launch path.
+
+### Release Highlights
+
+- Whole-game Deep Analysis is now the recommended first item under Auto Analyze. Stage 1 fills the complete win-rate curve at 32 visits, then Stage 2 deepens every position to at least 500 visits, with real progress, ETA, hide/restore, and retained partial results.
+- Fixed Zhizi Cloud sessions that could stop after Continue Analysis. The watchdog now renews only when visits actually grow, recovers queued or disconnected requests, and prevents late stale packets from suppressing a required restart.
+- Fixed handicap SGFs reusing the wrong komi or stale embedded analysis. A `KM[0] / HA[2]` game is analyzed immediately at zero komi and was verified around Black +21 at the opening.
+- Unified local KataGo discovery and repair across bundled, absolute, relative, non-ASCII, and space-containing paths while preserving Default, Last Used, Manual, and No Engine startup choices.
+- Position Estimate now reuses the ready foreground KataGo instead of loading another large model on every click. A TensorRT test returned in about 300 ms and restored normal board analysis afterward.
+- Update checks now run only from Help → Check for Updates and ignore GitHub pre-releases. Windows launcher, bundled readboard Alt+O, configuration restoration, and smoke-process cleanup were also hardened.
+- This build integrates PRs #127–#133 and was accepted through the real OpenCL portable EXE on Windows 11 at 150% scaling with bundled KataGo 1.16.5.
+
+### Read Before Downloading
+
+- Recommended bundles include KataGo `v1.16.5` and the default Zhizi 28B model.
+- Most Windows users should choose the OpenCL portable. NVIDIA users should select the standard NVIDIA or RTX 50 CUDA build for their GPU generation.
+- Existing portable users can keep `user-data`, custom weights, and TensorRT in place, but should still back up before overwriting an installation.
+- This is a pre-release for early validation of whole-game analysis, Zhizi recovery, and all platform packages.
+
+### Download Guide
+
+| Your computer | Download |
+| --- | --- |
+| Windows OpenCL recommended, portable / installer | [portable][win-opencl-portable] / [installer][win-opencl-installer] |
+| Existing Windows portable, small core update | [core update][win-core-update] |
+| Windows CPU compatible, portable / installer | [portable][win-cpu-portable] / [installer][win-cpu-installer] |
+| Windows NVIDIA RTX 20/30/40, portable / installer | [portable][win-nvidia-portable] / [installer][win-nvidia-installer] |
+| Windows RTX 5070/5080/5090 CUDA, portable / installer | [portable][win-nvidia50-portable] / [installer][win-nvidia50-installer] |
+| Advanced optional TensorRT split package | [TensorRT README][win-tensorrt-readme] |
+| Windows, configure your own engine, portable / installer | [portable][win-no-engine-portable] / [installer][win-no-engine-installer] |
+| macOS Apple Silicon / Intel | [Apple Silicon][mac-arm64] / [Intel][mac-intel] |
+| Linux CPU / OpenCL / NVIDIA CUDA | [CPU][linux-cpu] / [OpenCL][linux-opencl] / [NVIDIA][linux-nvidia] |
+
+### Why Test This Release
+
+- Auto Analyze now takes a user from a fast complete curve to deep whole-game analysis through one recommended action.
+- Local and remote pause, resume, game switching, and reconnect paths expose clear state and recover automatically.
+- Verification covered 162 test suites and 1484 tests (0 failures, 0 errors, 2 skipped), full packaging, and real Windows acceptance.
+
+### Contact
+
+- QQ group: `299419120`
+
+---
+
+## 日本語
+
+`next-2026-07-13.2` 以降の分析信頼性と一般ユーザー操作を改善した pre-release です。ワンクリックの全局精密分析、Zhizi Cloud の復旧、handicap score、形勢判断、local engine 修復、Windows 起動経路を強化しました。
+
+### 主な更新
+
+- Auto Analyze の先頭を推奨の Whole-game Deep Analysis にしました。Stage 1 は 32 visits で全局 curve を埋め、Stage 2 は各局面を 500 visits 以上まで深掘りします。進捗、残り時間、非表示からの復帰、途中結果の保持に対応します。
+- Continue Analysis 後に Zhizi Cloud が停止する問題を修正しました。watchdog は visits が実際に増えた時だけ延長され、切断、queue、重複した古い進捗を復旧し、遅延 packet が再起動を妨げません。
+- handicap SGF が誤った komi や古い analysis を使う問題を修正しました。`KM[0] / HA[2]` は komi 0 で直ちに再解析され、序盤は黒約 21 目リードを確認しました。
+- bundle、絶対/相対 path、非 ASCII path、空白を含む path から local KataGo を一貫して検出・修復し、既存の engine 起動設定を保持します。
+- 形勢判断は起動済み foreground KataGo を再利用します。TensorRT 環境では約 300 ms で結果を確認し、その後通常分析へ復帰します。
+- 更新確認は Help メニューからの手動操作だけに変更し、GitHub pre-release を通知対象外にしました。Windows launcher、Alt+O readboard、設定復元、process cleanup も強化しました。
+- PR #127–#133 を統合し、Windows 11、150% scale、OpenCL portable、内蔵 KataGo 1.16.5 の実 EXE で受入試験を行いました。
+
+### ダウンロード前に
+
+- 推奨 bundle は KataGo `v1.16.5` と既定 Zhizi 28B model を同梱します。
+- 多くの Windows ユーザーは OpenCL portable、NVIDIA ユーザーは GPU 世代に合う NVIDIA または RTX 50 CUDA build を選んでください。
+- portable 版は `user-data`、custom weight、TensorRT を保持できますが、上書き前の backup を推奨します。
+- whole-game analysis、Zhizi 復旧、全 platform package を正式版前に確認する pre-release です。
+
+### ダウンロード案内
+
+| 環境 | ダウンロード |
+| --- | --- |
+| Windows OpenCL portable / installer | [portable][win-opencl-portable] / [installer][win-opencl-installer] |
+| Windows portable 小型更新 | [core update][win-core-update] |
+| Windows CPU portable / installer | [portable][win-cpu-portable] / [installer][win-cpu-installer] |
+| Windows NVIDIA portable / installer | [portable][win-nvidia-portable] / [installer][win-nvidia-installer] |
+| Windows RTX 50 CUDA portable / installer | [portable][win-nvidia50-portable] / [installer][win-nvidia50-installer] |
+| TensorRT 分割 package | [README][win-tensorrt-readme] |
+| macOS Apple Silicon / Intel | [Apple Silicon][mac-arm64] / [Intel][mac-intel] |
+| Linux CPU / OpenCL / NVIDIA | [CPU][linux-cpu] / [OpenCL][linux-opencl] / [NVIDIA][linux-nvidia] |
+
+### このリリースを試す理由
+
+- Auto Analyze の先頭項目だけで curve の高速補完から全局の深い解析まで実行できます。
+- local/remote の一時停止、再開、棋譜切替、再接続に明確な状態と自動復旧があります。
+- 162 suites、1484 tests（failure 0 / error 0 / skipped 2）、full package、Windows 実機試験を完了しました。
+
+### 連絡先
+
+- QQ group: `299419120`
+
+---
+
+## 한국어
+
+`next-2026-07-13.2` 이후 분석 신뢰성과 일반 사용자 흐름을 개선한 pre-release입니다. 원클릭 전체 기보 정밀 분석, Zhizi Cloud 복구, handicap 점수, 형세 판단, local engine 복구, Windows 실행 경로를 강화했습니다.
+
+### 주요 업데이트
+
+- Auto Analyze 첫 항목을 권장 Whole-game Deep Analysis로 변경했습니다. Stage 1은 32 visits로 전체 win-rate curve를 채우고 Stage 2는 각 국면을 최소 500 visits까지 심화하며 실제 진행률, 남은 시간, 숨김/복원, 부분 결과 보존을 지원합니다.
+- Continue Analysis 뒤 Zhizi Cloud가 멈추는 문제를 수정했습니다. watchdog은 visits가 실제 증가할 때만 갱신되고, 연결 끊김, queue, 반복된 이전 진행을 복구하며 늦은 packet이 필요한 재시작을 막지 않습니다.
+- handicap SGF가 잘못된 komi 또는 오래된 analysis를 재사용하는 문제를 수정했습니다. `KM[0] / HA[2]`는 komi 0으로 즉시 다시 분석되며 초반 흑 약 21집 우세를 확인했습니다.
+- bundle, 절대/상대 path, 비 ASCII 및 공백 path의 local KataGo 탐색과 복구를 통합하고 기존 engine 시작 설정을 유지합니다.
+- 형세 판단은 준비된 foreground KataGo를 재사용합니다. TensorRT 환경에서 약 300 ms 결과를 확인했고 완료 또는 취소 뒤 기존 바둑판 분석을 복원합니다.
+- 업데이트 확인은 Help 메뉴에서 사용자가 직접 실행할 때만 동작하며 GitHub pre-release는 알리지 않습니다. Windows launcher, Alt+O readboard, 설정 복원, process 정리도 강화했습니다.
+- PR #127–#133을 통합하고 Windows 11, 150% scale, OpenCL portable, 내장 KataGo 1.16.5 실제 EXE로 사용자 검수를 완료했습니다.
+
+### 다운로드 전 확인
+
+- 추천 bundle은 KataGo `v1.16.5`와 기본 Zhizi 28B model을 포함합니다.
+- 대부분의 Windows 사용자는 OpenCL portable, NVIDIA 사용자는 GPU 세대에 맞는 NVIDIA 또는 RTX 50 CUDA build를 선택하세요.
+- portable 사용자는 `user-data`, custom weight, TensorRT를 유지할 수 있지만 덮어쓰기 전 backup을 권장합니다.
+- whole-game analysis, Zhizi 복구, 전체 platform package를 안정판 전 미리 확인하는 pre-release입니다.
+
+### 다운로드 안내
+
+| 환경 | 다운로드 |
+| --- | --- |
+| Windows OpenCL portable / installer | [portable][win-opencl-portable] / [installer][win-opencl-installer] |
+| Windows portable 소형 업데이트 | [core update][win-core-update] |
+| Windows CPU portable / installer | [portable][win-cpu-portable] / [installer][win-cpu-installer] |
+| Windows NVIDIA portable / installer | [portable][win-nvidia-portable] / [installer][win-nvidia-installer] |
+| Windows RTX 50 CUDA portable / installer | [portable][win-nvidia50-portable] / [installer][win-nvidia50-installer] |
+| TensorRT 분할 package | [README][win-tensorrt-readme] |
+| macOS Apple Silicon / Intel | [Apple Silicon][mac-arm64] / [Intel][mac-intel] |
+| Linux CPU / OpenCL / NVIDIA | [CPU][linux-cpu] / [OpenCL][linux-opencl] / [NVIDIA][linux-nvidia] |
+
+### 이 릴리스를 테스트할 이유
+
+- Auto Analyze 첫 항목만으로 curve 빠른 완성과 전체 기보 심층 분석을 연속 실행할 수 있습니다.
+- local/remote 일시정지, 재개, 기보 전환, 재연결 경로에 명확한 상태와 자동 복구가 있습니다.
+- 162 suites, 1484 tests(실패 0 / 오류 0 / skipped 2), 전체 package, Windows 실기 검수를 완료했습니다.
+
+### 연락처
+
+- QQ 그룹: `299419120`
+
+---
+
+## ภาษาไทย
+
+pre-release นี้ต่อยอดจาก `next-2026-07-13.2` เพื่อให้การวิเคราะห์น่าเชื่อถือและใช้ง่ายขึ้น: วิเคราะห์ทั้งเกมด้วยคลิกเดียว, กู้คืน Zhizi Cloud, แก้คะแนน handicap, เร่ง Position Estimate, ซ่อม local engine และเพิ่มความเสถียรของการเปิดโปรแกรมบน Windows
+
+### ไฮไลต์ของเวอร์ชันนี้
+
+- Whole-game Deep Analysis เป็นรายการแนะนำอันดับแรกใน Auto Analyze: Stage 1 เติม win-rate curve ทั้งเกมที่ 32 visits แล้ว Stage 2 วิเคราะห์ทุกตำแหน่งอย่างน้อย 500 visits พร้อม progress จริง, เวลาคงเหลือ, ซ่อน/เรียกคืน และเก็บผลที่ทำเสร็จแล้ว
+- แก้ Zhizi Cloud หยุดหลัง Continue Analysis โดย watchdog จะต่อเวลาเมื่อ visits เพิ่มจริงเท่านั้น กู้คำสั่งที่ค้างหรือหลุดการเชื่อมต่อ และไม่ให้ packet เก่าที่มาช้าขัดขวางการ restart
+- แก้ SGF แบบ handicap ใช้ komi ผิดหรือ analysis เก่า เกม `KM[0] / HA[2]` จะวิเคราะห์ใหม่ด้วย komi 0 ทันที และทดสอบได้ว่าช่วงต้นดำได้นำประมาณ 21 แต้ม
+- รวมการค้นหาและซ่อม local KataGo สำหรับ engine ใน bundle, path แบบ absolute/relative, path ที่มีอักษร non-ASCII หรือเว้นวรรค และคงค่าเริ่ม engine เดิมของผู้ใช้
+- Position Estimate reuse foreground KataGo ที่พร้อมอยู่ ทดสอบ TensorRT ได้ผลประมาณ 300 ms และคืนการวิเคราะห์กระดานเดิมหลังเสร็จหรือยกเลิก
+- ตรวจอัปเดตเฉพาะเมื่อผู้ใช้กด Help → Check for Updates และไม่แจ้ง GitHub pre-release พร้อมเพิ่มความทนทานของ Windows launcher, Alt+O readboard, การคืน config และการเก็บ process
+- รวม PR #127–#133 และทดสอบ EXE จริงบน Windows 11, scale 150%, OpenCL portable และ KataGo 1.16.5 ที่มากับแพ็กเกจ
+
+### ก่อนดาวน์โหลด
+
+- แพ็กเกจแนะนำรวม KataGo `v1.16.5` และ Zhizi 28B model เริ่มต้น
+- ผู้ใช้ Windows ส่วนใหญ่เลือก OpenCL portable; ผู้ใช้ NVIDIA เลือก NVIDIA หรือ RTX 50 CUDA build ตามรุ่น GPU
+- portable เดิมเก็บ `user-data`, custom weight และ TensorRT ได้ แต่ควร backup ก่อนเขียนทับ
+- นี่คือ pre-release สำหรับทดสอบ whole-game analysis, การกู้คืน Zhizi และ package ทุก platform ก่อนเลื่อนเป็น stable release
+
+### คำแนะนำดาวน์โหลด
+
+| ระบบ | ดาวน์โหลด |
+| --- | --- |
+| Windows OpenCL portable / installer | [portable][win-opencl-portable] / [installer][win-opencl-installer] |
+| อัปเดตเล็กสำหรับ Windows portable เดิม | [core update][win-core-update] |
+| Windows CPU portable / installer | [portable][win-cpu-portable] / [installer][win-cpu-installer] |
+| Windows NVIDIA portable / installer | [portable][win-nvidia-portable] / [installer][win-nvidia-installer] |
+| Windows RTX 50 CUDA portable / installer | [portable][win-nvidia50-portable] / [installer][win-nvidia50-installer] |
+| TensorRT split package | [README][win-tensorrt-readme] |
+| macOS Apple Silicon / Intel | [Apple Silicon][mac-arm64] / [Intel][mac-intel] |
+| Linux CPU / OpenCL / NVIDIA | [CPU][linux-cpu] / [OpenCL][linux-opencl] / [NVIDIA][linux-nvidia] |
+
+### ทำไมควรทดสอบเวอร์ชันนี้
+
+- ผู้ใช้เปิด Auto Analyze แล้วเลือกรายการแรกเพื่อเติม curve อย่างรวดเร็วและวิเคราะห์ทั้งเกมต่อได้ทันที
+- เส้นทาง pause, resume, เปลี่ยน SGF และ reconnect ของ local/remote แสดงสถานะชัดเจนและกู้คืนอัตโนมัติ
+- ก่อนเผยแพร่ผ่าน 162 test suites และ 1484 tests (failure 0 / error 0 / skipped 2), full packaging และ Windows real-device acceptance
+
+### ติดต่อ
+
+- QQ group: `299419120`
+
+[win-opencl-portable]: https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-22.2/2026-07-22-windows64.opencl.portable.zip
+[win-core-update]: https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-22.2/2026-07-22-windows64.core-update.zip
+[win-opencl-installer]: https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-22.2/2026-07-22-windows64.opencl.installer.exe
+[win-cpu-portable]: https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-22.2/2026-07-22-windows64.with-katago.portable.zip
+[win-cpu-installer]: https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-22.2/2026-07-22-windows64.with-katago.installer.exe
+[win-nvidia-portable]: https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-22.2/2026-07-22-windows64.nvidia.portable.zip
+[win-nvidia-installer]: https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-22.2/2026-07-22-windows64.nvidia.installer.exe
+[win-nvidia50-portable]: https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-22.2/2026-07-22-windows64.nvidia50.cuda.portable.zip
+[win-nvidia50-installer]: https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-22.2/2026-07-22-windows64.nvidia50.cuda.installer.exe
+[win-tensorrt-readme]: https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-22.2/2026-07-22-windows64.nvidia.tensorrt.portable.README.txt
+[win-no-engine-portable]: https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-22.2/2026-07-22-windows64.without.engine.portable.zip
+[win-no-engine-installer]: https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-22.2/2026-07-22-windows64.without.engine.installer.exe
+[mac-arm64]: https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-22.2/2026-07-22-mac-apple-silicon.with-katago.dmg
+[mac-intel]: https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-22.2/2026-07-22-mac-intel.with-katago.dmg
+[linux-cpu]: https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-22.2/2026-07-22-linux64.with-katago.zip
+[linux-opencl]: https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-22.2/2026-07-22-linux64.opencl.zip
+[linux-nvidia]: https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-22.2/2026-07-22-linux64.nvidia.zip

--- a/.github/release-requests/next-2026-07-22.2.json
+++ b/.github/release-requests/next-2026-07-22.2.json
@@ -1,0 +1,7 @@
+{
+  "date_tag": "2026-07-22",
+  "release_tag": "next-2026-07-22.2",
+  "title": "LizzieYzy Next next-2026-07-22.2",
+  "prerelease": true,
+  "notes_file": ".github/release-notes/next-2026-07-22.2.md"
+}


### PR DESCRIPTION
## 发布范围

这是经过 Windows 真机验收和完整自动化回归的多平台 pre-release 请求。应用内容整合 PR #127–#133；发布基础设施修复由已合并的 PR #136 提供。

## 审核内容

- 新增 `next-2026-07-22.2` reviewed release request。
- 六语 Release Notes 完整覆盖简中、繁中、English、日本語、한국어、ไทย。
- 所有 Windows / Linux / macOS 下载链接均指向 `.2`，不移动或复用失败的 `.1` 标签。
- 发布器只有在四个平台工作流全部成功、资产清单完整且六语说明保留后，才会将 draft 改为公开 pre-release。

## 已完成验证

- Windows 11、150% 缩放、OpenCL portable 真机 EXE：启动、本地 KataGo、智子云、整盘精析、SGF、Alt+O readboard 均通过。
- Maven：162 suites / 1484 tests / 0 failures / 0 errors / 2 skipped。
- shaded JAR package：BUILD SUCCESS。
- 发布器专项：13 tests / 0 failures；GitHub Linux CI 无跳过执行 macOS retry 行为测试。
- Windows launcher packaging、release notes、Bash syntax、Markdown links、`git diff --check`：全部通过。

合并后自动构建并核验 Windows 全系列、Linux CPU/OpenCL/NVIDIA、macOS Apple Silicon/Intel 资产；任一失败都会保留 draft，不公开残缺版本。