### PR TITLE
Retry detached release against its original tag

### DIFF
--- a/.github/release-requests/next-2026-07-22.2.json
+++ b/.github/release-requests/next-2026-07-22.2.json
@@ -1,7 +1,7 @@
 {
-  "date_tag": "2026-07-22",
-  "release_tag": "next-2026-07-22.2",
-  "title": "LizzieYzy Next next-2026-07-22.2",
-  "prerelease": true,
-  "notes_file": ".github/release-notes/next-2026-07-22.2.md"
+    "date_tag": "2026-07-22",
+    "release_tag": "next-2026-07-22.2",
+    "title": "LizzieYzy Next next-2026-07-22.2",
+    "prerelease": true,
+    "notes_file": ".github/release-notes/next-2026-07-22.2.md"
 }

--- a/.github/workflows/publish-requested-pre-release.yml
+++ b/.github/workflows/publish-requested-pre-release.yml
@@ -70,14 +70,17 @@ jobs:
               ;;
           esac
           test -f "$request_file"
+          release_tag="$(
+            python3 -c \
+              'import json, sys; print(json.load(open(sys.argv[1], encoding="utf-8"))["release_tag"])' \
+              "$request_file"
+          )"
           target_sha="$TARGET_SHA"
-          if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
-            release_tag="$(
-              python3 -c \
-                'import json, sys; print(json.load(open(sys.argv[1], encoding="utf-8"))["release_tag"])' \
-                "$request_file"
-            )"
+          if git show-ref --verify --quiet "refs/tags/$release_tag"; then
             target_sha="$(git rev-parse "refs/tags/${release_tag}^{commit}")"
+          elif [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
+            echo "Manual recovery requires an existing release tag: $release_tag" >&2
+            exit 1
           fi
           echo "request_file=$request_file" >> "$GITHUB_OUTPUT"
           echo "target_sha=$target_sha" >> "$GITHUB_OUTPUT"

--- a/scripts/test_publish_release_request.py
+++ b/scripts/test_publish_release_request.py
@@ -247,7 +247,7 @@ class ReviewedReleaseNotesTest(unittest.TestCase):
 
 
 class ReleaseWorkflowResilienceTest(unittest.TestCase):
-    def test_manual_recovery_uses_the_requested_tag_target(self) -> None:
+    def test_release_retry_uses_the_existing_requested_tag_target(self) -> None:
         workflow = (
             SCRIPT_PATH.parents[1]
             / ".github"
@@ -256,7 +256,11 @@ class ReleaseWorkflowResilienceTest(unittest.TestCase):
         ).read_text(encoding="utf-8")
 
         self.assertIn('git rev-parse "refs/tags/${release_tag}^{commit}"', workflow)
+        self.assertIn(
+            'git show-ref --verify --quiet "refs/tags/$release_tag"', workflow
+        )
         self.assertIn('target_sha="$TARGET_SHA"', workflow)
+        self.assertIn("Manual recovery requires an existing release tag", workflow)
         self.assertIn('echo "target_sha=$target_sha" >> "$GITHUB_OUTPUT"', workflow)
         self.assertIn(
             '--target-sha "${{ steps.request.outputs.target_sha }}"', workflow


### PR DESCRIPTION
## Summary

- make every release retry reuse an existing request tag's original commit instead of the current `main` SHA
- keep first-time push-triggered releases bound to the merge commit when the tag does not exist yet
- reject a manual recovery request when its tag does not exist
- reformat only the existing `.2` request JSON, without changing any metadata, to trigger the audited recovery workflow after merge

## Why

All 22 `next-2026-07-22.2` platform assets are already built and verified, but GitHub exposed the Release as `untagged-302a246c143f0a6c7158`. PR #139 added safe orphan recovery and public tag validation. This follow-up invokes that recovery through the repository's normal reviewed-request path and preserves the original release target `b726790f...`.

## Validation

- release publisher and notes tests: 19 tests, 0 failures, 1 Windows-only Bash behavior test skipped
- Windows launcher packaging guard: passed
- `git diff --check`: passed
- request values before and after are identical; only JSON indentation changes
- remote tree SHA matches the locally tested tree: `5fabe49655547214d7abb308c7903fcacc8d20b1`

After merge, `Publish Requested Pre-release` should restore the existing Release association and finish without dispatching any platform rebuild.