### PR TITLE
Request next-2026-07-26.1 pre-release

### DIFF
--- a/.github/release-notes/next-2026-07-26.1.md
+++ b/.github/release-notes/next-2026-07-26.1.md
@@ -1,0 +1,293 @@
+# LizzieYzy Next next-2026-07-26.1
+
+## 中文
+
+这是 `next-2026-07-24.3` 之后的安装体验与稳定性预览版，重点重做 macOS 拖拽安装界面，并加强 Windows TensorRT 分离运行库的回归保障。
+
+### 本版主要更新
+
+- macOS DMG 改为品牌化拖拽安装界面，清楚展示应用、Applications 文件夹、拖拽箭头和中英双语安装提示。
+- Apple Silicon 与 Intel 安装包继续明确区分芯片类型，并在安装画面显示对应标识，降低下载错误版本的概率。
+- 正式构建会验证 DMG 背景、Finder 布局、Applications 链接和最终镜像结构；布局失败时直接终止发布，不再退回空白安装界面。
+- 签名、公证和最终 DMG 重建继续复用同一安装背景与布局，避免发布资产在最后阶段丢失拖拽提示。
+- 为 Windows 免安装目录含空格、TensorRT 引擎与 NVIDIA 运行库分开存放的场景增加精确回归测试，运行库无需重复复制到引擎目录。
+
+### 下载前先看这几句
+
+- macOS 用户必须下载对应芯片的完整 DMG，才能获得新的拖拽安装界面；请拖入“应用程序”后弹出镜像，再从“应用程序”启动。
+- 完整包继续内置 KataGo `v1.16.5` 和默认智子 28B 权重。
+- Windows 普通用户优先下载 OpenCL 免安装版；RTX 20/30/40 可选 NVIDIA 包，RTX 50 可选 CUDA 12.8 包。
+- 已有 Windows 免安装版可使用小更新包，配置、棋谱、自定义权重和 TensorRT 文件会保留。
+- 这是 Pre-release，适合提前验证新版 macOS 安装流程和多平台稳定性。
+
+### 下载建议
+
+| 你的电脑 | 直接下载这个 |
+| --- | --- |
+| Windows OpenCL 推荐版，免安装 / 安装器 | [portable][win-opencl-portable] / [installer][win-opencl-installer] |
+| 已有 Windows 免安装版，日常小更新 | [core update][win-core-update] |
+| Windows CPU 兼容版，免安装 / 安装器 | [portable][win-cpu-portable] / [installer][win-cpu-installer] |
+| Windows NVIDIA RTX 20/30/40，免安装 / 安装器 | [portable][win-nvidia-portable] / [installer][win-nvidia-installer] |
+| Windows RTX 50 CUDA，免安装 / 安装器 | [portable][win-nvidia50-portable] / [installer][win-nvidia50-installer] |
+| 高级可选 TensorRT 分卷包 | [下载与解压说明][win-tensorrt-readme] |
+| Windows 自行配置引擎，免安装 / 安装器 | [portable][win-no-engine-portable] / [installer][win-no-engine-installer] |
+| macOS Apple Silicon / Intel | [Apple Silicon][mac-arm64] / [Intel][mac-intel] |
+| Linux CPU / OpenCL / NVIDIA CUDA | [CPU][linux-cpu] / [OpenCL][linux-opencl] / [NVIDIA][linux-nvidia] |
+
+### 这一版为什么值得测试
+
+- macOS 安装步骤更直观，不容易误从已挂载的 DMG 中直接运行应用。
+- DMG 布局现在是发布质量门禁的一部分，签名和公证后的最终文件也会重新检查。
+- 合并版本通过 1530 项完整测试，PR 与 `main` 合并后 CI 均通过。
+
+### 交流
+
+- QQ 群：`299419120`
+
+---
+
+## 繁體中文
+
+這是 `next-2026-07-24.3` 之後的安裝體驗與穩定性預覽版，重點重做 macOS 拖曳安裝畫面，並加強 Windows TensorRT 分離執行階段的回歸保障。
+
+### 本版主要更新
+
+- macOS DMG 改為品牌化拖曳安裝畫面，清楚顯示應用程式、Applications 資料夾、拖曳箭頭與中英雙語提示。
+- Apple Silicon 與 Intel 安裝包繼續明確區分晶片類型，安裝畫面也顯示對應標識，降低下載錯誤版本的機會。
+- 正式建置會驗證 DMG 背景、Finder 版面、Applications 連結與最終映像結構；版面失敗時直接停止發布，不再退回空白安裝畫面。
+- 簽章、公證與最終 DMG 重建繼續沿用同一背景及版面，避免發布資產在最後階段遺失拖曳提示。
+- 為 Windows portable 路徑含空格、TensorRT 引擎與 NVIDIA runtime 分開存放的情況加入精確回歸測試，不必把 runtime DLL 重複複製到引擎目錄。
+
+### 下載前先看這幾句
+
+- macOS 使用者必須下載對應晶片的完整 DMG 才能使用新安裝畫面；請拖入 Applications、退出映像，再從 Applications 啟動。
+- 完整套件繼續內建 KataGo `v1.16.5` 與預設智子 28B 權重。
+- Windows 一般使用者優先選 OpenCL portable；RTX 20/30/40 可選 NVIDIA，RTX 50 可選 CUDA 12.8。
+- 舊 Windows portable 可使用小型更新，並保留設定、棋譜、自訂權重與 TensorRT。
+- 這是 Pre-release，適合提前驗證新版 macOS 安裝流程與多平台穩定性。
+
+### 下載建議
+
+| 你的電腦 | 直接下載這個 |
+| --- | --- |
+| Windows OpenCL 推薦版，免安裝 / 安裝器 | [portable][win-opencl-portable] / [installer][win-opencl-installer] |
+| 舊 Windows 免安裝版，小型更新 | [core update][win-core-update] |
+| Windows CPU 相容版，免安裝 / 安裝器 | [portable][win-cpu-portable] / [installer][win-cpu-installer] |
+| Windows NVIDIA RTX 20/30/40，免安裝 / 安裝器 | [portable][win-nvidia-portable] / [installer][win-nvidia-installer] |
+| Windows RTX 50 CUDA，免安裝 / 安裝器 | [portable][win-nvidia50-portable] / [installer][win-nvidia50-installer] |
+| 進階 TensorRT 分卷套件 | [下載與解壓說明][win-tensorrt-readme] |
+| Windows 自行設定引擎，免安裝 / 安裝器 | [portable][win-no-engine-portable] / [installer][win-no-engine-installer] |
+| macOS Apple Silicon / Intel | [Apple Silicon][mac-arm64] / [Intel][mac-intel] |
+| Linux CPU / OpenCL / NVIDIA CUDA | [CPU][linux-cpu] / [OpenCL][linux-opencl] / [NVIDIA][linux-nvidia] |
+
+### 這一版為什麼值得測試
+
+- macOS 安裝步驟更直觀，較不容易誤從已掛載的 DMG 直接執行應用程式。
+- DMG 版面已成為發布品質門檻，簽章與公證後的最終檔案也會重新檢查。
+- 合併版本通過 1530 項完整測試，PR 與 `main` 合併後 CI 均通過。
+
+### 交流
+
+- QQ 群：`299419120`
+
+---
+
+## English
+
+This installation and stability preview follows `next-2026-07-24.3`. It redesigns the macOS drag-install experience and strengthens regression coverage for separated Windows TensorRT runtimes.
+
+### Release Highlights
+
+- Replaces the plain macOS DMG with a branded drag-install window showing the app, Applications folder, a clear arrow, and bilingual instructions.
+- Keeps Apple Silicon and Intel packages clearly separated and adds the matching processor badge to the installation artwork.
+- Makes the DMG background, Finder layout, Applications link, and final image structure release gates; a broken layout now fails the build instead of producing a blank installer.
+- Preserves the same artwork and layout through signing, notarization, and final DMG reconstruction.
+- Adds an exact regression for Windows portable paths containing spaces with the TensorRT engine and NVIDIA runtime stored separately, without duplicating runtime DLLs into the engine directory.
+
+### Read Before Downloading
+
+- macOS users need the complete DMG for their processor to get the new installer. Drag the app to Applications, eject the image, and launch it from Applications.
+- Full bundles continue to include KataGo `v1.16.5` and the default Zhizi 28B model.
+- Most Windows users should choose OpenCL portable. RTX 20/30/40 users can choose NVIDIA, while RTX 50 users can choose CUDA 12.8.
+- Existing Windows portable users can use the small core update while keeping settings, games, custom weights, and TensorRT files.
+- This is a Pre-release for early validation of the new macOS installation flow and cross-platform stability.
+
+### Download Guide
+
+| Your computer | Download |
+| --- | --- |
+| Windows OpenCL recommended, portable / installer | [portable][win-opencl-portable] / [installer][win-opencl-installer] |
+| Existing Windows portable, small update | [core update][win-core-update] |
+| Windows CPU compatible, portable / installer | [portable][win-cpu-portable] / [installer][win-cpu-installer] |
+| Windows NVIDIA RTX 20/30/40, portable / installer | [portable][win-nvidia-portable] / [installer][win-nvidia-installer] |
+| Windows RTX 50 CUDA, portable / installer | [portable][win-nvidia50-portable] / [installer][win-nvidia50-installer] |
+| Advanced optional TensorRT split package | [download instructions][win-tensorrt-readme] |
+| Windows, configure your own engine | [portable][win-no-engine-portable] / [installer][win-no-engine-installer] |
+| macOS Apple Silicon / Intel | [Apple Silicon][mac-arm64] / [Intel][mac-intel] |
+| Linux CPU / OpenCL / NVIDIA CUDA | [CPU][linux-cpu] / [OpenCL][linux-opencl] / [NVIDIA][linux-nvidia] |
+
+### Why Test This Release
+
+- The macOS installation path is now obvious, reducing accidental launches directly from the mounted DMG.
+- DMG layout is now a release quality gate, including revalidation after signing and notarization.
+- The merged build passed all 1530 tests, with both PR and post-merge `main` CI passing.
+
+### Contact
+
+- QQ group: `299419120`
+
+---
+
+## 日本語
+
+これは `next-2026-07-24.3` に続く installation と stability の Pre-release です。macOS の drag-install 体験を刷新し、Windows TensorRT runtime 分離構成の regression coverage を強化しました。
+
+### 主な更新
+
+- macOS DMG をブランド化し、app、Applications folder、明確な矢印、中英二言語の案内を表示します。
+- Apple Silicon と Intel package を明確に分け、インストール画面にも対応する processor badge を表示します。
+- DMG background、Finder layout、Applications link、最終 image structure を release gate とし、layout が壊れた場合は blank installer を生成せず build を失敗させます。
+- signing、notarization、最終 DMG rebuild の後も同じ artwork と layout を保持します。
+- space を含む Windows portable path で、TensorRT engine と NVIDIA runtime を別 directory に置く構成の regression test を追加し、runtime DLL の重複コピーを不要にしました。
+
+### ダウンロード前に
+
+- macOS は processor に合う complete DMG が必要です。Applications にドラッグし、DMG を eject してから Applications から起動してください。
+- full bundle は引き続き KataGo `v1.16.5` と既定の Zhizi 28B model を含みます。
+- Windows は通常 OpenCL portable、RTX 20/30/40 は NVIDIA、RTX 50 は CUDA 12.8 を選択できます。
+- 既存 Windows portable は small core update を利用でき、設定、棋譜、custom weight、TensorRT を保持します。
+- 新しい macOS installation flow と cross-platform stability を先行確認する Pre-release です。
+
+### ダウンロード案内
+
+| 環境 | ダウンロード |
+| --- | --- |
+| Windows OpenCL portable / installer | [portable][win-opencl-portable] / [installer][win-opencl-installer] |
+| Windows portable 小型更新 | [core update][win-core-update] |
+| Windows CPU portable / installer | [portable][win-cpu-portable] / [installer][win-cpu-installer] |
+| Windows NVIDIA portable / installer | [portable][win-nvidia-portable] / [installer][win-nvidia-installer] |
+| Windows RTX 50 CUDA portable / installer | [portable][win-nvidia50-portable] / [installer][win-nvidia50-installer] |
+| TensorRT split package | [README][win-tensorrt-readme] |
+| Windows no-engine portable / installer | [portable][win-no-engine-portable] / [installer][win-no-engine-installer] |
+| macOS Apple Silicon / Intel | [Apple Silicon][mac-arm64] / [Intel][mac-intel] |
+| Linux CPU / OpenCL / NVIDIA | [CPU][linux-cpu] / [OpenCL][linux-opencl] / [NVIDIA][linux-nvidia] |
+
+### このリリースを試す理由
+
+- macOS のインストール手順が明確になり、mount 済み DMG から直接起動する間違いを減らします。
+- signing と notarization 後の再検証を含め、DMG layout が release quality gate になりました。
+- merged build は 1530 tests をすべて通過し、PR と post-merge `main` CI も成功しました。
+
+### 連絡先
+
+- QQ group: `299419120`
+
+---
+
+## 한국어
+
+`next-2026-07-24.3` 이후의 installation 및 stability Pre-release입니다. macOS drag-install 경험을 새로 설계하고 Windows TensorRT runtime 분리 구성의 regression coverage를 강화했습니다.
+
+### 주요 업데이트
+
+- macOS DMG에 app, Applications folder, 명확한 화살표와 중영 이중 언어 안내가 있는 브랜드 설치 화면을 적용했습니다.
+- Apple Silicon과 Intel package를 명확히 구분하고 설치 화면에도 해당 processor badge를 표시합니다.
+- DMG background, Finder layout, Applications link, 최종 image structure를 release gate로 검증하며, layout이 깨지면 blank installer를 만들지 않고 build를 실패시킵니다.
+- signing, notarization, 최종 DMG rebuild 이후에도 동일한 artwork와 layout을 유지합니다.
+- 공백이 포함된 Windows portable path에서 TensorRT engine과 NVIDIA runtime을 별도 directory에 저장하는 정확한 regression test를 추가해 runtime DLL 중복 복사가 필요 없도록 보장합니다.
+
+### 다운로드 전 확인
+
+- macOS는 processor에 맞는 complete DMG가 필요합니다. Applications로 드래그하고 DMG를 eject한 뒤 Applications에서 실행하세요.
+- full bundle은 계속 KataGo `v1.16.5`와 기본 Zhizi 28B model을 포함합니다.
+- Windows 일반 사용자는 OpenCL portable, RTX 20/30/40은 NVIDIA, RTX 50은 CUDA 12.8을 선택할 수 있습니다.
+- 기존 Windows portable은 small core update를 사용할 수 있으며 설정, 기보, custom weight, TensorRT를 유지합니다.
+- 새 macOS installation flow와 cross-platform stability를 먼저 검증하는 Pre-release입니다.
+
+### 다운로드 안내
+
+| 환경 | 다운로드 |
+| --- | --- |
+| Windows OpenCL portable / installer | [portable][win-opencl-portable] / [installer][win-opencl-installer] |
+| Windows portable 소형 업데이트 | [core update][win-core-update] |
+| Windows CPU portable / installer | [portable][win-cpu-portable] / [installer][win-cpu-installer] |
+| Windows NVIDIA portable / installer | [portable][win-nvidia-portable] / [installer][win-nvidia-installer] |
+| Windows RTX 50 CUDA portable / installer | [portable][win-nvidia50-portable] / [installer][win-nvidia50-installer] |
+| TensorRT split package | [README][win-tensorrt-readme] |
+| Windows no-engine portable / installer | [portable][win-no-engine-portable] / [installer][win-no-engine-installer] |
+| macOS Apple Silicon / Intel | [Apple Silicon][mac-arm64] / [Intel][mac-intel] |
+| Linux CPU / OpenCL / NVIDIA | [CPU][linux-cpu] / [OpenCL][linux-opencl] / [NVIDIA][linux-nvidia] |
+
+### 이 릴리스를 테스트할 이유
+
+- macOS 설치 경로가 명확해져 mount된 DMG에서 앱을 직접 실행하는 실수를 줄입니다.
+- signing 및 notarization 뒤의 재검증을 포함해 DMG layout이 release quality gate가 되었습니다.
+- merged build는 1530 tests를 모두 통과했으며 PR과 post-merge `main` CI도 성공했습니다.
+
+### 연락처
+
+- QQ 그룹: `299419120`
+
+---
+
+## ภาษาไทย
+
+นี่คือ Pre-release ด้านการติดตั้งและความเสถียรต่อจาก `next-2026-07-24.3` โดยออกแบบประสบการณ์ drag-install บน macOS ใหม่ และเพิ่ม regression coverage สำหรับ TensorRT runtime ที่แยกออกจาก engine บน Windows
+
+### ไฮไลต์ของเวอร์ชันนี้
+
+- เปลี่ยน macOS DMG เป็นหน้าติดตั้งที่มีแบรนด์ แสดง app, โฟลเดอร์ Applications, ลูกศรลาก และคำแนะนำสองภาษาที่ชัดเจน
+- แยก package ของ Apple Silicon และ Intel อย่างชัดเจน พร้อมแสดง processor badge ที่ตรงกันในหน้าติดตั้ง
+- ตรวจ background, Finder layout, Applications link และโครงสร้าง image สุดท้ายเป็น release gate หาก layout ผิด build จะล้มเหลวแทนการสร้าง installer ว่าง
+- รักษา artwork และ layout เดิมตลอดขั้นตอน signing, notarization และการ rebuild DMG ขั้นสุดท้าย
+- เพิ่ม regression test สำหรับ Windows portable path ที่มีช่องว่าง และเก็บ TensorRT engine แยกจาก NVIDIA runtime โดยไม่ต้องคัดลอก runtime DLL ซ้ำเข้า engine directory
+
+### ก่อนดาวน์โหลด
+
+- ผู้ใช้ macOS ต้องดาวน์โหลด complete DMG ให้ตรงกับ processor ลาก app ไปที่ Applications, eject DMG แล้วเปิดจาก Applications
+- full bundle ยังคงรวม KataGo `v1.16.5` และ Zhizi 28B model เริ่มต้น
+- ผู้ใช้ Windows ทั่วไปเลือก OpenCL portable, RTX 20/30/40 เลือก NVIDIA และ RTX 50 เลือก CUDA 12.8
+- portable เดิมบน Windows ใช้ small core update ได้ โดยเก็บ settings, game records, custom weights และ TensorRT ไว้
+- นี่คือ Pre-release สำหรับตรวจสอบ installation flow ใหม่บน macOS และความเสถียรข้าม platform
+
+### คำแนะนำดาวน์โหลด
+
+| คอมพิวเตอร์ของคุณ | ดาวน์โหลด |
+| --- | --- |
+| Windows OpenCL portable / installer | [portable][win-opencl-portable] / [installer][win-opencl-installer] |
+| Windows portable อัปเดตขนาดเล็ก | [core update][win-core-update] |
+| Windows CPU portable / installer | [portable][win-cpu-portable] / [installer][win-cpu-installer] |
+| Windows NVIDIA portable / installer | [portable][win-nvidia-portable] / [installer][win-nvidia-installer] |
+| Windows RTX 50 CUDA portable / installer | [portable][win-nvidia50-portable] / [installer][win-nvidia50-installer] |
+| TensorRT split package | [README][win-tensorrt-readme] |
+| Windows no-engine portable / installer | [portable][win-no-engine-portable] / [installer][win-no-engine-installer] |
+| macOS Apple Silicon / Intel | [Apple Silicon][mac-arm64] / [Intel][mac-intel] |
+| Linux CPU / OpenCL / NVIDIA | [CPU][linux-cpu] / [OpenCL][linux-opencl] / [NVIDIA][linux-nvidia] |
+
+### ทำไมควรทดสอบเวอร์ชันนี้
+
+- ขั้นตอนติดตั้ง macOS ชัดเจนขึ้น ลดการเปิด app โดยตรงจาก DMG ที่ mount อยู่
+- DMG layout เป็นส่วนหนึ่งของ release quality gate รวมถึงการตรวจซ้ำหลัง signing และ notarization
+- merged build ผ่าน 1530 tests ทั้งหมด และ CI ของ PR กับ post-merge `main` ผ่านแล้ว
+
+### ติดต่อ
+
+- QQ group: `299419120`
+
+[win-opencl-portable]: https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-26.1/2026-07-26-windows64.opencl.portable.zip
+[win-core-update]: https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-26.1/2026-07-26-windows64.core-update.zip
+[win-opencl-installer]: https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-26.1/2026-07-26-windows64.opencl.installer.exe
+[win-cpu-portable]: https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-26.1/2026-07-26-windows64.with-katago.portable.zip
+[win-cpu-installer]: https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-26.1/2026-07-26-windows64.with-katago.installer.exe
+[win-nvidia-portable]: https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-26.1/2026-07-26-windows64.nvidia.portable.zip
+[win-nvidia-installer]: https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-26.1/2026-07-26-windows64.nvidia.installer.exe
+[win-nvidia50-portable]: https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-26.1/2026-07-26-windows64.nvidia50.cuda.portable.zip
+[win-nvidia50-installer]: https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-26.1/2026-07-26-windows64.nvidia50.cuda.installer.exe
+[win-tensorrt-readme]: https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-26.1/2026-07-26-windows64.nvidia.tensorrt.portable.README.txt
+[win-no-engine-portable]: https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-26.1/2026-07-26-windows64.without.engine.portable.zip
+[win-no-engine-installer]: https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-26.1/2026-07-26-windows64.without.engine.installer.exe
+[mac-arm64]: https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-26.1/2026-07-26-mac-apple-silicon.with-katago.dmg
+[mac-intel]: https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-26.1/2026-07-26-mac-intel.with-katago.dmg
+[linux-cpu]: https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-26.1/2026-07-26-linux64.with-katago.zip
+[linux-opencl]: https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-26.1/2026-07-26-linux64.opencl.zip
+[linux-nvidia]: https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-26.1/2026-07-26-linux64.nvidia.zip

--- a/.github/release-requests/next-2026-07-26.1.json
+++ b/.github/release-requests/next-2026-07-26.1.json
@@ -1,0 +1,7 @@
+{
+  "date_tag": "2026-07-26",
+  "release_tag": "next-2026-07-26.1",
+  "title": "LizzieYzy Next next-2026-07-26.1",
+  "prerelease": true,
+  "notes_file": ".github/release-notes/next-2026-07-26.1.md"
+}


### PR DESCRIPTION
## Summary

- requests the audited `next-2026-07-26.1` multi-platform pre-release
- documents the redesigned macOS drag-install DMG and its fail-closed layout validation
- documents the Windows TensorRT separated-runtime regression coverage
- keeps the six-language release-note structure and current download matrix

## Validation

- `python3 -m unittest scripts.test_publish_release_request scripts.test_generate_release_notes` (22 passed)
- `python3 scripts/check_markdown_links.py`
- `git diff --cached --check`
- release request validated with all six localized sections
- source commit already passed 1530 tests and post-merge `main` CI

After merge, the audited publisher will keep the release as a draft until Windows, Linux, macOS Intel, and macOS Apple Silicon assets all pass validation.