### PR TITLE
Clean synthetic detached release tag aliases

### DIFF
--- a/.github/release-requests/next-2026-07-22.2.json
+++ b/.github/release-requests/next-2026-07-22.2.json
@@ -1,7 +1,7 @@
 {
-    "date_tag": "2026-07-22",
-    "release_tag": "next-2026-07-22.2",
-    "title": "LizzieYzy Next next-2026-07-22.2",
-    "prerelease": true,
-    "notes_file": ".github/release-notes/next-2026-07-22.2.md"
+  "date_tag": "2026-07-22",
+  "release_tag": "next-2026-07-22.2",
+  "title": "LizzieYzy Next next-2026-07-22.2",
+  "prerelease": true,
+  "notes_file": ".github/release-notes/next-2026-07-22.2.md"
 }

--- a/scripts/publish_release_request.py
+++ b/scripts/publish_release_request.py
@@ -266,6 +266,34 @@ class GitHubClient:
             )
         return candidates[0] if candidates else None
 
+    def list_detached_tag_aliases(self, target_sha: str) -> list[str]:
+        _status, payload = self._request(
+            "GET",
+            f"/repos/{self.repository}/git/matching-refs/tags/untagged-",
+        )
+        assert isinstance(payload, list)
+        aliases: list[str] = []
+        for ref in payload:
+            if not isinstance(ref, dict):
+                continue
+            name = str(ref.get("ref") or "").removeprefix("refs/tags/")
+            obj = ref.get("object")
+            if (
+                re.fullmatch(r"untagged-[0-9a-f]{20}", name)
+                and isinstance(obj, dict)
+                and obj.get("type") == "commit"
+                and obj.get("sha") == target_sha
+            ):
+                aliases.append(name)
+        return aliases
+
+    def delete_tag(self, tag: str) -> None:
+        self._request(
+            "DELETE",
+            f"/repos/{self.repository}/git/refs/tags/{quote(tag, safe='')}",
+            expected=(204,),
+        )
+
     def create_draft_release(
         self, request: ReleaseRequest, target_sha: str
     ) -> dict[str, object]:
@@ -428,6 +456,13 @@ class ReleasePublisher:
             raise PublishError("Release is not publicly visible as a pre-release")
         return release
 
+    def _cleanup_detached_tag_aliases(self) -> None:
+        for alias in self.client.list_detached_tag_aliases(self.target_sha):
+            if self.client.get_release_by_tag(alias) is not None:
+                continue
+            self.client.delete_tag(alias)
+            print(f"Removed detached release tag alias {alias}", flush=True)
+
     def _ensure_draft_release(self) -> tuple[dict[str, object], bool]:
         release = self.client.get_release(self.request.release_tag)
         if release is None:
@@ -567,6 +602,7 @@ class ReleasePublisher:
             if not self._notes_complete(release):
                 raise PublishError("Published pre-release does not contain all six language sections")
             release = self._verify_public_release_identity(release_id)
+            self._cleanup_detached_tag_aliases()
             print(f"{self.request.release_tag} is already complete", flush=True)
             self._publish_summary(release, assets)
             return release
@@ -622,6 +658,7 @@ class ReleasePublisher:
         if release.get("draft") is not False or release.get("prerelease") is not True:
             raise PublishError("GitHub did not publish the release as a pre-release")
         release = self._verify_public_release_identity(release_id)
+        self._cleanup_detached_tag_aliases()
         assets = self._verify_platform_assets(release_id)
         self._publish_summary(release, assets)
         print(f"Published pre-release: {release.get('html_url', '')}", flush=True)

--- a/scripts/test_publish_release_request.py
+++ b/scripts/test_publish_release_request.py
@@ -72,6 +72,9 @@ class FakeClient:
         self.dispatched: list[str] = []
         self.dispatched_inputs: dict[str, dict[str, str]] = {}
         self.update_payloads: list[dict[str, object]] = []
+        self.detached_tag_aliases: dict[str, str] = {}
+        self.deleted_tags: list[str] = []
+        self.protected_release_tags: set[str] = set()
 
     def get_tag_sha(self, _tag: str) -> str | None:
         return self.tag_sha
@@ -80,6 +83,14 @@ class FakeClient:
         self.tag_sha = target_sha
 
     def get_release_by_tag(self, tag: str) -> dict[str, object] | None:
+        if tag in self.protected_release_tags:
+            return {
+                "id": 8,
+                "tag_name": tag,
+                "target_commitish": TARGET_SHA,
+                "draft": False,
+                "prerelease": True,
+            }
         if self.release is None or self.release.get("tag_name") != tag:
             return None
         if self.hide_public_by_tag and self.release.get("draft") is False:
@@ -102,6 +113,15 @@ class FakeClient:
         ):
             return dict(self.release)
         return None
