### PR TITLE
Standardize direct release download tables

### DIFF
--- a/.github/release-notes/next-2026-07-22.2.md
+++ b/.github/release-notes/next-2026-07-22.2.md
@@ -25,23 +25,23 @@
 
 | 你的电脑 | 直接下载这个 |
 | --- | --- |
-| Windows 64 位，OpenCL 推荐版，免安装 | [windows64.opencl.portable.zip][win-opencl-portable] |
-| 已有 Windows 免安装版，日常小更新 | [windows64.core-update.zip][win-core-update] |
-| Windows 64 位，OpenCL 推荐版，安装器 | [windows64.opencl.installer.exe][win-opencl-installer] |
-| Windows 64 位，CPU 兼容版，免安装 | [windows64.with-katago.portable.zip][win-cpu-portable] |
-| Windows 64 位，CPU 兼容版，安装器 | [windows64.with-katago.installer.exe][win-cpu-installer] |
-| Windows 64 位，NVIDIA 20/30/40 系，免安装 | [windows64.nvidia.portable.zip][win-nvidia-portable] |
-| Windows 64 位，NVIDIA 20/30/40 系，安装器 | [windows64.nvidia.installer.exe][win-nvidia-installer] |
-| Windows 64 位，RTX 5070/5080/5090，免安装 | [windows64.nvidia50.cuda.portable.zip][win-nvidia50-portable] |
-| Windows 64 位，RTX 5070/5080/5090，安装器 | [windows64.nvidia50.cuda.installer.exe][win-nvidia50-installer] |
-| 高级可选 TensorRT 分卷包说明 | [TensorRT README][win-tensorrt-readme] |
-| Windows 64 位，自己配置引擎，免安装 | [windows64.without.engine.portable.zip][win-no-engine-portable] |
-| Windows 64 位，自己配置引擎，安装器 | [windows64.without.engine.installer.exe][win-no-engine-installer] |
-| macOS Apple Silicon | [mac-apple-silicon.with-katago.dmg][mac-arm64] |
-| macOS Intel | [mac-intel.with-katago.dmg][mac-intel] |
-| Linux 64 位，CPU 兼容版 | [linux64.with-katago.zip][linux-cpu] |
-| Linux 64 位，OpenCL 版 | [linux64.opencl.zip][linux-opencl] |
-| Linux 64 位，NVIDIA CUDA 版 | [linux64.nvidia.zip][linux-nvidia] |
+| Windows 64 位，OpenCL 版，推荐更快，免安装 | [`2026-07-22-windows64.opencl.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-22.2/2026-07-22-windows64.opencl.portable.zip) |
+| 已有 Windows 免安装版，日常升级小包 | [`2026-07-22-windows64.core-update.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-22.2/2026-07-22-windows64.core-update.zip) |
+| Windows 64 位，OpenCL 版，想安装 | [`2026-07-22-windows64.opencl.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-22.2/2026-07-22-windows64.opencl.installer.exe) |
+| Windows 64 位，CPU 版，兼容兜底，免安装 | [`2026-07-22-windows64.with-katago.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-22.2/2026-07-22-windows64.with-katago.portable.zip) |
+| Windows 64 位，CPU 版，兼容兜底，想安装 | [`2026-07-22-windows64.with-katago.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-22.2/2026-07-22-windows64.with-katago.installer.exe) |
+| Windows 64 位，英伟达显卡，想更快，免安装 | [`2026-07-22-windows64.nvidia.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-22.2/2026-07-22-windows64.nvidia.portable.zip) |
+| Windows 64 位，英伟达显卡，想更快，也想安装 | [`2026-07-22-windows64.nvidia.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-22.2/2026-07-22-windows64.nvidia.installer.exe) |
+| Windows 64 位，RTX 50 CUDA 版，5070/5080/5090 优先，免安装 | [`2026-07-22-windows64.nvidia50.cuda.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-22.2/2026-07-22-windows64.nvidia50.cuda.portable.zip) |
+| 高级可选：TensorRT 预装分卷包说明（需下载全部 .7z.00N） | [`2026-07-22-windows64.nvidia.tensorrt.portable.7z.001`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-22.2/2026-07-22-windows64.nvidia.tensorrt.portable.7z.001)<br>[`2026-07-22-windows64.nvidia.tensorrt.portable.7z.002`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-22.2/2026-07-22-windows64.nvidia.tensorrt.portable.7z.002) |
+| Windows 64 位，RTX 50 CUDA 版，5070/5080/5090 优先，想安装 | [`2026-07-22-windows64.nvidia50.cuda.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-22.2/2026-07-22-windows64.nvidia50.cuda.installer.exe) |
+| Windows 64 位，想自己配引擎 | [`2026-07-22-windows64.without.engine.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-22.2/2026-07-22-windows64.without.engine.portable.zip) |
+| Windows 64 位，想自己配引擎，也想安装器 | [`2026-07-22-windows64.without.engine.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-22.2/2026-07-22-windows64.without.engine.installer.exe) |
+| macOS Apple Silicon | [`2026-07-22-mac-apple-silicon.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-22.2/2026-07-22-mac-apple-silicon.with-katago.dmg) |
+| macOS Intel | [`2026-07-22-mac-intel.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-22.2/2026-07-22-mac-intel.with-katago.dmg) |
+| Linux 64 位，CPU 兼容版 | [`2026-07-22-linux64.with-katago.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-22.2/2026-07-22-linux64.with-katago.zip) |
+| Linux 64 位，OpenCL 版，AMD/Intel GPU | [`2026-07-22-linux64.opencl.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-22.2/2026-07-22-linux64.opencl.zip) |
+| Linux 64 位，NVIDIA CUDA 版 | [`2026-07-22-linux64.nvidia.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-22.2/2026-07-22-linux64.nvidia.zip) |
 
 ### 这一版为什么值得测试
 
@@ -80,16 +80,23 @@
 
 | 你的電腦 | 直接下載這個 |
 | --- | --- |
-| Windows OpenCL 推薦版，免安裝 | [windows64.opencl.portable.zip][win-opencl-portable] |
-| 既有 Windows 免安裝版，小更新 | [windows64.core-update.zip][win-core-update] |
-| Windows OpenCL 推薦版，安裝器 | [windows64.opencl.installer.exe][win-opencl-installer] |
-| Windows CPU 相容版，免安裝 / 安裝器 | [portable][win-cpu-portable] / [installer][win-cpu-installer] |
-| Windows NVIDIA 20/30/40 系，免安裝 / 安裝器 | [portable][win-nvidia-portable] / [installer][win-nvidia-installer] |
-| Windows RTX 50 CUDA，免安裝 / 安裝器 | [portable][win-nvidia50-portable] / [installer][win-nvidia50-installer] |
-| 進階 TensorRT 分卷包說明 | [TensorRT README][win-tensorrt-readme] |
-| Windows 自行配置引擎，免安裝 / 安裝器 | [portable][win-no-engine-portable] / [installer][win-no-engine-installer] |
-| macOS Apple Silicon / Intel | [Apple Silicon][mac-arm64] / [Intel][mac-intel] |
-| Linux CPU / OpenCL / NVIDIA CUDA | [CPU][linux-cpu] / [OpenCL][linux-opencl] / [NVIDIA][linux-nvidia] |
+| Windows 64 位，OpenCL 版，推薦更快，免安裝 | [`2026-07-22-windows64.opencl.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-22.2/2026-07-22-windows64.opencl.portable.zip) |
+| 已有 Windows 免安裝版，日常升級小包 | [`2026-07-22-windows64.core-update.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-22.2/2026-07-22-windows64.core-update.zip) |
+| Windows 64 位，OpenCL 版，想安裝 | [`2026-07-22-windows64.opencl.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-22.2/2026-07-22-windows64.opencl.installer.exe) |
+| Windows 64 位，CPU 版，相容兜底，免安裝 | [`2026-07-22-windows64.with-katago.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-22.2/2026-07-22-windows64.with-katago.portable.zip) |
+| Windows 64 位，CPU 版，相容兜底，想安裝 | [`2026-07-22-windows64.with-katago.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-22.2/2026-07-22-windows64.with-katago.installer.exe) |
+| Windows 64 位，NVIDIA 顯示卡，想更快，免安裝 | [`2026-07-22-windows64.nvidia.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-22.2/2026-07-22-windows64.nvidia.portable.zip) |
+| Windows 64 位，NVIDIA 顯示卡，想更快，也想安裝 | [`2026-07-22-windows64.nvidia.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-22.2/2026-07-22-windows64.nvidia.installer.exe) |
+| Windows 64 位，RTX 50 CUDA 版，5070/5080/5090 優先，免安裝 | [`2026-07-22-windows64.nvidia50.cuda.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-22.2/2026-07-22-windows64.nvidia50.cuda.portable.zip) |
+| 進階可選：TensorRT 預裝分卷包說明（需下載全部 .7z.00N） | [`2026-07-22-windows64.nvidia.tensorrt.portable.7z.001`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-22.2/2026-07-22-windows64.nvidia.tensorrt.portable.7z.001)<br>[`2026-07-22-windows64.nvidia.tensorrt.portable.7z.002`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-22.2/2026-07-22-windows64.nvidia.tensorrt.portable.7z.002) |
+| Windows 64 位，RTX 50 CUDA 版，5070/5080/5090 優先，想安裝 | [`2026-07-22-windows64.nvidia50.cuda.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-22.2/2026-07-22-windows64.nvidia50.cuda.installer.exe) |
+| Windows 64 位，想自己配引擎 | [`2026-07-22-windows64.without.engine.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-22.2/2026-07-22-windows64.without.engine.portable.zip) |
+| Windows 64 位，想自己配引擎，也想安裝器 | [`2026-07-22-windows64.without.engine.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-22.2/2026-07-22-windows64.without.engine.installer.exe) |
+| macOS Apple Silicon | [`2026-07-22-mac-apple-silicon.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-22.2/2026-07-22-mac-apple-silicon.with-katago.dmg) |
+| macOS Intel | [`2026-07-22-mac-intel.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-22.2/2026-07-22-mac-intel.with-katago.dmg) |
+| Linux 64 位，CPU 相容版 | [`2026-07-22-linux64.with-katago.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-22.2/2026-07-22-linux64.with-katago.zip) |
+| Linux 64 位，OpenCL 版，AMD/Intel GPU | [`2026-07-22-linux64.opencl.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-22.2/2026-07-22-linux64.opencl.zip) |
+| Linux 64 位，NVIDIA CUDA 版 | [`2026-07-22-linux64.nvidia.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-22.2/2026-07-22-linux64.nvidia.zip) |
 
 ### 這一版為什麼值得測試
 
@@ -126,17 +133,25 @@ This pre-release builds on `next-2026-07-13.2` with a more dependable analysis w
 
 ### Download Guide
 
-| Your computer | Download |
+| Your computer | Download this file |
 | --- | --- |
