### PR TITLE
Request next-2026-07-24.2 pre-release

### DIFF
--- a/.github/release-notes/next-2026-07-24.2.md
+++ b/.github/release-notes/next-2026-07-24.2.md
@@ -1,0 +1,293 @@
+# LizzieYzy Next next-2026-07-24.2
+
+## 中文
+
+这是 `next-2026-07-22.2` 之后的稳定性预览版，重点完善整盘精析，并修复 macOS 本地 KataGo 与 Windows NVIDIA OpenCL 的关键启动问题。
+
+### 本版主要更新
+
+- 新增“整盘精析（推荐）”：先用 32 visits 快速补齐整盘曲线，再把主线逐手深入到至少 500 visits。
+- 支持真实进度、预计剩余时间、隐藏后恢复、取消及保留部分结果；分析时仍可自由看棋和跳转。
+- 同时支持本地 KataGo 与智子等远程 GTP 引擎；复用已完成节点，并拒绝棋谱或规则变化后的迟到结果。
+- 修复 macOS KataGo 打包，完整内置 protobuf、abseil 等动态库并移除 Homebrew 路径依赖；兼容 Xcode 16 对当前动态库签名布局的严格检查。
+- 修复 Windows NVIDIA OpenCL 可能发生的 `0xC0000409` 原生退出，以隔离调优缓存安全恢复并继续使用 NVIDIA GPU。
+
+### 下载前先看这几句
+
+- 完整包内置 KataGo `v1.16.5` 和默认智子 28B 权重。
+- macOS 用户请重新下载对应芯片的完整 DMG；小更新无法补齐旧包缺失的动态库。
+- Windows 普通用户优先下载 OpenCL 免安装版；RTX 20/30/40 可选 NVIDIA 包，RTX 50 可选 CUDA 12.8 包。
+- 已有 Windows 免安装版可使用小更新包，配置、棋谱、自定义权重和 TensorRT 文件会保留。
+- 这是 Pre-release，适合提前验证整盘精析与多平台引擎稳定性。
+
+### 下载建议
+
+| 你的电脑 | 直接下载这个 |
+| --- | --- |
+| Windows OpenCL 推荐版，免安装 / 安装器 | [portable][win-opencl-portable] / [installer][win-opencl-installer] |
+| 已有 Windows 免安装版，日常小更新 | [core update][win-core-update] |
+| Windows CPU 兼容版，免安装 / 安装器 | [portable][win-cpu-portable] / [installer][win-cpu-installer] |
+| Windows NVIDIA RTX 20/30/40，免安装 / 安装器 | [portable][win-nvidia-portable] / [installer][win-nvidia-installer] |
+| Windows RTX 50 CUDA，免安装 / 安装器 | [portable][win-nvidia50-portable] / [installer][win-nvidia50-installer] |
+| 高级可选 TensorRT 分卷包 | [下载与解压说明][win-tensorrt-readme] |
+| Windows 自行配置引擎，免安装 / 安装器 | [portable][win-no-engine-portable] / [installer][win-no-engine-installer] |
+| macOS Apple Silicon / Intel | [Apple Silicon][mac-arm64] / [Intel][mac-intel] |
+| Linux CPU / OpenCL / NVIDIA CUDA | [CPU][linux-cpu] / [OpenCL][linux-opencl] / [NVIDIA][linux-nvidia] |
+
+### 这一版为什么值得测试
+
+- 整盘曲线会先快速出现，再在后台逐手加深，不阻塞棋谱操作。
+- macOS 发布流程会挂载最终 DMG，检查签名、依赖闭包并实际运行 `katago version`。
+- 合并版本通过 1529 项完整测试、4 项 macOS 动态库专项测试、真实 84 个动态库的 KataGo Metal 打包验证，以及 Apple Silicon 加载棋谱与本地分析冒烟。
+
+### 交流
+
+- QQ 群：`299419120`
+
+---
+
+## 繁體中文
+
+這是 `next-2026-07-22.2` 之後的穩定性預覽版，重點完善整盤精析，並修正 macOS 本機 KataGo 與 Windows NVIDIA OpenCL 的重要啟動問題。
+
+### 本版主要更新
+
+- 新增「整盤精析（推薦）」：先以 32 visits 快速補齊整盤曲線，再把主線逐手深入到至少 500 visits。
+- 支援真實進度、預計剩餘時間、隱藏後恢復、取消及保留部分結果；分析時仍可自由看棋和跳轉。
+- 同時支援本機 KataGo 與智子等遠端 GTP 引擎；重用完成節點，並拒絕棋譜或規則改變後的過期結果。
+- 修正 macOS KataGo 打包，完整內建 protobuf、abseil 等動態庫並移除 Homebrew 路徑；相容 Xcode 16 對目前簽章配置的嚴格檢查。
+- 修正 Windows NVIDIA OpenCL 可能發生的 `0xC0000409` 原生退出，以隔離調校快取安全恢復並繼續使用 NVIDIA GPU。
+
+### 下載前先看這幾句
+
+- 完整套件內建 KataGo `v1.16.5` 與預設智子 28B 權重。
+- macOS 使用者請重新下載對應晶片的完整 DMG；小型更新無法補齊舊套件缺少的動態庫。
+- Windows 一般使用者優先選 OpenCL portable；NVIDIA 使用者依顯示卡世代選一般 NVIDIA 或 RTX 50 CUDA 套件。
+- 舊 Windows portable 可使用小型更新，並保留設定、棋譜、自訂權重與 TensorRT。
+- 這是 Pre-release，適合提前驗證整盤精析與多平台引擎穩定性。
+
+### 下載建議
+
+| 你的電腦 | 直接下載這個 |
+| --- | --- |
+| Windows OpenCL 推薦版，免安裝 / 安裝器 | [portable][win-opencl-portable] / [installer][win-opencl-installer] |
+| 舊 Windows 免安裝版，小型更新 | [core update][win-core-update] |
+| Windows CPU 相容版，免安裝 / 安裝器 | [portable][win-cpu-portable] / [installer][win-cpu-installer] |
+| Windows NVIDIA RTX 20/30/40，免安裝 / 安裝器 | [portable][win-nvidia-portable] / [installer][win-nvidia-installer] |
+| Windows RTX 50 CUDA，免安裝 / 安裝器 | [portable][win-nvidia50-portable] / [installer][win-nvidia50-installer] |
+| 進階 TensorRT 分卷套件 | [下載與解壓說明][win-tensorrt-readme] |
+| Windows 自行設定引擎，免安裝 / 安裝器 | [portable][win-no-engine-portable] / [installer][win-no-engine-installer] |
+| macOS Apple Silicon / Intel | [Apple Silicon][mac-arm64] / [Intel][mac-intel] |
+| Linux CPU / OpenCL / NVIDIA CUDA | [CPU][linux-cpu] / [OpenCL][linux-opencl] / [NVIDIA][linux-nvidia] |
+
+### 這一版為什麼值得測試
+
+- 整盤曲線會先快速出現，再於背景逐手加深，不會阻塞棋譜操作。
+- macOS 發布流程會掛載最終 DMG，檢查簽章、依賴閉包並實際執行 `katago version`。
+- 合併版本通過 1529 項完整測試、4 項 macOS 動態庫專項測試、真實 84 個動態庫的 KataGo Metal 打包驗證，以及 Apple Silicon 載入棋譜與本機分析冒煙。
+
+### 交流
+
+- QQ 群：`299419120`
+
+---
+
+## English
+
+This stability preview follows `next-2026-07-22.2`. It completes Whole-game Deep Analysis and fixes critical local KataGo startup issues on macOS and NVIDIA OpenCL native exits on Windows.
+
+### Release Highlights
+
+- Adds Whole-game Deep Analysis: a 32-visit pass fills the complete curve first, then every main-line position is deepened to at least 500 visits.
+- Provides real progress, ETA, hide and restore, cancellation, and retained partial results while keeping game navigation responsive.
+- Supports local KataGo and remote GTP engines such as Zhizi, reuses completed nodes, and rejects stale results after game or rules changes.
+- Fixes macOS KataGo packaging by bundling protobuf, abseil, and all other non-system dylibs without Homebrew paths, including Xcode 16 signature-layout compatibility.
+- Fixes possible Windows NVIDIA OpenCL native exit `0xC0000409` with isolated tuning-cache recovery while continuing to use the NVIDIA GPU.
+
+### Read Before Downloading
+
+- Full bundles include KataGo `v1.16.5` and the default Zhizi 28B model.
+- macOS users should download the complete DMG for their processor; a core update cannot restore dylibs missing from an older package.
+- Most Windows users should choose OpenCL portable. NVIDIA users can select the standard NVIDIA or RTX 50 CUDA build for their GPU generation.
+- Existing Windows portable users can use the small core update while keeping settings, games, custom weights, and TensorRT files.
+- This is a Pre-release for early validation of deep analysis and cross-platform engine reliability.
+
+### Download Guide
+
+| Your computer | Download |
+| --- | --- |
+| Windows OpenCL recommended, portable / installer | [portable][win-opencl-portable] / [installer][win-opencl-installer] |
+| Existing Windows portable, small update | [core update][win-core-update] |
+| Windows CPU compatible, portable / installer | [portable][win-cpu-portable] / [installer][win-cpu-installer] |
+| Windows NVIDIA RTX 20/30/40, portable / installer | [portable][win-nvidia-portable] / [installer][win-nvidia-installer] |
+| Windows RTX 50 CUDA, portable / installer | [portable][win-nvidia50-portable] / [installer][win-nvidia50-installer] |
+| Advanced optional TensorRT split package | [download instructions][win-tensorrt-readme] |
+| Windows, configure your own engine | [portable][win-no-engine-portable] / [installer][win-no-engine-installer] |
+| macOS Apple Silicon / Intel | [Apple Silicon][mac-arm64] / [Intel][mac-intel] |
+| Linux CPU / OpenCL / NVIDIA CUDA | [CPU][linux-cpu] / [OpenCL][linux-opencl] / [NVIDIA][linux-nvidia] |
+
+### Why Test This Release
+
+- The complete curve appears first and positions deepen in the background without locking game navigation.
+- The macOS release gate mounts the final DMG, audits signatures and dependency closure, and runs `katago version`.
+- The merged build passed all 1529 tests, 4 macOS dylib tests, a real 84-library KataGo Metal bundle verification, and an Apple Silicon SGF plus local-analysis smoke test.
+
+### Contact
+
+- QQ group: `299419120`
+
+---
+
+## 日本語
+
+`next-2026-07-22.2` 以降の安定性 preview です。Whole-game Deep Analysis を完成し、macOS の local KataGo 起動と Windows NVIDIA OpenCL native exit の重要問題を修正しました。
+
+### 主な更新
+
+- Whole-game Deep Analysis を追加しました。まず 32 visits で全体 curve を埋め、その後 main line の各局面を 500 visits 以上まで深掘りします。
+- 実際の progress、残り時間、hide/restore、cancel、途中結果保持に対応し、分析中も棋譜操作を妨げません。
+- local KataGo と Zhizi などの remote GTP engine に対応し、完了 node を再利用し、棋譜や rules 変更後の古い結果を拒否します。
+- macOS package に protobuf、abseil など全 non-system dylib を含め、Homebrew path を除去し、Xcode 16 の signature layout 検査にも対応しました。
+- Windows NVIDIA OpenCL の `0xC0000409` native exit を isolated tuning cache で安全に復旧し、NVIDIA GPU の使用を継続します。
+
+### ダウンロード前に
+
+- full bundle は KataGo `v1.16.5` と既定 Zhizi 28B model を含みます。
+- macOS は CPU に合う complete DMG を再ダウンロードしてください。core update だけでは旧 package の不足 dylib を補えません。
+- Windows は通常 OpenCL portable、NVIDIA は GPU 世代に合う NVIDIA または RTX 50 CUDA build を選択してください。
+- 既存 Windows portable は small core update を利用でき、設定、棋譜、custom weight、TensorRT を保持します。
+- deep analysis と cross-platform engine の安定性を先行確認する Pre-release です。
+
+### ダウンロード案内
+
+| 環境 | ダウンロード |
+| --- | --- |
+| Windows OpenCL portable / installer | [portable][win-opencl-portable] / [installer][win-opencl-installer] |
+| Windows portable 小型更新 | [core update][win-core-update] |
+| Windows CPU portable / installer | [portable][win-cpu-portable] / [installer][win-cpu-installer] |
+| Windows NVIDIA portable / installer | [portable][win-nvidia-portable] / [installer][win-nvidia-installer] |
+| Windows RTX 50 CUDA portable / installer | [portable][win-nvidia50-portable] / [installer][win-nvidia50-installer] |
+| TensorRT split package | [README][win-tensorrt-readme] |
+| Windows no-engine portable / installer | [portable][win-no-engine-portable] / [installer][win-no-engine-installer] |
+| macOS Apple Silicon / Intel | [Apple Silicon][mac-arm64] / [Intel][mac-intel] |
+| Linux CPU / OpenCL / NVIDIA | [CPU][linux-cpu] / [OpenCL][linux-opencl] / [NVIDIA][linux-nvidia] |
+
+### このリリースを試す理由
+
+- まず完全な curve を表示し、その後 background で深掘りするため、分析中も棋譜を操作できます。
+- macOS release gate は最終 DMG を mount し、signature、dependency closure、`katago version` を検証します。
+- 1529 tests、4 macOS dylib tests、84 libraries の real KataGo Metal bundle 検証、Apple Silicon の SGF + local analysis smoke に合格しました。
+
+### 連絡先
+
+- QQ group: `299419120`
+
+---
+
+## 한국어
+
+`next-2026-07-22.2` 이후의 안정성 preview입니다. Whole-game Deep Analysis를 완성하고 macOS local KataGo 시작과 Windows NVIDIA OpenCL native exit의 핵심 문제를 수정했습니다.
+
+### 주요 업데이트
+
+- Whole-game Deep Analysis를 추가했습니다. 먼저 32 visits로 전체 curve를 채운 뒤 main line 각 국면을 최소 500 visits까지 심화합니다.
+- 실제 progress, 남은 시간, hide/restore, cancel, 부분 결과 보존을 지원하며 분석 중에도 기보 탐색을 막지 않습니다.
+- local KataGo와 Zhizi 같은 remote GTP engine을 지원하고 완료 node를 재사용하며 게임이나 rules 변경 뒤 도착한 오래된 결과를 거부합니다.
+- macOS package에 protobuf, abseil 등 모든 non-system dylib를 포함하고 Homebrew path를 제거했으며 Xcode 16 signature-layout 검사에도 대응했습니다.
+- Windows NVIDIA OpenCL `0xC0000409` native exit를 isolated tuning cache로 안전하게 복구하면서 NVIDIA GPU 사용을 유지합니다.
+
+### 다운로드 전 확인
+
+- full bundle은 KataGo `v1.16.5`와 기본 Zhizi 28B model을 포함합니다.
+- macOS 사용자는 CPU에 맞는 complete DMG를 다시 받으세요. core update만으로 예전 package에 빠진 dylib를 복구할 수 없습니다.
+- Windows 일반 사용자는 OpenCL portable, NVIDIA 사용자는 GPU 세대에 맞는 NVIDIA 또는 RTX 50 CUDA build를 선택하세요.
+- 기존 Windows portable은 small core update를 사용하며 설정, 기보, custom weight, TensorRT를 유지할 수 있습니다.
+- deep analysis와 cross-platform engine 안정성을 먼저 검증하는 Pre-release입니다.
+
+### 다운로드 안내
+
+| 환경 | 다운로드 |
+| --- | --- |
+| Windows OpenCL portable / installer | [portable][win-opencl-portable] / [installer][win-opencl-installer] |
+| Windows portable 소형 업데이트 | [core update][win-core-update] |
+| Windows CPU portable / installer | [portable][win-cpu-portable] / [installer][win-cpu-installer] |
+| Windows NVIDIA portable / installer | [portable][win-nvidia-portable] / [installer][win-nvidia-installer] |
+| Windows RTX 50 CUDA portable / installer | [portable][win-nvidia50-portable] / [installer][win-nvidia50-installer] |
+| TensorRT split package | [README][win-tensorrt-readme] |
+| Windows no-engine portable / installer | [portable][win-no-engine-portable] / [installer][win-no-engine-installer] |
+| macOS Apple Silicon / Intel | [Apple Silicon][mac-arm64] / [Intel][mac-intel] |
+| Linux CPU / OpenCL / NVIDIA | [CPU][linux-cpu] / [OpenCL][linux-opencl] / [NVIDIA][linux-nvidia] |
+
+### 이 릴리스를 테스트할 이유
+
+- 전체 curve를 먼저 표시한 뒤 background에서 심화하므로 분석 중에도 기보를 조작할 수 있습니다.
+- macOS release gate는 최종 DMG를 mount해 signature, dependency closure, `katago version`을 검증합니다.
+- 1529 tests, 4 macOS dylib tests, 84-library real KataGo Metal bundle 검증, Apple Silicon SGF + local analysis smoke를 통과했습니다.
+
+### 연락처
+
+- QQ 그룹: `299419120`
+
+---
+
+## ภาษาไทย
+
+นี่คือ Pre-release ด้านความเสถียรต่อจาก `next-2026-07-22.2` ซึ่งทำ Whole-game Deep Analysis ให้สมบูรณ์ และแก้ปัญหาสำคัญของ local KataGo บน macOS กับ NVIDIA OpenCL native exit บน Windows
+
+### ไฮไลต์ของเวอร์ชันนี้
+
+- เพิ่ม Whole-game Deep Analysis โดยเริ่มด้วย 32 visits เพื่อเติม curve ทั้งเกม จากนั้นวิเคราะห์ main line แต่ละจุดอย่างน้อย 500 visits
+- รองรับ progress จริง เวลาคงเหลือ hide/restore การยกเลิก และเก็บผลบางส่วน โดยยังเลื่อนดูเกมได้ระหว่างวิเคราะห์
+- รองรับ local KataGo และ remote GTP เช่น Zhizi, reuse node ที่เสร็จแล้ว และปฏิเสธผลเก่าหลัง game หรือ rules เปลี่ยน
+- แพ็ก macOS รวม non-system dylib ทั้งหมด เช่น protobuf และ abseil โดยไม่มี Homebrew path และรองรับการตรวจ signature layout ที่เข้มงวดของ Xcode 16
+- แก้ Windows NVIDIA OpenCL native exit `0xC0000409` ด้วย isolated tuning cache โดยยังคงใช้ NVIDIA GPU
+
+### ก่อนดาวน์โหลด
+
+- full bundle รวม KataGo `v1.16.5` และ Zhizi 28B model เริ่มต้น
+- ผู้ใช้ macOS ควรดาวน์โหลด complete DMG ตามชนิด CPU ใหม่ เพราะ core update ไม่สามารถเติม dylib ที่ขาดใน package เก่าได้
+- ผู้ใช้ Windows ทั่วไปเลือก OpenCL portable ส่วน NVIDIA เลือก NVIDIA หรือ RTX 50 CUDA build ตามรุ่น GPU
+- portable เดิมบน Windows ใช้ small core update ได้ โดยเก็บ settings, game records, custom weights และ TensorRT ไว้
+- นี่คือ Pre-release สำหรับทดสอบ deep analysis และความเสถียรของ engine ทุก platform
+
+### คำแนะนำดาวน์โหลด
+
+| คอมพิวเตอร์ของคุณ | ดาวน์โหลด |
+| --- | --- |
+| Windows OpenCL portable / installer | [portable][win-opencl-portable] / [installer][win-opencl-installer] |
+| Windows portable อัปเดตขนาดเล็ก | [core update][win-core-update] |
+| Windows CPU portable / installer | [portable][win-cpu-portable] / [installer][win-cpu-installer] |
+| Windows NVIDIA portable / installer | [portable][win-nvidia-portable] / [installer][win-nvidia-installer] |
+| Windows RTX 50 CUDA portable / installer | [portable][win-nvidia50-portable] / [installer][win-nvidia50-installer] |
+| TensorRT split package | [README][win-tensorrt-readme] |
+| Windows no-engine portable / installer | [portable][win-no-engine-portable] / [installer][win-no-engine-installer] |
+| macOS Apple Silicon / Intel | [Apple Silicon][mac-arm64] / [Intel][mac-intel] |
+| Linux CPU / OpenCL / NVIDIA | [CPU][linux-cpu] / [OpenCL][linux-opencl] / [NVIDIA][linux-nvidia] |
+
+### ทำไมควรทดสอบเวอร์ชันนี้
+
+- แสดง curve ทั้งเกมก่อน แล้ววิเคราะห์ลึกต่อใน background โดยไม่ล็อกการเลื่อนดูเกม
+- macOS release gate mount DMG จริง ตรวจ signature, dependency closure และรัน `katago version`
+- ผ่าน 1529 tests, 4 macOS dylib tests, การตรวจ real KataGo Metal bundle ที่มี 84 libraries และ Apple Silicon SGF + local analysis smoke
+
+### ติดต่อ
+
+- QQ group: `299419120`
+
+[win-opencl-portable]: https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-24.2/2026-07-24-windows64.opencl.portable.zip
+[win-core-update]: https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-24.2/2026-07-24-windows64.core-update.zip
+[win-opencl-installer]: https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-24.2/2026-07-24-windows64.opencl.installer.exe
+[win-cpu-portable]: https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-24.2/2026-07-24-windows64.with-katago.portable.zip
+[win-cpu-installer]: https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-24.2/2026-07-24-windows64.with-katago.installer.exe
+[win-nvidia-portable]: https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-24.2/2026-07-24-windows64.nvidia.portable.zip
+[win-nvidia-installer]: https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-24.2/2026-07-24-windows64.nvidia.installer.exe
+[win-nvidia50-portable]: https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-24.2/2026-07-24-windows64.nvidia50.cuda.portable.zip
+[win-nvidia50-installer]: https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-24.2/2026-07-24-windows64.nvidia50.cuda.installer.exe
+[win-tensorrt-readme]: https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-24.2/2026-07-24-windows64.nvidia.tensorrt.portable.README.txt
+[win-no-engine-portable]: https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-24.2/2026-07-24-windows64.without.engine.portable.zip
+[win-no-engine-installer]: https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-24.2/2026-07-24-windows64.without.engine.installer.exe
+[mac-arm64]: https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-24.2/2026-07-24-mac-apple-silicon.with-katago.dmg
+[mac-intel]: https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-24.2/2026-07-24-mac-intel.with-katago.dmg
+[linux-cpu]: https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-24.2/2026-07-24-linux64.with-katago.zip
+[linux-opencl]: https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-24.2/2026-07-24-linux64.opencl.zip
+[linux-nvidia]: https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-24.2/2026-07-24-linux64.nvidia.zip

--- a/.github/release-requests/next-2026-07-24.2.json
+++ b/.github/release-requests/next-2026-07-24.2.json
@@ -1,0 +1,7 @@
+{
+  "date_tag": "2026-07-24",
+  "release_tag": "next-2026-07-24.2",
+  "title": "LizzieYzy Next next-2026-07-24.2",
+  "prerelease": true,
+  "notes_file": ".github/release-notes/next-2026-07-24.2.md"
+}


### PR DESCRIPTION
## Summary

- requests the replacement `next-2026-07-24.2` pre-release from the fixed `main` commit
- documents Whole-game Deep Analysis, macOS local KataGo packaging, and Windows NVIDIA OpenCL recovery
- keeps six languages in the same five-section structure with tag-specific asset links

## Validation

- 22 release publisher and notes-generator tests passed
- release notes contain 6 languages and 30 subsections
- Markdown link validation passed
- `git diff --check` passed

## Publishing safety

The earlier `.1` request correctly remained unpublished after macOS CI failed. This new tag will be published only if Windows, Linux, macOS Intel, and macOS Apple Silicon workflows all pass and the expected assets are verified.