### PR TITLE
Promote next-2026-07-28.1 to stable release

### DIFF
--- a/.github/release-notes/next-2026-07-28.1.md
+++ b/.github/release-notes/next-2026-07-28.1.md
@@ -2,7 +2,7 @@
 
 ## 中文
 
-这是 `next-2026-07-27.1` 之后的 macOS 安装体验与发布可靠性预览版，重点解决拖入“应用程序”后不易找到应用、旧挂载镜像干扰系统识别，以及发布依赖下载中断的问题。
+这是 `next-2026-07-27.1` 之后的 macOS 安装体验与发布可靠性正式版，重点解决拖入“应用程序”后不易找到应用、旧挂载镜像干扰系统识别，以及发布依赖下载中断的问题。
 
 ### 本版主要更新
 
@@ -16,7 +16,7 @@
 - macOS 用户请打开 DMG，把 `LizzieYzy Next` 拖到 `Applications`，弹出镜像后再从“应用程序”启动。
 - Apple Silicon 适用于 M1/M2/M3/M4/M5；Intel Mac 请下载单独标明 Intel 的版本。
 - 完整包继续内置 KataGo `v1.16.5` 和默认智子 28B 权重。
-- 这是 Pre-release，Windows 和 Linux 功能没有减少；已有 Windows 免安装版仍可使用小更新包。
+- 本版已完成多平台发布验收；Windows 和 Linux 功能没有减少，已有 Windows 免安装版仍可使用小更新包。
 
 ### 下载建议
 
@@ -54,7 +54,7 @@
 
 ## 繁體中文
 
-這是 `next-2026-07-27.1` 之後的 macOS 安裝體驗與發佈可靠性預覽版，重點改善拖入「應用程式」後不易找到 App、舊掛載映像干擾系統識別，以及發佈依賴下載中斷的問題。
+這是 `next-2026-07-27.1` 之後的 macOS 安裝體驗與發佈可靠性正式版，重點改善拖入「應用程式」後不易找到 App、舊掛載映像干擾系統識別，以及發佈依賴下載中斷的問題。
 
 ### 本版主要更新
 
@@ -68,7 +68,7 @@
 - macOS 使用者請開啟 DMG，把 `LizzieYzy Next` 拖到 `Applications`，退出映像後再從「應用程式」啟動。
 - Apple Silicon 適用 M1/M2/M3/M4/M5；Intel Mac 請下載清楚標示 Intel 的版本。
 - 完整套件繼續內建 KataGo `v1.16.5` 與預設智子 28B 權重。
-- 這是 Pre-release；Windows 與 Linux 功能沒有減少，舊 Windows portable 仍可使用小型更新。
+- 本版已完成多平台發佈驗收；Windows 與 Linux 功能沒有減少，舊 Windows portable 仍可使用小型更新。
 
 ### 下載建議
 
@@ -106,7 +106,7 @@
 
 ## English
 
-This macOS installation and release-reliability preview follows `next-2026-07-27.1`. It improves app discovery after drag installation, prevents stale mounted images from confusing system indexing, and hardens release dependency downloads.
+This stable macOS installation and release-reliability update follows `next-2026-07-27.1`. It improves app discovery after drag installation, prevents stale mounted images from confusing system indexing, and hardens release dependency downloads.
 
 ### Release Highlights
 
@@ -120,7 +120,7 @@ This macOS installation and release-reliability preview follows `next-2026-07-27
 - On macOS, open the DMG, drag `LizzieYzy Next` to `Applications`, eject the image, and launch the installed app from Applications.
 - Apple Silicon is for M1/M2/M3/M4/M5 Macs. Intel Macs must use the separately labeled Intel build.
 - Full bundles still include KataGo `v1.16.5` and the default Zhizi 28B model.
-- This is a Pre-release. Windows and Linux features are unchanged, and existing Windows portable users can still use the small core update.
+- This release passed the full multi-platform publication audit. Windows and Linux features are unchanged, and existing Windows portable users can still use the small core update.
 
 ### Download Guide
 
@@ -158,7 +158,7 @@ This macOS installation and release-reliability preview follows `next-2026-07-27
 
 ## 日本語
 
-これは `next-2026-07-27.1` に続く macOS インストール体験とリリース信頼性の Pre-release です。ドラッグ後に App を見つけにくい問題、古いマウント済みイメージによる識別混乱、依存ファイルの不完全ダウンロードを改善します。
+これは `next-2026-07-27.1` に続く macOS インストール体験とリリース信頼性の正式版です。ドラッグ後に App を見つけにくい問題、古いマウント済みイメージによる識別混乱、依存ファイルの不完全ダウンロードを改善します。
 
 ### 主な更新
 
