### PR TITLE
Request next-2026-07-24.1 pre-release

### DIFF
--- a/.github/release-notes/next-2026-07-24.1.md
+++ b/.github/release-notes/next-2026-07-24.1.md
@@ -1,0 +1,297 @@
+# LizzieYzy Next next-2026-07-24.1
+
+## 中文
+
+这是 `next-2026-07-22.2` 之后的稳定性预览版，重点解决 macOS 本地 KataGo 无法启动、Windows NVIDIA OpenCL 原生退出，并把“整盘精析”完善成可续跑、可取消、不会阻塞看棋的推荐分析流程。
+
+### 本版主要更新
+
+- 重构“整盘精析（推荐）”：先用 32 visits 快速补齐整盘胜率曲线，再把主线逐手深入到至少 500 visits；支持真实进度、预计剩余时间、隐藏后恢复和停止后保留结果。
+- 整盘精析同时支持本地 KataGo 与智子等远程 GTP 引擎；已完成的节点会直接复用，切换棋谱、贴目、规则、棋盘大小或取消任务后，迟到结果不会写入错误棋谱。
+- 严重修复 macOS KataGo 打包：递归内置 protobuf、abseil 等全部非系统动态库，彻底移除 Homebrew 路径依赖。发布前会挂载最终 DMG、校验签名和依赖闭包，并真实运行 `katago version`。
+- 修复 Windows NVIDIA 显卡使用 OpenCL 包时可能发生的 `0xC0000409` 原生退出：隔离旧调优缓存，避免首次调优并发；仅在真实故障时自动用隔离的 FP32 OpenCL 缓存恢复，仍继续使用 NVIDIA GPU。
+- 保留原有“整盘速览（闪电）”和 `Ctrl+B` 习惯；新的整盘精析快捷键为 `Ctrl+Shift+B`，不会覆盖旧流程。
+
+### 下载前先看这几句
+
+- 完整包继续内置 KataGo `v1.16.5` 和默认智子 28B 权重。
+- macOS 用户请重新下载对应芯片的完整 DMG；只替换主程序无法补齐旧包缺失的 KataGo 动态库。
+- Windows 普通用户优先下载 OpenCL 免安装版；RTX 20/30/40 系可选 NVIDIA 包，RTX 50 系可选 CUDA 12.8 包。
+- 已有 Windows 免安装版可使用小更新包；配置、棋谱、自定义权重和 TensorRT 文件会保留。
+- 这是 Pre-release，适合提前验证整盘精析和多平台引擎修复。
+
+### 下载建议
+
+| 你的电脑 | 直接下载这个 |
+| --- | --- |
+| Windows 64 位，OpenCL 推荐版，免安装 | [windows64.opencl.portable.zip][win-opencl-portable] |
+| 已有 Windows 免安装版，日常小更新 | [windows64.core-update.zip][win-core-update] |
+| Windows 64 位，OpenCL 推荐版，安装器 | [windows64.opencl.installer.exe][win-opencl-installer] |
+| Windows 64 位，CPU 兼容版，免安装 / 安装器 | [portable][win-cpu-portable] / [installer][win-cpu-installer] |
+| Windows NVIDIA RTX 20/30/40，免安装 / 安装器 | [portable][win-nvidia-portable] / [installer][win-nvidia-installer] |
+| Windows RTX 50 CUDA，免安装 / 安装器 | [portable][win-nvidia50-portable] / [installer][win-nvidia50-installer] |
+| 高级可选 TensorRT 分卷包 | [下载与解压说明][win-tensorrt-readme] |
+| Windows 自行配置引擎，免安装 / 安装器 | [portable][win-no-engine-portable] / [installer][win-no-engine-installer] |
+| macOS Apple Silicon | [mac-apple-silicon.with-katago.dmg][mac-arm64] |
+| macOS Intel | [mac-intel.with-katago.dmg][mac-intel] |
+| Linux CPU / OpenCL / NVIDIA CUDA | [CPU][linux-cpu] / [OpenCL][linux-opencl] / [NVIDIA][linux-nvidia] |
+
+### 这一版为什么值得测试
+
+- 整盘分析现在会先快速给出完整曲线，再在后台逐手加深，用户可以随时看棋、跳转和停止。
+- macOS 发布包新增最终 DMG 级别的硬性引擎验收，避免再次发布依赖开发机 Homebrew 的坏包。
+- 合并版本通过 1529 项完整测试、3 项真实 Mach-O 依赖链测试、完整构建，以及 Apple Silicon 上加载棋谱和本地 KataGo 分析的真实 UI 冒烟。
+
+### 交流
+
+- QQ 群：`299419120`
+
+---
+
+## 繁體中文
+
+這是 `next-2026-07-22.2` 之後的穩定性預覽版，重點修正 macOS 本機 KataGo 無法啟動、Windows NVIDIA OpenCL 原生退出，並把「整盤精析」完善為可續跑、可取消且不阻塞看棋的推薦流程。
+
+### 本版主要更新
+
+- 重構「整盤精析（推薦）」：先以 32 visits 補齊整盤勝率曲線，再把主線逐手深入到至少 500 visits；支援真實進度、預計剩餘時間、隱藏後恢復及停止後保留結果。
+- 同時支援本機 KataGo 與智子等遠端 GTP 引擎；完成節點會直接重用，棋譜、貼目、規則、棋盤大小改變或取消後，遲到結果不會寫進錯誤棋譜。
+- 嚴重修正 macOS KataGo 打包：遞迴內建 protobuf、abseil 等全部非系統動態庫，移除 Homebrew 路徑。發布前會掛載最終 DMG、驗證簽章及依賴閉包，並實際執行 `katago version`。
+- 修正 Windows NVIDIA 顯示卡使用 OpenCL 套件時可能發生的 `0xC0000409` 原生退出；舊調校快取會隔離，真正失敗時才以隔離的 FP32 OpenCL 快取自動恢復，仍使用 NVIDIA GPU。
+- 保留原本「整盤速覽（閃電）」與 `Ctrl+B`；新整盤精析使用 `Ctrl+Shift+B`，不改變既有操作習慣。
+
+### 下載前先看這幾句
+
+- 完整套件繼續內建 KataGo `v1.16.5` 與預設智子 28B 權重。
+- macOS 使用者請重新下載對應晶片的完整 DMG；只替換主程式無法補齊舊包缺少的動態庫。
+- Windows 一般使用者優先選 OpenCL portable；NVIDIA 使用者依顯示卡世代選一般 NVIDIA 或 RTX 50 CUDA 套件。
+- 舊 Windows portable 可使用小更新包，並保留設定、棋譜、自訂權重與 TensorRT。
+- 這是 Pre-release，適合提前驗證整盤精析與多平台引擎修復。
+
+### 下載建議
+
+| 你的電腦 | 直接下載這個 |
+| --- | --- |
+| Windows OpenCL 推薦版，免安裝 | [portable][win-opencl-portable] |
+| 舊 Windows 免安裝版，小更新 | [core update][win-core-update] |
+| Windows OpenCL 推薦版，安裝器 | [installer][win-opencl-installer] |
+| Windows CPU 相容版，免安裝 / 安裝器 | [portable][win-cpu-portable] / [installer][win-cpu-installer] |
+| Windows NVIDIA RTX 20/30/40，免安裝 / 安裝器 | [portable][win-nvidia-portable] / [installer][win-nvidia-installer] |
+| Windows RTX 50 CUDA，免安裝 / 安裝器 | [portable][win-nvidia50-portable] / [installer][win-nvidia50-installer] |
+| 進階 TensorRT 分卷包 | [下載與解壓說明][win-tensorrt-readme] |
+| Windows 自行配置引擎，免安裝 / 安裝器 | [portable][win-no-engine-portable] / [installer][win-no-engine-installer] |
+| macOS Apple Silicon / Intel | [Apple Silicon][mac-arm64] / [Intel][mac-intel] |
+| Linux CPU / OpenCL / NVIDIA CUDA | [CPU][linux-cpu] / [OpenCL][linux-opencl] / [NVIDIA][linux-nvidia] |
+
+### 這一版為什麼值得測試
+
+- 整盤分析會先快速顯示完整曲線，再於背景逐手加深，期間仍可看棋、跳轉和停止。
+- macOS 發布包加入最終 DMG 等級的強制引擎驗收，避免再次發布依賴開發機 Homebrew 的套件。
+- 合併版本通過 1529 項完整測試、3 項真實 Mach-O 依賴鏈測試、完整建置及 Apple Silicon 真實 UI 冒煙。
+
+### 交流
+
+- QQ 群：`299419120`
+
+---
+
+## English
+
+This stability preview builds on `next-2026-07-22.2`. It fixes broken local KataGo launches in recent macOS packages, recovers NVIDIA OpenCL native exits on Windows, and turns Whole-game Deep Analysis into a resumable, cancellable workflow that remains responsive while reviewing a game.
+
+### Release Highlights
+
+- Reworked Whole-game Deep Analysis: a 32-visit baseline fills the complete win-rate curve first, then the main line is deepened to at least 500 visits per position with real progress, ETA, hide/restore, and retained partial results.
+- Supports both local KataGo and remote GTP backends such as Zhizi. Completed nodes are reused, while cancellation or changes to the game, komi, rules, or board size reject late stale responses.
+- Critically fixes macOS KataGo packaging by recursively bundling every non-system dependency, including protobuf and abseil libraries. The final mounted DMG is audited for signatures, dependency closure, and a real `katago version` launch.
+- Fixes possible Windows NVIDIA OpenCL native exit `0xC0000409` by isolating legacy tuning caches and serializing first-run tuning. A real failure can recover once with an isolated FP32 OpenCL cache while continuing to use the NVIDIA GPU.
+- Keeps the existing Lightning Overview and `Ctrl+B` unchanged. The new deep workflow uses `Ctrl+Shift+B`.
+
+### Read Before Downloading
+
+- Full bundles include KataGo `v1.16.5` and the default Zhizi 28B model.
+- macOS users should download the complete DMG for their CPU architecture; replacing only the application jar cannot restore dylibs missing from an older package.
+- Most Windows users should choose the OpenCL portable. NVIDIA users can select the standard NVIDIA or RTX 50 CUDA build for their GPU generation.
+- Existing Windows portable users can use the small core update while keeping settings, games, custom weights, and TensorRT files.
+- This is a Pre-release intended for early validation of deep analysis and cross-platform engine reliability.
+
+### Download Guide
+
+| Your computer | Download |
+| --- | --- |
+| Windows OpenCL recommended, portable | [portable][win-opencl-portable] |
+| Existing Windows portable, small update | [core update][win-core-update] |
+| Windows OpenCL recommended, installer | [installer][win-opencl-installer] |
+| Windows CPU compatible, portable / installer | [portable][win-cpu-portable] / [installer][win-cpu-installer] |
+| Windows NVIDIA RTX 20/30/40, portable / installer | [portable][win-nvidia-portable] / [installer][win-nvidia-installer] |
+| Windows RTX 50 CUDA, portable / installer | [portable][win-nvidia50-portable] / [installer][win-nvidia50-installer] |
+| Advanced optional TensorRT split package | [download instructions][win-tensorrt-readme] |
+| Windows, configure your own engine | [portable][win-no-engine-portable] / [installer][win-no-engine-installer] |
+| macOS Apple Silicon / Intel | [Apple Silicon][mac-arm64] / [Intel][mac-intel] |
+| Linux CPU / OpenCL / NVIDIA CUDA | [CPU][linux-cpu] / [OpenCL][linux-opencl] / [NVIDIA][linux-nvidia] |
+
+### Why Test This Release
+
+- Whole-game analysis presents a complete curve quickly, then deepens positions in the background without locking navigation.
+- The macOS release gate now validates the actual mounted DMG, preventing another package that accidentally depends on the build machine's Homebrew installation.
+- The merged build passed all 1529 tests, 3 real Mach-O dependency-chain tests, packaging, and an Apple Silicon UI smoke test with a loaded SGF and local KataGo analysis.
+
+### Contact
+
+- QQ group: `299419120`
+
+---
+
+## 日本語
+
+`next-2026-07-22.2` 以降の安定性 preview です。macOS package で local KataGo が起動しない問題、Windows NVIDIA OpenCL の native exit を修正し、Whole-game Deep Analysis を中断・再開できる responsive な推奨 workflow にしました。
+
+### 主な更新
+
+- Whole-game Deep Analysis を再設計しました。まず 32 visits で全体の win-rate curve を埋め、その後 main line を各局面 500 visits 以上まで深掘りします。進捗、残り時間、hide/restore、途中結果保持に対応します。
+- local KataGo と Zhizi などの remote GTP backend に対応します。完了済み node は再利用し、cancel または棋譜、komi、rules、board size の変更後に届く古い結果は保存しません。
+- macOS KataGo package を重要修正しました。protobuf、abseil を含む全 non-system dylib を再帰的に同梱し、Homebrew path を除去します。最終 DMG を mount して signature、依存 closure、`katago version` を検証します。
+- Windows NVIDIA OpenCL の `0xC0000409` native exit を修正しました。古い tuning cache を隔離し、初回 tuning の競合を防ぎ、実際の障害時だけ isolated FP32 OpenCL cache で一度自動復旧します。
+- 従来の Lightning Overview と `Ctrl+B` は維持し、新しい deep analysis は `Ctrl+Shift+B` を使用します。
+
+### ダウンロード前に
+
+- full bundle は KataGo `v1.16.5` と既定 Zhizi 28B model を含みます。
+- macOS は CPU に合う complete DMG を再ダウンロードしてください。jar だけでは旧 package の不足 dylib を補えません。
+- Windows は通常 OpenCL portable、NVIDIA は GPU 世代に合う NVIDIA または RTX 50 CUDA build を選択してください。
+- 既存 Windows portable は small core update を利用でき、設定、棋譜、custom weight、TensorRT を保持します。
+- deep analysis と cross-platform engine 修正を先行確認する Pre-release です。
+
+### ダウンロード案内
+
+| 環境 | ダウンロード |
+| --- | --- |
+| Windows OpenCL portable / installer | [portable][win-opencl-portable] / [installer][win-opencl-installer] |
+| Windows portable 小型更新 | [core update][win-core-update] |
+| Windows CPU portable / installer | [portable][win-cpu-portable] / [installer][win-cpu-installer] |
+| Windows NVIDIA portable / installer | [portable][win-nvidia-portable] / [installer][win-nvidia-installer] |
+| Windows RTX 50 CUDA portable / installer | [portable][win-nvidia50-portable] / [installer][win-nvidia50-installer] |
+| TensorRT split package | [README][win-tensorrt-readme] |
+| Windows no-engine portable / installer | [portable][win-no-engine-portable] / [installer][win-no-engine-installer] |
+| macOS Apple Silicon / Intel | [Apple Silicon][mac-arm64] / [Intel][mac-intel] |
+| Linux CPU / OpenCL / NVIDIA | [CPU][linux-cpu] / [OpenCL][linux-opencl] / [NVIDIA][linux-nvidia] |
+
+### このリリースを試す理由
+
+- 最初に完全な curve を短時間で表示し、その後 background で深掘りするため、分析中も棋譜を操作できます。
+- macOS は最終 DMG 内の engine を実行する release gate を追加し、build machine の Homebrew に依存する package を防ぎます。
+- 1529 tests、3 real Mach-O dependency tests、package build、Apple Silicon での SGF + local KataGo UI smoke に合格しました。
+
+### 連絡先
+
+- QQ group: `299419120`
+
+---
+
+## 한국어
+
+`next-2026-07-22.2` 이후의 안정성 preview입니다. macOS package에서 local KataGo가 시작되지 않는 문제와 Windows NVIDIA OpenCL native exit를 수정하고, Whole-game Deep Analysis를 재개·취소할 수 있는 responsive workflow로 완성했습니다.
+
+### 주요 업데이트
+
+- Whole-game Deep Analysis는 먼저 32 visits로 전체 win-rate curve를 채우고, 이후 main line의 각 국면을 최소 500 visits까지 심화합니다. 실제 진행률, 남은 시간, hide/restore, 부분 결과 보존을 지원합니다.
+- local KataGo와 Zhizi 같은 remote GTP backend를 모두 지원합니다. 완료 node는 재사용하고, cancel 또는 게임, komi, rules, board size 변경 후 도착한 오래된 응답은 저장하지 않습니다.
+- macOS KataGo package를 중요 수정했습니다. protobuf와 abseil을 포함한 모든 non-system dylib를 재귀적으로 포함하고 Homebrew path를 제거합니다. 최종 DMG를 mount하여 signature, dependency closure, `katago version`을 검사합니다.
+- Windows NVIDIA OpenCL `0xC0000409` native exit를 수정했습니다. 이전 tuning cache를 격리하고 최초 tuning 경쟁을 막으며, 실제 장애일 때만 isolated FP32 OpenCL cache로 한 번 자동 복구합니다.
+- 기존 Lightning Overview와 `Ctrl+B`는 유지하고 새 deep analysis는 `Ctrl+Shift+B`를 사용합니다.
+
+### 다운로드 전 확인
+
+- full bundle은 KataGo `v1.16.5`와 기본 Zhizi 28B model을 포함합니다.
+- macOS 사용자는 CPU에 맞는 complete DMG를 다시 받으세요. jar만 교체하면 예전 package의 누락 dylib를 복구할 수 없습니다.
+- Windows 일반 사용자는 OpenCL portable, NVIDIA 사용자는 GPU 세대에 맞는 NVIDIA 또는 RTX 50 CUDA build를 선택하세요.
+- 기존 Windows portable은 small core update를 사용하며 설정, 기보, custom weight, TensorRT를 유지할 수 있습니다.
+- deep analysis와 cross-platform engine 수정을 먼저 검증하는 Pre-release입니다.
+
+### 다운로드 안내
+
+| 환경 | 다운로드 |
+| --- | --- |
+| Windows OpenCL portable / installer | [portable][win-opencl-portable] / [installer][win-opencl-installer] |
+| Windows portable 소형 업데이트 | [core update][win-core-update] |
+| Windows CPU portable / installer | [portable][win-cpu-portable] / [installer][win-cpu-installer] |
+| Windows NVIDIA portable / installer | [portable][win-nvidia-portable] / [installer][win-nvidia-installer] |
+| Windows RTX 50 CUDA portable / installer | [portable][win-nvidia50-portable] / [installer][win-nvidia50-installer] |
+| TensorRT split package | [README][win-tensorrt-readme] |
+| Windows no-engine portable / installer | [portable][win-no-engine-portable] / [installer][win-no-engine-installer] |
+| macOS Apple Silicon / Intel | [Apple Silicon][mac-arm64] / [Intel][mac-intel] |
+| Linux CPU / OpenCL / NVIDIA | [CPU][linux-cpu] / [OpenCL][linux-opencl] / [NVIDIA][linux-nvidia] |
+
+### 이 릴리스를 테스트할 이유
+
+- 전체 curve를 먼저 빠르게 표시한 뒤 background에서 심화하므로 분석 중에도 기보를 자유롭게 탐색할 수 있습니다.
+- macOS release gate가 최종 DMG의 engine을 직접 실행하여 build machine의 Homebrew에 의존하는 package를 차단합니다.
+- 1529 tests, 3 real Mach-O dependency tests, package build, Apple Silicon SGF + local KataGo UI smoke를 통과했습니다.
+
+### 연락처
+
+- QQ 그룹: `299419120`
+
+---
+
+## ภาษาไทย
+
+นี่คือ Pre-release ด้านความเสถียรต่อจาก `next-2026-07-22.2` แก้ local KataGo ที่เปิดไม่ได้ในแพ็กเกจ macOS, แก้ native exit ของ NVIDIA OpenCL บน Windows และทำให้ Whole-game Deep Analysis ดำเนินต่อ ยกเลิก และใช้งานระหว่างดูเกมได้อย่างราบรื่น
+
+### ไฮไลต์ของเวอร์ชันนี้
+
+- ปรับ Whole-game Deep Analysis ใหม่: เริ่มด้วย 32 visits เพื่อสร้าง win-rate curve ทั้งเกมอย่างรวดเร็ว จากนั้นวิเคราะห์ main line ลึกอย่างน้อย 500 visits ต่อจุด พร้อม progress จริง เวลาคงเหลือ hide/restore และเก็บผลบางส่วน
+- รองรับทั้ง local KataGo และ remote GTP เช่น Zhizi โดย reuse node ที่เสร็จแล้ว และไม่เขียน response เก่าหลัง cancel หรือเมื่อ game, komi, rules หรือ board size เปลี่ยน
+- แก้ macOS KataGo package ครั้งสำคัญ โดยรวม non-system dylib ทั้งหมดแบบ recursive รวมถึง protobuf และ abseil และลบ Homebrew path ก่อน release จะ mount DMG จริง ตรวจ signature, dependency closure และรัน `katago version`
+- แก้ Windows NVIDIA OpenCL native exit `0xC0000409` ด้วยการแยก tuning cache เก่า ป้องกัน first-run tuning ชนกัน และกู้คืนหนึ่งครั้งด้วย isolated FP32 OpenCL cache เฉพาะเมื่อเกิดข้อผิดพลาดจริง โดยยังใช้ NVIDIA GPU
+- คง Lightning Overview และ `Ctrl+B` เดิมไว้ ส่วน deep analysis ใหม่ใช้ `Ctrl+Shift+B`
+
+### ก่อนดาวน์โหลด
+
+- full bundle ยังรวม KataGo `v1.16.5` และ Zhizi 28B model เริ่มต้น
+- ผู้ใช้ macOS ควรดาวน์โหลด complete DMG ตามชนิด CPU ใหม่ การเปลี่ยนเฉพาะ jar ไม่สามารถเพิ่ม dylib ที่หายไปใน package เก่าได้
+- ผู้ใช้ Windows ทั่วไปเลือก OpenCL portable ส่วน NVIDIA เลือก NVIDIA หรือ RTX 50 CUDA build ตามรุ่น GPU
+- portable เดิมบน Windows ใช้ small core update ได้ โดยเก็บ settings, game records, custom weights และ TensorRT ไว้
+- นี่คือ Pre-release สำหรับทดสอบ deep analysis และความเสถียรของ engine ทุก platform
+
+### คำแนะนำดาวน์โหลด
+
+| คอมพิวเตอร์ของคุณ | ดาวน์โหลด |
+| --- | --- |
+| Windows OpenCL portable / installer | [portable][win-opencl-portable] / [installer][win-opencl-installer] |
+| Windows portable อัปเดตขนาดเล็ก | [core update][win-core-update] |
+| Windows CPU portable / installer | [portable][win-cpu-portable] / [installer][win-cpu-installer] |
+| Windows NVIDIA portable / installer | [portable][win-nvidia-portable] / [installer][win-nvidia-installer] |
+| Windows RTX 50 CUDA portable / installer | [portable][win-nvidia50-portable] / [installer][win-nvidia50-installer] |
+| TensorRT split package | [README][win-tensorrt-readme] |
+| Windows no-engine portable / installer | [portable][win-no-engine-portable] / [installer][win-no-engine-installer] |
+| macOS Apple Silicon / Intel | [Apple Silicon][mac-arm64] / [Intel][mac-intel] |
+| Linux CPU / OpenCL / NVIDIA | [CPU][linux-cpu] / [OpenCL][linux-opencl] / [NVIDIA][linux-nvidia] |
+
+### ทำไมควรทดสอบเวอร์ชันนี้
+
+- แสดง curve ทั้งเกมอย่างรวดเร็วก่อน แล้ววิเคราะห์ลึกต่อใน background โดยผู้ใช้ยังเลื่อนดูเกมและหยุดงานได้
+- macOS release gate รัน engine จาก DMG จริง จึงป้องกัน package ที่พึ่ง Homebrew บน build machine
+- ผ่าน 1529 tests, 3 real Mach-O dependency tests, package build และ Apple Silicon UI smoke ด้วย SGF และ local KataGo
+
+### ติดต่อ
+
+- QQ group: `299419120`
+
+[win-opencl-portable]: https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-24.1/2026-07-24-windows64.opencl.portable.zip
+[win-core-update]: https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-24.1/2026-07-24-windows64.core-update.zip
+[win-opencl-installer]: https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-24.1/2026-07-24-windows64.opencl.installer.exe
+[win-cpu-portable]: https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-24.1/2026-07-24-windows64.with-katago.portable.zip
+[win-cpu-installer]: https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-24.1/2026-07-24-windows64.with-katago.installer.exe
+[win-nvidia-portable]: https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-24.1/2026-07-24-windows64.nvidia.portable.zip
+[win-nvidia-installer]: https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-24.1/2026-07-24-windows64.nvidia.installer.exe
+[win-nvidia50-portable]: https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-24.1/2026-07-24-windows64.nvidia50.cuda.portable.zip
+[win-nvidia50-installer]: https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-24.1/2026-07-24-windows64.nvidia50.cuda.installer.exe
+[win-tensorrt-readme]: https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-24.1/2026-07-24-windows64.nvidia.tensorrt.portable.README.txt
+[win-no-engine-portable]: https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-24.1/2026-07-24-windows64.without.engine.portable.zip
+[win-no-engine-installer]: https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-24.1/2026-07-24-windows64.without.engine.installer.exe
+[mac-arm64]: https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-24.1/2026-07-24-mac-apple-silicon.with-katago.dmg
+[mac-intel]: https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-24.1/2026-07-24-mac-intel.with-katago.dmg
+[linux-cpu]: https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-24.1/2026-07-24-linux64.with-katago.zip
+[linux-opencl]: https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-24.1/2026-07-24-linux64.opencl.zip
+[linux-nvidia]: https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-24.1/2026-07-24-linux64.nvidia.zip

--- a/.github/release-requests/next-2026-07-24.1.json
+++ b/.github/release-requests/next-2026-07-24.1.json
@@ -1,0 +1,7 @@
+{
+  "date_tag": "2026-07-24",
+  "release_tag": "next-2026-07-24.1",
+  "title": "LizzieYzy Next next-2026-07-24.1",
+  "prerelease": true,
+  "notes_file": ".github/release-notes/next-2026-07-24.1.md"
+}


### PR DESCRIPTION
## Summary

- Requests the audited `next-2026-07-24.1` multi-platform Pre-release.
- Covers whole-game deep analysis reliability, the critical self-contained macOS KataGo runtime fix, and Windows NVIDIA OpenCL native-exit recovery.
- Keeps the fixed six-language, five-section release-note structure with direct links for every supported package.

## Validation

- Full Maven suite: 1529 tests passed.
- Shaded jar packaging passed.
- macOS KataGo dependency bundler: 3 tests passed.
- Real Apple Silicon UI smoke: fresh profile, bundled local KataGo, SGF load, candidates, win-rate and score curves.
- Release publisher tests: 22 passed.
- `git diff --check` and Markdown link checks passed.