### PR TITLE
Fix release tag identity and recover detached pre-releases

### DIFF
--- a/.github/workflows/publish-requested-pre-release.yml
+++ b/.github/workflows/publish-requested-pre-release.yml
@@ -70,7 +70,17 @@ jobs:
               ;;
           esac
           test -f "$request_file"
+          target_sha="$TARGET_SHA"
+          if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
+            release_tag="$(
+              python3 -c \
+                'import json, sys; print(json.load(open(sys.argv[1], encoding="utf-8"))["release_tag"])' \
+                "$request_file"
+            )"
+            target_sha="$(git rev-parse "refs/tags/${release_tag}^{commit}")"
+          fi
           echo "request_file=$request_file" >> "$GITHUB_OUTPUT"
+          echo "target_sha=$target_sha" >> "$GITHUB_OUTPUT"
 
       - name: Test release metadata and fail-closed publishing
         run: |
@@ -85,4 +95,4 @@ jobs:
           python3 scripts/publish_release_request.py \
             --request "${{ steps.request.outputs.request_file }}" \
             --repository "${{ github.repository }}" \
-            --target-sha "${{ github.sha }}"
+            --target-sha "${{ steps.request.outputs.target_sha }}"

--- a/scripts/publish_release_request.py
+++ b/scripts/publish_release_request.py
@@ -223,22 +223,48 @@ class GitHubClient:
             expected=(201,),
         )
 
-    def get_release(self, tag: str) -> dict[str, object] | None:
+    def get_release_by_tag(self, tag: str) -> dict[str, object] | None:
         path = f"/repos/{self.repository}/releases/tags/{quote(tag, safe='')}"
         _status, payload = self._request("GET", path, allow_not_found=True)
         if payload is not None:
             assert isinstance(payload, dict)
             return payload
+        return None
 
