### PR TITLE
Fix macOS KataGo runtime packaging

### DIFF
--- a/.github/workflows/build-macos-amd64-release.yml
+++ b/.github/workflows/build-macos-amd64-release.yml
@@ -45,6 +45,9 @@ jobs:
           python3 -m pip install pillow
           python3 scripts/generate_app_icons.py
 
+      - name: Verify macOS KataGo dependency bundler
+        run: python3 scripts/test_macos_katago_bundle.py
+
       - name: Build shaded jar
         run: mvn -DskipTests package
 

--- a/.github/workflows/build-macos-arm64-release.yml
+++ b/.github/workflows/build-macos-arm64-release.yml
@@ -45,6 +45,9 @@ jobs:
           python3 -m pip install pillow
           python3 scripts/generate_app_icons.py
 
+      - name: Verify macOS KataGo dependency bundler
+        run: python3 scripts/test_macos_katago_bundle.py
+
       - name: Build shaded jar
         run: mvn -DskipTests package
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,19 +36,24 @@ jobs:
         run: |
           python3 -m py_compile \
             scripts/generate_release_notes.py \
+            scripts/macos_katago_bundle.py \
             scripts/package_runtime_tools.py \
             scripts/prepare_bundled_jcef.py \
             scripts/publish_release_request.py \
             scripts/summarize_jfr.py \
             scripts/test_generate_release_notes.py \
+            scripts/test_macos_katago_bundle.py \
             scripts/test_publish_release_request.py \
             scripts/test_windows_launcher_packaging.py
           python3 scripts/test_generate_release_notes.py
+          python3 scripts/test_macos_katago_bundle.py
           python3 scripts/test_prepare_bundled_jcef.py
           python3 scripts/test_publish_release_request.py
           python3 scripts/test_windows_launcher_packaging.py
           bash -n \
+            scripts/prepare_bundled_katago.sh \
             scripts/package_macos_dmg.sh \
+            scripts/validate_macos_dmg_layout.sh \
             scripts/package_release.sh \
             scripts/package_windows_exe.sh \
             scripts/run_jfr_benchmark.sh \

--- a/docs/PACKAGES.md
+++ b/docs/PACKAGES.md
@@ -155,6 +155,7 @@
 - Windows 启动内存：启动器不再固定申请 `-Xmx4096m`，而是按机器可用内存自适应设置 JVM 上限。这样低内存电脑不会因为无法预留 4 GB 堆而只显示 `Failed to launch JVM`，高内存电脑仍可按需使用更多内存；KataGo 引擎显存和内存仍由独立进程管理。
 - Base CDS 启动共享：`jlink` runtime 构建后会执行 `java -Xshare:dump` 生成可随应用目录移动的基础类归档，启动参数使用 `-Xshare:auto`。不再打包绑定构建路径的 AppCDS；实测该归档在安装或解压到新目录后会因 classpath 不匹配而失效，移除后可避免无效体积和小更新后的归档过期。
 - JCEF 浏览器运行时：Windows 和 macOS 发布包都内置与 CPU 架构匹配的 JCEF，弈客网页版、弈客大厅和网页棋谱无需首次启动下载；macOS 打包及签名流程会校验 Chromium framework、`libjcef` 和全部 Helper app，缺失时直接终止发布。
+- macOS KataGo 运行库：发布脚本会递归收集 Homebrew KataGo 的全部非系统动态库，并改写为 App 内相对路径；打包前和最终 DMG 挂载后都会检查外部依赖并实际运行 `katago version`。只要仍引用 `/opt/homebrew`、`/usr/local`、`@rpath` 或缺少运行库，发布流程会直接失败。
 - JCEF 语言资源：发布包只保留软件六种语言需要的 Chromium 语言包（简体中文、繁体中文、英语、日语、韩语、泰语），浏览器内核、HTTPS、弈客、腾讯棋谱等功能文件完整保留；CEF locale 会按软件语言或系统语言安全回退。
 - 包体审计报告：每次打包会在 `dist/release-meta/` 生成 `*-package-size-audit.md` 和 `*.json`，记录 shaded jar、runtime、平台内置 JCEF、权重、引擎、readboard、最终 release asset 的大小。报告会写入 GitHub Actions summary，并对异常增大的 jar、custom runtime、接近 GitHub 单资产上限的 release asset 给出 warning；第一阶段只预警，不阻断紧急发版。
 

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -55,6 +55,7 @@
 - `scripts/generate_app_icons.py`
 - `scripts/package_release.sh`
 - `scripts/package_macos_dmg.sh`
