### PR TITLE
Release next-2026-07-28.1

### DIFF
--- a/.github/release-notes/next-2026-07-28.1.md
+++ b/.github/release-notes/next-2026-07-28.1.md
@@ -1,0 +1,311 @@
+# LizzieYzy Next next-2026-07-28.1
+
+## 中文
+
+这是 `next-2026-07-27.1` 之后的 macOS 安装体验与发布可靠性预览版，重点解决拖入“应用程序”后不易找到应用、旧挂载镜像干扰系统识别，以及发布依赖下载中断的问题。
+
+### 本版主要更新
+
+- macOS DMG 使用清晰的品牌化拖拽安装画面，分别标明 Apple Silicon 与 Intel，明确引导用户拖入“应用程序”后再启动。
+- macOS App 每次发布使用唯一、递增且符合 Apple 规则的 bundle 版本，改善 Finder、Spotlight 和 Launch Services 对新旧版本的识别。
+- 打包、签名、公证后的最终 DMG 都会校验应用标识、版本、芯片类型、背景与拖拽布局；异常发布包会直接阻止发布。
+- JCEF 下载加入临时文件校验与自动重试，网络中断得到的残缺文件不会再污染缓存或导致后续构建失败。
+
+### 下载前先看这几句
+
+- macOS 用户请打开 DMG，把 `LizzieYzy Next` 拖到 `Applications`，弹出镜像后再从“应用程序”启动。
+- Apple Silicon 适用于 M1/M2/M3/M4/M5；Intel Mac 请下载单独标明 Intel 的版本。
+- 完整包继续内置 KataGo `v1.16.5` 和默认智子 28B 权重。
+- 这是 Pre-release，Windows 和 Linux 功能没有减少；已有 Windows 免安装版仍可使用小更新包。
+
+### 下载建议
+
+| 你的电脑 | 直接下载这个 |
+| --- | --- |
+| Windows 64 位，OpenCL 版，推荐更快，免安装 | [`2026-07-28-windows64.opencl.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-28.1/2026-07-28-windows64.opencl.portable.zip) |
+| 已有 Windows 免安装版，日常升级小包 | [`2026-07-28-windows64.core-update.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-28.1/2026-07-28-windows64.core-update.zip) |
+| Windows 64 位，OpenCL 版，想安装 | [`2026-07-28-windows64.opencl.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-28.1/2026-07-28-windows64.opencl.installer.exe) |
+| Windows 64 位，CPU 版，兼容兜底，免安装 | [`2026-07-28-windows64.with-katago.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-28.1/2026-07-28-windows64.with-katago.portable.zip) |
+| Windows 64 位，CPU 版，兼容兜底，想安装 | [`2026-07-28-windows64.with-katago.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-28.1/2026-07-28-windows64.with-katago.installer.exe) |
+| Windows 64 位，英伟达显卡，想更快，免安装 | [`2026-07-28-windows64.nvidia.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-28.1/2026-07-28-windows64.nvidia.portable.zip) |
+| Windows 64 位，英伟达显卡，想更快，也想安装 | [`2026-07-28-windows64.nvidia.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-28.1/2026-07-28-windows64.nvidia.installer.exe) |
+| Windows 64 位，RTX 50 CUDA 版，5070/5080/5090 优先，免安装 | [`2026-07-28-windows64.nvidia50.cuda.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-28.1/2026-07-28-windows64.nvidia50.cuda.portable.zip) |
+| 高级可选：TensorRT 预装分卷包（需下载全部 .7z.00N） | [`2026-07-28-windows64.nvidia.tensorrt.portable.7z.001`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-28.1/2026-07-28-windows64.nvidia.tensorrt.portable.7z.001)<br>[`2026-07-28-windows64.nvidia.tensorrt.portable.7z.002`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-28.1/2026-07-28-windows64.nvidia.tensorrt.portable.7z.002) |
+| Windows 64 位，RTX 50 CUDA 版，5070/5080/5090 优先，想安装 | [`2026-07-28-windows64.nvidia50.cuda.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-28.1/2026-07-28-windows64.nvidia50.cuda.installer.exe) |
+| Windows 64 位，想自己配引擎 | [`2026-07-28-windows64.without.engine.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-28.1/2026-07-28-windows64.without.engine.portable.zip) |
+| Windows 64 位，想自己配引擎，也想安装器 | [`2026-07-28-windows64.without.engine.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-28.1/2026-07-28-windows64.without.engine.installer.exe) |
+| macOS Apple Silicon | [`2026-07-28-mac-apple-silicon.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-28.1/2026-07-28-mac-apple-silicon.with-katago.dmg) |
+| macOS Intel | [`2026-07-28-mac-intel.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-28.1/2026-07-28-mac-intel.with-katago.dmg) |
+| Linux 64 位，CPU 兼容版 | [`2026-07-28-linux64.with-katago.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-28.1/2026-07-28-linux64.with-katago.zip) |
+| Linux 64 位，OpenCL 版，AMD/Intel GPU | [`2026-07-28-linux64.opencl.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-28.1/2026-07-28-linux64.opencl.zip) |
+| Linux 64 位，NVIDIA CUDA 版 | [`2026-07-28-linux64.nvidia.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-28.1/2026-07-28-linux64.nvidia.zip) |
+
+### 这一版为什么值得测试
+
+- macOS 安装步骤一眼可懂，能明显减少用户直接在挂载镜像里运行、随后找不到应用的情况。
+- App 版本与最终镜像均进入自动审计，避免签名或重建后退回错误元数据和普通白底 DMG。
+- 合并版本通过 1542 项完整测试，并在 Apple Silicon 真机完成带 KataGo DMG 的构建、挂载与 Finder 拖拽界面复测。
+
+### 交流
+
+- QQ 群：`299419120`
+
+---
+
+## 繁體中文
+
+這是 `next-2026-07-27.1` 之後的 macOS 安裝體驗與發佈可靠性預覽版，重點改善拖入「應用程式」後不易找到 App、舊掛載映像干擾系統識別，以及發佈依賴下載中斷的問題。
+
+### 本版主要更新
+
+- macOS DMG 改用清楚的品牌化拖放安裝畫面，分別標示 Apple Silicon 與 Intel，提示拖入「應用程式」後再啟動。
+- 每次發佈使用唯一、遞增且符合 Apple 規則的 bundle 版本，改善 Finder、Spotlight 與 Launch Services 對新舊版本的識別。
+- 打包、簽署、公證後的最終 DMG 都會驗證 App 識別碼、版本、晶片類型、背景與拖放版面；異常套件不會被發佈。
+- JCEF 下載加入暫存檔校驗與自動重試，網路中斷產生的不完整檔案不再污染快取。
+
+### 下載前先看這幾句
+
+- macOS 使用者請開啟 DMG，把 `LizzieYzy Next` 拖到 `Applications`，退出映像後再從「應用程式」啟動。
+- Apple Silicon 適用 M1/M2/M3/M4/M5；Intel Mac 請下載清楚標示 Intel 的版本。
+- 完整套件繼續內建 KataGo `v1.16.5` 與預設智子 28B 權重。
+- 這是 Pre-release；Windows 與 Linux 功能沒有減少，舊 Windows portable 仍可使用小型更新。
+
+### 下載建議
+
+| 你的電腦 | 直接下載這個 |
+| --- | --- |
+| Windows 64 位，OpenCL 推薦高速版，免安裝 | [`2026-07-28-windows64.opencl.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-28.1/2026-07-28-windows64.opencl.portable.zip) |
+| 已有 Windows 免安裝版，日常小型更新 | [`2026-07-28-windows64.core-update.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-28.1/2026-07-28-windows64.core-update.zip) |
+| Windows 64 位，OpenCL 安裝版 | [`2026-07-28-windows64.opencl.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-28.1/2026-07-28-windows64.opencl.installer.exe) |
+| Windows 64 位，CPU 相容版，免安裝 | [`2026-07-28-windows64.with-katago.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-28.1/2026-07-28-windows64.with-katago.portable.zip) |
+| Windows 64 位，CPU 相容安裝版 | [`2026-07-28-windows64.with-katago.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-28.1/2026-07-28-windows64.with-katago.installer.exe) |
+| Windows 64 位，NVIDIA 顯示卡高速版，免安裝 | [`2026-07-28-windows64.nvidia.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-28.1/2026-07-28-windows64.nvidia.portable.zip) |
+| Windows 64 位，NVIDIA 顯示卡高速安裝版 | [`2026-07-28-windows64.nvidia.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-28.1/2026-07-28-windows64.nvidia.installer.exe) |
+| Windows 64 位，RTX 50 CUDA，5070/5080/5090 優先，免安裝 | [`2026-07-28-windows64.nvidia50.cuda.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-28.1/2026-07-28-windows64.nvidia50.cuda.portable.zip) |
+| 進階可選：TensorRT 預裝分卷包（需下載全部 .7z.00N） | [`2026-07-28-windows64.nvidia.tensorrt.portable.7z.001`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-28.1/2026-07-28-windows64.nvidia.tensorrt.portable.7z.001)<br>[`2026-07-28-windows64.nvidia.tensorrt.portable.7z.002`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-28.1/2026-07-28-windows64.nvidia.tensorrt.portable.7z.002) |
+| Windows 64 位，RTX 50 CUDA，5070/5080/5090 優先，安裝版 | [`2026-07-28-windows64.nvidia50.cuda.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-28.1/2026-07-28-windows64.nvidia50.cuda.installer.exe) |
+| Windows 64 位，自行設定引擎，免安裝 | [`2026-07-28-windows64.without.engine.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-28.1/2026-07-28-windows64.without.engine.portable.zip) |
+| Windows 64 位，自行設定引擎，安裝版 | [`2026-07-28-windows64.without.engine.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-28.1/2026-07-28-windows64.without.engine.installer.exe) |
+| macOS Apple Silicon | [`2026-07-28-mac-apple-silicon.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-28.1/2026-07-28-mac-apple-silicon.with-katago.dmg) |
+| macOS Intel | [`2026-07-28-mac-intel.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-28.1/2026-07-28-mac-intel.with-katago.dmg) |
+| Linux 64 位，CPU 相容版 | [`2026-07-28-linux64.with-katago.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-28.1/2026-07-28-linux64.with-katago.zip) |
+| Linux 64 位，OpenCL，AMD/Intel GPU | [`2026-07-28-linux64.opencl.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-28.1/2026-07-28-linux64.opencl.zip) |
+| Linux 64 位，NVIDIA CUDA | [`2026-07-28-linux64.nvidia.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-28.1/2026-07-28-linux64.nvidia.zip) |
+
+### 這一版為什麼值得測試
+
+- macOS 安裝步驟一眼可懂，可減少直接從掛載映像執行後找不到 App 的情況。
+- App 版本與最終映像都進入自動審計，避免簽署或重建後退回錯誤中繼資料與白底 DMG。
+- 合併版本通過 1542 項完整測試，並在 Apple Silicon 真機完成內建 KataGo DMG 的建置、掛載與拖放畫面複測。
+
+### 交流
+
+- QQ 群：`299419120`
+
+---
+
+## English
+
+This macOS installation and release-reliability preview follows `next-2026-07-27.1`. It improves app discovery after drag installation, prevents stale mounted images from confusing system indexing, and hardens release dependency downloads.
+
+### Release Highlights
+
+- Adds a branded drag-to-Applications DMG with clear Apple Silicon or Intel labeling and bilingual installation guidance.
+- Gives every macOS release a unique, monotonically increasing Apple-compatible bundle version so Finder, Spotlight, and Launch Services distinguish new builds correctly.
+- Validates app identity, version, architecture, artwork, and drag layout in the final DMG after packaging, signing, and notarization; invalid artifacts cannot be published.
+- Verifies temporary JCEF downloads before caching and retries truncated transfers automatically.
+
+### Read Before Downloading
+
+- On macOS, open the DMG, drag `LizzieYzy Next` to `Applications`, eject the image, and launch the installed app from Applications.
+- Apple Silicon is for M1/M2/M3/M4/M5 Macs. Intel Macs must use the separately labeled Intel build.
+- Full bundles still include KataGo `v1.16.5` and the default Zhizi 28B model.
+- This is a Pre-release. Windows and Linux features are unchanged, and existing Windows portable users can still use the small core update.
+
+### Download Guide
+
+| Your computer | Download this file |
+| --- | --- |
+| Windows 64-bit, OpenCL, recommended and faster, no install | [`2026-07-28-windows64.opencl.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-28.1/2026-07-28-windows64.opencl.portable.zip) |
+| Existing Windows portable install, small routine update | [`2026-07-28-windows64.core-update.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-28.1/2026-07-28-windows64.core-update.zip) |
+| Windows 64-bit, OpenCL installer | [`2026-07-28-windows64.opencl.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-28.1/2026-07-28-windows64.opencl.installer.exe) |
+| Windows 64-bit, CPU fallback, no install | [`2026-07-28-windows64.with-katago.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-28.1/2026-07-28-windows64.with-katago.portable.zip) |
+| Windows 64-bit, CPU fallback installer | [`2026-07-28-windows64.with-katago.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-28.1/2026-07-28-windows64.with-katago.installer.exe) |
+| Windows 64-bit, NVIDIA GPU, faster, no install | [`2026-07-28-windows64.nvidia.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-28.1/2026-07-28-windows64.nvidia.portable.zip) |
+| Windows 64-bit, NVIDIA GPU installer | [`2026-07-28-windows64.nvidia.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-28.1/2026-07-28-windows64.nvidia.installer.exe) |
+| Windows 64-bit, RTX 50 CUDA, recommended for 5070/5080/5090, no install | [`2026-07-28-windows64.nvidia50.cuda.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-28.1/2026-07-28-windows64.nvidia50.cuda.portable.zip) |
+| Advanced optional TensorRT split package; download every .7z.00N part | [`2026-07-28-windows64.nvidia.tensorrt.portable.7z.001`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-28.1/2026-07-28-windows64.nvidia.tensorrt.portable.7z.001)<br>[`2026-07-28-windows64.nvidia.tensorrt.portable.7z.002`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-28.1/2026-07-28-windows64.nvidia.tensorrt.portable.7z.002) |
+| Windows 64-bit, RTX 50 CUDA installer | [`2026-07-28-windows64.nvidia50.cuda.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-28.1/2026-07-28-windows64.nvidia50.cuda.installer.exe) |
+| Windows 64-bit, configure your own engine, no install | [`2026-07-28-windows64.without.engine.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-28.1/2026-07-28-windows64.without.engine.portable.zip) |
+| Windows 64-bit, configure your own engine, installer | [`2026-07-28-windows64.without.engine.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-28.1/2026-07-28-windows64.without.engine.installer.exe) |
+| macOS Apple Silicon | [`2026-07-28-mac-apple-silicon.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-28.1/2026-07-28-mac-apple-silicon.with-katago.dmg) |
+| macOS Intel | [`2026-07-28-mac-intel.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-28.1/2026-07-28-mac-intel.with-katago.dmg) |
+| Linux 64-bit, CPU fallback | [`2026-07-28-linux64.with-katago.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-28.1/2026-07-28-linux64.with-katago.zip) |
+| Linux 64-bit, OpenCL for AMD/Intel GPU | [`2026-07-28-linux64.opencl.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-28.1/2026-07-28-linux64.opencl.zip) |
+| Linux 64-bit, NVIDIA CUDA | [`2026-07-28-linux64.nvidia.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-28.1/2026-07-28-linux64.nvidia.zip) |
+
+### Why Test This Release
+
+- The macOS installation path is immediately understandable and discourages launching from the mounted image.
+- Automated auditing now protects both bundle metadata and the final signed DMG layout from release regressions.
+- The merged build passed all 1542 tests and a real Apple Silicon with-KataGo DMG was built, mounted, and visually verified in Finder.
+
+### Contact
+
+- QQ group: `299419120`
+
+---
+
+## 日本語
+
+これは `next-2026-07-27.1` に続く macOS インストール体験とリリース信頼性の Pre-release です。ドラッグ後に App を見つけにくい問題、古いマウント済みイメージによる識別混乱、依存ファイルの不完全ダウンロードを改善します。
+
+### 主な更新
+
+- Apple Silicon と Intel を明確に表示したブランド付き drag-to-Applications DMG と日英インストール案内を追加しました。
+- 各 macOS release に Apple 互換の一意で増加する bundle version を設定し、Finder、Spotlight、Launch Services が新旧 build を正しく区別します。
+- packaging、signing、notarization 後の最終 DMG で App ID、version、architecture、背景、drag layout を検証し、異常な artifact の公開を防ぎます。
+- JCEF の一時ダウンロードを checksum 検証し、途中で切れた転送を自動再試行します。
+
+### ダウンロード前に
+
+- macOS では DMG を開き、`LizzieYzy Next` を `Applications` にドラッグし、image を取り出してから「アプリケーション」から起動してください。
+- Apple Silicon は M1/M2/M3/M4/M5 用です。Intel Mac は Intel と明記された build を選んでください。
+- full bundle は引き続き KataGo `v1.16.5` と既定の Zhizi 28B model を含みます。
+- これは Pre-release です。Windows/Linux の機能は減らしておらず、既存 Windows portable は small core update を利用できます。
+
+### ダウンロード案内
+
+| お使いの環境 | ダウンロードするファイル |
+| --- | --- |
+| Windows 64-bit、OpenCL 推奨高速版、インストール不要 | [`2026-07-28-windows64.opencl.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-28.1/2026-07-28-windows64.opencl.portable.zip) |
+| 既存 Windows portable 向け小型更新 | [`2026-07-28-windows64.core-update.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-28.1/2026-07-28-windows64.core-update.zip) |
+| Windows 64-bit、OpenCL installer | [`2026-07-28-windows64.opencl.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-28.1/2026-07-28-windows64.opencl.installer.exe) |
+| Windows 64-bit、CPU fallback、インストール不要 | [`2026-07-28-windows64.with-katago.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-28.1/2026-07-28-windows64.with-katago.portable.zip) |
+| Windows 64-bit、CPU fallback installer | [`2026-07-28-windows64.with-katago.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-28.1/2026-07-28-windows64.with-katago.installer.exe) |
+| Windows 64-bit、NVIDIA GPU 高速版、インストール不要 | [`2026-07-28-windows64.nvidia.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-28.1/2026-07-28-windows64.nvidia.portable.zip) |
+| Windows 64-bit、NVIDIA GPU installer | [`2026-07-28-windows64.nvidia.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-28.1/2026-07-28-windows64.nvidia.installer.exe) |
+| Windows 64-bit、RTX 50 CUDA、5070/5080/5090 推奨、インストール不要 | [`2026-07-28-windows64.nvidia50.cuda.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-28.1/2026-07-28-windows64.nvidia50.cuda.portable.zip) |
+| 上級者向け TensorRT 分割 package、すべての .7z.00N が必要 | [`2026-07-28-windows64.nvidia.tensorrt.portable.7z.001`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-28.1/2026-07-28-windows64.nvidia.tensorrt.portable.7z.001)<br>[`2026-07-28-windows64.nvidia.tensorrt.portable.7z.002`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-28.1/2026-07-28-windows64.nvidia.tensorrt.portable.7z.002) |
+| Windows 64-bit、RTX 50 CUDA installer | [`2026-07-28-windows64.nvidia50.cuda.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-28.1/2026-07-28-windows64.nvidia50.cuda.installer.exe) |
+| Windows 64-bit、自分で engine を設定、インストール不要 | [`2026-07-28-windows64.without.engine.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-28.1/2026-07-28-windows64.without.engine.portable.zip) |
+| Windows 64-bit、自分で engine を設定、installer | [`2026-07-28-windows64.without.engine.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-28.1/2026-07-28-windows64.without.engine.installer.exe) |
+| macOS Apple Silicon | [`2026-07-28-mac-apple-silicon.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-28.1/2026-07-28-mac-apple-silicon.with-katago.dmg) |
+| macOS Intel | [`2026-07-28-mac-intel.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-28.1/2026-07-28-mac-intel.with-katago.dmg) |
+| Linux 64-bit、CPU fallback | [`2026-07-28-linux64.with-katago.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-28.1/2026-07-28-linux64.with-katago.zip) |
+| Linux 64-bit、OpenCL、AMD/Intel GPU | [`2026-07-28-linux64.opencl.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-28.1/2026-07-28-linux64.opencl.zip) |
+| Linux 64-bit、NVIDIA CUDA | [`2026-07-28-linux64.nvidia.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-28.1/2026-07-28-linux64.nvidia.zip) |
+
+### このリリースを試す理由
+
+- macOS のインストール手順が一目で分かり、マウント中の image から誤って実行する状況を減らします。
+- bundle metadata と最終 signed DMG layout の両方を自動監査し、release regression を防ぎます。
+- merged build は 1542 tests を通過し、実機 Apple Silicon で KataGo 入り DMG の build、mount、Finder 表示を確認しました。
+
+### 連絡先
+
+- QQ group: `299419120`
+
+---
+
+## 한국어
+
+`next-2026-07-27.1` 이후의 macOS 설치 경험과 릴리스 신뢰성 Pre-release입니다. 드래그 설치 후 앱을 찾기 어려운 문제, 오래된 마운트 이미지가 시스템 인덱싱을 혼동시키는 문제, 의존성 다운로드 중단을 개선합니다.
+
+### 주요 업데이트
+
+- Apple Silicon과 Intel을 명확히 구분한 브랜드 drag-to-Applications DMG와 중영문 설치 안내를 추가했습니다.
+- 각 macOS 릴리스에 Apple 규칙을 따르는 고유하고 증가하는 bundle version을 사용해 Finder, Spotlight, Launch Services가 새 빌드를 올바르게 구분합니다.
+- packaging, signing, notarization 후 최종 DMG에서 App ID, version, architecture, 배경, drag layout을 검사하며 잘못된 artifact는 게시하지 않습니다.
+- JCEF 임시 다운로드를 checksum으로 검증하고 잘린 전송을 자동으로 다시 시도합니다.
+
+### 다운로드 전 확인
+
+- macOS에서 DMG를 열고 `LizzieYzy Next`를 `Applications`로 드래그한 뒤 image를 추출하고 “응용 프로그램”에서 실행하세요.
+- Apple Silicon은 M1/M2/M3/M4/M5용입니다. Intel Mac은 Intel 표시가 있는 build를 선택하세요.
+- full bundle은 계속 KataGo `v1.16.5`와 기본 Zhizi 28B model을 포함합니다.
+- 이 버전은 Pre-release입니다. Windows/Linux 기능은 줄지 않았으며 기존 Windows portable은 small core update를 사용할 수 있습니다.
+
+### 다운로드 안내
+
+| 환경 | 다운로드할 파일 |
+| --- | --- |
+| Windows 64-bit, OpenCL 권장 고속판, 설치 불필요 | [`2026-07-28-windows64.opencl.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-28.1/2026-07-28-windows64.opencl.portable.zip) |
+| 기존 Windows portable용 소형 업데이트 | [`2026-07-28-windows64.core-update.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-28.1/2026-07-28-windows64.core-update.zip) |
+| Windows 64-bit, OpenCL installer | [`2026-07-28-windows64.opencl.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-28.1/2026-07-28-windows64.opencl.installer.exe) |
+| Windows 64-bit, CPU fallback, 설치 불필요 | [`2026-07-28-windows64.with-katago.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-28.1/2026-07-28-windows64.with-katago.portable.zip) |
+| Windows 64-bit, CPU fallback installer | [`2026-07-28-windows64.with-katago.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-28.1/2026-07-28-windows64.with-katago.installer.exe) |
+| Windows 64-bit, NVIDIA GPU 고속판, 설치 불필요 | [`2026-07-28-windows64.nvidia.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-28.1/2026-07-28-windows64.nvidia.portable.zip) |
+| Windows 64-bit, NVIDIA GPU installer | [`2026-07-28-windows64.nvidia.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-28.1/2026-07-28-windows64.nvidia.installer.exe) |
+| Windows 64-bit, RTX 50 CUDA, 5070/5080/5090 권장, 설치 불필요 | [`2026-07-28-windows64.nvidia50.cuda.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-28.1/2026-07-28-windows64.nvidia50.cuda.portable.zip) |
+| 고급 선택 사항: TensorRT 분할 package, 모든 .7z.00N 필요 | [`2026-07-28-windows64.nvidia.tensorrt.portable.7z.001`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-28.1/2026-07-28-windows64.nvidia.tensorrt.portable.7z.001)<br>[`2026-07-28-windows64.nvidia.tensorrt.portable.7z.002`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-28.1/2026-07-28-windows64.nvidia.tensorrt.portable.7z.002) |
+| Windows 64-bit, RTX 50 CUDA installer | [`2026-07-28-windows64.nvidia50.cuda.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-28.1/2026-07-28-windows64.nvidia50.cuda.installer.exe) |
+| Windows 64-bit, 직접 engine 설정, 설치 불필요 | [`2026-07-28-windows64.without.engine.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-28.1/2026-07-28-windows64.without.engine.portable.zip) |
+| Windows 64-bit, 직접 engine 설정, installer | [`2026-07-28-windows64.without.engine.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-28.1/2026-07-28-windows64.without.engine.installer.exe) |
+| macOS Apple Silicon | [`2026-07-28-mac-apple-silicon.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-28.1/2026-07-28-mac-apple-silicon.with-katago.dmg) |
+| macOS Intel | [`2026-07-28-mac-intel.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-28.1/2026-07-28-mac-intel.with-katago.dmg) |
+| Linux 64-bit, CPU fallback | [`2026-07-28-linux64.with-katago.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-28.1/2026-07-28-linux64.with-katago.zip) |
+| Linux 64-bit, OpenCL, AMD/Intel GPU | [`2026-07-28-linux64.opencl.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-28.1/2026-07-28-linux64.opencl.zip) |
+| Linux 64-bit, NVIDIA CUDA | [`2026-07-28-linux64.nvidia.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-28.1/2026-07-28-linux64.nvidia.zip) |
+
+### 이 릴리스를 테스트할 이유
+
+- macOS 설치 절차를 즉시 이해할 수 있어 마운트된 image에서 잘못 실행하는 상황을 줄입니다.
+- bundle metadata와 최종 signed DMG layout을 모두 자동 감사해 release regression을 막습니다.
+- merged build는 1542 tests를 통과했으며 실제 Apple Silicon에서 KataGo 포함 DMG의 build, mount, Finder 화면을 검증했습니다.
+
+### 연락처
+
+- QQ group: `299419120`
+
+---
+
+## ภาษาไทย
+
+นี่คือ Pre-release ด้านประสบการณ์ติดตั้ง macOS และความน่าเชื่อถือของการเผยแพร่ ต่อจาก `next-2026-07-27.1` โดยแก้ปัญหาหาแอปไม่พบหลังลากติดตั้ง ภาพดิสก์เก่ารบกวนการจัดทำดัชนีของระบบ และไฟล์ส่วนประกอบดาวน์โหลดไม่ครบ
+
+### การอัปเดตหลัก
+
+- เพิ่ม DMG แบบลากไป Applications ที่มีภาพแบรนด์ชัดเจน แยก Apple Silicon กับ Intel และมีคำแนะนำภาษาจีนกับอังกฤษ
+- แต่ละ macOS release ใช้ bundle version ที่ไม่ซ้ำ เพิ่มขึ้นตามลำดับ และตรงตามกฎของ Apple เพื่อให้ Finder, Spotlight และ Launch Services แยก build ใหม่ได้ถูกต้อง
+- ตรวจสอบ App ID, version, architecture, ภาพพื้นหลัง และ drag layout ใน DMG สุดท้ายหลัง packaging, signing และ notarization; artifact ที่ผิดจะไม่ถูกเผยแพร่
+- ตรวจ checksum ของไฟล์ JCEF ชั่วคราวและดาวน์โหลดใหม่อัตโนมัติเมื่อการรับส่งถูกตัดกลางทาง
+
+### อ่านก่อนดาวน์โหลด
+
+- บน macOS ให้เปิด DMG ลาก `LizzieYzy Next` ไปที่ `Applications` ถอด image แล้วเปิดจากโฟลเดอร์แอปพลิเคชัน
+- Apple Silicon ใช้กับ M1/M2/M3/M4/M5 ส่วน Intel Mac ต้องเลือก build ที่ระบุ Intel
+- ชุดเต็มยังรวม KataGo `v1.16.5` และโมเดล Zhizi 28B เริ่มต้น
+- นี่คือ Pre-release ฟังก์ชัน Windows/Linux ไม่ลดลง และผู้ใช้ Windows portable เดิมยังใช้ small core update ได้
+
+### คำแนะนำการดาวน์โหลด
+
+| คอมพิวเตอร์ของคุณ | ดาวน์โหลดไฟล์นี้ |
+| --- | --- |
+| Windows 64-bit, OpenCL แนะนำและเร็วกว่า ไม่ต้องติดตั้ง | [`2026-07-28-windows64.opencl.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-28.1/2026-07-28-windows64.opencl.portable.zip) |
+| มี Windows portable อยู่แล้ว ใช้ชุดอัปเดตขนาดเล็ก | [`2026-07-28-windows64.core-update.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-28.1/2026-07-28-windows64.core-update.zip) |
+| Windows 64-bit, OpenCL แบบติดตั้ง | [`2026-07-28-windows64.opencl.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-28.1/2026-07-28-windows64.opencl.installer.exe) |
+| Windows 64-bit, CPU สำรอง ไม่ต้องติดตั้ง | [`2026-07-28-windows64.with-katago.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-28.1/2026-07-28-windows64.with-katago.portable.zip) |
+| Windows 64-bit, CPU สำรอง แบบติดตั้ง | [`2026-07-28-windows64.with-katago.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-28.1/2026-07-28-windows64.with-katago.installer.exe) |
+| Windows 64-bit, NVIDIA GPU แบบเร็ว ไม่ต้องติดตั้ง | [`2026-07-28-windows64.nvidia.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-28.1/2026-07-28-windows64.nvidia.portable.zip) |
+| Windows 64-bit, NVIDIA GPU แบบติดตั้ง | [`2026-07-28-windows64.nvidia.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-28.1/2026-07-28-windows64.nvidia.installer.exe) |
+| Windows 64-bit, RTX 50 CUDA สำหรับ 5070/5080/5090 ไม่ต้องติดตั้ง | [`2026-07-28-windows64.nvidia50.cuda.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-28.1/2026-07-28-windows64.nvidia50.cuda.portable.zip) |
+| ตัวเลือกขั้นสูง: ชุด TensorRT แบ่งส่วน ต้องดาวน์โหลด .7z.00N ทุกไฟล์ | [`2026-07-28-windows64.nvidia.tensorrt.portable.7z.001`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-28.1/2026-07-28-windows64.nvidia.tensorrt.portable.7z.001)<br>[`2026-07-28-windows64.nvidia.tensorrt.portable.7z.002`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-28.1/2026-07-28-windows64.nvidia.tensorrt.portable.7z.002) |
+| Windows 64-bit, RTX 50 CUDA แบบติดตั้ง | [`2026-07-28-windows64.nvidia50.cuda.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-28.1/2026-07-28-windows64.nvidia50.cuda.installer.exe) |
+| Windows 64-bit, ตั้งค่า engine เอง ไม่ต้องติดตั้ง | [`2026-07-28-windows64.without.engine.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-28.1/2026-07-28-windows64.without.engine.portable.zip) |
+| Windows 64-bit, ตั้งค่า engine เอง แบบติดตั้ง | [`2026-07-28-windows64.without.engine.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-28.1/2026-07-28-windows64.without.engine.installer.exe) |
+| macOS Apple Silicon | [`2026-07-28-mac-apple-silicon.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-28.1/2026-07-28-mac-apple-silicon.with-katago.dmg) |
+| macOS Intel | [`2026-07-28-mac-intel.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-28.1/2026-07-28-mac-intel.with-katago.dmg) |
+| Linux 64-bit, CPU สำรอง | [`2026-07-28-linux64.with-katago.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-28.1/2026-07-28-linux64.with-katago.zip) |
+| Linux 64-bit, OpenCL สำหรับ AMD/Intel GPU | [`2026-07-28-linux64.opencl.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-28.1/2026-07-28-linux64.opencl.zip) |
+| Linux 64-bit, NVIDIA CUDA | [`2026-07-28-linux64.nvidia.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-07-28.1/2026-07-28-linux64.nvidia.zip) |
+
+### เหตุผลที่ควรทดสอบรุ่นนี้
+
+- ขั้นตอนติดตั้ง macOS เข้าใจได้ทันที และลดการเปิดแอปจาก image ที่ยัง mount อยู่
+- การตรวจอัตโนมัติครอบคลุมทั้ง bundle metadata และ layout ของ signed DMG สุดท้าย
+- build ที่รวมแล้วผ่านการทดสอบครบ 1542 รายการ และสร้าง mount พร้อมตรวจภาพ Finder ของ DMG ที่มี KataGo บน Apple Silicon จริง
+
+### ติดต่อ
+
+- กลุ่ม QQ: `299419120`

--- a/.github/release-requests/next-2026-07-28.1.json
+++ b/.github/release-requests/next-2026-07-28.1.json
@@ -1,0 +1,7 @@
+{
+  "date_tag": "2026-07-28",
+  "release_tag": "next-2026-07-28.1",
+  "title": "LizzieYzy Next next-2026-07-28.1",
+  "prerelease": true,
+  "notes_file": ".github/release-notes/next-2026-07-28.1.md"
+}


### PR DESCRIPTION
## Summary

- requests the next-2026-07-28.1 pre-release from the merged PR #155 commit
- documents the macOS drag-install and app-indexing reliability improvements
- keeps the fixed six-language, five-section release-note structure with direct links to every expected asset

## Validation

- direct-download table validation passed for all six languages
- each language contains exactly five standard sections
- release publisher tests passed (22 tests)
- local Markdown-link and git diff checks passed
- merged feature CI passed all 1542 tests and shaded-jar packaging