### PR TITLE
Fix macOS Intel KataGo libzip detection

### DIFF
--- a/scripts/build_macos_katago.sh
+++ b/scripts/build_macos_katago.sh
@@ -62,9 +62,32 @@ if [[ "$actual_commit" != "$KATAGO_COMMIT" ]]; then
   exit 1
 fi
 
-cmake_prefix=()
+cmake_options=()
 if command -v brew >/dev/null 2>&1; then
-  cmake_prefix=(-DCMAKE_PREFIX_PATH="$(brew --prefix)")
+  brew_root="$(brew --prefix)"
+  prefix_paths=("$brew_root")
+  libzip_prefix="$(brew --prefix libzip 2>/dev/null || true)"
+  if [[ -n "$libzip_prefix" ]]; then
+    libzip_include="$libzip_prefix/include"
+    libzip_library="$libzip_prefix/lib/libzip.dylib"
+    for required_file in \
+      "$libzip_include/zip.h" \
+      "$libzip_include/zipconf.h" \
+      "$libzip_library"; do
+      if [[ ! -e "$required_file" ]]; then
+        echo "Homebrew libzip is incomplete; missing $required_file" >&2
+        exit 1
+      fi
+    done
+    prefix_paths+=("$libzip_prefix")
+    cmake_options+=(
+      -DLIBZIP_INCLUDE_DIR_ZIP="$libzip_include"
+      -DLIBZIP_INCLUDE_DIR_ZIPCONF="$libzip_include"
+      -DLIBZIP_LIBRARY="$libzip_library"
+    )
+  fi
+  prefix_path="$(IFS=';'; echo "${prefix_paths[*]}")"
+  cmake_options+=(-DCMAKE_PREFIX_PATH="$prefix_path")
 fi
 
 rm -rf "$BUILD_DIR"
@@ -76,7 +99,7 @@ cmake \
   -DCMAKE_OSX_ARCHITECTURES="$ARCH" \
   -DUSE_BACKEND=METAL \
   -DBUILD_DISTRIBUTED=0 \
-  "${cmake_prefix[@]}" >&2
+  "${cmake_options[@]}" >&2
 cmake --build "$BUILD_DIR" --target katago --parallel "$(sysctl -n hw.logicalcpu)" >&2
 
 if ! is_expected_binary "$OUTPUT_BIN"; then

--- a/scripts/test_macos_katago_bundle.py
+++ b/scripts/test_macos_katago_bundle.py
@@ -16,12 +16,22 @@ from pathlib import Path
 
 SCRIPT_DIR = Path(__file__).resolve().parent
 MODULE_PATH = SCRIPT_DIR / "macos_katago_bundle.py"
+BUILD_SCRIPT_PATH = SCRIPT_DIR / "build_macos_katago.sh"
 SPEC = importlib.util.spec_from_file_location("macos_katago_bundle", MODULE_PATH)
 if SPEC is None or SPEC.loader is None:
     raise RuntimeError(f"Unable to load {MODULE_PATH}")
 MODULE = importlib.util.module_from_spec(SPEC)
 sys.modules[SPEC.name] = MODULE
 SPEC.loader.exec_module(MODULE)
+
+
+class MacosKataGoBuildScriptTest(unittest.TestCase):
+    def test_homebrew_libzip_paths_are_passed_explicitly_to_cmake(self) -> None:
+        script = BUILD_SCRIPT_PATH.read_text(encoding="utf-8")
+        self.assertIn("brew --prefix libzip", script)
+        self.assertIn('-DLIBZIP_INCLUDE_DIR_ZIP="$libzip_include"', script)
+        self.assertIn('-DLIBZIP_INCLUDE_DIR_ZIPCONF="$libzip_include"', script)
+        self.assertIn('-DLIBZIP_LIBRARY="$libzip_library"', script)
 
 
 class MacosKataGoBundleUnitTest(unittest.TestCase):


### PR DESCRIPTION
## Summary

- Fixes the macOS Intel release failure while compiling the pinned KataGo v1.17.0 Metal source.
- Resolves Homebrew's Intel-specific keg path for libzip instead of relying on `/usr/local/include` being an implicit compiler search path.
- Passes `zip.h`, `zipconf.h`, and `libzip.dylib` explicitly to CMake.
- Fails early with a clear error if the Homebrew libzip installation is incomplete.
- Adds a regression assertion to the existing macOS KataGo bundler test suite.

## Root cause

The Intel runner found libzip during CMake configure, but AppleClang with the active SDK did not search `/usr/local/include` while compiling `dataio/numpywrite.cpp`. The build therefore failed with `fatal error: 'zip.h' file not found`. Apple Silicon uses a different Homebrew prefix and did not expose the same gap.

## Validation

- `bash -n scripts/build_macos_katago.sh`
- `python3 scripts/test_macos_katago_bundle.py`: 5 tests passed
- `git diff --check`
- Fresh source build on Apple Silicon with an empty cache: completed all 204 build steps
- Built executable reports KataGo v1.17.0, the pinned Git revision, and the Metal backend

After merge, the unpublished failed draft release will be rebuilt from one exact fixed source commit across all platforms.