-| Windows OpenCL recommended, portable / installer | [portable][win-opencl-portable] / [installer][win-opencl-installer] |
-| Existing Windows portable, small core update | [core update][win-core-update] |
-| Windows CPU compatible, portable / installer | [portable][win-cpu-portable] / [installer][win-cpu-installer] |
-| Windows NVIDIA RTX 20/30/40, portable / installer | [portable][win-nvidia-portable] / [installer][win-nvidia-installer] |
-| Windows RTX 5070/5080/5090 CUDA, portable / installer | [portable][win-nvidia50-portable] / [installer][win-nvidia50-installer] |
-| Advanced optional TensorRT split package | [TensorRT README][win-tensorrt-readme] |
-| Windows, configure your own engine, portable / installer | [portable][win-no-engine-portable] / [installer][win-no-engine-installer] |
-| macOS Apple Silicon / Intel | [Apple Silicon][mac-arm64] / [Intel][mac-intel] |
-| Linux CPU / OpenCL / NVIDIA CUDA | [CPU][linux-cpu] / [OpenCL][linux-opencl] / [NVIDIA][linux-nvidia] |
+| Windows 64-bit, OpenCL, recommended and faster, no install | [`2026-07-22-windows64.opencl.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-22.2/2026-07-22-windows64.opencl.portable.zip) |
+| Existing Windows portable install, small routine update | [`2026-07-22-windows64.core-update.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-22.2/2026-07-22-windows64.core-update.zip) |
+| Windows 64-bit, OpenCL, installer | [`2026-07-22-windows64.opencl.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-22.2/2026-07-22-windows64.opencl.installer.exe) |
+| Windows 64-bit, CPU fallback, no install | [`2026-07-22-windows64.with-katago.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-22.2/2026-07-22-windows64.with-katago.portable.zip) |
+| Windows 64-bit, CPU fallback, installer | [`2026-07-22-windows64.with-katago.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-22.2/2026-07-22-windows64.with-katago.installer.exe) |
+| Windows 64-bit, NVIDIA GPU, faster, no install | [`2026-07-22-windows64.nvidia.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-22.2/2026-07-22-windows64.nvidia.portable.zip) |
+| Windows 64-bit, NVIDIA GPU, faster, installer | [`2026-07-22-windows64.nvidia.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-22.2/2026-07-22-windows64.nvidia.installer.exe) |
+| Windows 64-bit, RTX 50 CUDA, recommended for 5070/5080/5090, no install | [`2026-07-22-windows64.nvidia50.cuda.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-22.2/2026-07-22-windows64.nvidia50.cuda.portable.zip) |
+| Advanced optional TensorRT split package guide; download every .7z.00N part | [`2026-07-22-windows64.nvidia.tensorrt.portable.7z.001`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-22.2/2026-07-22-windows64.nvidia.tensorrt.portable.7z.001)<br>[`2026-07-22-windows64.nvidia.tensorrt.portable.7z.002`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-22.2/2026-07-22-windows64.nvidia.tensorrt.portable.7z.002) |
+| Windows 64-bit, RTX 50 CUDA, recommended for 5070/5080/5090, installer | [`2026-07-22-windows64.nvidia50.cuda.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-22.2/2026-07-22-windows64.nvidia50.cuda.installer.exe) |
+| Windows 64-bit, configure your own engine | [`2026-07-22-windows64.without.engine.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-22.2/2026-07-22-windows64.without.engine.portable.zip) |
+| Windows 64-bit, configure your own engine, installer | [`2026-07-22-windows64.without.engine.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-22.2/2026-07-22-windows64.without.engine.installer.exe) |
+| macOS Apple Silicon | [`2026-07-22-mac-apple-silicon.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-22.2/2026-07-22-mac-apple-silicon.with-katago.dmg) |
+| macOS Intel | [`2026-07-22-mac-intel.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-22.2/2026-07-22-mac-intel.with-katago.dmg) |
+| Linux 64-bit, CPU fallback | [`2026-07-22-linux64.with-katago.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-22.2/2026-07-22-linux64.with-katago.zip) |
+| Linux 64-bit, OpenCL for AMD/Intel GPU | [`2026-07-22-linux64.opencl.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-22.2/2026-07-22-linux64.opencl.zip) |
+| Linux 64-bit, NVIDIA CUDA | [`2026-07-22-linux64.nvidia.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-22.2/2026-07-22-linux64.nvidia.zip) |
 
 ### Why Test This Release
 
@@ -173,16 +188,25 @@ This pre-release builds on `next-2026-07-13.2` with a more dependable analysis w
 
 ### ダウンロード案内
 
-| 環境 | ダウンロード |
+| お使いの環境 | ダウンロードするファイル |
 | --- | --- |
-| Windows OpenCL portable / installer | [portable][win-opencl-portable] / [installer][win-opencl-installer] |
-| Windows portable 小型更新 | [core update][win-core-update] |
-| Windows CPU portable / installer | [portable][win-cpu-portable] / [installer][win-cpu-installer] |
-| Windows NVIDIA portable / installer | [portable][win-nvidia-portable] / [installer][win-nvidia-installer] |
-| Windows RTX 50 CUDA portable / installer | [portable][win-nvidia50-portable] / [installer][win-nvidia50-installer] |
-| TensorRT 分割 package | [README][win-tensorrt-readme] |
-| macOS Apple Silicon / Intel | [Apple Silicon][mac-arm64] / [Intel][mac-intel] |
-| Linux CPU / OpenCL / NVIDIA | [CPU][linux-cpu] / [OpenCL][linux-opencl] / [NVIDIA][linux-nvidia] |
+| Windows 64-bit、OpenCL 推奨高速版、インストール不要 | [`2026-07-22-windows64.opencl.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-22.2/2026-07-22-windows64.opencl.portable.zip) |
+| 既存の Windows portable 版向け小型更新 | [`2026-07-22-windows64.core-update.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-22.2/2026-07-22-windows64.core-update.zip) |
+| Windows 64-bit、OpenCL 版、インストーラ | [`2026-07-22-windows64.opencl.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-22.2/2026-07-22-windows64.opencl.installer.exe) |
+| Windows 64-bit、CPU fallback、インストール不要 | [`2026-07-22-windows64.with-katago.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-22.2/2026-07-22-windows64.with-katago.portable.zip) |
+| Windows 64-bit、CPU fallback、インストーラ | [`2026-07-22-windows64.with-katago.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-22.2/2026-07-22-windows64.with-katago.installer.exe) |
+| Windows 64-bit、NVIDIA GPU、高速版、インストール不要 | [`2026-07-22-windows64.nvidia.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-22.2/2026-07-22-windows64.nvidia.portable.zip) |
+| Windows 64-bit、NVIDIA GPU、高速版、インストーラ | [`2026-07-22-windows64.nvidia.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-22.2/2026-07-22-windows64.nvidia.installer.exe) |
+| Windows 64-bit、RTX 50 CUDA、5070/5080/5090 推奨、インストール不要 | [`2026-07-22-windows64.nvidia50.cuda.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-22.2/2026-07-22-windows64.nvidia50.cuda.portable.zip) |
+| 上級者向け任意：TensorRT 分割パッケージ案内（.7z.00N を全て取得） | [`2026-07-22-windows64.nvidia.tensorrt.portable.7z.001`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-22.2/2026-07-22-windows64.nvidia.tensorrt.portable.7z.001)<br>[`2026-07-22-windows64.nvidia.tensorrt.portable.7z.002`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-22.2/2026-07-22-windows64.nvidia.tensorrt.portable.7z.002) |
+| Windows 64-bit、RTX 50 CUDA、5070/5080/5090 推奨、インストーラ | [`2026-07-22-windows64.nvidia50.cuda.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-22.2/2026-07-22-windows64.nvidia50.cuda.installer.exe) |
+| Windows 64-bit、自分でエンジンを設定したい場合 | [`2026-07-22-windows64.without.engine.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-22.2/2026-07-22-windows64.without.engine.portable.zip) |
+| Windows 64-bit、自分でエンジンを設定したい場合、インストーラ | [`2026-07-22-windows64.without.engine.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-22.2/2026-07-22-windows64.without.engine.installer.exe) |
+| macOS Apple Silicon | [`2026-07-22-mac-apple-silicon.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-22.2/2026-07-22-mac-apple-silicon.with-katago.dmg) |
+| macOS Intel | [`2026-07-22-mac-intel.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-22.2/2026-07-22-mac-intel.with-katago.dmg) |
+| Linux 64-bit、CPU fallback | [`2026-07-22-linux64.with-katago.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-22.2/2026-07-22-linux64.with-katago.zip) |
+| Linux 64-bit、OpenCL、AMD/Intel GPU | [`2026-07-22-linux64.opencl.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-22.2/2026-07-22-linux64.opencl.zip) |
+| Linux 64-bit、NVIDIA CUDA | [`2026-07-22-linux64.nvidia.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-22.2/2026-07-22-linux64.nvidia.zip) |
 
 ### このリリースを試す理由
 
@@ -219,16 +243,25 @@ This pre-release builds on `next-2026-07-13.2` with a more dependable analysis w
 
 ### 다운로드 안내
 
-| 환경 | 다운로드 |
+| 내 컴퓨터 | 다운로드할 파일 |
 | --- | --- |
-| Windows OpenCL portable / installer | [portable][win-opencl-portable] / [installer][win-opencl-installer] |
-| Windows portable 소형 업데이트 | [core update][win-core-update] |
-| Windows CPU portable / installer | [portable][win-cpu-portable] / [installer][win-cpu-installer] |
-| Windows NVIDIA portable / installer | [portable][win-nvidia-portable] / [installer][win-nvidia-installer] |
-| Windows RTX 50 CUDA portable / installer | [portable][win-nvidia50-portable] / [installer][win-nvidia50-installer] |
-| TensorRT 분할 package | [README][win-tensorrt-readme] |
-| macOS Apple Silicon / Intel | [Apple Silicon][mac-arm64] / [Intel][mac-intel] |
-| Linux CPU / OpenCL / NVIDIA | [CPU][linux-cpu] / [OpenCL][linux-opencl] / [NVIDIA][linux-nvidia] |
+| Windows 64-bit, OpenCL 추천 고속판, 무설치 | [`2026-07-22-windows64.opencl.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-22.2/2026-07-22-windows64.opencl.portable.zip) |
+| 기존 Windows portable 사용자를 위한 소형 업데이트 | [`2026-07-22-windows64.core-update.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-22.2/2026-07-22-windows64.core-update.zip) |
+| Windows 64-bit, OpenCL, 설치형 | [`2026-07-22-windows64.opencl.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-22.2/2026-07-22-windows64.opencl.installer.exe) |
+| Windows 64-bit, CPU fallback, 무설치 | [`2026-07-22-windows64.with-katago.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-22.2/2026-07-22-windows64.with-katago.portable.zip) |
+| Windows 64-bit, CPU fallback, 설치형 | [`2026-07-22-windows64.with-katago.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-22.2/2026-07-22-windows64.with-katago.installer.exe) |
+| Windows 64-bit, NVIDIA GPU, 고속판, 무설치 | [`2026-07-22-windows64.nvidia.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-22.2/2026-07-22-windows64.nvidia.portable.zip) |
+| Windows 64-bit, NVIDIA GPU, 고속판, 설치형 | [`2026-07-22-windows64.nvidia.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-22.2/2026-07-22-windows64.nvidia.installer.exe) |
+| Windows 64-bit, RTX 50 CUDA, 5070/5080/5090 권장, 무설치 | [`2026-07-22-windows64.nvidia50.cuda.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-22.2/2026-07-22-windows64.nvidia50.cuda.portable.zip) |
+| 고급 선택: TensorRT 분할 패키지 안내(.7z.00N 전체 다운로드 필요) | [`2026-07-22-windows64.nvidia.tensorrt.portable.7z.001`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-22.2/2026-07-22-windows64.nvidia.tensorrt.portable.7z.001)<br>[`2026-07-22-windows64.nvidia.tensorrt.portable.7z.002`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-22.2/2026-07-22-windows64.nvidia.tensorrt.portable.7z.002) |
+| Windows 64-bit, RTX 50 CUDA, 5070/5080/5090 권장, 설치형 | [`2026-07-22-windows64.nvidia50.cuda.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-22.2/2026-07-22-windows64.nvidia50.cuda.installer.exe) |
+| Windows 64-bit, 직접 엔진 설정 | [`2026-07-22-windows64.without.engine.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-22.2/2026-07-22-windows64.without.engine.portable.zip) |
+| Windows 64-bit, 직접 엔진 설정, 설치형 | [`2026-07-22-windows64.without.engine.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-22.2/2026-07-22-windows64.without.engine.installer.exe) |
+| macOS Apple Silicon | [`2026-07-22-mac-apple-silicon.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-22.2/2026-07-22-mac-apple-silicon.with-katago.dmg) |
+| macOS Intel | [`2026-07-22-mac-intel.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-22.2/2026-07-22-mac-intel.with-katago.dmg) |
+| Linux 64-bit, CPU fallback | [`2026-07-22-linux64.with-katago.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-22.2/2026-07-22-linux64.with-katago.zip) |
+| Linux 64-bit, OpenCL, AMD/Intel GPU | [`2026-07-22-linux64.opencl.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-22.2/2026-07-22-linux64.opencl.zip) |
+| Linux 64-bit, NVIDIA CUDA | [`2026-07-22-linux64.nvidia.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-22.2/2026-07-22-linux64.nvidia.zip) |
 
 ### 이 릴리스를 테스트할 이유
 