+
+    def list_detached_tag_aliases(self, target_sha: str) -> list[str]:
+        return [
+            tag for tag, sha in self.detached_tag_aliases.items() if sha == target_sha
+        ]
+
+    def delete_tag(self, tag: str) -> None:
+        self.detached_tag_aliases.pop(tag)
+        self.deleted_tags.append(tag)
 
     def create_draft_release(
         self, request: PUBLISH.ReleaseRequest, _target_sha: str
@@ -197,6 +217,37 @@ class ReleaseRequestTest(unittest.TestCase):
     def test_rejects_unreviewable_title(self) -> None:
         with self.assertRaisesRegex(PUBLISH.PublishError, "title must be exactly"):
             self.load(request_payload(title="Surprise release"))
+
+
+class GitHubClientTagAliasTest(unittest.TestCase):
+    def test_only_returns_synthetic_lightweight_aliases_for_the_release_target(self) -> None:
+        client = PUBLISH.GitHubClient("owner/repository", "test-token")
+        client._request = lambda *_args, **_kwargs: (  # type: ignore[method-assign]
+            200,
+            [
+                {
+                    "ref": "refs/tags/untagged-0123456789abcdefabcd",
+                    "object": {"type": "commit", "sha": TARGET_SHA},
+                },
+                {
+                    "ref": "refs/tags/untagged-human-label",
+                    "object": {"type": "commit", "sha": TARGET_SHA},
+                },
+                {
+                    "ref": "refs/tags/untagged-fedcba9876543210abcd",
+                    "object": {"type": "commit", "sha": "b" * 40},
+                },
+                {
+                    "ref": "refs/tags/untagged-abcdef0123456789abcd",
+                    "object": {"type": "tag", "sha": TARGET_SHA},
+                },
+            ],
+        )
+
+        self.assertEqual(
+            ["untagged-0123456789abcdefabcd"],
+            client.list_detached_tag_aliases(TARGET_SHA),
+        )
 
 
 class WorkflowSpecTest(unittest.TestCase):
@@ -401,6 +452,52 @@ class ReleasePublisherTest(unittest.TestCase):
 
         self.assertFalse(release["draft"])
         self.assertEqual([], client.dispatched)
+
+    def test_cleans_unbound_synthetic_tag_alias_for_published_release(self) -> None:
+        client = FakeClient()
+        client.tag_sha = TARGET_SHA
+        client.assets = all_asset_names()
+        client.detached_tag_aliases = {
+            "untagged-0123456789abcdefabcd": TARGET_SHA,
+        }
+        client.release = {
+            "id": 7,
+            "tag_name": RELEASE_TAG,
+            "target_commitish": TARGET_SHA,
+            "name": self.request().title,
+            "body": self.release_notes(),
+            "draft": False,
+            "prerelease": True,
+            "html_url": "https://example.invalid/release",
+        }
+
+        self.publisher(client).publish()
+
+        self.assertEqual(["untagged-0123456789abcdefabcd"], client.deleted_tags)
+        self.assertEqual({}, client.detached_tag_aliases)
+
+    def test_preserves_synthetic_tag_alias_when_a_release_still_uses_it(self) -> None:
+        alias = "untagged-0123456789abcdefabcd"
+        client = FakeClient()
+        client.tag_sha = TARGET_SHA
+        client.assets = all_asset_names()
+        client.detached_tag_aliases = {alias: TARGET_SHA}
+        client.protected_release_tags = {alias}
+        client.release = {
+            "id": 7,
+            "tag_name": RELEASE_TAG,
+            "target_commitish": TARGET_SHA,
+            "name": self.request().title,
+            "body": self.release_notes(),
+            "draft": False,
+            "prerelease": True,
+            "html_url": "https://example.invalid/release",
+        }
+
+        self.publisher(client).publish()
+
+        self.assertEqual([], client.deleted_tags)
+        self.assertEqual({alias: TARGET_SHA}, client.detached_tag_aliases)
 
     def test_recovers_orphaned_published_release_without_rebuilding(self) -> None:
         client = FakeClient()


### PR DESCRIPTION
## Summary

- remove only unbound GitHub-style `untagged-<20 hex>` lightweight tag aliases that point to the exact published release target
- preserve every alias that has a Release binding, uses a non-synthetic name, is annotated, or points to another commit
- restore the `.2` request JSON's original formatting to trigger one final audited, idempotent cleanup run

## Context

PRs #139 and #140 restored `next-2026-07-22.2` to its correct public URL with all 22 assets. GitHub retained the synthetic ref `untagged-302a246c143f0a6c7158`, which still exposed a source-only tag page. This removes that stale alias without touching the real `next-2026-07-22.2` tag or Release.

## Validation

- publisher and release-note tests: 22 tests, 0 failures, 1 Windows-only Bash behavior test skipped
- coverage includes strict name/type/target filtering, deletion of an unbound alias, and preservation when an alias still owns a Release
- Windows launcher packaging guard: passed
- `git diff --check`: passed
- remote tree exactly matches local tested tree `4c83c4d8e69153513dee27051880f5f1d2642b50`

After merge, the reviewed request workflow should log removal of the single stale alias and finish without platform rebuilds.