### PR TITLE
fix(readboard): prevent per-move timing from affecting ordinary analysis

### DIFF
--- a/src/main/java/featurecat/lizzie/Lizzie.java
+++ b/src/main/java/featurecat/lizzie/Lizzie.java
@@ -881,7 +881,10 @@ public class Lizzie {
               .isKataGoPda) LizzieFrame.menu.showPda(true);
       else LizzieFrame.menu.showPda(false);
     } else {
-      LizzieFrame.sendAiTime(false, engine, false);
+      if (frame != null
+          && (frame.isPlayingAgainstLeelaz || frame.isAnaPlayingAgainstLeelaz)) {
+        LizzieFrame.sendAiTime(false, engine, false);
+      }
       LizzieFrame.menu.showPda(Lizzie.leelaz.isKataGoPda);
     }
     if (engine != leelaz) return;

--- a/src/main/java/featurecat/lizzie/Lizzie.java
+++ b/src/main/java/featurecat/lizzie/Lizzie.java
@@ -881,8 +881,13 @@ public class Lizzie {
               .isKataGoPda) LizzieFrame.menu.showPda(true);
       else LizzieFrame.menu.showPda(false);
     } else {
+      boolean readBoardGmaActive =
+          frame != null
+              && frame.readBoard != null
+              && frame.readBoard.isReadBoardGmaAutoPlayActive();
       if (frame != null
-          && (frame.isPlayingAgainstLeelaz || frame.isAnaPlayingAgainstLeelaz)) {
+          && (frame.isPlayingAgainstLeelaz
+              || (frame.isAnaPlayingAgainstLeelaz && !readBoardGmaActive))) {
         LizzieFrame.sendAiTime(false, engine, false);
       }
       LizzieFrame.menu.showPda(Lizzie.leelaz.isKataGoPda);

--- a/src/test/java/featurecat/lizzie/LizzieInitializationTimeControlTest.java
+++ b/src/test/java/featurecat/lizzie/LizzieInitializationTimeControlTest.java
@@ -1,0 +1,145 @@
+package featurecat.lizzie;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import featurecat.lizzie.analysis.EngineManager;
+import featurecat.lizzie.analysis.Leelaz;
+import featurecat.lizzie.gui.LizzieFrame;
+import featurecat.lizzie.gui.Menu;
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class LizzieInitializationTimeControlTest {
+  @Test
+  void ordinaryEngineInitializationDoesNotInstallGameMoveTime() throws Exception {
+    try (Harness harness = Harness.open()) {
+      harness.initialize(false);
+
+      assertEquals(List.of(), harness.engine.commands);
+    }
+  }
+
+  @Test
+  void automaticGameInitializationKeepsGameMoveTime() throws Exception {
+    try (Harness harness = Harness.open()) {
+      harness.frame.isAnaPlayingAgainstLeelaz = true;
+      harness.initialize(false);
+
+      assertEquals(
+          List.of("kata-time_settings none", "kata-set-param maxTime 2"), harness.engine.commands);
+    }
+  }
+
+  @Test
+  void humanGameInitializationKeepsGameMoveTime() throws Exception {
+    try (Harness harness = Harness.open()) {
+      harness.frame.isPlayingAgainstLeelaz = true;
+      harness.initialize(false);
+
+      assertEquals(
+          List.of("kata-time_settings none", "kata-set-param maxTime 2"), harness.engine.commands);
+    }
+  }
+
+  private static final class Harness implements AutoCloseable {
+    private final Config previousConfig;
+    private final LizzieFrame previousFrame;
+    private final Leelaz previousPrimaryEngine;
+    private final Menu previousMenu;
+    private final boolean previousEngineGame;
+    private final boolean previousPreEngineGame;
+    private final TestFrame frame;
+    private final RecordingLeelaz engine;
+
+    private Harness(
+        Config previousConfig,
+        LizzieFrame previousFrame,
+        Leelaz previousPrimaryEngine,
+        Menu previousMenu,
+        boolean previousEngineGame,
+        boolean previousPreEngineGame,
+        TestFrame frame,
+        RecordingLeelaz engine) {
+      this.previousConfig = previousConfig;
+      this.previousFrame = previousFrame;
+      this.previousPrimaryEngine = previousPrimaryEngine;
+      this.previousMenu = previousMenu;
+      this.previousEngineGame = previousEngineGame;
+      this.previousPreEngineGame = previousPreEngineGame;
+      this.frame = frame;
+      this.engine = engine;
+    }
+
+    private static Harness open() throws Exception {
+      Config config =
+          ConfigTestHelper.createForTests(Files.createTempDirectory("lizzie-init-time"));
+      config.maxGameThinkingTimeSeconds = 2;
+      TestFrame frame = allocate(TestFrame.class);
+      RecordingLeelaz engine = new RecordingLeelaz();
+      engine.isKatago = true;
+
+      Harness harness =
+          new Harness(
+              Lizzie.config,
+              Lizzie.frame,
+              Lizzie.leelaz,
+              LizzieFrame.menu,
+              EngineManager.isEngineGame,
+              EngineManager.isPreEngineGame,
+              frame,
+              engine);
+      Lizzie.config = config;
+      Lizzie.frame = frame;
+      Lizzie.leelaz = new Leelaz("");
+      LizzieFrame.menu = allocate(SilentMenu.class);
+      EngineManager.isEngineGame = false;
+      EngineManager.isPreEngineGame = false;
+      return harness;
+    }
+
+    private void initialize(boolean isEngineGame) {
+      Lizzie.initializeAfterVersionCheck(isEngineGame, engine);
+    }
+
+    @Override
+    public void close() {
+      Lizzie.config = previousConfig;
+      Lizzie.frame = previousFrame;
+      Lizzie.leelaz = previousPrimaryEngine;
+      LizzieFrame.menu = previousMenu;
+      EngineManager.isEngineGame = previousEngineGame;
+      EngineManager.isPreEngineGame = previousPreEngineGame;
+    }
+  }
+
+  private static final class TestFrame extends LizzieFrame {}
+
+  private static final class SilentMenu extends Menu {
+    @Override
+    public void showPda(boolean show) {}
+  }
+
+  private static final class RecordingLeelaz extends Leelaz {
+    private final List<String> commands = new ArrayList<>();
+
+    private RecordingLeelaz() throws IOException {
+      super("");
+    }
+
+    @Override
+    public void sendCommand(String command) {
+      commands.add(command);
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  private static <T> T allocate(Class<T> type) throws Exception {
+    Field field = sun.misc.Unsafe.class.getDeclaredField("theUnsafe");
+    field.setAccessible(true);
+    return (T) ((sun.misc.Unsafe) field.get(null)).allocateInstance(type);
+  }
+}

--- a/src/test/java/featurecat/lizzie/LizzieInitializationTimeControlTest.java
+++ b/src/test/java/featurecat/lizzie/LizzieInitializationTimeControlTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import featurecat.lizzie.analysis.EngineManager;
 import featurecat.lizzie.analysis.Leelaz;
+import featurecat.lizzie.analysis.ReadBoard;
 import featurecat.lizzie.gui.LizzieFrame;
 import featurecat.lizzie.gui.Menu;
 import java.io.IOException;
@@ -31,6 +32,17 @@ class LizzieInitializationTimeControlTest {
 
       assertEquals(
           List.of("kata-time_settings none", "kata-set-param maxTime 2"), harness.engine.commands);
+    }
+  }
+
+  @Test
+  void readBoardGmaInitializationDoesNotOverwriteGmaTime() throws Exception {
+    try (Harness harness = Harness.open()) {
+      harness.frame.isAnaPlayingAgainstLeelaz = true;
+      harness.frame.readBoard = allocate(ActiveGmaReadBoard.class);
+      harness.initialize(false);
+
+      assertEquals(List.of(), harness.engine.commands);
     }
   }
 
@@ -121,6 +133,17 @@ class LizzieInitializationTimeControlTest {
   private static final class SilentMenu extends Menu {
     @Override
     public void showPda(boolean show) {}
+  }
+
+  private static final class ActiveGmaReadBoard extends ReadBoard {
+    private ActiveGmaReadBoard() throws Exception {
+      super(false, false);
+    }
+
+    @Override
+    public boolean isReadBoardGmaAutoPlayActive() {
+      return true;
+    }
   }
 
   private static final class RecordingLeelaz extends Leelaz {

--- a/src/test/java/featurecat/lizzie/analysis/ReadBoardEngineResumeTest.java
+++ b/src/test/java/featurecat/lizzie/analysis/ReadBoardEngineResumeTest.java
@@ -12,6 +12,7 @@ import featurecat.lizzie.Lizzie;
 import featurecat.lizzie.gui.BoardRenderer;
 import featurecat.lizzie.gui.BottomToolbar;
 import featurecat.lizzie.gui.LizzieFrame;
+import featurecat.lizzie.gui.Menu;
 import featurecat.lizzie.rules.Board;
 import featurecat.lizzie.rules.BoardData;
 import featurecat.lizzie.rules.BoardHistoryList;
@@ -79,6 +80,50 @@ class ReadBoardEngineResumeTest {
 
       assertEquals(1, harness.frame.scheduleResumeAnalysisCount);
       assertNotNull(harness.frame.lastScheduledResumeAction);
+    }
+  }
+
+  @Test
+  void ordinaryReadBoardSyncStartsAnalysisWithoutInstallingGameMoveTime() throws Exception {
+    Menu previousMenu = LizzieFrame.menu;
+    boolean previousEngineGame = EngineManager.isEngineGame;
+    boolean previousPreEngineGame = EngineManager.isPreEngineGame;
+    try (EngineResumeHarness harness =
+        EngineResumeHarness.create(rootHistory(emptyStones(), true))) {
+      LizzieFrame.menu = allocate(SilentMenu.class);
+      LizzieFrame.toolbar = allocate(SilentBottomToolbar.class);
+      EngineManager.isEngineGame = false;
+      EngineManager.isPreEngineGame = false;
+      harness.frame.isPlayingAgainstLeelaz = false;
+      harness.frame.isAnaPlayingAgainstLeelaz = false;
+      harness.leelaz.isKatago = true;
+      Lizzie.config.maxGameThinkingTimeSeconds = 2;
+      Lizzie.config.notStartPondering = true;
+
+      SnapshotTrackingLeelaz previousPrimaryEngine = SnapshotTrackingLeelaz.create();
+      Lizzie.leelaz = previousPrimaryEngine;
+      try {
+        Lizzie.initializeAfterVersionCheck(false, harness.leelaz);
+      } finally {
+        Lizzie.leelaz = harness.leelaz;
+      }
+      harness.readBoard.parseLine("sync");
+      SwingUtilities.invokeAndWait(() -> {});
+
+      assertEquals(1, harness.leelaz.togglePonderCount);
+      assertEquals(1, harness.leelaz.ponderCount);
+      assertFalse(
+          harness.leelaz.sentCommands.stream()
+              .anyMatch(
+                  command ->
+                      command.startsWith("time_settings ")
+                          || command.startsWith("kata-time_settings ")
+                          || command.startsWith("kata-set-param maxTime ")),
+          "ordinary ReadBoard analysis must not inherit per-move game time commands.");
+    } finally {
+      LizzieFrame.menu = previousMenu;
+      EngineManager.isEngineGame = previousEngineGame;
+      EngineManager.isPreEngineGame = previousPreEngineGame;
     }
   }
 
@@ -2234,6 +2279,19 @@ class ReadBoardEngineResumeTest {
     void showForegroundEngineLeaseConflict() {}
   }
 
+  private static final class SilentMenu extends Menu {
+    @Override
+    public void showPda(boolean show) {}
+
+    @Override
+    public void updateMenuStatusForEngine() {}
+  }
+
+  private static final class SilentBottomToolbar extends BottomToolbar {
+    @Override
+    public void reSetButtonLocation() {}
+  }
+
   private static final class TrackingBoard extends Board {
     private int clearCount;
     private boolean clearCalledOnEdt;
@@ -2332,6 +2390,14 @@ class ReadBoardEngineResumeTest {
 
     @Override
     public void refresh() {}
+
+    @Override
+    public void reSetLoc() {}
+
+    @Override
+    public boolean resetMovelistFrameandAnalysisFrame() {
+      return false;
+    }
 
     @Override
     public void onMainEnginePonder() {}

--- a/src/test/java/featurecat/lizzie/rules/BoardMovelistExportTest.java
+++ b/src/test/java/featurecat/lizzie/rules/BoardMovelistExportTest.java
@@ -165,6 +165,7 @@ class BoardMovelistExportTest {
       assertTrue(
           engine.recordedCommands().get(1).startsWith("loadsgf "),
           "load-engine resend should land the edited current board through exact snapshot restore.");
+      assertEquals(2, engine.recordedCommands().size());
       assertArrayEquals(
           board.getHistory().getCurrentHistoryNode().getData().stones,
           engine.copyStones(),
@@ -216,6 +217,7 @@ class BoardMovelistExportTest {
       assertTrue(
           engine.recordedCommands().get(1).startsWith("loadsgf "),
           "load-engine restore should land the edited current board through exact snapshot restore.");
+      assertEquals(2, engine.recordedCommands().size());
       assertArrayEquals(
           board.getHistory().getCurrentHistoryNode().getData().stones,
           engine.copyStones(),
@@ -408,6 +410,7 @@ class BoardMovelistExportTest {
       assertTrue(
           engine.recordedCommands().get(1).startsWith("loadsgf "),
           "load-engine restore should still restore snapshot through loadsgf.");
+      assertEquals(2, engine.recordedCommands().size());
       assertEquals(5, engine.loadedBoardWidth(), "snapshot restore should use history width.");
       assertEquals(7, engine.loadedBoardHeight(), "snapshot restore should use history height.");
       assertTrue(
@@ -624,6 +627,7 @@ class BoardMovelistExportTest {
       assertTrue(
           engine.recordedCommands().get(1).startsWith("loadsgf "),
           "load-engine replay should restore the removed-stone setup snapshot through loadsgf.");
+      assertEquals(3, engine.recordedCommands().size());
     } finally {
       Lizzie.board = previousBoard;
       Lizzie.config = previousConfig;
@@ -670,6 +674,7 @@ class BoardMovelistExportTest {
       assertTrue(
           engine.recordedCommands().get(1).startsWith("loadsgf "),
           "load-engine replay should restore the nearest removed-stone snapshot through loadsgf.");
+      assertEquals(3, engine.recordedCommands().size());
     } finally {
       Lizzie.board = previousBoard;
       Lizzie.config = previousConfig;

--- a/src/test/java/featurecat/lizzie/rules/BoardMovelistExportTest.java
+++ b/src/test/java/featurecat/lizzie/rules/BoardMovelistExportTest.java
@@ -165,7 +165,6 @@ class BoardMovelistExportTest {
       assertTrue(
           engine.recordedCommands().get(1).startsWith("loadsgf "),
           "load-engine resend should land the edited current board through exact snapshot restore.");
-      assertEquals("time_settings 0 0 1", engine.recordedCommands().get(2));
       assertArrayEquals(
           board.getHistory().getCurrentHistoryNode().getData().stones,
           engine.copyStones(),
@@ -217,7 +216,6 @@ class BoardMovelistExportTest {
       assertTrue(
           engine.recordedCommands().get(1).startsWith("loadsgf "),
           "load-engine restore should land the edited current board through exact snapshot restore.");
-      assertEquals("time_settings 0 0 1", engine.recordedCommands().get(2));
       assertArrayEquals(
           board.getHistory().getCurrentHistoryNode().getData().stones,
           engine.copyStones(),
@@ -410,7 +408,6 @@ class BoardMovelistExportTest {
       assertTrue(
           engine.recordedCommands().get(1).startsWith("loadsgf "),
           "load-engine restore should still restore snapshot through loadsgf.");
-      assertEquals("time_settings 0 0 1", engine.recordedCommands().get(2));
       assertEquals(5, engine.loadedBoardWidth(), "snapshot restore should use history width.");
       assertEquals(7, engine.loadedBoardHeight(), "snapshot restore should use history height.");
       assertTrue(
@@ -619,11 +616,10 @@ class BoardMovelistExportTest {
       board.resendMoveToEngine(engine, true);
 
       assertEquals(
-          List.of("clear_board", "play B pass", "time_settings 0 0 1"),
+          List.of("clear_board", "play B pass"),
           List.of(
               engine.recordedCommands().get(0),
-              engine.recordedCommands().get(2),
-              engine.recordedCommands().get(3)),
+              engine.recordedCommands().get(2)),
           "load-engine replay should replay only later real actions after the removed-stone snapshot restore.");
       assertTrue(
           engine.recordedCommands().get(1).startsWith("loadsgf "),
@@ -666,12 +662,10 @@ class BoardMovelistExportTest {
       assertEquals(
           List.of(
               "clear_board",
-              "play W " + Board.convertCoordinatesToName(0, 1),
-              "time_settings 0 0 1"),
+              "play W " + Board.convertCoordinatesToName(0, 1)),
           List.of(
               engine.recordedCommands().get(0),
-              engine.recordedCommands().get(2),
-              engine.recordedCommands().get(3)),
+              engine.recordedCommands().get(2)),
           "load-engine replay should replay only later real actions after the nearest removed-stone snapshot restore.");
       assertTrue(
           engine.recordedCommands().get(1).startsWith("loadsgf "),


### PR DESCRIPTION
## Summary

- Prevent ordinary ReadBoard sync analysis from installing game per-move time controls.
- Preserve the existing time-control behavior for human-vs-engine and automatic engine games.
- Preserve ReadBoard GMA ownership of `maxTime` during engine initialization.
- Add regression coverage for ordinary sync, GMA initialization, and snapshot-restore command boundaries.

ReadBoard's per-move time previously flowed through a shared initialization path and could incorrectly limit ordinary analysis—for example, stopping analysis after two seconds.

## Type Of Change

- [x] Bug fix
- [ ] Feature
- [ ] Packaging / release update
- [ ] Docs / translation
- [ ] Refactor

## Testing

- [x] Tested locally
- [ ] Verified package contents if packaging changed
- [ ] Verified Fox sync flow if related
- [ ] Added screenshots if UI changed
- [ ] Updated README / docs if user-facing behavior changed
- [x] Noted affected platforms if the change is platform-specific

Verification results:

- Fresh post-rebase focused gate: 3 suites, 93 tests, 0 failures/errors/skips.
- Full WSL suite: 178 suites, 1,763 tests, 0 failures/errors, 5 existing skips.
- Full Windows suite: 178 suites, 1,763 tests, 0 failures/errors, 2 platform-conditional skips.
- Real Windows desktop validation with ReadBoard v3.0.9 and a real KataGo engine:
  - Ordinary analysis continued for more than eight seconds without `kata-time_settings`, `time_settings`, or `kata-set-param maxTime 2`.
  - GMA continued to enforce `maxTime=2`; two legitimate turns each produced one click, one acknowledgement, and zero retries.
  - Stopping synchronization restored the original `ponderingEnabled=true` and `maxTime=1e+20`.
  - The process chain remained limited to one KataGo and one ReadBoard instance.

## Notes

- Rebasing onto upstream `main` completed without conflicts.
- The change was checked against `docs/SNAPSHOT_NODE_KIND.md`, `docs/TRACKING_ANALYSIS_CONTRACT.md`, and the ReadBoard GMA design contract.
- It does not change `SNAPSHOT`, `PASS`, history, tracking ownership, or the GMA scheduling state machine.
- Real desktop GMA validation used `maxVisits=0`; positive `maxVisits` behavior remains covered by automated tests.