@@ -263,18 +296,27 @@ pre-release นี้ต่อยอดจาก `next-2026-07-13.2` เพื�
 - portable เดิมเก็บ `user-data`, custom weight และ TensorRT ได้ แต่ควร backup ก่อนเขียนทับ
 - นี่คือ pre-release สำหรับทดสอบ whole-game analysis, การกู้คืน Zhizi และ package ทุก platform ก่อนเลื่อนเป็น stable release
 
-### คำแนะนำดาวน์โหลด
+### แนะนำการดาวน์โหลด
 
-| ระบบ | ดาวน์โหลด |
+| เครื่องของคุณ | ดาวน์โหลดไฟล์นี้ |
 | --- | --- |
-| Windows OpenCL portable / installer | [portable][win-opencl-portable] / [installer][win-opencl-installer] |
-| อัปเดตเล็กสำหรับ Windows portable เดิม | [core update][win-core-update] |
-| Windows CPU portable / installer | [portable][win-cpu-portable] / [installer][win-cpu-installer] |
-| Windows NVIDIA portable / installer | [portable][win-nvidia-portable] / [installer][win-nvidia-installer] |
-| Windows RTX 50 CUDA portable / installer | [portable][win-nvidia50-portable] / [installer][win-nvidia50-installer] |
-| TensorRT split package | [README][win-tensorrt-readme] |
-| macOS Apple Silicon / Intel | [Apple Silicon][mac-arm64] / [Intel][mac-intel] |
-| Linux CPU / OpenCL / NVIDIA | [CPU][linux-cpu] / [OpenCL][linux-opencl] / [NVIDIA][linux-nvidia] |
+| Windows 64-bit, OpenCL, แนะนำและเร็วกว่า, ไม่ต้องติดตั้ง | [`2026-07-22-windows64.opencl.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-22.2/2026-07-22-windows64.opencl.portable.zip) |
+| อัปเดตเล็กสำหรับผู้ใช้ Windows portable เดิม | [`2026-07-22-windows64.core-update.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-22.2/2026-07-22-windows64.core-update.zip) |
+| Windows 64-bit, OpenCL, แบบติดตั้ง | [`2026-07-22-windows64.opencl.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-22.2/2026-07-22-windows64.opencl.installer.exe) |
+| Windows 64-bit, CPU fallback, ไม่ต้องติดตั้ง | [`2026-07-22-windows64.with-katago.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-22.2/2026-07-22-windows64.with-katago.portable.zip) |
+| Windows 64-bit, CPU fallback, แบบติดตั้ง | [`2026-07-22-windows64.with-katago.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-22.2/2026-07-22-windows64.with-katago.installer.exe) |
+| Windows 64-bit, การ์ดจอ NVIDIA, เร็วกว่า, ไม่ต้องติดตั้ง | [`2026-07-22-windows64.nvidia.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-22.2/2026-07-22-windows64.nvidia.portable.zip) |
+| Windows 64-bit, การ์ดจอ NVIDIA, เร็วกว่า, แบบติดตั้ง | [`2026-07-22-windows64.nvidia.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-22.2/2026-07-22-windows64.nvidia.installer.exe) |
+| Windows 64-bit, RTX 50 CUDA, แนะนำสำหรับ 5070/5080/5090, ไม่ต้องติดตั้ง | [`2026-07-22-windows64.nvidia50.cuda.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-22.2/2026-07-22-windows64.nvidia50.cuda.portable.zip) |
+| ตัวเลือกขั้นสูง: คู่มือ TensorRT split package ต้องดาวน์โหลด .7z.00N ครบทุกไฟล์ | [`2026-07-22-windows64.nvidia.tensorrt.portable.7z.001`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-22.2/2026-07-22-windows64.nvidia.tensorrt.portable.7z.001)<br>[`2026-07-22-windows64.nvidia.tensorrt.portable.7z.002`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-22.2/2026-07-22-windows64.nvidia.tensorrt.portable.7z.002) |
+| Windows 64-bit, RTX 50 CUDA, แนะนำสำหรับ 5070/5080/5090, แบบติดตั้ง | [`2026-07-22-windows64.nvidia50.cuda.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-22.2/2026-07-22-windows64.nvidia50.cuda.installer.exe) |
+| Windows 64-bit, ต้องการตั้งค่า engine เอง | [`2026-07-22-windows64.without.engine.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-22.2/2026-07-22-windows64.without.engine.portable.zip) |
+| Windows 64-bit, ต้องการตั้งค่า engine เองและอยากใช้ installer | [`2026-07-22-windows64.without.engine.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-22.2/2026-07-22-windows64.without.engine.installer.exe) |
+| macOS Apple Silicon | [`2026-07-22-mac-apple-silicon.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-22.2/2026-07-22-mac-apple-silicon.with-katago.dmg) |
+| macOS Intel | [`2026-07-22-mac-intel.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-22.2/2026-07-22-mac-intel.with-katago.dmg) |
+| Linux 64-bit, CPU fallback | [`2026-07-22-linux64.with-katago.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-22.2/2026-07-22-linux64.with-katago.zip) |
+| Linux 64-bit, OpenCL สำหรับ AMD/Intel GPU | [`2026-07-22-linux64.opencl.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-22.2/2026-07-22-linux64.opencl.zip) |
+| Linux 64-bit, NVIDIA CUDA | [`2026-07-22-linux64.nvidia.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-22.2/2026-07-22-linux64.nvidia.zip) |
 
 ### ทำไมควรทดสอบเวอร์ชันนี้
 

--- a/.github/release-notes/next-2026-07-24.3.md
+++ b/.github/release-notes/next-2026-07-24.3.md
@@ -25,15 +25,23 @@
 
 | 你的电脑 | 直接下载这个 |
 | --- | --- |
-| Windows OpenCL 推荐版，免安装 / 安装器 | [portable][win-opencl-portable] / [installer][win-opencl-installer] |
-| 已有 Windows 免安装版，日常小更新 | [core update][win-core-update] |
-| Windows CPU 兼容版，免安装 / 安装器 | [portable][win-cpu-portable] / [installer][win-cpu-installer] |
-| Windows NVIDIA RTX 20/30/40，免安装 / 安装器 | [portable][win-nvidia-portable] / [installer][win-nvidia-installer] |
-| Windows RTX 50 CUDA，免安装 / 安装器 | [portable][win-nvidia50-portable] / [installer][win-nvidia50-installer] |
-| 高级可选 TensorRT 分卷包 | [下载与解压说明][win-tensorrt-readme] |
-| Windows 自行配置引擎，免安装 / 安装器 | [portable][win-no-engine-portable] / [installer][win-no-engine-installer] |
-| macOS Apple Silicon / Intel | [Apple Silicon][mac-arm64] / [Intel][mac-intel] |
-| Linux CPU / OpenCL / NVIDIA CUDA | [CPU][linux-cpu] / [OpenCL][linux-opencl] / [NVIDIA][linux-nvidia] |
+| Windows 64 位，OpenCL 版，推荐更快，免安装 | [`2026-07-24-windows64.opencl.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-24.3/2026-07-24-windows64.opencl.portable.zip) |
+| 已有 Windows 免安装版，日常升级小包 | [`2026-07-24-windows64.core-update.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-24.3/2026-07-24-windows64.core-update.zip) |
+| Windows 64 位，OpenCL 版，想安装 | [`2026-07-24-windows64.opencl.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-24.3/2026-07-24-windows64.opencl.installer.exe) |
+| Windows 64 位，CPU 版，兼容兜底，免安装 | [`2026-07-24-windows64.with-katago.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-24.3/2026-07-24-windows64.with-katago.portable.zip) |
+| Windows 64 位，CPU 版，兼容兜底，想安装 | [`2026-07-24-windows64.with-katago.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-24.3/2026-07-24-windows64.with-katago.installer.exe) |
+| Windows 64 位，英伟达显卡，想更快，免安装 | [`2026-07-24-windows64.nvidia.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-24.3/2026-07-24-windows64.nvidia.portable.zip) |
+| Windows 64 位，英伟达显卡，想更快，也想安装 | [`2026-07-24-windows64.nvidia.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-24.3/2026-07-24-windows64.nvidia.installer.exe) |
+| Windows 64 位，RTX 50 CUDA 版，5070/5080/5090 优先，免安装 | [`2026-07-24-windows64.nvidia50.cuda.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-24.3/2026-07-24-windows64.nvidia50.cuda.portable.zip) |
+| 高级可选：TensorRT 预装分卷包说明（需下载全部 .7z.00N） | [`2026-07-24-windows64.nvidia.tensorrt.portable.7z.001`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-24.3/2026-07-24-windows64.nvidia.tensorrt.portable.7z.001)<br>[`2026-07-24-windows64.nvidia.tensorrt.portable.7z.002`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-24.3/2026-07-24-windows64.nvidia.tensorrt.portable.7z.002) |
+| Windows 64 位，RTX 50 CUDA 版，5070/5080/5090 优先，想安装 | [`2026-07-24-windows64.nvidia50.cuda.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-24.3/2026-07-24-windows64.nvidia50.cuda.installer.exe) |
+| Windows 64 位，想自己配引擎 | [`2026-07-24-windows64.without.engine.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-24.3/2026-07-24-windows64.without.engine.portable.zip) |
+| Windows 64 位，想自己配引擎，也想安装器 | [`2026-07-24-windows64.without.engine.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-24.3/2026-07-24-windows64.without.engine.installer.exe) |
+| macOS Apple Silicon | [`2026-07-24-mac-apple-silicon.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-24.3/2026-07-24-mac-apple-silicon.with-katago.dmg) |
+| macOS Intel | [`2026-07-24-mac-intel.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-24.3/2026-07-24-mac-intel.with-katago.dmg) |
+| Linux 64 位，CPU 兼容版 | [`2026-07-24-linux64.with-katago.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-24.3/2026-07-24-linux64.with-katago.zip) |
+| Linux 64 位，OpenCL 版，AMD/Intel GPU | [`2026-07-24-linux64.opencl.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-24.3/2026-07-24-linux64.opencl.zip) |
+| Linux 64 位，NVIDIA CUDA 版 | [`2026-07-24-linux64.nvidia.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-24.3/2026-07-24-linux64.nvidia.zip) |
 
 ### 这一版为什么值得测试
 
@@ -72,15 +80,23 @@
 
 | 你的電腦 | 直接下載這個 |
 | --- | --- |