@@ -172,7 +172,7 @@ This macOS installation and release-reliability preview follows `next-2026-07-27
 - macOS では DMG を開き、`LizzieYzy Next` を `Applications` にドラッグし、image を取り出してから「アプリケーション」から起動してください。
 - Apple Silicon は M1/M2/M3/M4/M5 用です。Intel Mac は Intel と明記された build を選んでください。
 - full bundle は引き続き KataGo `v1.16.5` と既定の Zhizi 28B model を含みます。
-- これは Pre-release です。Windows/Linux の機能は減らしておらず、既存 Windows portable は small core update を利用できます。
+- 本リリースは全 platform の公開監査を完了しています。Windows/Linux の機能は減らしておらず、既存 Windows portable は small core update を利用できます。
 
 ### ダウンロード案内
 
@@ -210,7 +210,7 @@ This macOS installation and release-reliability preview follows `next-2026-07-27
 
 ## 한국어
 
-`next-2026-07-27.1` 이후의 macOS 설치 경험과 릴리스 신뢰성 Pre-release입니다. 드래그 설치 후 앱을 찾기 어려운 문제, 오래된 마운트 이미지가 시스템 인덱싱을 혼동시키는 문제, 의존성 다운로드 중단을 개선합니다.
+`next-2026-07-27.1` 이후의 macOS 설치 경험과 릴리스 신뢰성 정식 버전입니다. 드래그 설치 후 앱을 찾기 어려운 문제, 오래된 마운트 이미지가 시스템 인덱싱을 혼동시키는 문제, 의존성 다운로드 중단을 개선합니다.
 
 ### 주요 업데이트
 
@@ -224,7 +224,7 @@ This macOS installation and release-reliability preview follows `next-2026-07-27
 - macOS에서 DMG를 열고 `LizzieYzy Next`를 `Applications`로 드래그한 뒤 image를 추출하고 “응용 프로그램”에서 실행하세요.
 - Apple Silicon은 M1/M2/M3/M4/M5용입니다. Intel Mac은 Intel 표시가 있는 build를 선택하세요.
 - full bundle은 계속 KataGo `v1.16.5`와 기본 Zhizi 28B model을 포함합니다.
-- 이 버전은 Pre-release입니다. Windows/Linux 기능은 줄지 않았으며 기존 Windows portable은 small core update를 사용할 수 있습니다.
+- 이 릴리스는 전체 platform 공개 검증을 완료했습니다. Windows/Linux 기능은 줄지 않았으며 기존 Windows portable은 small core update를 사용할 수 있습니다.
 
 ### 다운로드 안내
 
@@ -262,7 +262,7 @@ This macOS installation and release-reliability preview follows `next-2026-07-27
 
 ## ภาษาไทย
 
-นี่คือ Pre-release ด้านประสบการณ์ติดตั้ง macOS และความน่าเชื่อถือของการเผยแพร่ ต่อจาก `next-2026-07-27.1` โดยแก้ปัญหาหาแอปไม่พบหลังลากติดตั้ง ภาพดิสก์เก่ารบกวนการจัดทำดัชนีของระบบ และไฟล์ส่วนประกอบดาวน์โหลดไม่ครบ
+นี่คือรุ่นเสถียรด้านประสบการณ์ติดตั้ง macOS และความน่าเชื่อถือของการเผยแพร่ ต่อจาก `next-2026-07-27.1` โดยแก้ปัญหาหาแอปไม่พบหลังลากติดตั้ง ภาพดิสก์เก่ารบกวนการจัดทำดัชนีของระบบ และไฟล์ส่วนประกอบดาวน์โหลดไม่ครบ
 
 ### การอัปเดตหลัก
 
@@ -276,7 +276,7 @@ This macOS installation and release-reliability preview follows `next-2026-07-27
 - บน macOS ให้เปิด DMG ลาก `LizzieYzy Next` ไปที่ `Applications` ถอด image แล้วเปิดจากโฟลเดอร์แอปพลิเคชัน
 - Apple Silicon ใช้กับ M1/M2/M3/M4/M5 ส่วน Intel Mac ต้องเลือก build ที่ระบุ Intel
 - ชุดเต็มยังรวม KataGo `v1.16.5` และโมเดล Zhizi 28B เริ่มต้น
-- นี่คือ Pre-release ฟังก์ชัน Windows/Linux ไม่ลดลง และผู้ใช้ Windows portable เดิมยังใช้ small core update ได้
+- รุ่นนี้ผ่านการตรวจสอบการเผยแพร่ครบทุก platform แล้ว ฟังก์ชัน Windows/Linux ไม่ลดลง และผู้ใช้ Windows portable เดิมยังใช้ small core update ได้
 
 ### คำแนะนำการดาวน์โหลด
 


### PR DESCRIPTION
## Summary

- updates all six release-note languages from preview wording to stable-release wording
- keeps the existing fixed five-section structure and every audited direct asset link
- prepares the reviewed release body before promoting the GitHub release to Latest

## Validation

- six-language direct-download table validation passed
- no Pre-release, preview, 预览版, or 預覽版 wording remains
- git diff check passed