+- `scripts/macos_katago_bundle.py`
 - `scripts/package_windows_exe.sh`
 - `scripts/generate_release_notes.py`
 - `scripts/validate_release_assets.sh`
@@ -83,6 +84,7 @@ GitHub Actions：
 - `src/main/resources/assets/logo.png`、`packaging/icons/app-icon.ico`、`packaging/icons/app-icon.icns` 代表的是同一套当前图标
 - `weights/default.bin.gz` 存在
 - `engines/katago/` 下目标平台文件完整
+- macOS 内置 KataGo 不得引用 `/opt/homebrew`、`/usr/local` 或未解析的 `@rpath`；`macos_katago_bundle.py audit` 必须能直接运行引擎
 - 如需 bundled Java，对应 `runtime/` 目录仍然存在
 - 发版 tag 已确定，例如 `next-2026-04-24.2`；构建脚本最后一个参数必须传这个 tag
 
@@ -150,6 +152,10 @@ LEGACY_WINDOWS32_ZIP=1 LEGACY_OTHER_SYSTEMS_ZIP=1 ./scripts/package_release.sh 2
 ./scripts/package_macos_dmg.sh 2026-04-24 1.0.0 target/lizzie-yzy2.5.3-shaded.jar next-2026-04-24.2
 ./scripts/validate_release_assets.sh mac-arm64 dist/release 2026-04-24
 ```
+
+macOS 校验不是只看 DMG 布局：打包脚本会在 App image 中运行内置 KataGo，
+`validate_release_assets.sh` 还会挂载最终 DMG，再检查一次动态库闭包并运行
+`katago version`。任一步失败都不能上传该资产。
 
 ### 8. 生成发布页文案
 

--- a/scripts/macos_katago_bundle.py
+++ b/scripts/macos_katago_bundle.py
@@ -1,0 +1,468 @@
+#!/usr/bin/env python3
+"""Build and audit a self-contained macOS KataGo executable bundle."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import platform
+import re
+import shutil
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Iterable
+
+
+SYSTEM_DEPENDENCY_PREFIXES = (
+    "/System/Library/",
+    "/usr/lib/",
+)
+
+
+class BundleError(RuntimeError):
+    pass
+
+
+@dataclass
+class DependencyEdge:
+    original: str
+    source: Path
+    bundled_name: str
+
+
+@dataclass
+class BinaryNode:
+    source: Path
+    target: Path
+    executable: bool
+    install_id: str | None = None
+    edges: list[DependencyEdge] = field(default_factory=list)
+
+
+def run(
+    command: list[str],
+    *,
+    timeout: int = 60,
+    check: bool = True,
+) -> subprocess.CompletedProcess[str]:
+    try:
+        return subprocess.run(
+            command,
+            check=check,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired as error:
+        raise BundleError(f"Command timed out: {' '.join(command)}") from error
+    except subprocess.CalledProcessError as error:
+        detail = (error.stderr or error.stdout or "").strip()
+        raise BundleError(
+            f"Command failed ({error.returncode}): {' '.join(command)}"
+            + (f"\n{detail}" if detail else "")
+        ) from error
+
+
+def require_macos_tools() -> None:
+    if platform.system() != "Darwin":
+        raise BundleError("macOS KataGo bundling requires a macOS host")
+    missing = [
+        command
+        for command in ("otool", "install_name_tool", "codesign")
+        if shutil.which(command) is None
+    ]
+    if missing:
+        raise BundleError(f"Missing macOS build tools: {', '.join(missing)}")
+
+
+def is_system_dependency(reference: str) -> bool:
+    return reference.startswith(SYSTEM_DEPENDENCY_PREFIXES)
+
+
+def parse_otool_dependencies(output: str) -> list[str]:
+    dependencies: list[str] = []
+    for line in output.splitlines()[1:]:
+        match = re.match(r"\s*(.+?)\s+\(compatibility version ", line)
+        if match:
+            dependencies.append(match.group(1))
+    return dependencies
+
+
+def dependencies(path: Path) -> list[str]:
+    return parse_otool_dependencies(run(["otool", "-L", str(path)]).stdout)
+
+
+def install_id(path: Path) -> str | None:
+    result = run(["otool", "-D", str(path)], check=False)
+    lines = [line.strip() for line in result.stdout.splitlines()[1:] if line.strip()]
+    return lines[0] if lines else None
+
+
+def rpaths(path: Path) -> list[str]:
+    lines = run(["otool", "-l", str(path)]).stdout.splitlines()
+    values: list[str] = []
+    in_rpath = False
+    for line in lines:
+        stripped = line.strip()
+        if stripped == "cmd LC_RPATH":
+            in_rpath = True
+            continue
+        if in_rpath and stripped.startswith("path "):
+            values.append(stripped.split(" ", 2)[1])
+            in_rpath = False
+        elif stripped.startswith("cmd ") and stripped != "cmd LC_RPATH":
+            in_rpath = False
+    return values
+
+
+def expand_special_path(
+    value: str,
+    *,
+    loader_dir: Path,
+    executable_dir: Path,
+) -> Path | None:
+    if value.startswith("@loader_path/"):
+        return loader_dir / value.removeprefix("@loader_path/")
+    if value == "@loader_path":
+        return loader_dir
+    if value.startswith("@executable_path/"):
+        return executable_dir / value.removeprefix("@executable_path/")
+    if value == "@executable_path":
+        return executable_dir
+    if value.startswith("/"):
+        return Path(value)
+    return None
+
+
+def resolve_dependency(
+    reference: str,
+    *,
+    source: Path,
+    executable_source: Path,
+) -> Path:
+    loader_dir = source.parent
+    executable_dir = executable_source.parent
+    expanded = expand_special_path(
+        reference,
+        loader_dir=loader_dir,
+        executable_dir=executable_dir,
+    )
+    if expanded is not None:
+        return expanded.resolve()
+
+    if reference.startswith("@rpath/"):
+        suffix = reference.removeprefix("@rpath/")
+        search_paths = rpaths(source)
+        if source != executable_source:
+            search_paths.extend(rpaths(executable_source))
+        for search_path in search_paths:
+            base = expand_special_path(
+                search_path,
+                loader_dir=loader_dir,
+                executable_dir=executable_dir,
+            )
+            if base is None:
+                continue
+            candidate = (base / suffix).resolve()
+            if candidate.exists():
+                return candidate
+        raise BundleError(
+            f"Unable to resolve {reference} referenced by {source}; "
+            f"LC_RPATH values: {search_paths}"
+        )
+
+    raise BundleError(f"Unsupported dependency reference {reference} in {source}")
+
+
+def sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def portable_reference(node: BinaryNode, bundled_name: str) -> str:
+    if node.executable:
+        return f"@executable_path/lib/{bundled_name}"
+    return f"@loader_path/{bundled_name}"
+
+
+def remove_signature(path: Path) -> None:
+    run(["codesign", "--remove-signature", str(path)], check=False)
+
+
+def sign_ad_hoc(path: Path) -> None:
+    run(["codesign", "--force", "--sign", "-", str(path)])
+
+
+def build_bundle(
+    katago_source: Path,
+    output: Path,
+    expected_version: str | None,
+) -> None:
+    require_macos_tools()
+    katago_source = katago_source.expanduser().resolve()
+    if not katago_source.is_file() or not os.access(katago_source, os.X_OK):
+        raise BundleError(f"KataGo executable not found: {katago_source}")
+
+    if output.exists():
+        shutil.rmtree(output)
+    library_dir = output / "lib"
+    library_dir.mkdir(parents=True)
+
+    executable_target = output / "katago"
+    shutil.copy2(katago_source, executable_target)
+    executable_target.chmod(executable_target.stat().st_mode | 0o111)
+
+    nodes: dict[Path, BinaryNode] = {
+        katago_source: BinaryNode(katago_source, executable_target, True)
+    }
+    bundled_names: dict[str, Path] = {}
+    source_names: dict[Path, str] = {}
+    pending = [katago_source]
+
+    while pending:
+        source = pending.pop(0)
+        node = nodes[source]
+        node.install_id = install_id(source)
+        for reference in dependencies(source):
+            if node.install_id and reference == node.install_id:
+                continue
+            if is_system_dependency(reference):
+                continue
+            resolved = resolve_dependency(
+                reference,
+                source=source,
+                executable_source=katago_source,
+            )
+            if not resolved.is_file():
+                raise BundleError(
+                    f"Missing dependency {reference} referenced by {source}: {resolved}"
+                )
+            if resolved == source:
+                continue
+
+            bundled_name = Path(reference).name or resolved.name
+            existing_source = bundled_names.get(bundled_name)
+            if existing_source and existing_source != resolved:
+                if sha256(existing_source) != sha256(resolved):
+                    raise BundleError(
+                        f"Dependency basename collision for {bundled_name}: "
+                        f"{existing_source} and {resolved}"
+                    )
+                resolved = existing_source
+            else:
+                bundled_names[bundled_name] = resolved
+
+            bundled_name = source_names.setdefault(resolved, bundled_name)
+            node.edges.append(DependencyEdge(reference, resolved, bundled_name))
+            if resolved in nodes:
+                continue
+
+            target = library_dir / bundled_name
+            shutil.copy2(resolved, target)
+            target.chmod(target.stat().st_mode | 0o111)
+            nodes[resolved] = BinaryNode(resolved, target, False)
+            pending.append(resolved)
+
+    for node in nodes.values():
+        remove_signature(node.target)
+        for edge in node.edges:
+            run(
+                [
+                    "install_name_tool",
+                    "-change",
+                    edge.original,
+                    portable_reference(node, edge.bundled_name),
+                    str(node.target),
+                ]
+            )
+        if not node.executable:
+            run(
+                [
+                    "install_name_tool",
+                    "-id",
+                    f"@loader_path/{node.target.name}",
+                    str(node.target),
+                ]
+            )
+
+    for node in nodes.values():
+        if not node.executable:
+            sign_ad_hoc(node.target)
+    sign_ad_hoc(executable_target)
+
+    manifest = {
+        "schemaVersion": 1,
+        "katago": katago_source.name,
+        "expectedVersion": expected_version or "",
+        "libraries": sorted(node.target.name for node in nodes.values() if not node.executable),
+    }
+    (output / "bundle-manifest.json").write_text(
+        json.dumps(manifest, ensure_ascii=True, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    audit_bundle(output, expected_version)
+
+
+def resolve_bundled_reference(
+    reference: str,
+    *,
+    binary: Path,
+    executable: Path,
+) -> Path:
+    expanded = expand_special_path(
+        reference,
+        loader_dir=binary.parent,
+        executable_dir=executable.parent,
+    )
+    if expanded is None:
+        raise BundleError(
+            f"Non-portable dependency reference {reference} remains in {binary}"
+        )
+    return expanded.resolve()
+
+
+def files_to_audit(bundle: Path) -> Iterable[Path]:
+    yield bundle / "katago"
+    library_dir = bundle / "lib"
+    if library_dir.is_dir():
+        yield from sorted(library_dir.glob("*.dylib"))
+
+
+def normalize_expected_version(expected_version: str | None) -> str | None:
+    if not expected_version:
+        return None
+    return expected_version.removeprefix("v")
+
+
+def load_bundle_manifest(bundle: Path) -> dict[str, object] | None:
+    manifest_path = bundle / "bundle-manifest.json"
+    if not manifest_path.is_file():
+        return None
+    try:
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise BundleError(f"Invalid KataGo bundle manifest: {manifest_path}") from error
+    if manifest.get("schemaVersion") != 1:
+        raise BundleError(f"Unsupported KataGo bundle manifest: {manifest_path}")
+    return manifest
+
+
+def audit_bundle(bundle: Path, expected_version: str | None) -> None:
+    require_macos_tools()
+    bundle = bundle.expanduser().resolve()
+    executable = bundle / "katago"
+    if not executable.is_file() or not os.access(executable, os.X_OK):
+        raise BundleError(f"Bundled KataGo executable is missing: {executable}")
+
+    audited_files = list(files_to_audit(bundle))
+    manifest = load_bundle_manifest(bundle)
+    if manifest is not None:
+        expected_libraries = manifest.get("libraries")
+        if not isinstance(expected_libraries, list) or not all(
+            isinstance(value, str) for value in expected_libraries
+        ):
+            raise BundleError("KataGo bundle manifest has an invalid library list")
+        actual_libraries = sorted(path.name for path in audited_files if path != executable)
+        if sorted(expected_libraries) != actual_libraries:
+            raise BundleError(
+                "KataGo bundle libraries do not match bundle-manifest.json"
+            )
+        if not expected_version:
+            manifest_version = manifest.get("expectedVersion")
+            if isinstance(manifest_version, str) and manifest_version.strip():
+                expected_version = manifest_version.strip()
+
+    bundle_root = bundle.resolve()
+    for binary in audited_files:
+        binary_id = install_id(binary)
+        for reference in dependencies(binary):
+            if binary_id and reference == binary_id:
+                continue
+            if is_system_dependency(reference):
+                continue
+            if reference.startswith("/") or reference.startswith("@rpath"):
+                raise BundleError(
+                    f"Non-portable dependency reference {reference} remains in {binary}"
+                )
+            target = resolve_bundled_reference(
+                reference,
+                binary=binary,
+                executable=executable,
+            )
+            if not target.is_file():
+                raise BundleError(
+                    f"Bundled dependency {reference} referenced by {binary} is missing"
+                )
+            try:
+                target.relative_to(bundle_root)
+            except ValueError as error:
+                raise BundleError(
+                    f"Dependency escapes the KataGo bundle: {reference} -> {target}"
+                ) from error
+        run(["codesign", "--verify", "--strict", str(binary)])
+
+    # A freshly copied or downloaded binary can spend extra time in macOS
+    # provenance and code-signing checks on its first launch.
+    version_result = run([str(executable), "version"], timeout=90)
+    version_output = "\n".join(
+        value.strip()
+        for value in (version_result.stdout, version_result.stderr)
+        if value.strip()
+    )
+    normalized_version = normalize_expected_version(expected_version)
+    if normalized_version and f"KataGo v{normalized_version}" not in version_output:
+        raise BundleError(
+            f"Expected KataGo v{normalized_version}, got:\n{version_output}"
+        )
+
+    print(
+        f"Validated self-contained macOS KataGo bundle: "
+        f"{len(audited_files) - 1} dylibs"
+    )
+    if version_output:
+        print(version_output)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    bundle_parser = subparsers.add_parser(
+        "bundle",
+        help="Copy KataGo and recursively bundle all non-system dylibs",
+    )
+    bundle_parser.add_argument("--katago", type=Path, required=True)
+    bundle_parser.add_argument("--output", type=Path, required=True)
+    bundle_parser.add_argument("--expected-version")
+
+    audit_parser = subparsers.add_parser(
+        "audit",
+        help="Reject external dylib references and run bundled KataGo",
+    )
+    audit_parser.add_argument("--bundle", type=Path, required=True)
+    audit_parser.add_argument("--expected-version")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        if args.command == "bundle":
+            build_bundle(args.katago, args.output, args.expected_version)
+        else:
+            audit_bundle(args.bundle, args.expected_version)
+    except BundleError as error:
+        print(f"macOS KataGo bundle error: {error}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/package_macos_dmg.sh
+++ b/scripts/package_macos_dmg.sh
@@ -24,6 +24,7 @@ fi
 PYTHON_BIN=""
 RUNTIME_TOOLS_SCRIPT="$ROOT_DIR/scripts/package_runtime_tools.py"
 JCEF_BUNDLE_PREPARE_SCRIPT="$ROOT_DIR/scripts/prepare_bundled_jcef.py"
+KATAGO_BUNDLE_SCRIPT="$ROOT_DIR/scripts/macos_katago_bundle.py"
 JCEF_RELEASE_TAG="jcef-99c2f7a+cef-127.3.1+g6cbb30e+chromium-127.0.6533.100"
 JCEF_JAVA_OPTIONS=(
   "--add-exports=java.desktop/sun.awt=ALL-UNNAMED"
@@ -209,6 +210,12 @@ for option in "${JCEF_JAVA_OPTIONS[@]}"; do
     exit 1
   fi
 done
+
+if [[ "$PACKAGE_FLAVOR" == "with-katago" ]]; then
+  resolve_python_bin
+  "$PYTHON_BIN" "$KATAGO_BUNDLE_SCRIPT" audit \
+    --bundle "$APP_IMAGE_DIR/$APP_NAME.app/Contents/app/engines/katago/$ENGINE_PLATFORM_DIR"
+fi
 
 FINAL_DMG="$ROOT_DIR/dist/release/${DATE_TAG}-${PUBLIC_ARCH_TAG}.${PACKAGE_FLAVOR}.dmg"
 INSTALL_NOTE="$META_DIR/${DATE_TAG}-${PUBLIC_ARCH_TAG}-install.txt"

--- a/scripts/prepare_bundled_katago.sh
+++ b/scripts/prepare_bundled_katago.sh
@@ -192,60 +192,29 @@ prepare_linux_bundle() {
 
 prepare_macos_bundle() {
   local katago_prefix
-  local libzip_prefix
-  local xz_prefix
-  local zstd_prefix
   local platform_dir
 
   katago_prefix="$(brew_prefix_for katago)"
-  libzip_prefix="$(brew_prefix_for libzip)"
-  xz_prefix="$(brew_prefix_for xz)"
-  zstd_prefix="$(brew_prefix_for zstd)"
   platform_dir="$(detect_macos_platform_dir)"
 
   local macos_root="$ENGINES_ROOT/$platform_dir"
   local katago_bin="${MACOS_KATAGO_BIN:-${katago_prefix:+$katago_prefix/bin/katago}}"
-  local libzip_bin="${MACOS_LIBZIP_BIN:-${libzip_prefix:+$libzip_prefix/lib/libzip.5.dylib}}"
-  local liblzma_bin="${MACOS_LIBLZMA_BIN:-${xz_prefix:+$xz_prefix/lib/liblzma.5.dylib}}"
-  local libzstd_bin="${MACOS_LIBZSTD_BIN:-${zstd_prefix:+$zstd_prefix/lib/libzstd.1.dylib}}"
+  local bundler="$ROOT_DIR/scripts/macos_katago_bundle.py"
 
   if [[ ! -x "$katago_bin" ]]; then
     echo "Skipping $platform_dir bundle: $katago_bin not found"
     return 0
   fi
 
-  require_cmd install_name_tool
-
-  rm -rf "$macos_root"
-  mkdir -p "$macos_root/lib"
-
-  cp -Lf "$katago_bin" "$macos_root/katago"
-  cp -Lf "$libzip_bin" "$macos_root/lib/libzip.5.dylib"
-  cp -Lf "$liblzma_bin" "$macos_root/lib/liblzma.5.dylib"
-  cp -Lf "$libzstd_bin" "$macos_root/lib/libzstd.1.dylib"
-  chmod +x "$macos_root/katago"
-
-  install_name_tool \
-    -change "$libzip_bin" \
-    @executable_path/lib/libzip.5.dylib \
-    "$macos_root/katago"
-  install_name_tool -id @loader_path/libzip.5.dylib "$macos_root/lib/libzip.5.dylib"
-  install_name_tool -id @loader_path/liblzma.5.dylib "$macos_root/lib/liblzma.5.dylib"
-  install_name_tool -id @loader_path/libzstd.1.dylib "$macos_root/lib/libzstd.1.dylib"
-  install_name_tool \
-    -change "$liblzma_bin" \
-    @loader_path/liblzma.5.dylib \
-    "$macos_root/lib/libzip.5.dylib"
-  install_name_tool \
-    -change "$libzstd_bin" \
-    @loader_path/libzstd.1.dylib \
-    "$macos_root/lib/libzip.5.dylib"
-
-  if command -v codesign >/dev/null 2>&1; then
-    codesign --force --sign - "$macos_root/lib/"*.dylib "$macos_root/katago" >/dev/null 2>&1 || true
+  if [[ ! -f "$bundler" ]]; then
+    echo "Missing macOS KataGo bundler: $bundler"
+    exit 1
   fi
-
-  "$macos_root/katago" version >/dev/null
+  require_cmd python3
+  python3 "$bundler" bundle \
+    --katago "$katago_bin" \
+    --output "$macos_root" \
+    --expected-version "${KATAGO_TAG#v}"
 }
 
 write_manifest() {

--- a/scripts/test_macos_katago_bundle.py
+++ b/scripts/test_macos_katago_bundle.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+"""Regression tests for the self-contained macOS KataGo bundler."""
+
+from __future__ import annotations
+
+import importlib.util
+import platform
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+MODULE_PATH = SCRIPT_DIR / "macos_katago_bundle.py"
+SPEC = importlib.util.spec_from_file_location("macos_katago_bundle", MODULE_PATH)
+if SPEC is None or SPEC.loader is None:
+    raise RuntimeError(f"Unable to load {MODULE_PATH}")
+MODULE = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = MODULE
+SPEC.loader.exec_module(MODULE)
+
+
+class MacosKataGoBundleUnitTest(unittest.TestCase):
+    def test_system_dependencies_are_allowed(self) -> None:
+        self.assertTrue(MODULE.is_system_dependency("/usr/lib/libc++.1.dylib"))
+        self.assertTrue(
+            MODULE.is_system_dependency(
+                "/System/Library/Frameworks/CoreML.framework/Versions/A/CoreML"
+            )
+        )
+        self.assertFalse(
+            MODULE.is_system_dependency(
+                "/opt/homebrew/opt/protobuf/lib/libprotobuf.35.1.0.dylib"
+            )
+        )
+        self.assertFalse(
+            MODULE.is_system_dependency("/usr/local/opt/libzip/lib/libzip.5.dylib")
+        )
+
+    def test_otool_dependency_parser(self) -> None:
+        output = """/tmp/katago:
+\t/usr/lib/libc++.1.dylib (compatibility version 1.0.0, current version 1900.178.0)
+\t/opt/homebrew/opt/protobuf/lib/libprotobuf.35.1.0.dylib (compatibility version 35.0.0, current version 35.1.0)
+"""
+        self.assertEqual(
+            MODULE.parse_otool_dependencies(output),
+            [
+                "/usr/lib/libc++.1.dylib",
+                "/opt/homebrew/opt/protobuf/lib/libprotobuf.35.1.0.dylib",
+            ],
+        )
+
+
+@unittest.skipUnless(
+    platform.system() == "Darwin" and shutil.which("clang"),
+    "Mach-O integration test requires macOS and clang",
+)
+class MacosKataGoBundleIntegrationTest(unittest.TestCase):
+    def test_recursive_dependencies_work_after_sources_are_removed(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="katago-bundle-test.") as temp:
+            root = Path(temp)
+            source = root / "source"
+            output = root / "bundle"
+            source.mkdir()
+
+            leaf_source = source / "leaf.c"
+            middle_source = source / "middle.c"
+            main_source = source / "main.c"
+            leaf_source.write_text(
+                "int leaf_value(void) { return 41; }\n",
+                encoding="ascii",
+            )
+            middle_source.write_text(
+                "extern int leaf_value(void);\n"
+                "int middle_value(void) { return leaf_value() + 1; }\n",
+                encoding="ascii",
+            )
+            main_source.write_text(
+                "#include <stdio.h>\n"
+                "#include <string.h>\n"
+                "extern int middle_value(void);\n"
+                "int main(int argc, char **argv) {\n"
+                "  if (argc > 1 && strcmp(argv[1], \"version\") == 0) {\n"
+                "    printf(\"KataGo v9.9.9 fixture\\n\");\n"
+                "  }\n"
+                "  return middle_value() == 42 ? 0 : 2;\n"
+                "}\n",
+                encoding="ascii",
+            )
+
+            leaf = source / "libleaf.1.dylib"
+            middle = source / "libmiddle.1.dylib"
+            executable = source / "katago"
+            subprocess.run(
+                [
+                    "clang",
+                    "-dynamiclib",
+                    str(leaf_source),
+                    "-install_name",
+                    str(leaf),
+                    "-o",
+                    str(leaf),
+                ],
+                check=True,
+            )
+            subprocess.run(
+                [
+                    "clang",
+                    "-dynamiclib",
+                    str(middle_source),
+                    str(leaf),
+                    "-install_name",
+                    str(middle),
+                    "-o",
+                    str(middle),
+                ],
+                check=True,
+            )
+            subprocess.run(
+                ["clang", str(main_source), str(middle), "-o", str(executable)],
+                check=True,
+            )
+
+            subprocess.run(
+                [
+                    "python3",
+                    str(MODULE_PATH),
+                    "bundle",
+                    "--katago",
+                    str(executable),
+                    "--output",
+                    str(output),
+                    "--expected-version",
+                    "9.9.9",
+                ],
+                check=True,
+            )
+            shutil.move(str(source), str(root / "source.removed"))
+            subprocess.run(
+                [
+                    "python3",
+                    str(MODULE_PATH),
+                    "audit",
+                    "--bundle",
+                    str(output),
+                    "--expected-version",
+                    "9.9.9",
+                ],
+                check=True,
+            )
+            result = subprocess.run(
+                [str(output / "katago"), "version"],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+            self.assertIn("KataGo v9.9.9", result.stdout)
+            dependencies = subprocess.run(
+                ["otool", "-L", str(output / "katago")],
+                check=True,
+                capture_output=True,
+                text=True,
+            ).stdout
+            self.assertNotIn(str(source), dependencies)
+            self.assertIn("@executable_path/lib/libmiddle.1.dylib", dependencies)
+
+            missing_library = output / "lib" / "libleaf.1.dylib"
+            shutil.move(str(missing_library), str(root / missing_library.name))
+            failed_audit = subprocess.run(
+                [
+                    "python3",
+                    str(MODULE_PATH),
+                    "audit",
+                    "--bundle",
+                    str(output),
+                ],
+                capture_output=True,
+                text=True,
+            )
+            self.assertNotEqual(0, failed_audit.returncode)
+            self.assertIn(
+                "libraries do not match bundle-manifest.json",
+                failed_audit.stderr,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/validate_macos_dmg_layout.sh
+++ b/scripts/validate_macos_dmg_layout.sh
@@ -87,4 +87,23 @@ if [[ ! -f "$MOUNT_POINT/.DS_Store" ]]; then
   exit 1
 fi
 
+APP_PATH="$(find "$MOUNT_POINT" -maxdepth 1 -type d -name '*.app' -print -quit)"
+KATAGO_BUNDLES=()
+while IFS= read -r -d '' katago_path; do
+  KATAGO_BUNDLES+=("$(dirname "$katago_path")")
+done < <(
+  find "$APP_PATH/Contents/app/engines/katago" \
+    -mindepth 2 -maxdepth 2 -type f -name katago -print0 2>/dev/null
+)
+
+if [[ "${#KATAGO_BUNDLES[@]}" -gt 1 ]]; then
+  echo "Expected at most one native macOS KataGo bundle; found ${#KATAGO_BUNDLES[@]}." >&2
+  exit 1
+fi
+if [[ "${#KATAGO_BUNDLES[@]}" -eq 1 ]]; then
+  SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  python3 "$SCRIPT_DIR/macos_katago_bundle.py" audit \
+    --bundle "${KATAGO_BUNDLES[0]}"
+fi
+
 echo "Validated macOS drag-install DMG layout: $(basename "$DMG_PATH")"


### PR DESCRIPTION
## Summary

- Recursively bundles every non-system KataGo dylib dependency on macOS.
- Rejects Homebrew paths, unresolved rpaths, missing libraries, invalid signatures, and non-runnable bundles before release upload.
- Audits the final mounted DMG and adds real Mach-O dependency-chain regression coverage for Apple Silicon and Intel workflows.

## Root cause

Homebrew KataGo 1.16.5 added protobuf and abseil dylib dependencies, while the previous packaging script only copied libzip, liblzma, and libzstd. The published app therefore retained `/opt/homebrew` references that do not exist on user Macs, causing the misleading missing DLL or runtime error and preventing local analysis.

## Validation

- `python3 scripts/test_macos_katago_bundle.py`: 3 tests passed, including a real Mach-O transitive dependency chain.
- `mvn -B -Dfmt.skip=true test`: 1492 tests passed.
- `mvn -B -Dfmt.skip=true -DskipTests package`: passed.
- Built and mounted a complete Apple Silicon DMG from the latest `main`.
- Audited KataGo 1.16.5 with 84 bundled dylibs and no Homebrew or unresolved rpath references.
- Loaded the packaged default Zhizi model with Metal on Apple M4 Pro; GTP `play` and `genmove` completed successfully.
- Launched the packaged app through its real jpackage launcher and verified both GTP and analysis engines ran from inside the `.app` bundle.

## Release impact

This is a critical macOS packaging fix. Both macOS release workflows now fail before upload if bundled KataGo is not self-contained, correctly signed, version-matched, or runnable from the final DMG.

Apple Silicon has been validated on a real Mac. Intel uses the same closure audit and is covered by its native GitHub Actions runner plus the real Mach-O fixture test.
