### PR TITLE
Request next-2026-07-27.1 pre-release

### DIFF
--- a/.github/release-notes/next-2026-07-27.1.md
+++ b/.github/release-notes/next-2026-07-27.1.md
@@ -1,0 +1,317 @@
+# LizzieYzy Next next-2026-07-27.1
+
+## 中文
+
+这是 `next-2026-07-26.1` 之后的整盘分析交互预览版，重点恢复清晰的闪电分析入口，并完善整盘精析的开始、暂停、继续和停止体验。
+
+### 本版主要更新
+
+- 顶部“一键设置”旁恢复独立的“闪电分析”按钮，保留整盘速览、部分闪电分析、全分支闪电分析和闪电分析设置。
+- “整盘精析（推荐）”统一放在左下角“自动分析”菜单，移除顶部与底部重复入口。
+- 整盘精析窗口打开后先等待用户确认，点击“开始分析”才占用引擎。
+- 新增可靠的暂停、继续和停止流程；暂停会保留已完成结果，继续只补算尚未完成的局面。
+- 窗口改为内容自适应布局，修复 Windows 字体与 DPI 缩放下局面数、分析模式和剩余时间被裁切的问题。
+
+### 下载前先看这几句
+
+- 完整包继续内置 KataGo `v1.16.5` 和默认智子 28B 权重。
+- Windows 普通用户优先下载 OpenCL 免安装版；RTX 20/30/40 可选 NVIDIA 包，RTX 50 可选 CUDA 12.8 包。
+- 已有 Windows 免安装版可使用小更新包，配置、棋谱、自定义权重和 TensorRT 文件会保留。
+- 这是 Pre-release，建议重点测试 Windows 125% 至 200% 缩放下的整盘精析窗口。
+
+### 下载建议
+
+| 你的电脑 | 直接下载这个 |
+| --- | --- |
+| Windows 64 位，OpenCL 版，推荐更快，免安装 | [`2026-07-27-windows64.opencl.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-27.1/2026-07-27-windows64.opencl.portable.zip) |
+| 已有 Windows 免安装版，日常升级小包 | [`2026-07-27-windows64.core-update.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-27.1/2026-07-27-windows64.core-update.zip) |
+| Windows 64 位，OpenCL 版，想安装 | [`2026-07-27-windows64.opencl.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-27.1/2026-07-27-windows64.opencl.installer.exe) |
+| Windows 64 位，CPU 版，兼容兜底，免安装 | [`2026-07-27-windows64.with-katago.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-27.1/2026-07-27-windows64.with-katago.portable.zip) |
+| Windows 64 位，CPU 版，兼容兜底，想安装 | [`2026-07-27-windows64.with-katago.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-27.1/2026-07-27-windows64.with-katago.installer.exe) |
+| Windows 64 位，英伟达显卡，想更快，免安装 | [`2026-07-27-windows64.nvidia.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-27.1/2026-07-27-windows64.nvidia.portable.zip) |
+| Windows 64 位，英伟达显卡，想更快，也想安装 | [`2026-07-27-windows64.nvidia.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-27.1/2026-07-27-windows64.nvidia.installer.exe) |
+| Windows 64 位，RTX 50 CUDA 版，5070/5080/5090 优先，免安装 | [`2026-07-27-windows64.nvidia50.cuda.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-27.1/2026-07-27-windows64.nvidia50.cuda.portable.zip) |
+| 高级可选：TensorRT 预装分卷包（需下载全部 .7z.00N） | [`2026-07-27-windows64.nvidia.tensorrt.portable.7z.001`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-27.1/2026-07-27-windows64.nvidia.tensorrt.portable.7z.001)<br>[`2026-07-27-windows64.nvidia.tensorrt.portable.7z.002`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-27.1/2026-07-27-windows64.nvidia.tensorrt.portable.7z.002) |
+| Windows 64 位，RTX 50 CUDA 版，5070/5080/5090 优先，想安装 | [`2026-07-27-windows64.nvidia50.cuda.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-27.1/2026-07-27-windows64.nvidia50.cuda.installer.exe) |
+| Windows 64 位，想自己配引擎 | [`2026-07-27-windows64.without.engine.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-27.1/2026-07-27-windows64.without.engine.portable.zip) |
+| Windows 64 位，想自己配引擎，也想安装器 | [`2026-07-27-windows64.without.engine.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-27.1/2026-07-27-windows64.without.engine.installer.exe) |
+| macOS Apple Silicon | [`2026-07-27-mac-apple-silicon.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-27.1/2026-07-27-mac-apple-silicon.with-katago.dmg) |
+| macOS Intel | [`2026-07-27-mac-intel.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-27.1/2026-07-27-mac-intel.with-katago.dmg) |
+| Linux 64 位，CPU 兼容版 | [`2026-07-27-linux64.with-katago.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-27.1/2026-07-27-linux64.with-katago.zip) |
+| Linux 64 位，OpenCL 版，AMD/Intel GPU | [`2026-07-27-linux64.opencl.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-27.1/2026-07-27-linux64.opencl.zip) |
+| Linux 64 位，NVIDIA CUDA 版 | [`2026-07-27-linux64.nvidia.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-27.1/2026-07-27-linux64.nvidia.zip) |
+
+### 这一版为什么值得测试
+
+- 闪电分析和整盘精析入口职责更清楚，不再出现菜单重复和弹出位置异常。
+- 暂停后不会丢失已完成结果，继续分析也不会覆盖已经计算的局面。
+- 合并版本通过 1542 项完整测试，并使用真实 KataGo 验证了开始、暂停、继续、隐藏和恢复流程。
+
+### 交流
+
+- QQ 群：`299419120`
+
+---
+
+## 繁體中文
+
+這是 `next-2026-07-26.1` 之後的全盤分析互動預覽版，重點恢復清楚的閃電分析入口，並完善全盤精析的開始、暫停、繼續與停止流程。
+
+### 本版主要更新
+
+- 在「一鍵設定」旁恢復獨立的「閃電分析」按鈕，保留全盤速覽、部分閃電分析、全分支閃電分析與設定。
+- 「全盤精析（推薦）」統一放在左下角「自動分析」選單，移除上下重複入口。
+- 開啟全盤精析視窗後先等待使用者確認，按下「開始分析」才占用引擎。
+- 加入可靠的暫停、繼續與停止流程；暫停會保留完成結果，繼續只補算未完成局面。
+- 視窗改為內容自適應版面，修復 Windows 字型與 DPI 縮放下局面數、分析模式及剩餘時間被裁切。
+
+### 下載前先看這幾句
+
+- 完整套件繼續內建 KataGo `v1.16.5` 與預設智子 28B 權重。
+- Windows 一般使用者優先選 OpenCL portable；RTX 20/30/40 可選 NVIDIA，RTX 50 可選 CUDA 12.8。
+- 舊 Windows portable 可使用小型更新，並保留設定、棋譜、自訂權重與 TensorRT。
+- 這是 Pre-release，建議特別測試 Windows 125% 至 200% 縮放下的全盤精析視窗。
+
+### 下載建議
+
+| 你的電腦 | 直接下載這個 |
+| --- | --- |
+| Windows 64 位，OpenCL 版，推薦更快，免安裝 | [`2026-07-27-windows64.opencl.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-27.1/2026-07-27-windows64.opencl.portable.zip) |
+| 已有 Windows 免安裝版，日常升級小包 | [`2026-07-27-windows64.core-update.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-27.1/2026-07-27-windows64.core-update.zip) |
+| Windows 64 位，OpenCL 版，想安裝 | [`2026-07-27-windows64.opencl.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-27.1/2026-07-27-windows64.opencl.installer.exe) |
+| Windows 64 位，CPU 版，相容兜底，免安裝 | [`2026-07-27-windows64.with-katago.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-27.1/2026-07-27-windows64.with-katago.portable.zip) |
+| Windows 64 位，CPU 版，相容兜底，想安裝 | [`2026-07-27-windows64.with-katago.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-27.1/2026-07-27-windows64.with-katago.installer.exe) |
+| Windows 64 位，NVIDIA 顯示卡，想更快，免安裝 | [`2026-07-27-windows64.nvidia.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-27.1/2026-07-27-windows64.nvidia.portable.zip) |
+| Windows 64 位，NVIDIA 顯示卡，想更快，也想安裝 | [`2026-07-27-windows64.nvidia.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-27.1/2026-07-27-windows64.nvidia.installer.exe) |
+| Windows 64 位，RTX 50 CUDA 版，5070/5080/5090 優先，免安裝 | [`2026-07-27-windows64.nvidia50.cuda.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-27.1/2026-07-27-windows64.nvidia50.cuda.portable.zip) |
+| 進階可選：TensorRT 預裝分卷包（需下載全部 .7z.00N） | [`2026-07-27-windows64.nvidia.tensorrt.portable.7z.001`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-27.1/2026-07-27-windows64.nvidia.tensorrt.portable.7z.001)<br>[`2026-07-27-windows64.nvidia.tensorrt.portable.7z.002`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-27.1/2026-07-27-windows64.nvidia.tensorrt.portable.7z.002) |
+| Windows 64 位，RTX 50 CUDA 版，5070/5080/5090 優先，想安裝 | [`2026-07-27-windows64.nvidia50.cuda.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-27.1/2026-07-27-windows64.nvidia50.cuda.installer.exe) |
+| Windows 64 位，想自己設定引擎 | [`2026-07-27-windows64.without.engine.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-27.1/2026-07-27-windows64.without.engine.portable.zip) |
+| Windows 64 位，想自己設定引擎，也想使用安裝器 | [`2026-07-27-windows64.without.engine.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-27.1/2026-07-27-windows64.without.engine.installer.exe) |
+| macOS Apple Silicon | [`2026-07-27-mac-apple-silicon.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-27.1/2026-07-27-mac-apple-silicon.with-katago.dmg) |
+| macOS Intel | [`2026-07-27-mac-intel.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-27.1/2026-07-27-mac-intel.with-katago.dmg) |
+| Linux 64 位，CPU 相容版 | [`2026-07-27-linux64.with-katago.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-27.1/2026-07-27-linux64.with-katago.zip) |
+| Linux 64 位，OpenCL 版，AMD/Intel GPU | [`2026-07-27-linux64.opencl.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-27.1/2026-07-27-linux64.opencl.zip) |
+| Linux 64 位，NVIDIA CUDA 版 | [`2026-07-27-linux64.nvidia.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-27.1/2026-07-27-linux64.nvidia.zip) |
+
+### 這一版為什麼值得測試
+
+- 閃電分析與全盤精析入口職責更清楚，不再出現選單重複與彈出位置異常。
+- 暫停不會遺失已完成結果，繼續分析也不會覆蓋已計算局面。
+- 合併版本通過 1542 項完整測試，並以真實 KataGo 驗證開始、暫停、繼續、隱藏及恢復流程。
+
+### 交流
+
+- QQ 群：`299419120`
+
+---
+
+## English
+
+This whole-game analysis interaction preview follows `next-2026-07-26.1`. It restores a clear Lightning Analysis entry and completes the Start, Pause, Resume, and Stop workflow for Whole-game Deep Analysis.
+
+### Release Highlights
+
+- Restores the dedicated Lightning Analysis button beside KataGo Auto Setup with Overview, Partial, All Branches, and Settings actions.
+- Keeps Whole-game Deep Analysis in the bottom Auto Analysis menu and removes duplicate lightning entries.
+- Opens the deep-analysis window in a ready state and acquires the engine only after Start Analysis is selected.
+- Adds reliable Pause, Resume, and Stop behavior; completed results remain intact and resume processes only unfinished positions.
+- Replaces the fixed dialog size with adaptive layout so position counts, analysis mode, and remaining time stay visible under Windows font and DPI scaling.
+
+### Read Before Downloading
+
+- Full bundles continue to include KataGo `v1.16.5` and the default Zhizi 28B model.
+- Most Windows users should choose OpenCL portable. RTX 20/30/40 users can choose NVIDIA, while RTX 50 users can choose CUDA 12.8.
+- Existing Windows portable users can use the small core update while keeping settings, games, custom weights, and TensorRT files.
+- This is a Pre-release. Please focus on the Whole-game Deep Analysis dialog at 125% to 200% Windows scaling.
+
+### Download Guide
+
+| Your computer | Download this file |
+| --- | --- |
+| Windows 64-bit, OpenCL, recommended and faster, no install | [`2026-07-27-windows64.opencl.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-27.1/2026-07-27-windows64.opencl.portable.zip) |
+| Existing Windows portable install, small routine update | [`2026-07-27-windows64.core-update.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-27.1/2026-07-27-windows64.core-update.zip) |
+| Windows 64-bit, OpenCL, installer | [`2026-07-27-windows64.opencl.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-27.1/2026-07-27-windows64.opencl.installer.exe) |
+| Windows 64-bit, CPU fallback, no install | [`2026-07-27-windows64.with-katago.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-27.1/2026-07-27-windows64.with-katago.portable.zip) |
+| Windows 64-bit, CPU fallback, installer | [`2026-07-27-windows64.with-katago.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-27.1/2026-07-27-windows64.with-katago.installer.exe) |
+| Windows 64-bit, NVIDIA GPU, faster, no install | [`2026-07-27-windows64.nvidia.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-27.1/2026-07-27-windows64.nvidia.portable.zip) |
+| Windows 64-bit, NVIDIA GPU, faster, installer | [`2026-07-27-windows64.nvidia.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-27.1/2026-07-27-windows64.nvidia.installer.exe) |
+| Windows 64-bit, RTX 50 CUDA, recommended for 5070/5080/5090, no install | [`2026-07-27-windows64.nvidia50.cuda.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-27.1/2026-07-27-windows64.nvidia50.cuda.portable.zip) |
+| Advanced optional TensorRT split package; download every .7z.00N part | [`2026-07-27-windows64.nvidia.tensorrt.portable.7z.001`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-27.1/2026-07-27-windows64.nvidia.tensorrt.portable.7z.001)<br>[`2026-07-27-windows64.nvidia.tensorrt.portable.7z.002`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-27.1/2026-07-27-windows64.nvidia.tensorrt.portable.7z.002) |
+| Windows 64-bit, RTX 50 CUDA, recommended for 5070/5080/5090, installer | [`2026-07-27-windows64.nvidia50.cuda.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-27.1/2026-07-27-windows64.nvidia50.cuda.installer.exe) |
+| Windows 64-bit, configure your own engine | [`2026-07-27-windows64.without.engine.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-27.1/2026-07-27-windows64.without.engine.portable.zip) |
+| Windows 64-bit, configure your own engine, installer | [`2026-07-27-windows64.without.engine.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-27.1/2026-07-27-windows64.without.engine.installer.exe) |
+| macOS Apple Silicon | [`2026-07-27-mac-apple-silicon.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-27.1/2026-07-27-mac-apple-silicon.with-katago.dmg) |
+| macOS Intel | [`2026-07-27-mac-intel.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-27.1/2026-07-27-mac-intel.with-katago.dmg) |
+| Linux 64-bit, CPU fallback | [`2026-07-27-linux64.with-katago.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-27.1/2026-07-27-linux64.with-katago.zip) |
+| Linux 64-bit, OpenCL for AMD/Intel GPU | [`2026-07-27-linux64.opencl.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-27.1/2026-07-27-linux64.opencl.zip) |
+| Linux 64-bit, NVIDIA CUDA | [`2026-07-27-linux64.nvidia.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-27.1/2026-07-27-linux64.nvidia.zip) |
+
+### Why Test This Release
+
+- Lightning and deep-analysis entries now have clear, non-overlapping roles.
+- Pausing keeps completed data, and resuming does not overwrite already analyzed positions.
+- The merged build passed all 1542 tests and was smoke-tested with a real KataGo process through start, pause, resume, hide, and restore.
+
+### Contact
+
+- QQ group: `299419120`
+
+---
+
+## 日本語
+
+これは `next-2026-07-26.1` に続く全局解析操作の Pre-release です。Lightning Analysis の入口を明確に戻し、Whole-game Deep Analysis の開始、一時停止、再開、停止を完成させました。
+
+### 主な更新
+
+- KataGo 一鍵設定の横に Lightning Analysis 専用ボタンを戻し、全局概要、部分解析、全分岐解析、設定を保持しました。
+- Whole-game Deep Analysis は下部の Auto Analysis メニューに統一し、重複する Lightning 項目を削除しました。
+- ウィンドウを開いた時点では待機し、「解析開始」を押した後だけ engine を使用します。
+- 一時停止、再開、停止を安定化し、完了済み結果を保持したまま未完了局面だけを再開します。
+- 固定サイズを廃止して内容に応じた layout に変更し、Windows の font/DPI scaling で局面数、解析 mode、残り時間が切れないようにしました。
+
+### ダウンロード前に
+
+- full bundle は引き続き KataGo `v1.16.5` と既定の Zhizi 28B model を含みます。
+- Windows は通常 OpenCL portable、RTX 20/30/40 は NVIDIA、RTX 50 は CUDA 12.8 を選択できます。
+- 既存 Windows portable は small core update を利用でき、設定、棋譜、custom weight、TensorRT を保持します。
+- Pre-release のため、Windows 125% から 200% scaling で Whole-game Deep Analysis を重点確認してください。
+
+### ダウンロード案内
+
+| お使いの環境 | ダウンロードするファイル |
+| --- | --- |
+| Windows 64-bit、OpenCL 推奨高速版、インストール不要 | [`2026-07-27-windows64.opencl.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-27.1/2026-07-27-windows64.opencl.portable.zip) |
+| 既存の Windows portable 版向け小型更新 | [`2026-07-27-windows64.core-update.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-27.1/2026-07-27-windows64.core-update.zip) |
+| Windows 64-bit、OpenCL 版、インストーラ | [`2026-07-27-windows64.opencl.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-27.1/2026-07-27-windows64.opencl.installer.exe) |
+| Windows 64-bit、CPU fallback、インストール不要 | [`2026-07-27-windows64.with-katago.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-27.1/2026-07-27-windows64.with-katago.portable.zip) |
+| Windows 64-bit、CPU fallback、インストーラ | [`2026-07-27-windows64.with-katago.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-27.1/2026-07-27-windows64.with-katago.installer.exe) |
+| Windows 64-bit、NVIDIA GPU、高速版、インストール不要 | [`2026-07-27-windows64.nvidia.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-27.1/2026-07-27-windows64.nvidia.portable.zip) |
+| Windows 64-bit、NVIDIA GPU、高速版、インストーラ | [`2026-07-27-windows64.nvidia.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-27.1/2026-07-27-windows64.nvidia.installer.exe) |
+| Windows 64-bit、RTX 50 CUDA、5070/5080/5090 推奨、インストール不要 | [`2026-07-27-windows64.nvidia50.cuda.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-27.1/2026-07-27-windows64.nvidia50.cuda.portable.zip) |
+| 上級者向け任意：TensorRT 分割パッケージ（.7z.00N を全て取得） | [`2026-07-27-windows64.nvidia.tensorrt.portable.7z.001`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-27.1/2026-07-27-windows64.nvidia.tensorrt.portable.7z.001)<br>[`2026-07-27-windows64.nvidia.tensorrt.portable.7z.002`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-27.1/2026-07-27-windows64.nvidia.tensorrt.portable.7z.002) |
+| Windows 64-bit、RTX 50 CUDA、5070/5080/5090 推奨、インストーラ | [`2026-07-27-windows64.nvidia50.cuda.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-27.1/2026-07-27-windows64.nvidia50.cuda.installer.exe) |
+| Windows 64-bit、自分で engine を設定 | [`2026-07-27-windows64.without.engine.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-27.1/2026-07-27-windows64.without.engine.portable.zip) |
+| Windows 64-bit、自分で engine を設定、インストーラ | [`2026-07-27-windows64.without.engine.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-27.1/2026-07-27-windows64.without.engine.installer.exe) |
+| macOS Apple Silicon | [`2026-07-27-mac-apple-silicon.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-27.1/2026-07-27-mac-apple-silicon.with-katago.dmg) |
+| macOS Intel | [`2026-07-27-mac-intel.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-27.1/2026-07-27-mac-intel.with-katago.dmg) |
+| Linux 64-bit、CPU fallback | [`2026-07-27-linux64.with-katago.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-27.1/2026-07-27-linux64.with-katago.zip) |
+| Linux 64-bit、OpenCL、AMD/Intel GPU | [`2026-07-27-linux64.opencl.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-27.1/2026-07-27-linux64.opencl.zip) |
+| Linux 64-bit、NVIDIA CUDA | [`2026-07-27-linux64.nvidia.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-27.1/2026-07-27-linux64.nvidia.zip) |
+
+### このリリースを試す理由
+
+- Lightning Analysis と Whole-game Deep Analysis の役割が明確になり、重複 menu と popup 位置の問題を解消しました。
+- 一時停止後も完了済み結果を保持し、再開時に解析済み局面を上書きしません。
+- merged build は 1542 tests を通過し、実際の KataGo で開始、一時停止、再開、非表示、復帰を確認しました。
+
+### 連絡先
+
+- QQ group: `299419120`
+
+---
+
+## 한국어
+
+`next-2026-07-26.1` 이후의 전체 대국 분석 상호작용 Pre-release입니다. Lightning Analysis 진입점을 명확히 복원하고 Whole-game Deep Analysis의 시작, 일시 정지, 재개, 중지 흐름을 완성했습니다.
+
+### 주요 업데이트
+
+- KataGo 원클릭 설정 옆에 전용 Lightning Analysis 버튼과 전체 개요, 부분 분석, 모든 분기 분석, 설정을 복원했습니다.
+- Whole-game Deep Analysis는 하단 Auto Analysis 메뉴에만 두고 중복 Lightning 항목을 제거했습니다.
+- 창을 열면 준비 상태로 대기하고 Start Analysis를 누른 뒤에만 engine을 사용합니다.
+- 안정적인 일시 정지, 재개, 중지를 추가했으며 완료 결과를 보존하고 미완료 위치만 이어서 분석합니다.
+- 고정 크기를 제거하고 적응형 layout을 적용해 Windows font/DPI scaling에서 위치 수, 분석 mode, 남은 시간이 잘리지 않습니다.
+
+### 다운로드 전 확인
+
+- full bundle은 계속 KataGo `v1.16.5`와 기본 Zhizi 28B model을 포함합니다.
+- Windows 일반 사용자는 OpenCL portable, RTX 20/30/40은 NVIDIA, RTX 50은 CUDA 12.8을 선택할 수 있습니다.
+- 기존 Windows portable은 small core update를 사용할 수 있으며 설정, 기보, custom weight, TensorRT를 유지합니다.
+- Pre-release이므로 Windows 125%에서 200% scaling의 Whole-game Deep Analysis 창을 중점 확인해 주세요.
+
+### 다운로드 안내
+
+| 환경 | 다운로드할 파일 |
+| --- | --- |
+| Windows 64-bit, OpenCL 권장 고속판, 설치 불필요 | [`2026-07-27-windows64.opencl.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-27.1/2026-07-27-windows64.opencl.portable.zip) |
+| 기존 Windows portable용 소형 업데이트 | [`2026-07-27-windows64.core-update.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-27.1/2026-07-27-windows64.core-update.zip) |
+| Windows 64-bit, OpenCL 설치형 | [`2026-07-27-windows64.opencl.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-27.1/2026-07-27-windows64.opencl.installer.exe) |
+| Windows 64-bit, CPU fallback, 설치 불필요 | [`2026-07-27-windows64.with-katago.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-27.1/2026-07-27-windows64.with-katago.portable.zip) |
+| Windows 64-bit, CPU fallback, 설치형 | [`2026-07-27-windows64.with-katago.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-27.1/2026-07-27-windows64.with-katago.installer.exe) |
+| Windows 64-bit, NVIDIA GPU 고속판, 설치 불필요 | [`2026-07-27-windows64.nvidia.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-27.1/2026-07-27-windows64.nvidia.portable.zip) |
+| Windows 64-bit, NVIDIA GPU 고속판, 설치형 | [`2026-07-27-windows64.nvidia.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-27.1/2026-07-27-windows64.nvidia.installer.exe) |
+| Windows 64-bit, RTX 50 CUDA, 5070/5080/5090 권장, 설치 불필요 | [`2026-07-27-windows64.nvidia50.cuda.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-27.1/2026-07-27-windows64.nvidia50.cuda.portable.zip) |
+| 고급 선택 사항: TensorRT 분할 패키지, 모든 .7z.00N 필요 | [`2026-07-27-windows64.nvidia.tensorrt.portable.7z.001`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-27.1/2026-07-27-windows64.nvidia.tensorrt.portable.7z.001)<br>[`2026-07-27-windows64.nvidia.tensorrt.portable.7z.002`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-27.1/2026-07-27-windows64.nvidia.tensorrt.portable.7z.002) |
+| Windows 64-bit, RTX 50 CUDA, 5070/5080/5090 권장, 설치형 | [`2026-07-27-windows64.nvidia50.cuda.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-27.1/2026-07-27-windows64.nvidia50.cuda.installer.exe) |
+| Windows 64-bit, 직접 engine 설정 | [`2026-07-27-windows64.without.engine.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-27.1/2026-07-27-windows64.without.engine.portable.zip) |
+| Windows 64-bit, 직접 engine 설정, 설치형 | [`2026-07-27-windows64.without.engine.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-27.1/2026-07-27-windows64.without.engine.installer.exe) |
+| macOS Apple Silicon | [`2026-07-27-mac-apple-silicon.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-27.1/2026-07-27-mac-apple-silicon.with-katago.dmg) |
+| macOS Intel | [`2026-07-27-mac-intel.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-27.1/2026-07-27-mac-intel.with-katago.dmg) |
+| Linux 64-bit, CPU fallback | [`2026-07-27-linux64.with-katago.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-27.1/2026-07-27-linux64.with-katago.zip) |
+| Linux 64-bit, OpenCL, AMD/Intel GPU | [`2026-07-27-linux64.opencl.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-27.1/2026-07-27-linux64.opencl.zip) |
+| Linux 64-bit, NVIDIA CUDA | [`2026-07-27-linux64.nvidia.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-27.1/2026-07-27-linux64.nvidia.zip) |
+
+### 이 릴리스를 테스트할 이유
+
+- Lightning Analysis와 Whole-game Deep Analysis 역할이 명확해져 중복 menu와 popup 위치 문제를 없앴습니다.
+- 일시 정지 후 완료 결과가 유지되고 재개 시 이미 분석한 위치를 덮어쓰지 않습니다.
+- merged build는 1542 tests를 통과했고 실제 KataGo로 시작, 일시 정지, 재개, 숨기기, 복원을 확인했습니다.
+
+### 연락처
+
+- QQ group: `299419120`
+
+---
+
+## ภาษาไทย
+
+นี่คือ Pre-release การใช้งานวิเคราะห์ทั้งเกมต่อจาก `next-2026-07-26.1` โดยคืนปุ่ม Lightning Analysis ที่ชัดเจน และทำขั้นตอนเริ่ม หยุดชั่วคราว ทำต่อ และหยุดของ Whole-game Deep Analysis ให้สมบูรณ์
+
+### อัปเดตหลัก
+
+- คืนปุ่ม Lightning Analysis ข้าง KataGo Auto Setup พร้อม Overview, Partial, All Branches และ Settings
+- เก็บ Whole-game Deep Analysis ไว้ในเมนู Auto Analysis ด้านล่าง และลบรายการ Lightning ที่ซ้ำกัน
+- เมื่อเปิดหน้าต่างจะรอการยืนยัน และใช้ engine หลังจากกด Start Analysis เท่านั้น
+- เพิ่ม Pause, Resume และ Stop ที่เชื่อถือได้ เก็บผลที่เสร็จแล้ว และวิเคราะห์ต่อเฉพาะตำแหน่งที่ยังไม่เสร็จ
+- ยกเลิกขนาดหน้าต่างคงที่และใช้ layout แบบปรับตามเนื้อหา เพื่อไม่ให้จำนวนตำแหน่ง โหมดวิเคราะห์ และเวลาที่เหลือถูกตัดบน Windows DPI
+
+### ก่อนดาวน์โหลด
+
+- full bundle ยังคงมี KataGo `v1.16.5` และ Zhizi 28B model เริ่มต้น
+- ผู้ใช้ Windows ส่วนใหญ่ควรเลือก OpenCL portable ส่วน RTX 20/30/40 เลือก NVIDIA และ RTX 50 เลือก CUDA 12.8
+- ผู้ใช้ Windows portable เดิมใช้ small core update ได้ โดยเก็บ settings, game records, custom weights และ TensorRT
+- นี่คือ Pre-release โปรดตรวจสอบหน้าต่าง Whole-game Deep Analysis ที่ Windows scaling 125% ถึง 200%
+
+### แนะนำการดาวน์โหลด
+
+| เครื่องของคุณ | ดาวน์โหลดไฟล์นี้ |
+| --- | --- |
+| Windows 64-bit, OpenCL แนะนำและเร็วกว่า, ไม่ต้องติดตั้ง | [`2026-07-27-windows64.opencl.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-27.1/2026-07-27-windows64.opencl.portable.zip) |
+| อัปเดตเล็กสำหรับ Windows portable เดิม | [`2026-07-27-windows64.core-update.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-27.1/2026-07-27-windows64.core-update.zip) |
+| Windows 64-bit, OpenCL, แบบติดตั้ง | [`2026-07-27-windows64.opencl.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-27.1/2026-07-27-windows64.opencl.installer.exe) |
+| Windows 64-bit, CPU fallback, ไม่ต้องติดตั้ง | [`2026-07-27-windows64.with-katago.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-27.1/2026-07-27-windows64.with-katago.portable.zip) |
+| Windows 64-bit, CPU fallback, แบบติดตั้ง | [`2026-07-27-windows64.with-katago.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-27.1/2026-07-27-windows64.with-katago.installer.exe) |
+| Windows 64-bit, NVIDIA GPU, เร็วกว่า, ไม่ต้องติดตั้ง | [`2026-07-27-windows64.nvidia.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-27.1/2026-07-27-windows64.nvidia.portable.zip) |
+| Windows 64-bit, NVIDIA GPU, เร็วกว่า, แบบติดตั้ง | [`2026-07-27-windows64.nvidia.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-27.1/2026-07-27-windows64.nvidia.installer.exe) |
+| Windows 64-bit, RTX 50 CUDA, แนะนำสำหรับ 5070/5080/5090, ไม่ต้องติดตั้ง | [`2026-07-27-windows64.nvidia50.cuda.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-27.1/2026-07-27-windows64.nvidia50.cuda.portable.zip) |
+| ตัวเลือกขั้นสูง: TensorRT split package ต้องดาวน์โหลด .7z.00N ครบ | [`2026-07-27-windows64.nvidia.tensorrt.portable.7z.001`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-27.1/2026-07-27-windows64.nvidia.tensorrt.portable.7z.001)<br>[`2026-07-27-windows64.nvidia.tensorrt.portable.7z.002`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-27.1/2026-07-27-windows64.nvidia.tensorrt.portable.7z.002) |
+| Windows 64-bit, RTX 50 CUDA, แนะนำสำหรับ 5070/5080/5090, แบบติดตั้ง | [`2026-07-27-windows64.nvidia50.cuda.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-27.1/2026-07-27-windows64.nvidia50.cuda.installer.exe) |
+| Windows 64-bit, ตั้งค่า engine เอง | [`2026-07-27-windows64.without.engine.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-27.1/2026-07-27-windows64.without.engine.portable.zip) |
+| Windows 64-bit, ตั้งค่า engine เอง, แบบติดตั้ง | [`2026-07-27-windows64.without.engine.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-27.1/2026-07-27-windows64.without.engine.installer.exe) |
+| macOS Apple Silicon | [`2026-07-27-mac-apple-silicon.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-27.1/2026-07-27-mac-apple-silicon.with-katago.dmg) |
+| macOS Intel | [`2026-07-27-mac-intel.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-27.1/2026-07-27-mac-intel.with-katago.dmg) |
+| Linux 64-bit, CPU fallback | [`2026-07-27-linux64.with-katago.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-27.1/2026-07-27-linux64.with-katago.zip) |
+| Linux 64-bit, OpenCL สำหรับ AMD/Intel GPU | [`2026-07-27-linux64.opencl.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-27.1/2026-07-27-linux64.opencl.zip) |
+| Linux 64-bit, NVIDIA CUDA | [`2026-07-27-linux64.nvidia.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-27.1/2026-07-27-linux64.nvidia.zip) |
+
+### ทำไมควรทดสอบเวอร์ชันนี้
+
+- Lightning Analysis และ Whole-game Deep Analysis มีหน้าที่ชัดเจน ไม่มีเมนูซ้ำหรือตำแหน่ง popup ผิด
+- การ Pause เก็บผลที่เสร็จแล้ว และ Resume ไม่เขียนทับตำแหน่งที่วิเคราะห์แล้ว
+- merged build ผ่าน 1542 tests และทดสอบกับ KataGo จริงสำหรับ start, pause, resume, hide และ restore
+
+### ติดต่อ
+
+- QQ group: `299419120`