-| Windows OpenCL 推薦版，免安裝 / 安裝器 | [portable][win-opencl-portable] / [installer][win-opencl-installer] |
-| 舊 Windows 免安裝版，小型更新 | [core update][win-core-update] |
-| Windows CPU 相容版，免安裝 / 安裝器 | [portable][win-cpu-portable] / [installer][win-cpu-installer] |
-| Windows NVIDIA RTX 20/30/40，免安裝 / 安裝器 | [portable][win-nvidia-portable] / [installer][win-nvidia-installer] |
-| Windows RTX 50 CUDA，免安裝 / 安裝器 | [portable][win-nvidia50-portable] / [installer][win-nvidia50-installer] |
-| 進階 TensorRT 分卷套件 | [下載與解壓說明][win-tensorrt-readme] |
-| Windows 自行設定引擎，免安裝 / 安裝器 | [portable][win-no-engine-portable] / [installer][win-no-engine-installer] |
-| macOS Apple Silicon / Intel | [Apple Silicon][mac-arm64] / [Intel][mac-intel] |
-| Linux CPU / OpenCL / NVIDIA CUDA | [CPU][linux-cpu] / [OpenCL][linux-opencl] / [NVIDIA][linux-nvidia] |
+| Windows 64 位，OpenCL 版，推薦更快，免安裝 | [`2026-07-24-windows64.opencl.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-24.3/2026-07-24-windows64.opencl.portable.zip) |
+| 已有 Windows 免安裝版，日常升級小包 | [`2026-07-24-windows64.core-update.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-24.3/2026-07-24-windows64.core-update.zip) |
+| Windows 64 位，OpenCL 版，想安裝 | [`2026-07-24-windows64.opencl.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-24.3/2026-07-24-windows64.opencl.installer.exe) |
+| Windows 64 位，CPU 版，相容兜底，免安裝 | [`2026-07-24-windows64.with-katago.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-24.3/2026-07-24-windows64.with-katago.portable.zip) |
+| Windows 64 位，CPU 版，相容兜底，想安裝 | [`2026-07-24-windows64.with-katago.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-24.3/2026-07-24-windows64.with-katago.installer.exe) |
+| Windows 64 位，NVIDIA 顯示卡，想更快，免安裝 | [`2026-07-24-windows64.nvidia.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-24.3/2026-07-24-windows64.nvidia.portable.zip) |
+| Windows 64 位，NVIDIA 顯示卡，想更快，也想安裝 | [`2026-07-24-windows64.nvidia.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-24.3/2026-07-24-windows64.nvidia.installer.exe) |
+| Windows 64 位，RTX 50 CUDA 版，5070/5080/5090 優先，免安裝 | [`2026-07-24-windows64.nvidia50.cuda.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-24.3/2026-07-24-windows64.nvidia50.cuda.portable.zip) |
+| 進階可選：TensorRT 預裝分卷包說明（需下載全部 .7z.00N） | [`2026-07-24-windows64.nvidia.tensorrt.portable.7z.001`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-24.3/2026-07-24-windows64.nvidia.tensorrt.portable.7z.001)<br>[`2026-07-24-windows64.nvidia.tensorrt.portable.7z.002`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-24.3/2026-07-24-windows64.nvidia.tensorrt.portable.7z.002) |
+| Windows 64 位，RTX 50 CUDA 版，5070/5080/5090 優先，想安裝 | [`2026-07-24-windows64.nvidia50.cuda.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-24.3/2026-07-24-windows64.nvidia50.cuda.installer.exe) |
+| Windows 64 位，想自己配引擎 | [`2026-07-24-windows64.without.engine.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-24.3/2026-07-24-windows64.without.engine.portable.zip) |
+| Windows 64 位，想自己配引擎，也想安裝器 | [`2026-07-24-windows64.without.engine.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-24.3/2026-07-24-windows64.without.engine.installer.exe) |
+| macOS Apple Silicon | [`2026-07-24-mac-apple-silicon.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-24.3/2026-07-24-mac-apple-silicon.with-katago.dmg) |
+| macOS Intel | [`2026-07-24-mac-intel.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-24.3/2026-07-24-mac-intel.with-katago.dmg) |
+| Linux 64 位，CPU 相容版 | [`2026-07-24-linux64.with-katago.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-24.3/2026-07-24-linux64.with-katago.zip) |
+| Linux 64 位，OpenCL 版，AMD/Intel GPU | [`2026-07-24-linux64.opencl.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-24.3/2026-07-24-linux64.opencl.zip) |
+| Linux 64 位，NVIDIA CUDA 版 | [`2026-07-24-linux64.nvidia.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-24.3/2026-07-24-linux64.nvidia.zip) |
 
 ### 這一版為什麼值得測試
 
@@ -117,17 +133,25 @@ This stability preview follows `next-2026-07-22.2`. It completes Whole-game Deep
 
 ### Download Guide
 
-| Your computer | Download |
+| Your computer | Download this file |
 | --- | --- |
-| Windows OpenCL recommended, portable / installer | [portable][win-opencl-portable] / [installer][win-opencl-installer] |
-| Existing Windows portable, small update | [core update][win-core-update] |
-| Windows CPU compatible, portable / installer | [portable][win-cpu-portable] / [installer][win-cpu-installer] |
-| Windows NVIDIA RTX 20/30/40, portable / installer | [portable][win-nvidia-portable] / [installer][win-nvidia-installer] |
-| Windows RTX 50 CUDA, portable / installer | [portable][win-nvidia50-portable] / [installer][win-nvidia50-installer] |
-| Advanced optional TensorRT split package | [download instructions][win-tensorrt-readme] |
-| Windows, configure your own engine | [portable][win-no-engine-portable] / [installer][win-no-engine-installer] |
-| macOS Apple Silicon / Intel | [Apple Silicon][mac-arm64] / [Intel][mac-intel] |
-| Linux CPU / OpenCL / NVIDIA CUDA | [CPU][linux-cpu] / [OpenCL][linux-opencl] / [NVIDIA][linux-nvidia] |
+| Windows 64-bit, OpenCL, recommended and faster, no install | [`2026-07-24-windows64.opencl.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-24.3/2026-07-24-windows64.opencl.portable.zip) |
+| Existing Windows portable install, small routine update | [`2026-07-24-windows64.core-update.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-24.3/2026-07-24-windows64.core-update.zip) |
+| Windows 64-bit, OpenCL, installer | [`2026-07-24-windows64.opencl.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-24.3/2026-07-24-windows64.opencl.installer.exe) |
+| Windows 64-bit, CPU fallback, no install | [`2026-07-24-windows64.with-katago.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-24.3/2026-07-24-windows64.with-katago.portable.zip) |
+| Windows 64-bit, CPU fallback, installer | [`2026-07-24-windows64.with-katago.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-24.3/2026-07-24-windows64.with-katago.installer.exe) |
+| Windows 64-bit, NVIDIA GPU, faster, no install | [`2026-07-24-windows64.nvidia.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-24.3/2026-07-24-windows64.nvidia.portable.zip) |
+| Windows 64-bit, NVIDIA GPU, faster, installer | [`2026-07-24-windows64.nvidia.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-24.3/2026-07-24-windows64.nvidia.installer.exe) |
+| Windows 64-bit, RTX 50 CUDA, recommended for 5070/5080/5090, no install | [`2026-07-24-windows64.nvidia50.cuda.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-24.3/2026-07-24-windows64.nvidia50.cuda.portable.zip) |
+| Advanced optional TensorRT split package guide; download every .7z.00N part | [`2026-07-24-windows64.nvidia.tensorrt.portable.7z.001`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-24.3/2026-07-24-windows64.nvidia.tensorrt.portable.7z.001)<br>[`2026-07-24-windows64.nvidia.tensorrt.portable.7z.002`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-24.3/2026-07-24-windows64.nvidia.tensorrt.portable.7z.002) |
+| Windows 64-bit, RTX 50 CUDA, recommended for 5070/5080/5090, installer | [`2026-07-24-windows64.nvidia50.cuda.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-24.3/2026-07-24-windows64.nvidia50.cuda.installer.exe) |
+| Windows 64-bit, configure your own engine | [`2026-07-24-windows64.without.engine.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-24.3/2026-07-24-windows64.without.engine.portable.zip) |
+| Windows 64-bit, configure your own engine, installer | [`2026-07-24-windows64.without.engine.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-24.3/2026-07-24-windows64.without.engine.installer.exe) |
+| macOS Apple Silicon | [`2026-07-24-mac-apple-silicon.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-24.3/2026-07-24-mac-apple-silicon.with-katago.dmg) |
+| macOS Intel | [`2026-07-24-mac-intel.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-24.3/2026-07-24-mac-intel.with-katago.dmg) |
+| Linux 64-bit, CPU fallback | [`2026-07-24-linux64.with-katago.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-24.3/2026-07-24-linux64.with-katago.zip) |
+| Linux 64-bit, OpenCL for AMD/Intel GPU | [`2026-07-24-linux64.opencl.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-24.3/2026-07-24-linux64.opencl.zip) |
+| Linux 64-bit, NVIDIA CUDA | [`2026-07-24-linux64.nvidia.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-24.3/2026-07-24-linux64.nvidia.zip) |
 
 ### Why Test This Release
 
@@ -164,17 +188,25 @@ This stability preview follows `next-2026-07-22.2`. It completes Whole-game Deep
 
 ### ダウンロード案内
 
-| 環境 | ダウンロード |
+| お使いの環境 | ダウンロードするファイル |
 | --- | --- |
-| Windows OpenCL portable / installer | [portable][win-opencl-portable] / [installer][win-opencl-installer] |
-| Windows portable 小型更新 | [core update][win-core-update] |
-| Windows CPU portable / installer | [portable][win-cpu-portable] / [installer][win-cpu-installer] |
-| Windows NVIDIA portable / installer | [portable][win-nvidia-portable] / [installer][win-nvidia-installer] |
-| Windows RTX 50 CUDA portable / installer | [portable][win-nvidia50-portable] / [installer][win-nvidia50-installer] |
-| TensorRT split package | [README][win-tensorrt-readme] |
-| Windows no-engine portable / installer | [portable][win-no-engine-portable] / [installer][win-no-engine-installer] |
-| macOS Apple Silicon / Intel | [Apple Silicon][mac-arm64] / [Intel][mac-intel] |
-| Linux CPU / OpenCL / NVIDIA | [CPU][linux-cpu] / [OpenCL][linux-opencl] / [NVIDIA][linux-nvidia] |
+| Windows 64-bit、OpenCL 推奨高速版、インストール不要 | [`2026-07-24-windows64.opencl.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-24.3/2026-07-24-windows64.opencl.portable.zip) |
+| 既存の Windows portable 版向け小型更新 | [`2026-07-24-windows64.core-update.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-24.3/2026-07-24-windows64.core-update.zip) |
+| Windows 64-bit、OpenCL 版、インストーラ | [`2026-07-24-windows64.opencl.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-24.3/2026-07-24-windows64.opencl.installer.exe) |
+| Windows 64-bit、CPU fallback、インストール不要 | [`2026-07-24-windows64.with-katago.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-24.3/2026-07-24-windows64.with-katago.portable.zip) |
+| Windows 64-bit、CPU fallback、インストーラ | [`2026-07-24-windows64.with-katago.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-24.3/2026-07-24-windows64.with-katago.installer.exe) |
+| Windows 64-bit、NVIDIA GPU、高速版、インストール不要 | [`2026-07-24-windows64.nvidia.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-24.3/2026-07-24-windows64.nvidia.portable.zip) |
+| Windows 64-bit、NVIDIA GPU、高速版、インストーラ | [`2026-07-24-windows64.nvidia.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-24.3/2026-07-24-windows64.nvidia.installer.exe) |
+| Windows 64-bit、RTX 50 CUDA、5070/5080/5090 推奨、インストール不要 | [`2026-07-24-windows64.nvidia50.cuda.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-24.3/2026-07-24-windows64.nvidia50.cuda.portable.zip) |
+| 上級者向け任意：TensorRT 分割パッケージ案内（.7z.00N を全て取得） | [`2026-07-24-windows64.nvidia.tensorrt.portable.7z.001`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-24.3/2026-07-24-windows64.nvidia.tensorrt.portable.7z.001)<br>[`2026-07-24-windows64.nvidia.tensorrt.portable.7z.002`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-24.3/2026-07-24-windows64.nvidia.tensorrt.portable.7z.002) |
+| Windows 64-bit、RTX 50 CUDA、5070/5080/5090 推奨、インストーラ | [`2026-07-24-windows64.nvidia50.cuda.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-24.3/2026-07-24-windows64.nvidia50.cuda.installer.exe) |
+| Windows 64-bit、自分でエンジンを設定したい場合 | [`2026-07-24-windows64.without.engine.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-24.3/2026-07-24-windows64.without.engine.portable.zip) |
+| Windows 64-bit、自分でエンジンを設定したい場合、インストーラ | [`2026-07-24-windows64.without.engine.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-24.3/2026-07-24-windows64.without.engine.installer.exe) |
+| macOS Apple Silicon | [`2026-07-24-mac-apple-silicon.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-24.3/2026-07-24-mac-apple-silicon.with-katago.dmg) |
+| macOS Intel | [`2026-07-24-mac-intel.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-24.3/2026-07-24-mac-intel.with-katago.dmg) |
+| Linux 64-bit、CPU fallback | [`2026-07-24-linux64.with-katago.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-24.3/2026-07-24-linux64.with-katago.zip) |
+| Linux 64-bit、OpenCL、AMD/Intel GPU | [`2026-07-24-linux64.opencl.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-24.3/2026-07-24-linux64.opencl.zip) |
+| Linux 64-bit、NVIDIA CUDA | [`2026-07-24-linux64.nvidia.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-24.3/2026-07-24-linux64.nvidia.zip) |
 
 ### このリリースを試す理由
 
@@ -211,17 +243,25 @@ This stability preview follows `next-2026-07-22.2`. It completes Whole-game Deep
 
 ### 다운로드 안내
 
