### PR TITLE
Prepare next-2026-08-01.1 pre-release

### DIFF
--- a/.github/release-notes/next-2026-08-01.1.md
+++ b/.github/release-notes/next-2026-08-01.1.md
@@ -1,0 +1,323 @@
+# LizzieYzy Next next-2026-08-01.1
+
+## 中文
+
+这是 `next-2026-07-28.1` 之后的 KataGo 1.17 与 Transformer 默认模型预览版。完整包已统一升级引擎，并用更小、更强的新架构模型替换旧内置默认权重。
+
+### 本版主要更新
+
+- Windows、macOS、Linux 完整包统一升级到 KataGo `v1.17.0`。
+- 默认权重改为官方 `Transformer 10B 均衡版`，约 94 MB；相比旧内置智子 28B，模型文件减少约 177 MB。
+- 一键设置提供轻量、均衡、旗舰三款官方 Transformer，支持断点续传、文件长度和 SHA-256 校验。
+- 仅仍使用旧内置默认权重的托管引擎会自动迁移；自定义权重、远程算力、无引擎模式和启动方式保持不变。
+- Windows NVIDIA 使用 CUDA 12.1 + cuDNN 9.8，RTX 50 使用 CUDA 12.8 + cuDNN 9.8；TensorRT 引擎同步升级到 KataGo 1.17。
+
+### 下载前先看这几句
+
+- 新用户或需要 KataGo 1.17 / Transformer 的用户必须下载完整包。
+- `windows64.core-update.zip` 只更新主程序，不含新引擎和新权重，也不会静默联网下载。
+- 普通 Windows 用户优先选择 OpenCL 免安装版；NVIDIA 用户可选择 NVIDIA CUDA 版。
+- OpenCL 首次运行可能需要几分钟生成调优缓存，之后会直接复用，不是程序卡死。
+- Transformer 需要 KataGo 1.17；旧引擎选择该模型时会提示升级完整包。
+
+### 下载建议
+
+| 你的电脑 | 直接下载这个 |
+| --- | --- |
+| Windows 64 位，OpenCL 版，推荐，免安装 | [`2026-08-01-windows64.opencl.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.1/2026-08-01-windows64.opencl.portable.zip) |
+| 已有 Windows 免安装版，只更新主程序 | [`2026-08-01-windows64.core-update.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.1/2026-08-01-windows64.core-update.zip) |
+| Windows 64 位，OpenCL 安装版 | [`2026-08-01-windows64.opencl.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.1/2026-08-01-windows64.opencl.installer.exe) |
+| Windows 64 位，CPU 兼容版，免安装 | [`2026-08-01-windows64.with-katago.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.1/2026-08-01-windows64.with-katago.portable.zip) |
+| Windows 64 位，CPU 兼容安装版 | [`2026-08-01-windows64.with-katago.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.1/2026-08-01-windows64.with-katago.installer.exe) |
+| Windows 64 位，NVIDIA CUDA 版，免安装 | [`2026-08-01-windows64.nvidia.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.1/2026-08-01-windows64.nvidia.portable.zip) |
+| Windows 64 位，NVIDIA CUDA 安装版 | [`2026-08-01-windows64.nvidia.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.1/2026-08-01-windows64.nvidia.installer.exe) |
+| Windows 64 位，RTX 5070/5080/5090，免安装 | [`2026-08-01-windows64.nvidia50.cuda.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.1/2026-08-01-windows64.nvidia50.cuda.portable.zip) |
+| 高级可选：TensorRT 预装分卷包，需下载全部分卷 | [`2026-08-01-windows64.nvidia.tensorrt.portable.7z.001`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.1/2026-08-01-windows64.nvidia.tensorrt.portable.7z.001)<br>[`2026-08-01-windows64.nvidia.tensorrt.portable.7z.002`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.1/2026-08-01-windows64.nvidia.tensorrt.portable.7z.002) |
+| Windows 64 位，RTX 50 CUDA 安装版 | [`2026-08-01-windows64.nvidia50.cuda.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.1/2026-08-01-windows64.nvidia50.cuda.installer.exe) |
+| Windows 64 位，自行配置引擎，免安装 | [`2026-08-01-windows64.without.engine.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.1/2026-08-01-windows64.without.engine.portable.zip) |
+| Windows 64 位，自行配置引擎，安装版 | [`2026-08-01-windows64.without.engine.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.1/2026-08-01-windows64.without.engine.installer.exe) |
+| macOS Apple Silicon | [`2026-08-01-mac-apple-silicon.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.1/2026-08-01-mac-apple-silicon.with-katago.dmg) |
+| macOS Intel | [`2026-08-01-mac-intel.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.1/2026-08-01-mac-intel.with-katago.dmg) |
+| Linux 64 位，CPU 兼容版 | [`2026-08-01-linux64.with-katago.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.1/2026-08-01-linux64.with-katago.zip) |
+| Linux 64 位，OpenCL 版 | [`2026-08-01-linux64.opencl.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.1/2026-08-01-linux64.opencl.zip) |
+| Linux 64 位，NVIDIA CUDA 版 | [`2026-08-01-linux64.nvidia.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.1/2026-08-01-linux64.nvidia.zip) |
+
+### 这一版为什么值得测试
+
+- 官方中型 Transformer 每次访问棋力强于最强 28B，通常速度相当或更快，同时明显减少完整包体积。
+- 已在 RTX 3070 Windows 真机验证 CPU、OpenCL、CUDA、整盘精析和 150% 缩放界面；CUDA 基准约 102 visits/s。
+- 完整测试共 1785 项通过；macOS Apple Silicon 也已真实验证 Metal 引擎加载新模型并完成分析。
+
+### 交流
+
+- QQ 群：`299419120`
+
+---
+
+## 繁體中文
+
+這是 `next-2026-07-28.1` 之後的 KataGo 1.17 與 Transformer 預設模型預覽版。完整套件已統一升級引擎，並以更小、更強的新架構模型取代舊預設權重。
+
+### 本版主要更新
+
+- Windows、macOS、Linux 完整套件統一升級到 KataGo `v1.17.0`。
+- 預設權重改為官方 `Transformer 10B 均衡版`，約 94 MB；比舊內建智子 28B 減少約 177 MB。
+- 一鍵設定提供輕量、均衡、旗艦三款官方 Transformer，支援續傳、檔案長度與 SHA-256 驗證。
+- 只有仍使用舊內建預設權重的託管引擎會自動遷移；自訂權重、遠端算力、無引擎模式與啟動方式不變。
+- Windows NVIDIA 使用 CUDA 12.1 + cuDNN 9.8，RTX 50 使用 CUDA 12.8 + cuDNN 9.8；TensorRT 引擎同步升級到 KataGo 1.17。
+
+### 下載前先看這幾句
+
+- 新使用者或需要 KataGo 1.17 / Transformer 的使用者必須下載完整套件。
+- `windows64.core-update.zip` 只更新主程式，不含新引擎或新權重，也不會靜默下載。
+- 一般 Windows 使用者優先選 OpenCL portable；NVIDIA 使用者可選 NVIDIA CUDA 版。
+- OpenCL 首次執行可能需數分鐘建立調校快取，之後會直接重用，並非程式卡住。
+- Transformer 需要 KataGo 1.17；舊引擎選擇時會提示升級完整套件。
+
+### 下載建議
+
+| 你的電腦 | 直接下載這個 |
+| --- | --- |
+| Windows 64 位，OpenCL 推薦版，免安裝 | [`2026-08-01-windows64.opencl.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.1/2026-08-01-windows64.opencl.portable.zip) |
+| 既有 Windows portable，只更新主程式 | [`2026-08-01-windows64.core-update.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.1/2026-08-01-windows64.core-update.zip) |
+| Windows 64 位，OpenCL 安裝版 | [`2026-08-01-windows64.opencl.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.1/2026-08-01-windows64.opencl.installer.exe) |
+| Windows 64 位，CPU 相容版，免安裝 | [`2026-08-01-windows64.with-katago.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.1/2026-08-01-windows64.with-katago.portable.zip) |
+| Windows 64 位，CPU 相容安裝版 | [`2026-08-01-windows64.with-katago.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.1/2026-08-01-windows64.with-katago.installer.exe) |
+| Windows 64 位，NVIDIA CUDA，免安裝 | [`2026-08-01-windows64.nvidia.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.1/2026-08-01-windows64.nvidia.portable.zip) |
+| Windows 64 位，NVIDIA CUDA 安裝版 | [`2026-08-01-windows64.nvidia.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.1/2026-08-01-windows64.nvidia.installer.exe) |
+| Windows 64 位，RTX 5070/5080/5090，免安裝 | [`2026-08-01-windows64.nvidia50.cuda.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.1/2026-08-01-windows64.nvidia50.cuda.portable.zip) |
+| 進階可選：TensorRT 預裝分卷，需下載全部檔案 | [`2026-08-01-windows64.nvidia.tensorrt.portable.7z.001`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.1/2026-08-01-windows64.nvidia.tensorrt.portable.7z.001)<br>[`2026-08-01-windows64.nvidia.tensorrt.portable.7z.002`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.1/2026-08-01-windows64.nvidia.tensorrt.portable.7z.002) |
+| Windows 64 位，RTX 50 CUDA 安裝版 | [`2026-08-01-windows64.nvidia50.cuda.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.1/2026-08-01-windows64.nvidia50.cuda.installer.exe) |
+| Windows 64 位，自行設定引擎，免安裝 | [`2026-08-01-windows64.without.engine.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.1/2026-08-01-windows64.without.engine.portable.zip) |
+| Windows 64 位，自行設定引擎，安裝版 | [`2026-08-01-windows64.without.engine.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.1/2026-08-01-windows64.without.engine.installer.exe) |
+| macOS Apple Silicon | [`2026-08-01-mac-apple-silicon.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.1/2026-08-01-mac-apple-silicon.with-katago.dmg) |
+| macOS Intel | [`2026-08-01-mac-intel.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.1/2026-08-01-mac-intel.with-katago.dmg) |
+| Linux 64 位，CPU 相容版 | [`2026-08-01-linux64.with-katago.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.1/2026-08-01-linux64.with-katago.zip) |
+| Linux 64 位，OpenCL 版 | [`2026-08-01-linux64.opencl.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.1/2026-08-01-linux64.opencl.zip) |
+| Linux 64 位，NVIDIA CUDA 版 | [`2026-08-01-linux64.nvidia.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.1/2026-08-01-linux64.nvidia.zip) |
+
+### 這一版為什麼值得測試
+
+- 官方中型 Transformer 每次訪問棋力強於最強 28B，通常速度相當或更快，並明顯縮小完整套件。
+- 已在 RTX 3070 Windows 真機驗證 CPU、OpenCL、CUDA、整盤精析與 150% 縮放；CUDA 約 102 visits/s。
+- 1785 項完整測試通過；macOS Apple Silicon 也已實機驗證 Metal 引擎載入新模型並完成分析。
+
+### 交流
+
+- QQ 群：`299419120`
+
+---
+
+## English
+
+This pre-release follows `next-2026-07-28.1` and upgrades the complete packages to KataGo 1.17 with a smaller and stronger Transformer model as the new bundled default.
+
+### Release Highlights
+
+- Upgrades complete Windows, macOS, and Linux packages to KataGo `v1.17.0`.
+- Uses the official `Transformer 10B Balanced` model by default. At about 94 MB, it is about 177 MB smaller than the previous bundled Zhizi 28B model.
+- Offers light, balanced, and flagship official Transformer models with resumable downloads, length checks, and SHA-256 verification.
+- Migrates only managed engines that still use the old bundled default. Custom weights, remote compute, no-engine mode, and startup preferences remain unchanged.
+- Uses CUDA 12.1 + cuDNN 9.8 for standard Windows NVIDIA packages and CUDA 12.8 + cuDNN 9.8 for RTX 50; the TensorRT engine is also upgraded to KataGo 1.17.
+
+### Read Before Downloading
+
+- New users and anyone who wants KataGo 1.17 or Transformer support must download a complete package.
+- `windows64.core-update.zip` updates only the application. It contains no new engine or weight and never downloads them silently.
+- Most Windows users should choose the OpenCL portable package. NVIDIA users may choose the NVIDIA CUDA package.
+- The first OpenCL run can spend several minutes creating a tuning cache. Later launches reuse it; this is not a hang.
+- Transformer weights require KataGo 1.17. Older engines show a full-package upgrade message instead of trying to run them.
+
+### Download Guide
+
+| Your computer | Download this file |
+| --- | --- |
+| Windows 64-bit, OpenCL, recommended, portable | [`2026-08-01-windows64.opencl.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.1/2026-08-01-windows64.opencl.portable.zip) |
+| Existing Windows portable install, application-only update | [`2026-08-01-windows64.core-update.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.1/2026-08-01-windows64.core-update.zip) |
+| Windows 64-bit, OpenCL installer | [`2026-08-01-windows64.opencl.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.1/2026-08-01-windows64.opencl.installer.exe) |
+| Windows 64-bit, CPU fallback, portable | [`2026-08-01-windows64.with-katago.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.1/2026-08-01-windows64.with-katago.portable.zip) |
+| Windows 64-bit, CPU fallback installer | [`2026-08-01-windows64.with-katago.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.1/2026-08-01-windows64.with-katago.installer.exe) |
+| Windows 64-bit, NVIDIA CUDA, portable | [`2026-08-01-windows64.nvidia.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.1/2026-08-01-windows64.nvidia.portable.zip) |
+| Windows 64-bit, NVIDIA CUDA installer | [`2026-08-01-windows64.nvidia.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.1/2026-08-01-windows64.nvidia.installer.exe) |
+| Windows 64-bit, RTX 5070/5080/5090, portable | [`2026-08-01-windows64.nvidia50.cuda.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.1/2026-08-01-windows64.nvidia50.cuda.portable.zip) |
+| Advanced optional TensorRT split package; download every part | [`2026-08-01-windows64.nvidia.tensorrt.portable.7z.001`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.1/2026-08-01-windows64.nvidia.tensorrt.portable.7z.001)<br>[`2026-08-01-windows64.nvidia.tensorrt.portable.7z.002`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.1/2026-08-01-windows64.nvidia.tensorrt.portable.7z.002) |
+| Windows 64-bit, RTX 50 CUDA installer | [`2026-08-01-windows64.nvidia50.cuda.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.1/2026-08-01-windows64.nvidia50.cuda.installer.exe) |
+| Windows 64-bit, configure your own engine, portable | [`2026-08-01-windows64.without.engine.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.1/2026-08-01-windows64.without.engine.portable.zip) |
+| Windows 64-bit, configure your own engine, installer | [`2026-08-01-windows64.without.engine.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.1/2026-08-01-windows64.without.engine.installer.exe) |
+| macOS Apple Silicon | [`2026-08-01-mac-apple-silicon.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.1/2026-08-01-mac-apple-silicon.with-katago.dmg) |
+| macOS Intel | [`2026-08-01-mac-intel.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.1/2026-08-01-mac-intel.with-katago.dmg) |
+| Linux 64-bit, CPU fallback | [`2026-08-01-linux64.with-katago.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.1/2026-08-01-linux64.with-katago.zip) |
+| Linux 64-bit, OpenCL | [`2026-08-01-linux64.opencl.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.1/2026-08-01-linux64.opencl.zip) |
+| Linux 64-bit, NVIDIA CUDA | [`2026-08-01-linux64.nvidia.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.1/2026-08-01-linux64.nvidia.zip) |
+
+### Why Test This Release
+
+- KataGo reports that the medium Transformer is stronger per visit than the strongest 28B and is usually similarly fast or faster, while substantially reducing package size.
+- Real Windows testing on an RTX 3070 covered CPU, OpenCL, CUDA, whole-game analysis, and 150% UI scaling; CUDA measured about 102 visits/s.
+- All 1,785 tests passed, and a real Apple Silicon Mac loaded the new model with the Metal backend and completed analysis.
+
+### Contact
+
+- QQ group: `299419120`
+
+---
+
+## 日本語
+
+`next-2026-07-28.1` に続く、KataGo 1.17 と Transformer 既定モデルのプレリリースです。完全版 package の engine を統一して更新し、旧既定 weight をより小さく強い新 architecture model に置き換えました。
+
+### 主な更新
+
+- Windows、macOS、Linux の完全版 package を KataGo `v1.17.0` に更新しました。
+- 既定 weight を公式 `Transformer 10B Balanced` に変更しました。約 94 MB で、旧 Zhizi 28B より約 177 MB 小さくなります。
+- 軽量、均衡、旗艦の公式 Transformer 3 種を用意し、resume、size、SHA-256 検証に対応しました。
+- 旧 bundled default を使う managed engine だけを移行します。custom weight、remote compute、no-engine mode、起動設定は変更しません。
+- Windows NVIDIA は CUDA 12.1 + cuDNN 9.8、RTX 50 は CUDA 12.8 + cuDNN 9.8 を使用し、TensorRT engine も KataGo 1.17 に更新しました。
+
+### ダウンロード前に
+
+- KataGo 1.17 / Transformer が必要な場合は完全版 package をダウンロードしてください。
+- `windows64.core-update.zip` はアプリ本体だけを更新し、新 engine と weight は含まず、自動 download もしません。
+- 一般的な Windows は OpenCL portable、NVIDIA GPU は NVIDIA CUDA 版を推奨します。
+- OpenCL 初回起動は tuning cache 作成に数分かかる場合があります。次回から再利用され、hang ではありません。
+- Transformer は KataGo 1.17 以上が必要です。旧 engine では完全版への更新案内を表示します。
+
+### ダウンロード案内
+
+| お使いの環境 | ダウンロードするファイル |
+| --- | --- |
+| Windows 64-bit、OpenCL 推奨 portable | [`2026-08-01-windows64.opencl.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.1/2026-08-01-windows64.opencl.portable.zip) |
+| 既存 Windows portable、アプリ本体のみ更新 | [`2026-08-01-windows64.core-update.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.1/2026-08-01-windows64.core-update.zip) |
+| Windows 64-bit、OpenCL installer | [`2026-08-01-windows64.opencl.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.1/2026-08-01-windows64.opencl.installer.exe) |
+| Windows 64-bit、CPU fallback portable | [`2026-08-01-windows64.with-katago.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.1/2026-08-01-windows64.with-katago.portable.zip) |
+| Windows 64-bit、CPU fallback installer | [`2026-08-01-windows64.with-katago.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.1/2026-08-01-windows64.with-katago.installer.exe) |
+| Windows 64-bit、NVIDIA CUDA portable | [`2026-08-01-windows64.nvidia.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.1/2026-08-01-windows64.nvidia.portable.zip) |
+| Windows 64-bit、NVIDIA CUDA installer | [`2026-08-01-windows64.nvidia.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.1/2026-08-01-windows64.nvidia.installer.exe) |
+| Windows 64-bit、RTX 5070/5080/5090 portable | [`2026-08-01-windows64.nvidia50.cuda.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.1/2026-08-01-windows64.nvidia50.cuda.portable.zip) |
+| 上級者向け TensorRT 分割 package、全 part が必要 | [`2026-08-01-windows64.nvidia.tensorrt.portable.7z.001`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.1/2026-08-01-windows64.nvidia.tensorrt.portable.7z.001)<br>[`2026-08-01-windows64.nvidia.tensorrt.portable.7z.002`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.1/2026-08-01-windows64.nvidia.tensorrt.portable.7z.002) |
+| Windows 64-bit、RTX 50 CUDA installer | [`2026-08-01-windows64.nvidia50.cuda.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.1/2026-08-01-windows64.nvidia50.cuda.installer.exe) |
+| Windows 64-bit、engine を自分で設定、portable | [`2026-08-01-windows64.without.engine.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.1/2026-08-01-windows64.without.engine.portable.zip) |
+| Windows 64-bit、engine を自分で設定、installer | [`2026-08-01-windows64.without.engine.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.1/2026-08-01-windows64.without.engine.installer.exe) |
+| macOS Apple Silicon | [`2026-08-01-mac-apple-silicon.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.1/2026-08-01-mac-apple-silicon.with-katago.dmg) |
+| macOS Intel | [`2026-08-01-mac-intel.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.1/2026-08-01-mac-intel.with-katago.dmg) |
+| Linux 64-bit、CPU fallback | [`2026-08-01-linux64.with-katago.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.1/2026-08-01-linux64.with-katago.zip) |
+| Linux 64-bit、OpenCL | [`2026-08-01-linux64.opencl.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.1/2026-08-01-linux64.opencl.zip) |
+| Linux 64-bit、NVIDIA CUDA | [`2026-08-01-linux64.nvidia.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.1/2026-08-01-linux64.nvidia.zip) |
+
+### このリリースを試す理由
+
+- 公式中型 Transformer は最強 28B より visit 当たりで強く、通常は同等以上の速度で package も小さくなります。
+- RTX 3070 Windows 実機で CPU、OpenCL、CUDA、whole-game analysis、150% scaling を検証し、CUDA は約 102 visits/s でした。
+- 全 1785 tests が通過し、Apple Silicon 実機でも Metal engine で新 model の分析を確認しました。
+
+### 連絡先
+
+- QQ group: `299419120`
+
+---
+
+## 한국어
+
+`next-2026-07-28.1` 이후의 KataGo 1.17 및 Transformer 기본 모델 프리릴리스입니다. 전체 패키지 엔진을 통합 업그레이드하고 기존 기본 weight를 더 작고 강한 새 architecture 모델로 교체했습니다.
+
+### 주요 업데이트
+
+- Windows, macOS, Linux 전체 패키지를 KataGo `v1.17.0`으로 업그레이드했습니다.
+- 기본 weight를 공식 `Transformer 10B Balanced`로 변경했습니다. 약 94 MB이며 기존 Zhizi 28B보다 약 177 MB 작습니다.
+- 경량, 균형, 플래그십 Transformer 3종과 이어받기, 길이, SHA-256 검증을 제공합니다.
+- 기존 bundled default를 계속 사용하는 managed engine만 이전합니다. custom weight, remote compute, no-engine mode, 시작 설정은 유지됩니다.
+- Windows NVIDIA는 CUDA 12.1 + cuDNN 9.8, RTX 50은 CUDA 12.8 + cuDNN 9.8을 사용하며 TensorRT engine도 KataGo 1.17로 업그레이드했습니다.
+
+### 다운로드 전 확인
+
+- KataGo 1.17 또는 Transformer가 필요하면 전체 패키지를 다운로드해야 합니다.
+- `windows64.core-update.zip`은 앱만 업데이트하며 새 engine이나 weight를 포함하거나 몰래 다운로드하지 않습니다.
+- 일반 Windows 사용자는 OpenCL portable, NVIDIA 사용자는 NVIDIA CUDA 패키지를 권장합니다.
+- OpenCL 첫 실행은 tuning cache 생성에 몇 분 걸릴 수 있습니다. 이후 재사용되며 멈춘 것이 아닙니다.
+- Transformer는 KataGo 1.17이 필요합니다. 이전 engine에서는 전체 패키지 업그레이드 안내를 표시합니다.
+
+### 다운로드 안내
+
+| 환경 | 다운로드할 파일 |
+| --- | --- |
+| Windows 64-bit, OpenCL 권장 portable | [`2026-08-01-windows64.opencl.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.1/2026-08-01-windows64.opencl.portable.zip) |
+| 기존 Windows portable, 앱만 업데이트 | [`2026-08-01-windows64.core-update.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.1/2026-08-01-windows64.core-update.zip) |
+| Windows 64-bit, OpenCL installer | [`2026-08-01-windows64.opencl.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.1/2026-08-01-windows64.opencl.installer.exe) |
+| Windows 64-bit, CPU fallback portable | [`2026-08-01-windows64.with-katago.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.1/2026-08-01-windows64.with-katago.portable.zip) |
+| Windows 64-bit, CPU fallback installer | [`2026-08-01-windows64.with-katago.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.1/2026-08-01-windows64.with-katago.installer.exe) |
+| Windows 64-bit, NVIDIA CUDA portable | [`2026-08-01-windows64.nvidia.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.1/2026-08-01-windows64.nvidia.portable.zip) |
+| Windows 64-bit, NVIDIA CUDA installer | [`2026-08-01-windows64.nvidia.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.1/2026-08-01-windows64.nvidia.installer.exe) |
+| Windows 64-bit, RTX 5070/5080/5090 portable | [`2026-08-01-windows64.nvidia50.cuda.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.1/2026-08-01-windows64.nvidia50.cuda.portable.zip) |
+| 고급 선택: TensorRT 분할 패키지, 모든 part 필요 | [`2026-08-01-windows64.nvidia.tensorrt.portable.7z.001`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.1/2026-08-01-windows64.nvidia.tensorrt.portable.7z.001)<br>[`2026-08-01-windows64.nvidia.tensorrt.portable.7z.002`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.1/2026-08-01-windows64.nvidia.tensorrt.portable.7z.002) |
+| Windows 64-bit, RTX 50 CUDA installer | [`2026-08-01-windows64.nvidia50.cuda.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.1/2026-08-01-windows64.nvidia50.cuda.installer.exe) |
+| Windows 64-bit, 직접 engine 설정, portable | [`2026-08-01-windows64.without.engine.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.1/2026-08-01-windows64.without.engine.portable.zip) |
+| Windows 64-bit, 직접 engine 설정, installer | [`2026-08-01-windows64.without.engine.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.1/2026-08-01-windows64.without.engine.installer.exe) |
+| macOS Apple Silicon | [`2026-08-01-mac-apple-silicon.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.1/2026-08-01-mac-apple-silicon.with-katago.dmg) |
+| macOS Intel | [`2026-08-01-mac-intel.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.1/2026-08-01-mac-intel.with-katago.dmg) |
+| Linux 64-bit, CPU fallback | [`2026-08-01-linux64.with-katago.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.1/2026-08-01-linux64.with-katago.zip) |
+| Linux 64-bit, OpenCL | [`2026-08-01-linux64.opencl.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.1/2026-08-01-linux64.opencl.zip) |
+| Linux 64-bit, NVIDIA CUDA | [`2026-08-01-linux64.nvidia.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.1/2026-08-01-linux64.nvidia.zip) |
+
+### 이 릴리스를 테스트할 이유
+
+- 공식 중형 Transformer는 가장 강한 28B보다 visit당 더 강하고 일반적으로 비슷하거나 더 빠르며 패키지 크기도 줄입니다.
+- RTX 3070 Windows 실기에서 CPU, OpenCL, CUDA, whole-game analysis, 150% scaling을 검증했고 CUDA는 약 102 visits/s였습니다.
+- 전체 1785 tests를 통과했고 Apple Silicon 실기에서도 Metal engine으로 새 모델 분석을 확인했습니다.
+
+### 연락처
+
+- QQ group: `299419120`
+
+---
+
+## ภาษาไทย
+
+นี่คือรุ่นทดสอบหลัง `next-2026-07-28.1` ที่อัปเกรดแพ็กเกจเต็มเป็น KataGo 1.17 และเปลี่ยนโมเดลเริ่มต้นเป็น Transformer รุ่นใหม่ที่เล็กกว่าและแข็งแรงกว่า
+
+### การอัปเดตหลัก
+
+- แพ็กเกจเต็มสำหรับ Windows, macOS และ Linux อัปเกรดเป็น KataGo `v1.17.0`
+- โมเดลเริ่มต้นเปลี่ยนเป็น `Transformer 10B Balanced` อย่างเป็นทางการ ขนาดประมาณ 94 MB และเล็กกว่า Zhizi 28B เดิมประมาณ 177 MB
+- มี Transformer แบบเบา สมดุล และเรือธง พร้อมดาวน์โหลดต่อ ตรวจขนาด และตรวจ SHA-256
+- ย้ายเฉพาะ engine ที่ยังใช้โมเดลเริ่มต้นเดิมเท่านั้น โมเดลกำหนดเอง remote compute โหมดไม่มี engine และการเริ่มโปรแกรมจะไม่ถูกเปลี่ยน
+- Windows NVIDIA ใช้ CUDA 12.1 + cuDNN 9.8 ส่วน RTX 50 ใช้ CUDA 12.8 + cuDNN 9.8 และ TensorRT engine อัปเกรดเป็น KataGo 1.17
+
+### อ่านก่อนดาวน์โหลด
+
+- ผู้ใช้ใหม่หรือผู้ที่ต้องการ KataGo 1.17 / Transformer ต้องดาวน์โหลดแพ็กเกจเต็ม
+- `windows64.core-update.zip` อัปเดตเฉพาะโปรแกรม ไม่มี engine หรือโมเดลใหม่ และจะไม่ดาวน์โหลดเอง
+- ผู้ใช้ Windows ทั่วไปควรเลือก OpenCL portable ส่วนผู้ใช้ NVIDIA เลือก NVIDIA CUDA ได้
+- การเปิด OpenCL ครั้งแรกอาจใช้เวลาหลายนาทีเพื่อสร้าง tuning cache ครั้งต่อไปจะนำกลับมาใช้ ไม่ใช่อาการค้าง
+- Transformer ต้องใช้ KataGo 1.17 หากเป็น engine เก่าจะแจ้งให้อัปเกรดแพ็กเกจเต็ม
+
+### คู่มือดาวน์โหลด
+
+| คอมพิวเตอร์ของคุณ | ดาวน์โหลดไฟล์นี้ |
+| --- | --- |
+| Windows 64-bit, OpenCL แนะนำ, portable | [`2026-08-01-windows64.opencl.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.1/2026-08-01-windows64.opencl.portable.zip) |
+| มี Windows portable แล้ว อัปเดตเฉพาะโปรแกรม | [`2026-08-01-windows64.core-update.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.1/2026-08-01-windows64.core-update.zip) |
+| Windows 64-bit, OpenCL installer | [`2026-08-01-windows64.opencl.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.1/2026-08-01-windows64.opencl.installer.exe) |
+| Windows 64-bit, CPU portable | [`2026-08-01-windows64.with-katago.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.1/2026-08-01-windows64.with-katago.portable.zip) |
+| Windows 64-bit, CPU installer | [`2026-08-01-windows64.with-katago.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.1/2026-08-01-windows64.with-katago.installer.exe) |
+| Windows 64-bit, NVIDIA CUDA portable | [`2026-08-01-windows64.nvidia.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.1/2026-08-01-windows64.nvidia.portable.zip) |
+| Windows 64-bit, NVIDIA CUDA installer | [`2026-08-01-windows64.nvidia.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.1/2026-08-01-windows64.nvidia.installer.exe) |
+| Windows 64-bit, RTX 5070/5080/5090 portable | [`2026-08-01-windows64.nvidia50.cuda.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.1/2026-08-01-windows64.nvidia50.cuda.portable.zip) |
+| ตัวเลือกขั้นสูง TensorRT แบบแบ่งส่วน ต้องดาวน์โหลดทุกส่วน | [`2026-08-01-windows64.nvidia.tensorrt.portable.7z.001`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.1/2026-08-01-windows64.nvidia.tensorrt.portable.7z.001)<br>[`2026-08-01-windows64.nvidia.tensorrt.portable.7z.002`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.1/2026-08-01-windows64.nvidia.tensorrt.portable.7z.002) |
+| Windows 64-bit, RTX 50 CUDA installer | [`2026-08-01-windows64.nvidia50.cuda.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.1/2026-08-01-windows64.nvidia50.cuda.installer.exe) |
+| Windows 64-bit, ตั้งค่า engine เอง, portable | [`2026-08-01-windows64.without.engine.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.1/2026-08-01-windows64.without.engine.portable.zip) |
+| Windows 64-bit, ตั้งค่า engine เอง, installer | [`2026-08-01-windows64.without.engine.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.1/2026-08-01-windows64.without.engine.installer.exe) |
+| macOS Apple Silicon | [`2026-08-01-mac-apple-silicon.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.1/2026-08-01-mac-apple-silicon.with-katago.dmg) |
+| macOS Intel | [`2026-08-01-mac-intel.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.1/2026-08-01-mac-intel.with-katago.dmg) |
+| Linux 64-bit, CPU | [`2026-08-01-linux64.with-katago.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.1/2026-08-01-linux64.with-katago.zip) |
+| Linux 64-bit, OpenCL | [`2026-08-01-linux64.opencl.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.1/2026-08-01-linux64.opencl.zip) |
+| Linux 64-bit, NVIDIA CUDA | [`2026-08-01-linux64.nvidia.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.1/2026-08-01-linux64.nvidia.zip) |
+
+### เหตุผลที่ควรทดสอบรุ่นนี้
+
+- KataGo ระบุว่า Transformer ขนาดกลางแข็งแรงต่อ visit มากกว่า 28B ที่แข็งแรงที่สุด และมักเร็วเท่ากันหรือเร็วกว่า พร้อมลดขนาดแพ็กเกจ
+- ทดสอบจริงบน Windows RTX 3070 ครอบคลุม CPU, OpenCL, CUDA, whole-game analysis และ scaling 150%; CUDA ประมาณ 102 visits/s
+- ผ่านการทดสอบทั้งหมด 1785 รายการ และ Mac Apple Silicon จริงโหลดโมเดลใหม่ด้วย Metal พร้อมวิเคราะห์สำเร็จ
+
+### ติดต่อ
+
+- กลุ่ม QQ: `299419120`

