### PR TITLE
fix(gui): render next moves from Web trial node

### DIFF
--- a/src/main/java/featurecat/lizzie/gui/BoardRenderer.java
+++ b/src/main/java/featurecat/lizzie/gui/BoardRenderer.java
@@ -3323,9 +3323,10 @@ public class BoardRenderer {
   }
 
   private void drawNextMoves(Graphics2D g) {
+    BoardHistoryNode displayNode = Lizzie.frame.getDisplayNode();
     List<BoardHistoryNode> nexts = new ArrayList<BoardHistoryNode>();
-    for (BoardHistoryNode next : Lizzie.board.getHistory().getNexts()) {
-      if (next.getData().isMoveNode()) {
+    for (BoardHistoryNode next : displayNode.getVariations()) {
+      if (next.getData().isMoveNode() && !next.getData().dummy) {
         nexts.add(next);
       }
     }
@@ -3346,12 +3347,12 @@ public class BoardRenderer {
                         && !Lizzie.board.isPkBoard
                         && !Lizzie.frame.isShowingHeatmap
                         && !Lizzie.frame.isShowingPolicy
-                        && ((Lizzie.board.getHistory().isBlacksTurn()
+                        && ((displayNode.getData().blackToPlay
                                 && Lizzie.config.showBlackCandidates)
-                            || (!Lizzie.board.getHistory().isBlacksTurn()
+                            || (!displayNode.getData().blackToPlay
                                 && Lizzie.config.showWhiteCandidates))) {
                       BoardData nextData = nexts.get(0).getData();
-                      BoardData thisData = Lizzie.board.getHistory().getData();
+                      BoardData thisData = displayNode.getData();
                       boolean isMain = this.boardIndex != 1;
                       List<MoveData> thisBestMoves =
                           isMain ? thisData.bestMoves : thisData.bestMoves2;
@@ -3362,7 +3363,8 @@ public class BoardRenderer {
                           && !(isMain ? nextData.isChanged : nextData.isChanged2)
                           && thisBestMoves != null
                           && thisBestMoves.size() > 0) {
-                        if (notEnoughSuggestionAt(nextMove[0], nextMove[1], bestMoves)) {
+                        if (notEnoughSuggestionAt(
+                            nextMove[0], nextMove[1], bestMoves, displayNode, nexts.get(0))) {
                           isShowingNextMoveBlunder = true;
                           nextMoveX = nextMove[0];
                           nextMoveY = nextMove[1];
@@ -3453,9 +3455,10 @@ public class BoardRenderer {
     if (nextCoords == null || nextCoords.isEmpty()) {
       return;
     }
+    BoardHistoryNode displayNode = Lizzie.frame.getDisplayNode();
     List<BoardHistoryNode> nexts = new ArrayList<BoardHistoryNode>();
-    for (BoardHistoryNode next : Lizzie.board.getHistory().getNexts()) {
-      if (next.getData().isMoveNode()) {
+    for (BoardHistoryNode next : displayNode.getVariations()) {
+      if (next.getData().isMoveNode() && !next.getData().dummy) {
         nexts.add(next);
       }
     }
@@ -3493,24 +3496,22 @@ public class BoardRenderer {
     }
   }
 
-  private boolean notEnoughSuggestionAt(int coordX, int coordY, List<MoveData> bestMoves) {
+  private boolean notEnoughSuggestionAt(
+      int coordX,
+      int coordY,
+      List<MoveData> bestMoves,
+      BoardHistoryNode displayNode,
+      BoardHistoryNode nextMoveNode) {
     // TODO Auto-generated method stub
     if (bestMoves.isEmpty()) return true;
-    if ((Lizzie.board.getHistory().isBlacksTurn() && Lizzie.config.showBlackCandidates)
-        || (!Lizzie.board.getHistory().isBlacksTurn() && Lizzie.config.showWhiteCandidates)) {
+    if ((displayNode.getData().blackToPlay && Lizzie.config.showBlackCandidates)
+        || (!displayNode.getData().blackToPlay && Lizzie.config.showWhiteCandidates)) {
       String coordsName = Board.convertCoordinatesToName(coordX, coordY);
       for (MoveData move : bestMoves) {
         if (move.coordinate.equals(coordsName)) {
           if (move.order > 0
               && move.playouts < Lizzie.config.minPlayoutsForNextMove
-              && Lizzie.board.getHistory().getCurrentHistoryNode().next().isPresent()
-              && Lizzie.board
-                      .getHistory()
-                      .getCurrentHistoryNode()
-                      .next()
-                      .get()
-                      .getData()
-                      .getPlayouts()
+              && nextMoveNode.getData().getPlayouts()
                   >= Lizzie.config.minPlayoutsForNextMove) {
             shouldIgnoreBestMove = true;
             this.ignoreBestMoveX = coordX;
@@ -3527,13 +3528,12 @@ public class BoardRenderer {
     // TODO Auto-generated method stub
     int moveX = x + scaledMarginWidth + squareWidth * nextMoveX;
     int moveY = y + scaledMarginHeight + squareHeight * nextMoveY;
+    boolean blackToPlay = Lizzie.frame.getDisplayNode().getData().blackToPlay;
     if (Lizzie.config.usePureStone)
-      drawStoneSimple(
-          g, g, moveX, moveY, Lizzie.board.getHistory().isBlacksTurn() ? Stone.BLACK : Stone.WHITE);
+      drawStoneSimple(g, g, moveX, moveY, blackToPlay ? Stone.BLACK : Stone.WHITE);
     else
-      drawStone(
-          g, g, moveX, moveY, Lizzie.board.getHistory().isBlacksTurn() ? Stone.BLACK : Stone.WHITE);
-    if (Lizzie.board.getHistory().isBlacksTurn()) g.setColor(Color.WHITE);
+      drawStone(g, g, moveX, moveY, blackToPlay ? Stone.BLACK : Stone.WHITE);
+    if (blackToPlay) g.setColor(Color.WHITE);
     else g.setColor(Color.BLACK);
     if (showBlunderWinrate && showBlunderScore) {
       if (Lizzie.config.suggestionInfoWinrate <= Lizzie.config.suggestionInfoScoreLead) {

--- a/src/test/java/featurecat/lizzie/gui/MoveOnlyUiGateTest.java
+++ b/src/test/java/featurecat/lizzie/gui/MoveOnlyUiGateTest.java
@@ -15,8 +15,10 @@ import featurecat.lizzie.analysis.MoveRankEvaluationMode;
 import featurecat.lizzie.rules.Board;
 import featurecat.lizzie.rules.BoardData;
 import featurecat.lizzie.rules.BoardHistoryList;
+import featurecat.lizzie.rules.BoardHistoryNode;
 import featurecat.lizzie.rules.Stone;
 import featurecat.lizzie.rules.Zobrist;
+import java.awt.Color;
 import java.awt.Font;
 import java.awt.Graphics2D;
 import java.awt.image.BufferedImage;
@@ -140,6 +142,113 @@ class MoveOnlyUiGateTest {
 
       assertTrue(
           frame.isMouseOver, "real next moves should still activate next-move blunder hover.");
+    } finally {
+      env.close();
+    }
+  }
+
+  @Test
+  void trialDisplayNodeDoesNotDrawItsOwnMoveAsNextMove() throws Exception {
+    TestEnvironment env = TestEnvironment.open();
+    try {
+      TrackingLizzieFrame frame = configuredFrame();
+      Lizzie.frame = frame;
+      BoardHistoryList history =
+          historyWithNext(currentData(), moveData(new int[] {1, 1}, 2));
+      BoardHistoryNode anchor = history.getStart();
+      insertDummyAsFirstVariation(anchor);
+      BoardHistoryNode displayNode = anchor.variations.get(1);
+      Lizzie.board = boardWith(history);
+      frame.setDisplayNodeOverride(displayNode);
+      BoardRenderer renderer = configuredBranchRenderer();
+
+      assertFalse(
+          hasVisiblePaintNear(renderNextMoveOverlay(renderer), 1, 1),
+          "the trial branch's first stone must not be drawn as the display node's future move.");
+    } finally {
+      env.close();
+    }
+  }
+
+  @Test
+  void trialDisplayNodeDrawsItsRealNextMoveAndIgnoresDummy() throws Exception {
+    TestEnvironment env = TestEnvironment.open();
+    try {
+      TrackingLizzieFrame frame = configuredFrame();
+      Lizzie.frame = frame;
+      BoardHistoryList history =
+          historyWithNext(currentData(), moveData(new int[] {1, 1}, 2));
+      BoardHistoryNode displayNode = history.getStart().variations.get(0);
+      MoveData displayCandidate = bestMove(2, 1);
+      displayCandidate.order = 1;
+      displayNode.getData().bestMoves = new ArrayList<>(List.of(displayCandidate));
+      insertDummyAsFirstVariation(displayNode);
+      BoardData realNextMove = moveData(new int[] {2, 1}, 3);
+      realNextMove.setPlayoutsForce(40);
+      realNextMove.bestMoves.get(0).variation = new ArrayList<>();
+      displayNode.addAtLast(realNextMove);
+      Lizzie.board = boardWith(history);
+      frame.setDisplayNodeOverride(displayNode);
+      Lizzie.config.showBlackCandidates = true;
+      Lizzie.config.showWhiteCandidates = true;
+      Lizzie.config.minPlayoutsForNextMove = 30;
+      BoardRenderer renderer = configuredBranchRenderer();
+      setField(BoardRenderer.class, renderer, "bestMoves", displayNode.getData().bestMoves);
+      BufferedImage overlay = renderNextMoveOverlay(renderer);
+
+      assertFalse(
+          hasVisiblePaintNear(overlay, 1, 1),
+          "the trial display node must not be outlined as its own future move.");
+      assertTrue(
+          hasVisiblePaintNear(overlay, 2, 1),
+          "the trial display node's real next move should keep its outline.");
+      assertTrue(
+          (boolean) getField(BoardRenderer.class, renderer, "isShowingNextMoveBlunder"),
+          "the dummy placeholder must not displace the real next move from first-move handling.");
+    } finally {
+      env.close();
+    }
+  }
+
+  @Test
+  void trialNextBlunderStoneUsesDisplayNodeTurn() throws Exception {
+    TestEnvironment env = TestEnvironment.open();
+    try {
+      TrackingLizzieFrame frame = configuredFrame();
+      Lizzie.frame = frame;
+      BoardHistoryList history =
+          historyWithNext(currentData(), moveData(new int[] {1, 1}, 2));
+      Lizzie.board = boardWith(history);
+      frame.setDisplayNodeOverride(history.getStart().variations.get(0));
+      Lizzie.config.usePureStone = true;
+      BoardRenderer renderer = configuredBranchRenderer();
+
+      BufferedImage image = renderNextBlunderFirstMove(renderer, 1, 1);
+      int centerRgb =
+          image.getRGB(SCALED_MARGIN + SQUARE_SIZE, SCALED_MARGIN + SQUARE_SIZE);
+
+      assertEquals(
+          Color.BLACK.getRGB(),
+          centerRgb,
+          "the next-move preview stone should use the trial display node's side to play.");
+    } finally {
+      env.close();
+    }
+  }
+
+  @Test
+  void currentNodeStillDrawsItsRealNextMove() throws Exception {
+    TestEnvironment env = TestEnvironment.open();
+    try {
+      TrackingLizzieFrame frame = configuredFrame();
+      Lizzie.frame = frame;
+      Lizzie.board =
+          boardWith(historyWithNext(currentData(), moveData(new int[] {1, 1}, 2)));
+      BoardRenderer renderer = configuredBranchRenderer();
+
+      assertTrue(
+          hasVisiblePaint(renderNextMoveOverlay(renderer)),
+          "the normal current-node path should keep its real next-move outline.");
     } finally {
       env.close();
     }
@@ -597,9 +706,59 @@ class MoveOnlyUiGateTest {
     }
   }
 
+  private static BufferedImage renderNextMoveOverlay(BoardRenderer renderer) throws Exception {
+    BufferedImage image = new BufferedImage(CANVAS_SIZE, CANVAS_SIZE, BufferedImage.TYPE_INT_ARGB);
+    Graphics2D graphics = image.createGraphics();
+    try {
+      setField(BoardRenderer.class, renderer, "nextCoords", new ArrayList<int[]>());
+      Method drawNextMoves =
+          BoardRenderer.class.getDeclaredMethod("drawNextMoves", Graphics2D.class);
+      drawNextMoves.setAccessible(true);
+      drawNextMoves.invoke(renderer, graphics);
+      Method drawOutlines =
+          BoardRenderer.class.getDeclaredMethod("drawNextMoveOutlinesOnTop", Graphics2D.class);
+      drawOutlines.setAccessible(true);
+      drawOutlines.invoke(renderer, graphics);
+      return image;
+    } finally {
+      graphics.dispose();
+    }
+  }
+
+  private static BufferedImage renderNextBlunderFirstMove(
+      BoardRenderer renderer, int boardX, int boardY) throws Exception {
+    BufferedImage image = new BufferedImage(CANVAS_SIZE, CANVAS_SIZE, BufferedImage.TYPE_INT_ARGB);
+    Graphics2D graphics = image.createGraphics();
+    try {
+      setIntField(renderer, "nextMoveX", boardX);
+      setIntField(renderer, "nextMoveY", boardY);
+      Method method =
+          BoardRenderer.class.getDeclaredMethod("drawNextBlunderFirstMove", Graphics2D.class);
+      method.setAccessible(true);
+      method.invoke(renderer, graphics);
+      return image;
+    } finally {
+      graphics.dispose();
+    }
+  }
+
   private static boolean hasVisiblePaint(BufferedImage image) {
     for (int x = 0; x < image.getWidth(); x++) {
       for (int y = 0; y < image.getHeight(); y++) {
+        if (((image.getRGB(x, y) >>> 24) & 0xFF) > 0) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  private static boolean hasVisiblePaintNear(BufferedImage image, int boardX, int boardY) {
+    int centerX = SCALED_MARGIN + SQUARE_SIZE * boardX;
+    int centerY = SCALED_MARGIN + SQUARE_SIZE * boardY;
+    int radius = STONE_RADIUS + 4;
+    for (int x = centerX - radius; x <= centerX + radius; x++) {
+      for (int y = centerY - radius; y <= centerY + radius; y++) {
         if (((image.getRGB(x, y) >>> 24) & 0xFF) > 0) {
           return true;
         }
@@ -638,6 +797,15 @@ class MoveOnlyUiGateTest {
     history.add(next);
     history.toStart();
     return history;
+  }
+
+  private static void insertDummyAsFirstVariation(BoardHistoryNode parent) {
+    BoardData dummyData = parent.getData().clone();
+    dummyData.dummy = true;
+    dummyData.lastMove = Optional.empty();
+    BoardHistoryNode dummy = new BoardHistoryNode(dummyData);
+    parent.variations.add(0, dummy);
+    parent.setPreviousForChild(dummy);
   }
 
   private static BoardHistoryList historyForCurrentNode(BoardData current) {


### PR DESCRIPTION
## Why

During Web trial mode, the board renders `displayNodeOverride`, but the next-move overlays still read the mainline current node. This can draw the first trial stone, such as Q16, as a future move over itself.

## What

- Read next-move overlays from the active display node.
- Ignore dummy placeholder nodes when selecting real next moves.
- Keep blunder evaluation, playout thresholds, and preview stone color aligned with the display node.
- Preserve existing behavior outside Web trial mode.
- Add regression coverage for the real `[dummy, trial child]` structure, real descendants, turn color, and the normal mainline path.

## Test Plan

- [x] `MoveOnlyUiGateTest`: 23 tests passed.
- [x] Full WSL/headless suite: 1762 tests, 0 failures, 0 errors, 5 skipped.
- [x] Windows Maven test-delivery build succeeded.
- [ ] Manual Windows GUI verification of the Q16 Web trial scenario.

## Related

- `docs/specs/2026-04-30-web-trial-mode-design.md`
- `docs/specs/2026-04-30-web-trial-engine-follow-design.md`
- `docs/SNAPSHOT_NODE_KIND.md`