-| 환경 | 다운로드 |
+| 내 컴퓨터 | 다운로드할 파일 |
 | --- | --- |
-| Windows OpenCL portable / installer | [portable][win-opencl-portable] / [installer][win-opencl-installer] |
-| Windows portable 소형 업데이트 | [core update][win-core-update] |
-| Windows CPU portable / installer | [portable][win-cpu-portable] / [installer][win-cpu-installer] |
-| Windows NVIDIA portable / installer | [portable][win-nvidia-portable] / [installer][win-nvidia-installer] |
-| Windows RTX 50 CUDA portable / installer | [portable][win-nvidia50-portable] / [installer][win-nvidia50-installer] |
-| TensorRT split package | [README][win-tensorrt-readme] |
-| Windows no-engine portable / installer | [portable][win-no-engine-portable] / [installer][win-no-engine-installer] |
-| macOS Apple Silicon / Intel | [Apple Silicon][mac-arm64] / [Intel][mac-intel] |
-| Linux CPU / OpenCL / NVIDIA | [CPU][linux-cpu] / [OpenCL][linux-opencl] / [NVIDIA][linux-nvidia] |
+| Windows 64-bit, OpenCL 추천 고속판, 무설치 | [`2026-07-24-windows64.opencl.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-24.3/2026-07-24-windows64.opencl.portable.zip) |
+| 기존 Windows portable 사용자를 위한 소형 업데이트 | [`2026-07-24-windows64.core-update.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-24.3/2026-07-24-windows64.core-update.zip) |
+| Windows 64-bit, OpenCL, 설치형 | [`2026-07-24-windows64.opencl.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-24.3/2026-07-24-windows64.opencl.installer.exe) |
+| Windows 64-bit, CPU fallback, 무설치 | [`2026-07-24-windows64.with-katago.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-24.3/2026-07-24-windows64.with-katago.portable.zip) |
+| Windows 64-bit, CPU fallback, 설치형 | [`2026-07-24-windows64.with-katago.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-24.3/2026-07-24-windows64.with-katago.installer.exe) |
+| Windows 64-bit, NVIDIA GPU, 고속판, 무설치 | [`2026-07-24-windows64.nvidia.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-24.3/2026-07-24-windows64.nvidia.portable.zip) |
+| Windows 64-bit, NVIDIA GPU, 고속판, 설치형 | [`2026-07-24-windows64.nvidia.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-24.3/2026-07-24-windows64.nvidia.installer.exe) |
+| Windows 64-bit, RTX 50 CUDA, 5070/5080/5090 권장, 무설치 | [`2026-07-24-windows64.nvidia50.cuda.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-24.3/2026-07-24-windows64.nvidia50.cuda.portable.zip) |
+| 고급 선택: TensorRT 분할 패키지 안내(.7z.00N 전체 다운로드 필요) | [`2026-07-24-windows64.nvidia.tensorrt.portable.7z.001`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-24.3/2026-07-24-windows64.nvidia.tensorrt.portable.7z.001)<br>[`2026-07-24-windows64.nvidia.tensorrt.portable.7z.002`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-24.3/2026-07-24-windows64.nvidia.tensorrt.portable.7z.002) |
+| Windows 64-bit, RTX 50 CUDA, 5070/5080/5090 권장, 설치형 | [`2026-07-24-windows64.nvidia50.cuda.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-24.3/2026-07-24-windows64.nvidia50.cuda.installer.exe) |
+| Windows 64-bit, 직접 엔진 설정 | [`2026-07-24-windows64.without.engine.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-24.3/2026-07-24-windows64.without.engine.portable.zip) |
+| Windows 64-bit, 직접 엔진 설정, 설치형 | [`2026-07-24-windows64.without.engine.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-24.3/2026-07-24-windows64.without.engine.installer.exe) |
+| macOS Apple Silicon | [`2026-07-24-mac-apple-silicon.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-24.3/2026-07-24-mac-apple-silicon.with-katago.dmg) |
+| macOS Intel | [`2026-07-24-mac-intel.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-24.3/2026-07-24-mac-intel.with-katago.dmg) |
+| Linux 64-bit, CPU fallback | [`2026-07-24-linux64.with-katago.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-24.3/2026-07-24-linux64.with-katago.zip) |
+| Linux 64-bit, OpenCL, AMD/Intel GPU | [`2026-07-24-linux64.opencl.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-24.3/2026-07-24-linux64.opencl.zip) |
+| Linux 64-bit, NVIDIA CUDA | [`2026-07-24-linux64.nvidia.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-24.3/2026-07-24-linux64.nvidia.zip) |
 
 ### 이 릴리스를 테스트할 이유
 
@@ -256,19 +296,27 @@ This stability preview follows `next-2026-07-22.2`. It completes Whole-game Deep
 - portable เดิมบน Windows ใช้ small core update ได้ โดยเก็บ settings, game records, custom weights และ TensorRT ไว้
 - นี่คือ Pre-release สำหรับทดสอบ deep analysis และความเสถียรของ engine ทุก platform
 
-### คำแนะนำดาวน์โหลด
+### แนะนำการดาวน์โหลด
 
-| คอมพิวเตอร์ของคุณ | ดาวน์โหลด |
+| เครื่องของคุณ | ดาวน์โหลดไฟล์นี้ |
 | --- | --- |
-| Windows OpenCL portable / installer | [portable][win-opencl-portable] / [installer][win-opencl-installer] |
-| Windows portable อัปเดตขนาดเล็ก | [core update][win-core-update] |
-| Windows CPU portable / installer | [portable][win-cpu-portable] / [installer][win-cpu-installer] |
-| Windows NVIDIA portable / installer | [portable][win-nvidia-portable] / [installer][win-nvidia-installer] |
-| Windows RTX 50 CUDA portable / installer | [portable][win-nvidia50-portable] / [installer][win-nvidia50-installer] |
-| TensorRT split package | [README][win-tensorrt-readme] |
-| Windows no-engine portable / installer | [portable][win-no-engine-portable] / [installer][win-no-engine-installer] |
-| macOS Apple Silicon / Intel | [Apple Silicon][mac-arm64] / [Intel][mac-intel] |
-| Linux CPU / OpenCL / NVIDIA | [CPU][linux-cpu] / [OpenCL][linux-opencl] / [NVIDIA][linux-nvidia] |
+| Windows 64-bit, OpenCL, แนะนำและเร็วกว่า, ไม่ต้องติดตั้ง | [`2026-07-24-windows64.opencl.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-24.3/2026-07-24-windows64.opencl.portable.zip) |
+| อัปเดตเล็กสำหรับผู้ใช้ Windows portable เดิม | [`2026-07-24-windows64.core-update.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-24.3/2026-07-24-windows64.core-update.zip) |
+| Windows 64-bit, OpenCL, แบบติดตั้ง | [`2026-07-24-windows64.opencl.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-24.3/2026-07-24-windows64.opencl.installer.exe) |
+| Windows 64-bit, CPU fallback, ไม่ต้องติดตั้ง | [`2026-07-24-windows64.with-katago.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-24.3/2026-07-24-windows64.with-katago.portable.zip) |
+| Windows 64-bit, CPU fallback, แบบติดตั้ง | [`2026-07-24-windows64.with-katago.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-24.3/2026-07-24-windows64.with-katago.installer.exe) |
+| Windows 64-bit, การ์ดจอ NVIDIA, เร็วกว่า, ไม่ต้องติดตั้ง | [`2026-07-24-windows64.nvidia.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-24.3/2026-07-24-windows64.nvidia.portable.zip) |
+| Windows 64-bit, การ์ดจอ NVIDIA, เร็วกว่า, แบบติดตั้ง | [`2026-07-24-windows64.nvidia.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-24.3/2026-07-24-windows64.nvidia.installer.exe) |
+| Windows 64-bit, RTX 50 CUDA, แนะนำสำหรับ 5070/5080/5090, ไม่ต้องติดตั้ง | [`2026-07-24-windows64.nvidia50.cuda.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-24.3/2026-07-24-windows64.nvidia50.cuda.portable.zip) |
+| ตัวเลือกขั้นสูง: คู่มือ TensorRT split package ต้องดาวน์โหลด .7z.00N ครบทุกไฟล์ | [`2026-07-24-windows64.nvidia.tensorrt.portable.7z.001`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-24.3/2026-07-24-windows64.nvidia.tensorrt.portable.7z.001)<br>[`2026-07-24-windows64.nvidia.tensorrt.portable.7z.002`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-24.3/2026-07-24-windows64.nvidia.tensorrt.portable.7z.002) |
+| Windows 64-bit, RTX 50 CUDA, แนะนำสำหรับ 5070/5080/5090, แบบติดตั้ง | [`2026-07-24-windows64.nvidia50.cuda.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-24.3/2026-07-24-windows64.nvidia50.cuda.installer.exe) |
+| Windows 64-bit, ต้องการตั้งค่า engine เอง | [`2026-07-24-windows64.without.engine.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-24.3/2026-07-24-windows64.without.engine.portable.zip) |
+| Windows 64-bit, ต้องการตั้งค่า engine เองและอยากใช้ installer | [`2026-07-24-windows64.without.engine.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-24.3/2026-07-24-windows64.without.engine.installer.exe) |
+| macOS Apple Silicon | [`2026-07-24-mac-apple-silicon.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-24.3/2026-07-24-mac-apple-silicon.with-katago.dmg) |
+| macOS Intel | [`2026-07-24-mac-intel.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-24.3/2026-07-24-mac-intel.with-katago.dmg) |
+| Linux 64-bit, CPU fallback | [`2026-07-24-linux64.with-katago.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-24.3/2026-07-24-linux64.with-katago.zip) |
+| Linux 64-bit, OpenCL สำหรับ AMD/Intel GPU | [`2026-07-24-linux64.opencl.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-24.3/2026-07-24-linux64.opencl.zip) |
+| Linux 64-bit, NVIDIA CUDA | [`2026-07-24-linux64.nvidia.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-24.3/2026-07-24-linux64.nvidia.zip) |
 
 ### ทำไมควรทดสอบเวอร์ชันนี้
 

--- a/.github/release-notes/next-2026-07-26.1.md
+++ b/.github/release-notes/next-2026-07-26.1.md
@@ -24,15 +24,23 @@
 
 | 你的电脑 | 直接下载这个 |
 | --- | --- |
