### PR TITLE
Fix ReadBoard autoplay restore race

### DIFF
--- a/src/main/java/featurecat/lizzie/analysis/ReadBoard.java
+++ b/src/main/java/featurecat/lizzie/analysis/ReadBoard.java
@@ -165,7 +165,7 @@ public class ReadBoard {
   private int readBoardGmaMaxVisits = 0;
   private volatile boolean readBoardGmaPending = false;
   private boolean readBoardGmaPendingLogicallyInvalid = false;
-  private boolean readBoardGmaAwaitingSyncedBoard = false;
+  private volatile boolean readBoardGmaAwaitingSyncedBoard = false;
   private volatile boolean readBoardGmaEngineRestorePending = false;
   private volatile boolean readBoardGmaEngineRestoreInProgress = false;
   private volatile BoardHistoryNode readBoardGmaDeferredRestoreNode = null;
@@ -3909,7 +3909,11 @@ public class ReadBoard {
     if (hasNewerRestoreNode) {
       return flushReadBoardGmaEngineRestoreIfReady(reason + "-latest");
     }
-    if (!readBoardGmaAutoPlayActive && Lizzie.leelaz != null) {
+    if (readBoardGmaAutoPlayActive) {
+      if (!readBoardGmaAwaitingSyncedBoard) {
+        scheduleReadBoardGmaIfNeeded(reason + "-restore-complete");
+      }
+    } else if (Lizzie.leelaz != null) {
       Lizzie.leelaz.restoreReadBoardGmaRuntimeSettingsIfNeeded();
     }
     return true;

--- a/src/test/java/featurecat/lizzie/analysis/ReadBoardEngineResumeTest.java
+++ b/src/test/java/featurecat/lizzie/analysis/ReadBoardEngineResumeTest.java
@@ -1560,12 +1560,20 @@ class ReadBoardEngineResumeTest {
 
       assertTrue(harness.readBoard.handleReadBoardGmaEnginePlay("pass"));
       harness.leelaz.isThinking = false;
+      harness.leelaz.blockNextLoadSgf();
       harness.readBoard.afterReadBoardGmaTerminalResponseConsumed("first-move");
-      assertTrue(waitForSentCommandPrefix(harness.leelaz, "loadsgf "));
+      assertTrue(harness.leelaz.awaitBlockedLoadSgf());
       harness.sync(snapshot(emptyStones(), Optional.empty(), Stone.EMPTY));
+      assertEquals(
+          1,
+          harness.leelaz.readBoardGmaCount,
+          "the next GMA request must wait until the exact engine restore has completed");
+      harness.leelaz.releaseBlockedLoadSgf();
 
       assertEquals(1, harness.frame.readBoardPonderingNoticeCount);
-      assertEquals(2, harness.leelaz.readBoardGmaCount);
+      assertTrue(
+          waitForReadBoardGmaCount(harness.leelaz, 2),
+          "the completed restore must resume GMA after the synced board arrived during loadsgf");
     }
   }
 
@@ -1987,6 +1995,17 @@ class ReadBoardEngineResumeTest {
     return false;
   }
 
+  private static boolean waitForReadBoardGmaCount(
+      SnapshotTrackingLeelaz leelaz, int expectedCount) throws InterruptedException {
+    for (int attempt = 0; attempt < 100; attempt++) {
+      if (leelaz.readBoardGmaCount >= expectedCount) {
+        return true;
+      }
+      Thread.sleep(10);
+    }
+    return false;
+  }
+
   private static final class EngineResumeHarness implements AutoCloseable {
     private final Config previousConfig;
     private final Board previousBoard;
@@ -2098,6 +2117,7 @@ class ReadBoardEngineResumeTest {
 
     @Override
     public void close() {
+      leelaz.releaseBlockedLoadSgf();
       Lizzie.config = previousConfig;
       Lizzie.board = previousBoard;
       Lizzie.leelaz = previousLeelaz;

--- a/src/test/java/featurecat/lizzie/analysis/SnapshotTrackingLeelaz.java
+++ b/src/test/java/featurecat/lizzie/analysis/SnapshotTrackingLeelaz.java
@@ -10,6 +10,8 @@ import java.nio.file.Path;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -23,7 +25,7 @@ class SnapshotTrackingLeelaz extends Leelaz {
   int togglePonderCount;
   int nameCmdCount;
   int genmoveCount;
-  int readBoardGmaCount;
+  volatile int readBoardGmaCount;
   boolean rejectReadBoardGma;
   String lastGenmoveColor;
   String lastReadBoardGmaColor;
@@ -35,6 +37,8 @@ class SnapshotTrackingLeelaz extends Leelaz {
   private Stone[] stones;
   private boolean blackToPlay = true;
   private Path lastLoadedSgf;
+  private volatile CountDownLatch blockedLoadSgfStarted;
+  private volatile CountDownLatch blockedLoadSgfRelease;
 
   private SnapshotTrackingLeelaz() throws IOException {
     super("");
@@ -206,7 +210,25 @@ class SnapshotTrackingLeelaz extends Leelaz {
   @Override
   public void loadSgf(Path sgfFile) {
     recordedCommands().add("loadsgf " + sgfFile.toAbsolutePath());
+    waitForBlockedLoadSgfRelease();
     restoreSnapshotSgf(sgfFile);
+  }
+
+  void blockNextLoadSgf() {
+    blockedLoadSgfStarted = new CountDownLatch(1);
+    blockedLoadSgfRelease = new CountDownLatch(1);
+  }
+
+  boolean awaitBlockedLoadSgf() throws InterruptedException {
+    CountDownLatch started = blockedLoadSgfStarted;
+    return started != null && started.await(2, TimeUnit.SECONDS);
+  }
+
+  void releaseBlockedLoadSgf() {
+    CountDownLatch release = blockedLoadSgfRelease;
+    if (release != null) {
+      release.countDown();
+    }
   }
 
   Stone[] copyStones() {
@@ -219,6 +241,28 @@ class SnapshotTrackingLeelaz extends Leelaz {
 
   Path lastLoadedSgf() {
     return lastLoadedSgf;
+  }
+
+  private void waitForBlockedLoadSgfRelease() {
+    CountDownLatch started = blockedLoadSgfStarted;
+    CountDownLatch release = blockedLoadSgfRelease;
+    if (started == null || release == null) {
+      return;
+    }
+    started.countDown();
+    try {
+      if (!release.await(5, TimeUnit.SECONDS)) {
+        throw new IllegalStateException("Timed out waiting to release blocked loadsgf fixture");
+      }
+    } catch (InterruptedException ex) {
+      Thread.currentThread().interrupt();
+      throw new IllegalStateException("Interrupted while blocking loadsgf fixture", ex);
+    } finally {
+      if (blockedLoadSgfStarted == started) {
+        blockedLoadSgfStarted = null;
+        blockedLoadSgfRelease = null;
+      }
+    }
   }
 
   private List<String> recordedCommands() {


### PR DESCRIPTION
## Summary

- resumes ReadBoard GMA autoplay when a synchronized board arrives while exact engine restoration is still running
- makes the synchronized-board gate visible across the restore and synchronization threads
- adds a deterministic regression test that pauses `loadsgf` to force the previously failing interleaving

## User impact

ReadBoard engine autoplay no longer stops after a pass or terminal result when board synchronization happens during the engine restore window.

## Validation

- deterministic race regression: 20 consecutive passes
- `ReadBoardEngineResumeTest`: 64/64 passed
- `mvn -B -Dfmt.skip=true test`: 1529/1529 passed
- `mvn -B -Dfmt.skip=true -DskipTests package`: passed
- `git diff --check`: passed

`fmt:check` still reports the repository-wide pre-existing formatting baseline (126 files); the same two touched legacy files were already reported before this change.