--- a/.github/release-requests/next-2026-08-01.1.json
+++ b/.github/release-requests/next-2026-08-01.1.json
@@ -1,0 +1,7 @@
+{
+  "date_tag": "2026-08-01",
+  "release_tag": "next-2026-08-01.1",
+  "title": "LizzieYzy Next next-2026-08-01.1",
+  "prerelease": true,
+  "notes_file": ".github/release-notes/next-2026-08-01.1.md"
+}


### PR DESCRIPTION
## Summary

- Adds the reviewed six-language release notes for `next-2026-08-01.1`.
- Adds the audited release request that publishes KataGo 1.17 and the new default Transformer model as a pre-release.
- Keeps the established 7/19-style download format with direct links for every platform asset.
- Clearly states that `windows64.core-update.zip` does not include KataGo 1.17 or Transformer weights; users who want the new engine/model must download a complete package.

## Release highlights

- KataGo v1.17.0 across Windows, macOS, and Linux complete packages.
- Official medium Transformer as the bundled default, reducing the model payload by about 177 MB.
- Light, balanced, and flagship Transformer downloads with resume, length, and SHA-256 validation.
- Safe migration that preserves custom weights, remote engines, no-engine mode, and startup preferences.
- Windows CUDA/cuDNN and TensorRT engine updates, plus pinned macOS Metal builds.

## Validation

- PR #166 CI: passed
- Windows 11 real-hardware acceptance on RTX 3070: CPU/OpenCL/CUDA, whole-game analysis, 150% scaling, clean process shutdown
- Full Maven suite: 1,785 tests passed
- Release publisher and release-note suites: 24 tests passed
- Six languages, five sections per language, and all required direct asset links: validated
- `git diff --check`: passed

Merging this PR intentionally triggers the fail-closed pre-release publisher. It keeps the release in draft state until all four platform workflows succeed and all expected assets are present.