-| Windows OpenCL 推荐版，免安装 / 安装器 | [portable][win-opencl-portable] / [installer][win-opencl-installer] |
-| 已有 Windows 免安装版，日常小更新 | [core update][win-core-update] |
-| Windows CPU 兼容版，免安装 / 安装器 | [portable][win-cpu-portable] / [installer][win-cpu-installer] |
-| Windows NVIDIA RTX 20/30/40，免安装 / 安装器 | [portable][win-nvidia-portable] / [installer][win-nvidia-installer] |
-| Windows RTX 50 CUDA，免安装 / 安装器 | [portable][win-nvidia50-portable] / [installer][win-nvidia50-installer] |
-| 高级可选 TensorRT 分卷包 | [下载与解压说明][win-tensorrt-readme] |
-| Windows 自行配置引擎，免安装 / 安装器 | [portable][win-no-engine-portable] / [installer][win-no-engine-installer] |
-| macOS Apple Silicon / Intel | [Apple Silicon][mac-arm64] / [Intel][mac-intel] |
-| Linux CPU / OpenCL / NVIDIA CUDA | [CPU][linux-cpu] / [OpenCL][linux-opencl] / [NVIDIA][linux-nvidia] |
+| Windows 64 位，OpenCL 版，推荐更快，免安装 | [`2026-07-26-windows64.opencl.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-26.1/2026-07-26-windows64.opencl.portable.zip) |
+| 已有 Windows 免安装版，日常升级小包 | [`2026-07-26-windows64.core-update.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-26.1/2026-07-26-windows64.core-update.zip) |
+| Windows 64 位，OpenCL 版，想安装 | [`2026-07-26-windows64.opencl.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-26.1/2026-07-26-windows64.opencl.installer.exe) |
+| Windows 64 位，CPU 版，兼容兜底，免安装 | [`2026-07-26-windows64.with-katago.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-26.1/2026-07-26-windows64.with-katago.portable.zip) |
+| Windows 64 位，CPU 版，兼容兜底，想安装 | [`2026-07-26-windows64.with-katago.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-26.1/2026-07-26-windows64.with-katago.installer.exe) |
+| Windows 64 位，英伟达显卡，想更快，免安装 | [`2026-07-26-windows64.nvidia.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-26.1/2026-07-26-windows64.nvidia.portable.zip) |
+| Windows 64 位，英伟达显卡，想更快，也想安装 | [`2026-07-26-windows64.nvidia.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-26.1/2026-07-26-windows64.nvidia.installer.exe) |
+| Windows 64 位，RTX 50 CUDA 版，5070/5080/5090 优先，免安装 | [`2026-07-26-windows64.nvidia50.cuda.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-26.1/2026-07-26-windows64.nvidia50.cuda.portable.zip) |
+| 高级可选：TensorRT 预装分卷包说明（需下载全部 .7z.00N） | [`2026-07-26-windows64.nvidia.tensorrt.portable.7z.001`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-26.1/2026-07-26-windows64.nvidia.tensorrt.portable.7z.001)<br>[`2026-07-26-windows64.nvidia.tensorrt.portable.7z.002`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-26.1/2026-07-26-windows64.nvidia.tensorrt.portable.7z.002) |
+| Windows 64 位，RTX 50 CUDA 版，5070/5080/5090 优先，想安装 | [`2026-07-26-windows64.nvidia50.cuda.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-26.1/2026-07-26-windows64.nvidia50.cuda.installer.exe) |
+| Windows 64 位，想自己配引擎 | [`2026-07-26-windows64.without.engine.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-26.1/2026-07-26-windows64.without.engine.portable.zip) |
+| Windows 64 位，想自己配引擎，也想安装器 | [`2026-07-26-windows64.without.engine.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-26.1/2026-07-26-windows64.without.engine.installer.exe) |
+| macOS Apple Silicon | [`2026-07-26-mac-apple-silicon.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-26.1/2026-07-26-mac-apple-silicon.with-katago.dmg) |
+| macOS Intel | [`2026-07-26-mac-intel.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-26.1/2026-07-26-mac-intel.with-katago.dmg) |
+| Linux 64 位，CPU 兼容版 | [`2026-07-26-linux64.with-katago.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-26.1/2026-07-26-linux64.with-katago.zip) |
+| Linux 64 位，OpenCL 版，AMD/Intel GPU | [`2026-07-26-linux64.opencl.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-26.1/2026-07-26-linux64.opencl.zip) |
+| Linux 64 位，NVIDIA CUDA 版 | [`2026-07-26-linux64.nvidia.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-26.1/2026-07-26-linux64.nvidia.zip) |
 
 ### 这一版为什么值得测试
 
@@ -70,15 +78,23 @@
 
 | 你的電腦 | 直接下載這個 |
 | --- | --- |
-| Windows OpenCL 推薦版，免安裝 / 安裝器 | [portable][win-opencl-portable] / [installer][win-opencl-installer] |
-| 舊 Windows 免安裝版，小型更新 | [core update][win-core-update] |
-| Windows CPU 相容版，免安裝 / 安裝器 | [portable][win-cpu-portable] / [installer][win-cpu-installer] |
-| Windows NVIDIA RTX 20/30/40，免安裝 / 安裝器 | [portable][win-nvidia-portable] / [installer][win-nvidia-installer] |
-| Windows RTX 50 CUDA，免安裝 / 安裝器 | [portable][win-nvidia50-portable] / [installer][win-nvidia50-installer] |
-| 進階 TensorRT 分卷套件 | [下載與解壓說明][win-tensorrt-readme] |
-| Windows 自行設定引擎，免安裝 / 安裝器 | [portable][win-no-engine-portable] / [installer][win-no-engine-installer] |
-| macOS Apple Silicon / Intel | [Apple Silicon][mac-arm64] / [Intel][mac-intel] |
-| Linux CPU / OpenCL / NVIDIA CUDA | [CPU][linux-cpu] / [OpenCL][linux-opencl] / [NVIDIA][linux-nvidia] |
+| Windows 64 位，OpenCL 版，推薦更快，免安裝 | [`2026-07-26-windows64.opencl.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-26.1/2026-07-26-windows64.opencl.portable.zip) |
+| 已有 Windows 免安裝版，日常升級小包 | [`2026-07-26-windows64.core-update.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-26.1/2026-07-26-windows64.core-update.zip) |
+| Windows 64 位，OpenCL 版，想安裝 | [`2026-07-26-windows64.opencl.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-26.1/2026-07-26-windows64.opencl.installer.exe) |
+| Windows 64 位，CPU 版，相容兜底，免安裝 | [`2026-07-26-windows64.with-katago.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-26.1/2026-07-26-windows64.with-katago.portable.zip) |
+| Windows 64 位，CPU 版，相容兜底，想安裝 | [`2026-07-26-windows64.with-katago.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-26.1/2026-07-26-windows64.with-katago.installer.exe) |
+| Windows 64 位，NVIDIA 顯示卡，想更快，免安裝 | [`2026-07-26-windows64.nvidia.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-26.1/2026-07-26-windows64.nvidia.portable.zip) |
+| Windows 64 位，NVIDIA 顯示卡，想更快，也想安裝 | [`2026-07-26-windows64.nvidia.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-26.1/2026-07-26-windows64.nvidia.installer.exe) |
+| Windows 64 位，RTX 50 CUDA 版，5070/5080/5090 優先，免安裝 | [`2026-07-26-windows64.nvidia50.cuda.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-26.1/2026-07-26-windows64.nvidia50.cuda.portable.zip) |
+| 進階可選：TensorRT 預裝分卷包說明（需下載全部 .7z.00N） | [`2026-07-26-windows64.nvidia.tensorrt.portable.7z.001`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-26.1/2026-07-26-windows64.nvidia.tensorrt.portable.7z.001)<br>[`2026-07-26-windows64.nvidia.tensorrt.portable.7z.002`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-26.1/2026-07-26-windows64.nvidia.tensorrt.portable.7z.002) |
+| Windows 64 位，RTX 50 CUDA 版，5070/5080/5090 優先，想安裝 | [`2026-07-26-windows64.nvidia50.cuda.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-26.1/2026-07-26-windows64.nvidia50.cuda.installer.exe) |
+| Windows 64 位，想自己配引擎 | [`2026-07-26-windows64.without.engine.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-26.1/2026-07-26-windows64.without.engine.portable.zip) |
+| Windows 64 位，想自己配引擎，也想安裝器 | [`2026-07-26-windows64.without.engine.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-26.1/2026-07-26-windows64.without.engine.installer.exe) |
+| macOS Apple Silicon | [`2026-07-26-mac-apple-silicon.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-26.1/2026-07-26-mac-apple-silicon.with-katago.dmg) |
+| macOS Intel | [`2026-07-26-mac-intel.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-26.1/2026-07-26-mac-intel.with-katago.dmg) |
+| Linux 64 位，CPU 相容版 | [`2026-07-26-linux64.with-katago.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-26.1/2026-07-26-linux64.with-katago.zip) |
+| Linux 64 位，OpenCL 版，AMD/Intel GPU | [`2026-07-26-linux64.opencl.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-26.1/2026-07-26-linux64.opencl.zip) |
+| Linux 64 位，NVIDIA CUDA 版 | [`2026-07-26-linux64.nvidia.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-26.1/2026-07-26-linux64.nvidia.zip) |
 
 ### 這一版為什麼值得測試
 
@@ -114,17 +130,25 @@ This installation and stability preview follows `next-2026-07-24.3`. It redesign
 
 ### Download Guide
 
-| Your computer | Download |
+| Your computer | Download this file |
 | --- | --- |
-| Windows OpenCL recommended, portable / installer | [portable][win-opencl-portable] / [installer][win-opencl-installer] |
-| Existing Windows portable, small update | [core update][win-core-update] |
-| Windows CPU compatible, portable / installer | [portable][win-cpu-portable] / [installer][win-cpu-installer] |
-| Windows NVIDIA RTX 20/30/40, portable / installer | [portable][win-nvidia-portable] / [installer][win-nvidia-installer] |
-| Windows RTX 50 CUDA, portable / installer | [portable][win-nvidia50-portable] / [installer][win-nvidia50-installer] |
-| Advanced optional TensorRT split package | [download instructions][win-tensorrt-readme] |
-| Windows, configure your own engine | [portable][win-no-engine-portable] / [installer][win-no-engine-installer] |
-| macOS Apple Silicon / Intel | [Apple Silicon][mac-arm64] / [Intel][mac-intel] |
-| Linux CPU / OpenCL / NVIDIA CUDA | [CPU][linux-cpu] / [OpenCL][linux-opencl] / [NVIDIA][linux-nvidia] |
+| Windows 64-bit, OpenCL, recommended and faster, no install | [`2026-07-26-windows64.opencl.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-26.1/2026-07-26-windows64.opencl.portable.zip) |
+| Existing Windows portable install, small routine update | [`2026-07-26-windows64.core-update.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-26.1/2026-07-26-windows64.core-update.zip) |
+| Windows 64-bit, OpenCL, installer | [`2026-07-26-windows64.opencl.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-26.1/2026-07-26-windows64.opencl.installer.exe) |
+| Windows 64-bit, CPU fallback, no install | [`2026-07-26-windows64.with-katago.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-26.1/2026-07-26-windows64.with-katago.portable.zip) |
+| Windows 64-bit, CPU fallback, installer | [`2026-07-26-windows64.with-katago.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-26.1/2026-07-26-windows64.with-katago.installer.exe) |
+| Windows 64-bit, NVIDIA GPU, faster, no install | [`2026-07-26-windows64.nvidia.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-26.1/2026-07-26-windows64.nvidia.portable.zip) |
+| Windows 64-bit, NVIDIA GPU, faster, installer | [`2026-07-26-windows64.nvidia.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-26.1/2026-07-26-windows64.nvidia.installer.exe) |
+| Windows 64-bit, RTX 50 CUDA, recommended for 5070/5080/5090, no install | [`2026-07-26-windows64.nvidia50.cuda.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-26.1/2026-07-26-windows64.nvidia50.cuda.portable.zip) |
+| Advanced optional TensorRT split package guide; download every .7z.00N part | [`2026-07-26-windows64.nvidia.tensorrt.portable.7z.001`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-26.1/2026-07-26-windows64.nvidia.tensorrt.portable.7z.001)<br>[`2026-07-26-windows64.nvidia.tensorrt.portable.7z.002`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-26.1/2026-07-26-windows64.nvidia.tensorrt.portable.7z.002) |
+| Windows 64-bit, RTX 50 CUDA, recommended for 5070/5080/5090, installer | [`2026-07-26-windows64.nvidia50.cuda.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-26.1/2026-07-26-windows64.nvidia50.cuda.installer.exe) |
+| Windows 64-bit, configure your own engine | [`2026-07-26-windows64.without.engine.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-26.1/2026-07-26-windows64.without.engine.portable.zip) |
+| Windows 64-bit, configure your own engine, installer | [`2026-07-26-windows64.without.engine.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-26.1/2026-07-26-windows64.without.engine.installer.exe) |
+| macOS Apple Silicon | [`2026-07-26-mac-apple-silicon.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-26.1/2026-07-26-mac-apple-silicon.with-katago.dmg) |
+| macOS Intel | [`2026-07-26-mac-intel.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-26.1/2026-07-26-mac-intel.with-katago.dmg) |
+| Linux 64-bit, CPU fallback | [`2026-07-26-linux64.with-katago.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-26.1/2026-07-26-linux64.with-katago.zip) |
+| Linux 64-bit, OpenCL for AMD/Intel GPU | [`2026-07-26-linux64.opencl.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-26.1/2026-07-26-linux64.opencl.zip) |
+| Linux 64-bit, NVIDIA CUDA | [`2026-07-26-linux64.nvidia.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-26.1/2026-07-26-linux64.nvidia.zip) |
 
 ### Why Test This Release
 
@@ -160,17 +184,25 @@ This installation and stability preview follows `next-2026-07-24.3`. It redesign
 
 ### ダウンロード案内
 
-| 環境 | ダウンロード |
+| お使いの環境 | ダウンロードするファイル |
 | --- | --- |
