### PR TITLE
Fix Xcode 16 macOS KataGo packaging

### DIFF
--- a/scripts/macos_katago_bundle.py
+++ b/scripts/macos_katago_bundle.py
@@ -192,12 +192,34 @@ def portable_reference(node: BinaryNode, bundled_name: str) -> str:
     return f"@loader_path/{bundled_name}"
 
 
-def remove_signature(path: Path) -> None:
-    run(["codesign", "--remove-signature", str(path)], check=False)
-
-
 def sign_ad_hoc(path: Path) -> None:
     run(["codesign", "--force", "--sign", "-", str(path)])
+
+
+def rewrite_binary(node: BinaryNode) -> None:
+    # Do not remove the existing signature first. Xcode 16's install_name_tool
+    # rejects some current Homebrew abseil binaries after --remove-signature
+    # because their __LINKEDIT layout no longer fills the segment. Rewriting
+    # invalidates the old signature safely; the bundle is force-signed below.
+    for edge in node.edges:
+        run(
+            [
+                "install_name_tool",
+                "-change",
+                edge.original,
+                portable_reference(node, edge.bundled_name),
+                str(node.target),
+            ]
+        )
+    if not node.executable:
+        run(
+            [
+                "install_name_tool",
+                "-id",
+                f"@loader_path/{node.target.name}",
+                str(node.target),
+            ]
+        )
 
 
 def build_bundle(
@@ -271,26 +293,7 @@ def build_bundle(
             pending.append(resolved)
 
     for node in nodes.values():
-        remove_signature(node.target)
-        for edge in node.edges:
-            run(
-                [
-                    "install_name_tool",
-                    "-change",
-                    edge.original,
-                    portable_reference(node, edge.bundled_name),
-                    str(node.target),
-                ]
-            )
-        if not node.executable:
-            run(
-                [
-                    "install_name_tool",
-                    "-id",
-                    f"@loader_path/{node.target.name}",
-                    str(node.target),
-                ]
-            )
+        rewrite_binary(node)
 
     for node in nodes.values():
         if not node.executable:

--- a/scripts/test_macos_katago_bundle.py
+++ b/scripts/test_macos_katago_bundle.py
@@ -10,6 +10,7 @@ import subprocess
 import sys
 import tempfile
 import unittest
+from unittest import mock
 from pathlib import Path
 
 
@@ -51,6 +52,52 @@ class MacosKataGoBundleUnitTest(unittest.TestCase):
                 "/usr/lib/libc++.1.dylib",
                 "/opt/homebrew/opt/protobuf/lib/libprotobuf.35.1.0.dylib",
             ],
+        )
+
+    def test_rewrite_keeps_signature_until_install_names_are_updated(self) -> None:
+        target = Path("/bundle/lib/libexample.dylib")
+        node = MODULE.BinaryNode(
+            source=Path("/source/libexample.dylib"),
+            target=target,
+            executable=False,
+            edges=[
+                MODULE.DependencyEdge(
+                    original="@rpath/libdependency.dylib",
+                    source=Path("/source/libdependency.dylib"),
+                    bundled_name="libdependency.dylib",
+                )
+            ],
+        )
+        commands: list[list[str]] = []
+
+        def record(command: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
+            commands.append(command)
+            return subprocess.CompletedProcess(command, 0, "", "")
+
+        with mock.patch.object(MODULE, "run", side_effect=record):
+            MODULE.rewrite_binary(node)
+
+        self.assertEqual(
+            commands,
+            [
+                [
+                    "install_name_tool",
+                    "-change",
+                    "@rpath/libdependency.dylib",
+                    "@loader_path/libdependency.dylib",
+                    str(target),
+                ],
+                [
+                    "install_name_tool",
+                    "-id",
+                    "@loader_path/libexample.dylib",
+                    str(target),
+                ],
+            ],
+        )
+        self.assertFalse(
+            any("--remove-signature" in command for command in commands),
+            "Removing a signature before rewriting regresses Xcode 16 compatibility",
         )
 
 
@@ -123,6 +170,11 @@ class MacosKataGoBundleIntegrationTest(unittest.TestCase):
                 ["clang", str(main_source), str(middle), "-o", str(executable)],
                 check=True,
             )
+            for binary in (leaf, middle, executable):
+                subprocess.run(
+                    ["codesign", "--force", "--sign", "-", str(binary)],
+                    check=True,
+                )
 
             subprocess.run(
                 [


### PR DESCRIPTION
## Summary

- keeps existing Mach-O signatures in place while rewriting bundled KataGo install names, then force-signs the completed dependency graph
- avoids the Xcode 16 `__LINKEDIT` failure seen with current Homebrew abseil 2601 libraries
- adds regression coverage for signed binaries and the exact rewrite sequence

## Validation

- `python3 scripts/test_macos_katago_bundle.py`: 4 passed
- real Homebrew KataGo bundle: 84 dylibs, KataGo v1.16.5 Metal backend, bundle verification passed
- `mvn -B -Dfmt.skip=true test`: 1529 passed
- `git diff --check`: passed

## Release impact

This fixes the macOS arm64 and amd64 packaging failure that correctly stopped the draft `next-2026-07-24.1` pre-release from being published. A fresh release request will use a new tag after this PR passes CI.