-        # The tag endpoint can omit drafts. The authenticated release listing includes them.
-        _status, listing = self._request(
+    def list_releases(self) -> list[dict[str, object]]:
+        _status, payload = self._request(
             "GET", f"/repos/{self.repository}/releases?per_page=100"
         )
-        assert isinstance(listing, list)
-        for release in listing:
-            if isinstance(release, dict) and release.get("tag_name") == tag:
+        assert isinstance(payload, list)
+        return [release for release in payload if isinstance(release, dict)]
+
+    def get_release(self, tag: str) -> dict[str, object] | None:
+        release = self.get_release_by_tag(tag)
+        if release is not None:
+            return release
+
+        # The tag endpoint can omit drafts. The authenticated release listing includes them.
+        for release in self.list_releases():
+            if release.get("tag_name") == tag:
                 return release
         return None
+
+    def find_orphaned_release(
+        self, title: str, target_sha: str
+    ) -> dict[str, object] | None:
+        candidates = [
+            release
+            for release in self.list_releases()
+            if str(release.get("tag_name") or "").startswith("untagged-")
+            and release.get("name") == title
+            and release.get("target_commitish") == target_sha
+            and release.get("prerelease") is True
+        ]
+        if len(candidates) > 1:
+            raise PublishError(
+                f"Found multiple orphaned releases for {title} at {target_sha}"
+            )
+        return candidates[0] if candidates else None
 
     def create_draft_release(
         self, request: ReleaseRequest, target_sha: str
@@ -349,12 +375,73 @@ class ReleasePublisher:
             )
         print(f"Reusing tag {self.request.release_tag} at {existing}", flush=True)
 
+    def _assert_release_identity(self, release: dict[str, object]) -> None:
+        actual_tag = str(release.get("tag_name") or "")
+        if actual_tag != self.request.release_tag:
+            raise PublishError(
+                "Release tag identity changed: "
+                f"expected {self.request.release_tag}, got {actual_tag or '<missing>'}"
+            )
+        actual_target = str(release.get("target_commitish") or "")
+        if actual_target != self.target_sha:
+            raise PublishError(
+                "Release target changed: "
+                f"expected {self.target_sha}, got {actual_target or '<missing>'}"
+            )
+
+    def _restore_orphaned_release(
+        self, release: dict[str, object]
+    ) -> dict[str, object]:
+        release_id = int(release["id"])
+        restored = self.client.update_release(
+            release_id,
+            {
+                "tag_name": self.request.release_tag,
+                "target_commitish": self.target_sha,
+                "name": self.request.title,
+                "draft": release.get("draft") is True,
+                "prerelease": True,
+                "make_latest": "false",
+            },
+        )
+        self._assert_release_identity(restored)
+        print(
+            f"Restored orphaned release {release_id} to {self.request.release_tag}",
+            flush=True,
+        )
+        return restored
+
+    def _verify_public_release_identity(
+        self, release_id: int
+    ) -> dict[str, object]:
+        release = self.client.get_release_by_tag(self.request.release_tag)
+        if release is None:
+            raise PublishError(
+                f"Published release is not addressable by tag {self.request.release_tag}"
+            )
+        if int(release.get("id", -1)) != release_id:
+            raise PublishError(
+                f"Tag {self.request.release_tag} resolves to a different release"
+            )
+        self._assert_release_identity(release)
+        if release.get("draft") is not False or release.get("prerelease") is not True:
+            raise PublishError("Release is not publicly visible as a pre-release")
+        return release
+
     def _ensure_draft_release(self) -> tuple[dict[str, object], bool]:
         release = self.client.get_release(self.request.release_tag)
         if release is None:
-            release = self.client.create_draft_release(self.request, self.target_sha)
-            print(f"Created draft pre-release {self.request.release_tag}", flush=True)
-            return release, False
+            orphaned = self.client.find_orphaned_release(
+                self.request.title, self.target_sha
+            )
+            if orphaned is not None:
+                release = self._restore_orphaned_release(orphaned)
+            else:
+                release = self.client.create_draft_release(self.request, self.target_sha)
+                print(f"Created draft pre-release {self.request.release_tag}", flush=True)
+                self._assert_release_identity(release)
+                return release, False
+        self._assert_release_identity(release)
         if release.get("prerelease") is not True:
             raise PublishError("Existing release is not marked as a pre-release")
         if release.get("draft") is False:
@@ -479,6 +566,7 @@ class ReleasePublisher:
             assets = self._verify_platform_assets(release_id)
             if not self._notes_complete(release):
                 raise PublishError("Published pre-release does not contain all six language sections")
+            release = self._verify_public_release_identity(release_id)
             print(f"{self.request.release_tag} is already complete", flush=True)
             self._publish_summary(release, assets)
             return release
@@ -506,6 +594,8 @@ class ReleasePublisher:
         release = self.client.update_release(
             release_id,
             {
+                "tag_name": self.request.release_tag,
+                "target_commitish": self.target_sha,
                 "name": self.request.title,
                 "body": self.release_notes,
                 "draft": True,
@@ -513,20 +603,25 @@ class ReleasePublisher:
                 "make_latest": "false",
             },
         )
+        self._assert_release_identity(release)
         if not self._notes_complete(release):
             raise PublishError("GitHub did not retain the reviewed six-language release notes")
 
         release = self.client.update_release(
             release_id,
             {
+                "tag_name": self.request.release_tag,
+                "target_commitish": self.target_sha,
                 "name": self.request.title,
                 "draft": False,
                 "prerelease": True,
                 "make_latest": "false",
             },
         )
+        self._assert_release_identity(release)
         if release.get("draft") is not False or release.get("prerelease") is not True:
             raise PublishError("GitHub did not publish the release as a pre-release")
+        release = self._verify_public_release_identity(release_id)
         assets = self._verify_platform_assets(release_id)
         self._publish_summary(release, assets)
         print(f"Published pre-release: {release.get('html_url', '')}", flush=True)

--- a/scripts/test_publish_release_request.py
+++ b/scripts/test_publish_release_request.py
@@ -54,7 +54,12 @@ def all_asset_names() -> list[str]:
 
 
 class FakeClient:
-    def __init__(self, failed_workflow: str | None = None) -> None:
+    def __init__(
+        self,
+        failed_workflow: str | None = None,
+        detach_on_publish: bool = False,
+        hide_public_by_tag: bool = False,
+    ) -> None:
         self.tag_sha: str | None = None
         self.release: dict[str, object] | None = None
         self.assets: list[str] = []
@@ -62,8 +67,11 @@ class FakeClient:
         self.workflow_runs: dict[str, list[dict[str, object]]] = {}
         self.next_run_id = 100
         self.failed_workflow = failed_workflow
+        self.detach_on_publish = detach_on_publish
+        self.hide_public_by_tag = hide_public_by_tag
         self.dispatched: list[str] = []
         self.dispatched_inputs: dict[str, dict[str, str]] = {}
+        self.update_payloads: list[dict[str, object]] = []
 
     def get_tag_sha(self, _tag: str) -> str | None:
         return self.tag_sha
@@ -71,8 +79,29 @@ class FakeClient:
     def create_tag(self, _tag: str, target_sha: str) -> None:
         self.tag_sha = target_sha
 
-    def get_release(self, _tag: str) -> dict[str, object] | None:
-        return dict(self.release) if self.release is not None else None
+    def get_release_by_tag(self, tag: str) -> dict[str, object] | None:
+        if self.release is None or self.release.get("tag_name") != tag:
+            return None
+        if self.hide_public_by_tag and self.release.get("draft") is False:
+            return None
+        return dict(self.release)
+
+    def get_release(self, tag: str) -> dict[str, object] | None:
+        return self.get_release_by_tag(tag)
+
+    def find_orphaned_release(
+        self, title: str, target_sha: str
+    ) -> dict[str, object] | None:
+        if self.release is None:
+            return None
+        if (
+            str(self.release.get("tag_name") or "").startswith("untagged-")
+            and self.release.get("name") == title
+            and self.release.get("target_commitish") == target_sha
+            and self.release.get("prerelease") is True
+        ):
+            return dict(self.release)
+        return None
 
     def create_draft_release(
         self, request: PUBLISH.ReleaseRequest, _target_sha: str
@@ -80,6 +109,7 @@ class FakeClient:
         self.release = {
             "id": 7,
             "tag_name": request.release_tag,
+            "target_commitish": _target_sha,
             "name": request.title,
             "body": "building",
             "draft": True,
@@ -92,7 +122,10 @@ class FakeClient:
         self, _release_id: int, payload: dict[str, object]
     ) -> dict[str, object]:
         assert self.release is not None
+        self.update_payloads.append(dict(payload))
         self.release.update(payload)
+        if payload.get("draft") is False and self.detach_on_publish:
+            self.release["tag_name"] = "untagged-detached-release"
         self.release["html_url"] = "https://example.invalid/release"
         return dict(self.release)
 
@@ -214,6 +247,22 @@ class ReviewedReleaseNotesTest(unittest.TestCase):
 
 
 class ReleaseWorkflowResilienceTest(unittest.TestCase):
+    def test_manual_recovery_uses_the_requested_tag_target(self) -> None:
+        workflow = (
+            SCRIPT_PATH.parents[1]
+            / ".github"
+            / "workflows"
+            / "publish-requested-pre-release.yml"
+        ).read_text(encoding="utf-8")
+
+        self.assertIn('git rev-parse "refs/tags/${release_tag}^{commit}"', workflow)
+        self.assertIn('target_sha="$TARGET_SHA"', workflow)
+        self.assertIn('echo "target_sha=$target_sha" >> "$GITHUB_OUTPUT"', workflow)
+        self.assertIn(
+            '--target-sha "${{ steps.request.outputs.target_sha }}"', workflow
+        )
+        self.assertNotIn('--target-sha "${{ github.sha }}"', workflow)
+
     def test_windows_draft_release_metadata_has_an_explicit_input_and_safe_fallback(self) -> None:
         workflow = (
             SCRIPT_PATH.parents[1] / ".github" / "workflows" / "build-windows-release.yml"
@@ -300,6 +349,8 @@ class ReleasePublisherTest(unittest.TestCase):
         self.assertEqual(TARGET_SHA, client.tag_sha)
         self.assertFalse(release["draft"])
         self.assertTrue(release["prerelease"])
+        self.assertEqual(RELEASE_TAG, release["tag_name"])
+        self.assertEqual(TARGET_SHA, release["target_commitish"])
         self.assertEqual(
             [spec.workflow_file for spec in PUBLISH.WORKFLOWS],
             client.dispatched,
@@ -312,6 +363,10 @@ class ReleasePublisherTest(unittest.TestCase):
             if workflow_file != "build-windows-release.yml":
                 self.assertNotIn("release_prerelease", inputs)
         self.assertCountEqual(all_asset_names(), client.assets)
+        self.assertTrue(client.update_payloads)
+        for payload in client.update_payloads:
+            self.assertEqual(RELEASE_TAG, payload["tag_name"])
+            self.assertEqual(TARGET_SHA, payload["target_commitish"])
 
     def test_failed_platform_keeps_release_as_draft(self) -> None:
         client = FakeClient(failed_workflow="build-linux-release.yml")
@@ -329,6 +384,9 @@ class ReleasePublisherTest(unittest.TestCase):
         client.assets = all_asset_names()
         client.release = {
             "id": 7,
+            "tag_name": RELEASE_TAG,
+            "target_commitish": TARGET_SHA,
+            "name": self.request().title,
             "body": self.release_notes(),
             "draft": False,
             "prerelease": True,
@@ -339,6 +397,43 @@ class ReleasePublisherTest(unittest.TestCase):
 
         self.assertFalse(release["draft"])
         self.assertEqual([], client.dispatched)
+
+    def test_recovers_orphaned_published_release_without_rebuilding(self) -> None:
+        client = FakeClient()
+        client.tag_sha = TARGET_SHA
+        client.assets = all_asset_names()
+        client.release = {
+            "id": 7,
+            "tag_name": "untagged-detached-release",
+            "target_commitish": TARGET_SHA,
+            "name": self.request().title,
+            "body": self.release_notes(),
+            "draft": False,
+            "prerelease": True,
+            "html_url": "https://example.invalid/orphaned",
+        }
+
+        release = self.publisher(client).publish()
+
+        self.assertEqual(RELEASE_TAG, release["tag_name"])
+        self.assertEqual(TARGET_SHA, release["target_commitish"])
+        self.assertEqual([], client.dispatched)
+        self.assertEqual(1, len(client.update_payloads))
+
+    def test_fails_closed_when_github_detaches_the_release_tag(self) -> None:
+        client = FakeClient(detach_on_publish=True)
+
+        with self.assertRaisesRegex(PUBLISH.PublishError, "tag identity changed"):
+            self.publisher(client).publish()
+
+        assert client.release is not None
+        self.assertEqual("untagged-detached-release", client.release["tag_name"])
+
+    def test_fails_closed_when_published_tag_is_not_publicly_addressable(self) -> None:
+        client = FakeClient(hide_public_by_tag=True)
+
+        with self.assertRaisesRegex(PUBLISH.PublishError, "not addressable by tag"):
+            self.publisher(client).publish()
 
     def test_rejects_incomplete_notes_before_creating_a_tag(self) -> None:
         client = FakeClient()


### PR DESCRIPTION
## Summary

- enforce the requested `tag_name` and exact target commit on every Release update
- fail closed unless the published pre-release is publicly addressable through its expected tag
- safely recover one uniquely matching `untagged-*` pre-release by exact title, target SHA, and pre-release state, preserving already verified assets
- make manual recovery resolve the original request tag commit while normal push-triggered publishing continues to use the merged main commit
- add fault-injection coverage for tag detachment, public tag lookup failure, orphan recovery without rebuilding, and manual target selection

## Root cause

The `next-2026-07-22.2` platform workflows all succeeded and uploaded all 22 assets, but GitHub detached the Release from its tag and exposed it as `untagged-302a246c143f0a6c7158`. The publisher only checked `draft` and `prerelease`, so the workflow could report success with the wrong public download URL.

## Validation

- `python -m unittest scripts.test_publish_release_request scripts.test_generate_release_notes`: 19 tests, 0 failures, 1 Windows-only Bash behavior test skipped
- `python scripts/test_windows_launcher_packaging.py`: passed
- `mvn -B -Dfmt.skip=true test`: 162 suites, 1484 tests, 0 failures, 0 errors, 2 skipped
- `mvn -B -Dfmt.skip=true -DskipTests package`: passed
- `git diff --check`: passed
- remote branch tree SHA exactly matches the locally tested commit tree (`df9f7912f64e67ad127b4ec5f1660aa9011b264b`)

After merge, manually rerunning the reviewed `.2` request will resolve `next-2026-07-22.2` back to its original `b726790f...` target, repair the existing Release association, and reuse all verified platform assets without rebuilding.