-| Windows OpenCL portable / installer | [portable][win-opencl-portable] / [installer][win-opencl-installer] |
-| Windows portable 小型更新 | [core update][win-core-update] |
-| Windows CPU portable / installer | [portable][win-cpu-portable] / [installer][win-cpu-installer] |
-| Windows NVIDIA portable / installer | [portable][win-nvidia-portable] / [installer][win-nvidia-installer] |
-| Windows RTX 50 CUDA portable / installer | [portable][win-nvidia50-portable] / [installer][win-nvidia50-installer] |
-| TensorRT split package | [README][win-tensorrt-readme] |
-| Windows no-engine portable / installer | [portable][win-no-engine-portable] / [installer][win-no-engine-installer] |
-| macOS Apple Silicon / Intel | [Apple Silicon][mac-arm64] / [Intel][mac-intel] |
-| Linux CPU / OpenCL / NVIDIA | [CPU][linux-cpu] / [OpenCL][linux-opencl] / [NVIDIA][linux-nvidia] |
+| Windows 64-bit、OpenCL 推奨高速版、インストール不要 | [`2026-07-26-windows64.opencl.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-26.1/2026-07-26-windows64.opencl.portable.zip) |
+| 既存の Windows portable 版向け小型更新 | [`2026-07-26-windows64.core-update.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-26.1/2026-07-26-windows64.core-update.zip) |
+| Windows 64-bit、OpenCL 版、インストーラ | [`2026-07-26-windows64.opencl.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-26.1/2026-07-26-windows64.opencl.installer.exe) |
+| Windows 64-bit、CPU fallback、インストール不要 | [`2026-07-26-windows64.with-katago.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-26.1/2026-07-26-windows64.with-katago.portable.zip) |
+| Windows 64-bit、CPU fallback、インストーラ | [`2026-07-26-windows64.with-katago.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-26.1/2026-07-26-windows64.with-katago.installer.exe) |
+| Windows 64-bit、NVIDIA GPU、高速版、インストール不要 | [`2026-07-26-windows64.nvidia.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-26.1/2026-07-26-windows64.nvidia.portable.zip) |
+| Windows 64-bit、NVIDIA GPU、高速版、インストーラ | [`2026-07-26-windows64.nvidia.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-26.1/2026-07-26-windows64.nvidia.installer.exe) |
+| Windows 64-bit、RTX 50 CUDA、5070/5080/5090 推奨、インストール不要 | [`2026-07-26-windows64.nvidia50.cuda.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-26.1/2026-07-26-windows64.nvidia50.cuda.portable.zip) |
+| 上級者向け任意：TensorRT 分割パッケージ案内（.7z.00N を全て取得） | [`2026-07-26-windows64.nvidia.tensorrt.portable.7z.001`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-26.1/2026-07-26-windows64.nvidia.tensorrt.portable.7z.001)<br>[`2026-07-26-windows64.nvidia.tensorrt.portable.7z.002`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-26.1/2026-07-26-windows64.nvidia.tensorrt.portable.7z.002) |
+| Windows 64-bit、RTX 50 CUDA、5070/5080/5090 推奨、インストーラ | [`2026-07-26-windows64.nvidia50.cuda.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-26.1/2026-07-26-windows64.nvidia50.cuda.installer.exe) |
+| Windows 64-bit、自分でエンジンを設定したい場合 | [`2026-07-26-windows64.without.engine.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-26.1/2026-07-26-windows64.without.engine.portable.zip) |
+| Windows 64-bit、自分でエンジンを設定したい場合、インストーラ | [`2026-07-26-windows64.without.engine.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-26.1/2026-07-26-windows64.without.engine.installer.exe) |
+| macOS Apple Silicon | [`2026-07-26-mac-apple-silicon.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-26.1/2026-07-26-mac-apple-silicon.with-katago.dmg) |
+| macOS Intel | [`2026-07-26-mac-intel.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-26.1/2026-07-26-mac-intel.with-katago.dmg) |
+| Linux 64-bit、CPU fallback | [`2026-07-26-linux64.with-katago.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-26.1/2026-07-26-linux64.with-katago.zip) |
+| Linux 64-bit、OpenCL、AMD/Intel GPU | [`2026-07-26-linux64.opencl.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-26.1/2026-07-26-linux64.opencl.zip) |
+| Linux 64-bit、NVIDIA CUDA | [`2026-07-26-linux64.nvidia.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-26.1/2026-07-26-linux64.nvidia.zip) |
 
 ### このリリースを試す理由
 
@@ -206,17 +238,25 @@ This installation and stability preview follows `next-2026-07-24.3`. It redesign
 
 ### 다운로드 안내
 
-| 환경 | 다운로드 |
+| 내 컴퓨터 | 다운로드할 파일 |
 | --- | --- |
-| Windows OpenCL portable / installer | [portable][win-opencl-portable] / [installer][win-opencl-installer] |
-| Windows portable 소형 업데이트 | [core update][win-core-update] |
-| Windows CPU portable / installer | [portable][win-cpu-portable] / [installer][win-cpu-installer] |
-| Windows NVIDIA portable / installer | [portable][win-nvidia-portable] / [installer][win-nvidia-installer] |
-| Windows RTX 50 CUDA portable / installer | [portable][win-nvidia50-portable] / [installer][win-nvidia50-installer] |
-| TensorRT split package | [README][win-tensorrt-readme] |
-| Windows no-engine portable / installer | [portable][win-no-engine-portable] / [installer][win-no-engine-installer] |
-| macOS Apple Silicon / Intel | [Apple Silicon][mac-arm64] / [Intel][mac-intel] |
-| Linux CPU / OpenCL / NVIDIA | [CPU][linux-cpu] / [OpenCL][linux-opencl] / [NVIDIA][linux-nvidia] |
+| Windows 64-bit, OpenCL 추천 고속판, 무설치 | [`2026-07-26-windows64.opencl.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-26.1/2026-07-26-windows64.opencl.portable.zip) |
+| 기존 Windows portable 사용자를 위한 소형 업데이트 | [`2026-07-26-windows64.core-update.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-26.1/2026-07-26-windows64.core-update.zip) |
+| Windows 64-bit, OpenCL, 설치형 | [`2026-07-26-windows64.opencl.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-26.1/2026-07-26-windows64.opencl.installer.exe) |
+| Windows 64-bit, CPU fallback, 무설치 | [`2026-07-26-windows64.with-katago.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-26.1/2026-07-26-windows64.with-katago.portable.zip) |
+| Windows 64-bit, CPU fallback, 설치형 | [`2026-07-26-windows64.with-katago.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-26.1/2026-07-26-windows64.with-katago.installer.exe) |
+| Windows 64-bit, NVIDIA GPU, 고속판, 무설치 | [`2026-07-26-windows64.nvidia.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-26.1/2026-07-26-windows64.nvidia.portable.zip) |
+| Windows 64-bit, NVIDIA GPU, 고속판, 설치형 | [`2026-07-26-windows64.nvidia.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-26.1/2026-07-26-windows64.nvidia.installer.exe) |
+| Windows 64-bit, RTX 50 CUDA, 5070/5080/5090 권장, 무설치 | [`2026-07-26-windows64.nvidia50.cuda.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-26.1/2026-07-26-windows64.nvidia50.cuda.portable.zip) |
+| 고급 선택: TensorRT 분할 패키지 안내(.7z.00N 전체 다운로드 필요) | [`2026-07-26-windows64.nvidia.tensorrt.portable.7z.001`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-26.1/2026-07-26-windows64.nvidia.tensorrt.portable.7z.001)<br>[`2026-07-26-windows64.nvidia.tensorrt.portable.7z.002`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-26.1/2026-07-26-windows64.nvidia.tensorrt.portable.7z.002) |
+| Windows 64-bit, RTX 50 CUDA, 5070/5080/5090 권장, 설치형 | [`2026-07-26-windows64.nvidia50.cuda.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-26.1/2026-07-26-windows64.nvidia50.cuda.installer.exe) |
+| Windows 64-bit, 직접 엔진 설정 | [`2026-07-26-windows64.without.engine.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-26.1/2026-07-26-windows64.without.engine.portable.zip) |
+| Windows 64-bit, 직접 엔진 설정, 설치형 | [`2026-07-26-windows64.without.engine.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-26.1/2026-07-26-windows64.without.engine.installer.exe) |
+| macOS Apple Silicon | [`2026-07-26-mac-apple-silicon.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-26.1/2026-07-26-mac-apple-silicon.with-katago.dmg) |
+| macOS Intel | [`2026-07-26-mac-intel.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-26.1/2026-07-26-mac-intel.with-katago.dmg) |
+| Linux 64-bit, CPU fallback | [`2026-07-26-linux64.with-katago.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-26.1/2026-07-26-linux64.with-katago.zip) |
+| Linux 64-bit, OpenCL, AMD/Intel GPU | [`2026-07-26-linux64.opencl.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-26.1/2026-07-26-linux64.opencl.zip) |
+| Linux 64-bit, NVIDIA CUDA | [`2026-07-26-linux64.nvidia.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-26.1/2026-07-26-linux64.nvidia.zip) |
 
 ### 이 릴리스를 테스트할 이유
 
@@ -250,19 +290,27 @@ This installation and stability preview follows `next-2026-07-24.3`. It redesign
 - portable เดิมบน Windows ใช้ small core update ได้ โดยเก็บ settings, game records, custom weights และ TensorRT ไว้
 - นี่คือ Pre-release สำหรับตรวจสอบ installation flow ใหม่บน macOS และความเสถียรข้าม platform
 
-### คำแนะนำดาวน์โหลด
+### แนะนำการดาวน์โหลด
 
-| คอมพิวเตอร์ของคุณ | ดาวน์โหลด |
+| เครื่องของคุณ | ดาวน์โหลดไฟล์นี้ |
 | --- | --- |