--- a/.github/release-requests/next-2026-07-27.1.json
+++ b/.github/release-requests/next-2026-07-27.1.json
@@ -1,0 +1,7 @@
+{
+  "date_tag": "2026-07-27",
+  "release_tag": "next-2026-07-27.1",
+  "title": "LizzieYzy Next next-2026-07-27.1",
+  "prerelease": true,
+  "notes_file": ".github/release-notes/next-2026-07-27.1.md"
+}


### PR DESCRIPTION
## Summary

- Publishes the merged whole-game analysis controls and high-DPI dialog fixes as `next-2026-07-27.1`.
- Restores the dedicated Flash Analysis toolbar entry and keeps Whole-game Deep Analysis in the Auto Analysis menu.
- Adds explicit start, pause/resume, and stop lifecycle with preserved completed results.
- Uses the fixed six-language release-note structure with direct links for every public asset.

## Validation

- Full feature test suite: 1542 tests passed.
- Targeted whole-game analysis tests: 21 tests passed.
- Maven package build passed.
- Real macOS Swing/KataGo smoke covered start, pause, resume, hide/restore, and process cleanup.
- `git diff --check` passed.
- Release request/generator tests: 24 passed.
- Direct-download tables validated for all six languages.

## Release

This request publishes a pre-release only. Windows 125%-200% DPI remains the primary true-machine acceptance focus.