-| Windows OpenCL portable / installer | [portable][win-opencl-portable] / [installer][win-opencl-installer] |
-| Windows portable อัปเดตขนาดเล็ก | [core update][win-core-update] |
-| Windows CPU portable / installer | [portable][win-cpu-portable] / [installer][win-cpu-installer] |
-| Windows NVIDIA portable / installer | [portable][win-nvidia-portable] / [installer][win-nvidia-installer] |
-| Windows RTX 50 CUDA portable / installer | [portable][win-nvidia50-portable] / [installer][win-nvidia50-installer] |
-| TensorRT split package | [README][win-tensorrt-readme] |
-| Windows no-engine portable / installer | [portable][win-no-engine-portable] / [installer][win-no-engine-installer] |
-| macOS Apple Silicon / Intel | [Apple Silicon][mac-arm64] / [Intel][mac-intel] |
-| Linux CPU / OpenCL / NVIDIA | [CPU][linux-cpu] / [OpenCL][linux-opencl] / [NVIDIA][linux-nvidia] |
+| Windows 64-bit, OpenCL, แนะนำและเร็วกว่า, ไม่ต้องติดตั้ง | [`2026-07-26-windows64.opencl.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-26.1/2026-07-26-windows64.opencl.portable.zip) |
+| อัปเดตเล็กสำหรับผู้ใช้ Windows portable เดิม | [`2026-07-26-windows64.core-update.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-26.1/2026-07-26-windows64.core-update.zip) |
+| Windows 64-bit, OpenCL, แบบติดตั้ง | [`2026-07-26-windows64.opencl.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-26.1/2026-07-26-windows64.opencl.installer.exe) |
+| Windows 64-bit, CPU fallback, ไม่ต้องติดตั้ง | [`2026-07-26-windows64.with-katago.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-26.1/2026-07-26-windows64.with-katago.portable.zip) |
+| Windows 64-bit, CPU fallback, แบบติดตั้ง | [`2026-07-26-windows64.with-katago.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-26.1/2026-07-26-windows64.with-katago.installer.exe) |
+| Windows 64-bit, การ์ดจอ NVIDIA, เร็วกว่า, ไม่ต้องติดตั้ง | [`2026-07-26-windows64.nvidia.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-26.1/2026-07-26-windows64.nvidia.portable.zip) |
+| Windows 64-bit, การ์ดจอ NVIDIA, เร็วกว่า, แบบติดตั้ง | [`2026-07-26-windows64.nvidia.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-26.1/2026-07-26-windows64.nvidia.installer.exe) |
+| Windows 64-bit, RTX 50 CUDA, แนะนำสำหรับ 5070/5080/5090, ไม่ต้องติดตั้ง | [`2026-07-26-windows64.nvidia50.cuda.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-26.1/2026-07-26-windows64.nvidia50.cuda.portable.zip) |
+| ตัวเลือกขั้นสูง: คู่มือ TensorRT split package ต้องดาวน์โหลด .7z.00N ครบทุกไฟล์ | [`2026-07-26-windows64.nvidia.tensorrt.portable.7z.001`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-26.1/2026-07-26-windows64.nvidia.tensorrt.portable.7z.001)<br>[`2026-07-26-windows64.nvidia.tensorrt.portable.7z.002`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-26.1/2026-07-26-windows64.nvidia.tensorrt.portable.7z.002) |
+| Windows 64-bit, RTX 50 CUDA, แนะนำสำหรับ 5070/5080/5090, แบบติดตั้ง | [`2026-07-26-windows64.nvidia50.cuda.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-26.1/2026-07-26-windows64.nvidia50.cuda.installer.exe) |
+| Windows 64-bit, ต้องการตั้งค่า engine เอง | [`2026-07-26-windows64.without.engine.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-26.1/2026-07-26-windows64.without.engine.portable.zip) |
+| Windows 64-bit, ต้องการตั้งค่า engine เองและอยากใช้ installer | [`2026-07-26-windows64.without.engine.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-26.1/2026-07-26-windows64.without.engine.installer.exe) |
+| macOS Apple Silicon | [`2026-07-26-mac-apple-silicon.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-26.1/2026-07-26-mac-apple-silicon.with-katago.dmg) |
+| macOS Intel | [`2026-07-26-mac-intel.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-26.1/2026-07-26-mac-intel.with-katago.dmg) |
+| Linux 64-bit, CPU fallback | [`2026-07-26-linux64.with-katago.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-26.1/2026-07-26-linux64.with-katago.zip) |
+| Linux 64-bit, OpenCL สำหรับ AMD/Intel GPU | [`2026-07-26-linux64.opencl.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-26.1/2026-07-26-linux64.opencl.zip) |
+| Linux 64-bit, NVIDIA CUDA | [`2026-07-26-linux64.nvidia.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-26.1/2026-07-26-linux64.nvidia.zip) |
 
 ### ทำไมควรทดสอบเวอร์ชันนี้
 

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -201,6 +201,13 @@ gh workflow run update-release-notes.yml \
 
 现在可以直接用 `scripts/generate_release_notes.py` 生成这份多语言正文，再更新到 GitHub release。
 
+六种语言的下载表统一沿用 `next-2026-07-19.1` 的直接格式：
+
+- 每个普通资产单独一行，显示带日期的完整文件名，并直接链接到该 release 的真实下载 URL。
+- 不把免安装包和安装器压缩成同一行，也不使用 `portable / installer` 这类需要用户猜测的短标签。
+- TensorRT 的 `.7z.001` 与 `.7z.002` 是同一套分卷，可以在同一行连续列出，但必须同时显示完整文件名和直链。
+- `publish_release_request.py` 会检查六种语言的下载表；任何语言缺少完整文件名直链都不能发布。
+
 ## 七、上传前自查
 
 至少逐项确认：

--- a/scripts/publish_release_request.py
+++ b/scripts/publish_release_request.py
@@ -31,11 +31,94 @@ LOCALIZED_NOTE_HEADINGS = (
     "## 한국어",
     "## ภาษาไทย",
 )
+DIRECT_DOWNLOAD_SUFFIXES = (
+    "windows64.opencl.portable.zip",
+    "windows64.core-update.zip",
+    "windows64.opencl.installer.exe",
+    "windows64.with-katago.portable.zip",
+    "windows64.with-katago.installer.exe",
+    "windows64.nvidia.portable.zip",
+    "windows64.nvidia.installer.exe",
+    "windows64.nvidia50.cuda.portable.zip",
+    "windows64.nvidia.tensorrt.portable.7z.001",
+    "windows64.nvidia.tensorrt.portable.7z.002",
+    "windows64.nvidia50.cuda.installer.exe",
+    "windows64.without.engine.portable.zip",
+    "windows64.without.engine.installer.exe",
+    "mac-apple-silicon.with-katago.dmg",
+    "mac-intel.with-katago.dmg",
+    "linux64.with-katago.zip",
+    "linux64.opencl.zip",
+    "linux64.nvidia.zip",
+)
 ACTIVE_RUN_STATUSES = {"queued", "in_progress", "waiting", "requested", "pending"}
 
 
 class PublishError(RuntimeError):
     """A release invariant or GitHub API operation failed."""
+
+
+def _localized_note_sections(body: str) -> dict[str, str]:
+    matches: list[tuple[str, re.Match[str]]] = []
+    for heading in LOCALIZED_NOTE_HEADINGS:
+        match = re.search(rf"^{re.escape(heading)}\s*$", body, re.MULTILINE)
+        if match is None:
+            raise PublishError(f"Reviewed release notes are missing {heading}")
+        matches.append((heading, match))
+    matches.sort(key=lambda item: item[1].start())
+
+    sections: dict[str, str] = {}
+    for index, (heading, match) in enumerate(matches):
+        end = matches[index + 1][1].start() if index + 1 < len(matches) else len(body)
+        sections[heading] = body[match.start():end]
+    return sections
+
+
+def validate_direct_download_tables(
+    body: str,
+    date_tag: str,
+    release_tag: str,
+    repository: str,
+) -> None:
+    """Require the user-facing 7/19-style direct asset table in every language."""
+
+    for language, section in _localized_note_sections(body).items():
+        subsections = list(re.finditer(r"^### .+$", section, re.MULTILINE))
+        if len(subsections) < 4:
+            raise PublishError(
+                f"{language} must keep the standard updates/before/download/why/contact structure"
+            )
+        download_start = subsections[2].start()
+        download_end = subsections[3].start()
+        download_section = section[download_start:download_end]
+        lines = download_section.splitlines()
+        expected_names = [
+            f"{date_tag}-{suffix}" for suffix in DIRECT_DOWNLOAD_SUFFIXES
+        ]
+
+        for filename in expected_names:
+            url = (
+                f"https://github.com/{repository}/releases/download/"
+                f"{release_tag}/{filename}"
+            )
+            direct_link = re.compile(
+                rf"\[(?:`)?{re.escape(filename)}(?:`)?\]\({re.escape(url)}\)"
+            )
+            matching_lines = [line for line in lines if direct_link.search(line)]
+            if len(matching_lines) != 1:
+                raise PublishError(
+                    f"{language} download guide must directly link the full filename {filename}"
+                )
+
+            if ".tensorrt.portable.7z." not in filename:
+                linked_assets = sum(
+                    expected_name in matching_lines[0]
+                    for expected_name in expected_names
+                )
+                if linked_assets != 1:
+                    raise PublishError(
+                        f"{language} download guide must put {filename} on its own row"
+                    )
 
 
 @dataclass(frozen=True)
@@ -390,6 +473,12 @@ class ReleasePublisher:
             raise PublishError("Reviewed release notes are missing the tag or a language section")
         if "{{" in release_notes or "}}" in release_notes:
             raise PublishError("Reviewed release notes contain an unresolved template token")
+        validate_direct_download_tables(
+            release_notes,
+            request.date_tag,
+            request.release_tag,
+            client.repository,
+        )
 
     def _ensure_tag(self) -> None:
         existing = self.client.get_tag_sha(self.request.release_tag)

--- a/scripts/test_publish_release_request.py
+++ b/scripts/test_publish_release_request.py
@@ -54,6 +54,8 @@ def all_asset_names() -> list[str]:
 
 
 class FakeClient:
+    repository = "wimi321/lizzieyzy-next"
+
     def __init__(
         self,
         failed_workflow: str | None = None,
@@ -383,7 +385,46 @@ class ReleasePublisherTest(unittest.TestCase):
         )
 
     def release_notes(self) -> str:
-        return RELEASE_TAG + "\n" + "\n".join(PUBLISH.LOCALIZED_NOTE_HEADINGS)
+        blocks: list[str] = [f"# LizzieYzy Next {RELEASE_TAG}"]
+        for heading in PUBLISH.LOCALIZED_NOTE_HEADINGS:
+            rows = [
+                (
+                    f"| Test platform | [`{DATE_TAG}-{suffix}`]"
+                    f"(https://github.com/wimi321/lizzieyzy-next/releases/download/"
+                    f"{RELEASE_TAG}/{DATE_TAG}-{suffix}) |"
+                )
+                for suffix in PUBLISH.DIRECT_DOWNLOAD_SUFFIXES
+            ]
+            blocks.append(
+                "\n".join(
+                    [
+                        heading,
+                        "",
+                        "### Updates",
+                        "",
+                        "- Reviewed",
+                        "",
+                        "### Before Downloading",
+                        "",
+                        "- Choose the matching platform",
+                        "",
+                        "### Download Guide",
+                        "",
+                        "| Platform | Direct download |",
+                        "| --- | --- |",
+                        *rows,
+                        "",
+                        "### Why",
+                        "",
+                        "- Stable",
+                        "",
+                        "### Contact",
+                        "",
+                        "- Community",
+                    ]
+                )
+            )
+        return "\n\n---\n\n".join(blocks)
 
     def publisher(self, client: FakeClient) -> PUBLISH.ReleasePublisher:
         return PUBLISH.ReleasePublisher(
@@ -548,6 +589,51 @@ class ReleasePublisherTest(unittest.TestCase):
             )
 
         self.assertIsNone(client.tag_sha)
+
+    def test_rejects_reference_style_download_labels(self) -> None:
+        client = FakeClient()
+        notes = self.release_notes().replace(
+            f"[`{DATE_TAG}-windows64.opencl.portable.zip`]"
+            f"(https://github.com/wimi321/lizzieyzy-next/releases/download/"
+            f"{RELEASE_TAG}/{DATE_TAG}-windows64.opencl.portable.zip)",
+            "[portable][win-opencl-portable]",
+        )
+
+        with self.assertRaisesRegex(
+            PUBLISH.PublishError,
+            "must directly link the full filename",
+        ):
+            PUBLISH.ReleasePublisher(
+                client,
+                self.request(),
+                TARGET_SHA,
+                notes,
+            )
+
+    def test_rejects_two_regular_assets_on_one_row(self) -> None:
+        client = FakeClient()
+        first = (
+            f"[`{DATE_TAG}-windows64.opencl.portable.zip`]"
+            f"(https://github.com/wimi321/lizzieyzy-next/releases/download/"
+            f"{RELEASE_TAG}/{DATE_TAG}-windows64.opencl.portable.zip)"
+        )
+        second = (
+            f"[`{DATE_TAG}-windows64.core-update.zip`]"
+            f"(https://github.com/wimi321/lizzieyzy-next/releases/download/"
+            f"{RELEASE_TAG}/{DATE_TAG}-windows64.core-update.zip)"
+        )
+        notes = self.release_notes().replace(
+            f"| Test platform | {first} |\n| Test platform | {second} |",
+            f"| Test platform | {first} / {second} |",
+        )
+
+        with self.assertRaisesRegex(PUBLISH.PublishError, "on its own row"):
+            PUBLISH.ReleasePublisher(
+                client,
+                self.request(),
+                TARGET_SHA,
+                notes,
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Restores the clear `next-2026-07-19.1` download-table format for the three recent pre-releases.
- Shows each regular asset on its own row with the complete dated filename and a direct GitHub download URL.
- Keeps both TensorRT volumes together while linking `.001` and `.002` explicitly.
- Adds a six-language publishing guard so compact `portable / installer` reference links cannot regress.

## Validation

- `python3 -m unittest scripts.test_publish_release_request scripts.test_generate_release_notes`
- `python3 -m py_compile scripts/publish_release_request.py scripts/test_publish_release_request.py scripts/generate_release_notes.py`
- `python3 scripts/check_markdown_links.py`
- `mvn -B -Dfmt.skip=true test` (1530 tests)
- `git diff --check`
- Verified the three public release bodies remain non-draft pre-releases with 22 assets and six valid direct-download tables.
