### PR TITLE
Fix KataGo 1.17 Windows runtime validation

### DIFF
--- a/.github/workflows/build-windows-release.yml
+++ b/.github/workflows/build-windows-release.yml
@@ -116,7 +116,8 @@ jobs:
       - name: Audit Windows bundle UX checkpoints
         shell: bash
         run: |
-          set -euo pipefail
+          # Trace every assertion so a future packaging regression identifies the exact failed check.
+          set -euxo pipefail
           note_file="dist/release-meta/${{ inputs.date_tag }}-windows64-install.txt"
           test -f "$note_file"
           grep -q "Release display version: ${{ inputs.release_tag }}" "$note_file"
@@ -181,7 +182,7 @@ jobs:
           grep -q "java-options=-Dlizzie.next.version=${{ inputs.release_tag }}" "dist/windows/app-image-without.engine/LizzieYzy Next/app/LizzieYzy Next.cfg"
           test -f "dist/windows/input-nvidia/engines/katago/windows-x64/cublasLt64_12.dll"
           test -f "dist/windows/input-nvidia/engines/katago/windows-x64/cudnn64_9.dll"
-          test -f "dist/windows/input-nvidia/engines/katago/windows-x64/libz.dll"
+          test -f "dist/windows/input-nvidia/engines/katago/windows-x64/z.dll"
           test -f "dist/windows/input-nvidia/engines/katago/windows-x64/lizzieyzy-next-nvidia-runtime-manifest.txt"
           grep -q "Profile: cuda12.1-cudnn9" "dist/windows/input-nvidia/engines/katago/windows-x64/lizzieyzy-next-nvidia-runtime-manifest.txt"
           find "dist/windows/input-nvidia/engines/katago/windows-x64" -maxdepth 1 -type f -name 'nvJitLink*.dll' | grep -q .
@@ -190,7 +191,7 @@ jobs:
           test -f "dist/windows/app-image-nvidia/LizzieYzy Next NVIDIA/app/engines/katago/windows-x64/cublas64_12.dll"
           test -f "dist/windows/app-image-nvidia/LizzieYzy Next NVIDIA/app/engines/katago/windows-x64/cublasLt64_12.dll"
           test -f "dist/windows/app-image-nvidia/LizzieYzy Next NVIDIA/app/engines/katago/windows-x64/cudnn64_9.dll"
-          test -f "dist/windows/app-image-nvidia/LizzieYzy Next NVIDIA/app/engines/katago/windows-x64/libz.dll"
+          test -f "dist/windows/app-image-nvidia/LizzieYzy Next NVIDIA/app/engines/katago/windows-x64/z.dll"
           find "dist/windows/app-image-nvidia/LizzieYzy Next NVIDIA/app/engines/katago/windows-x64" -maxdepth 1 -type f -name 'nvJitLink*.dll' | grep -q .
           test -f "dist/windows/app-image-nvidia50.cuda/LizzieYzy Next NVIDIA 50 CUDA/LizzieYzy Next NVIDIA 50 CUDA.exe"
           test -f "dist/windows/app-image-nvidia50.cuda/LizzieYzy Next NVIDIA 50 CUDA/app/PROJECT_INFO.txt"
@@ -205,7 +206,7 @@ jobs:
           test -f "dist/windows/input-nvidia50.cuda/engines/katago/windows-x64/cublas64_12.dll"
           test -f "dist/windows/input-nvidia50.cuda/engines/katago/windows-x64/cublasLt64_12.dll"
           test -f "dist/windows/input-nvidia50.cuda/engines/katago/windows-x64/cudnn64_9.dll"
-          test -f "dist/windows/input-nvidia50.cuda/engines/katago/windows-x64/libz.dll"
+          test -f "dist/windows/input-nvidia50.cuda/engines/katago/windows-x64/z.dll"
           test -f "dist/windows/input-nvidia50.cuda/engines/katago/windows-x64/lizzieyzy-next-nvidia-runtime-manifest.txt"
           grep -q "Profile: cuda12.8-cudnn9" "dist/windows/input-nvidia50.cuda/engines/katago/windows-x64/lizzieyzy-next-nvidia-runtime-manifest.txt"
           find "dist/windows/input-nvidia50.cuda/engines/katago/windows-x64" -maxdepth 1 -type f -name 'nvJitLink*.dll' | grep -q .
@@ -214,7 +215,7 @@ jobs:
           test -f "dist/windows/app-image-nvidia50.cuda/LizzieYzy Next NVIDIA 50 CUDA/app/engines/katago/windows-x64/cublas64_12.dll"
           test -f "dist/windows/app-image-nvidia50.cuda/LizzieYzy Next NVIDIA 50 CUDA/app/engines/katago/windows-x64/cublasLt64_12.dll"
           test -f "dist/windows/app-image-nvidia50.cuda/LizzieYzy Next NVIDIA 50 CUDA/app/engines/katago/windows-x64/cudnn64_9.dll"
-          test -f "dist/windows/app-image-nvidia50.cuda/LizzieYzy Next NVIDIA 50 CUDA/app/engines/katago/windows-x64/libz.dll"
+          test -f "dist/windows/app-image-nvidia50.cuda/LizzieYzy Next NVIDIA 50 CUDA/app/engines/katago/windows-x64/z.dll"
           find "dist/windows/app-image-nvidia50.cuda/LizzieYzy Next NVIDIA 50 CUDA/app/engines/katago/windows-x64" -maxdepth 1 -type f -name 'nvJitLink*.dll' | grep -q .
           test -f "dist/release/${{ inputs.date_tag }}-windows64.nvidia.tensorrt.portable.7z.001"
           test -f "dist/release/${{ inputs.date_tag }}-windows64.nvidia.tensorrt.portable.README.txt"

--- a/scripts/test_windows_launcher_packaging.py
+++ b/scripts/test_windows_launcher_packaging.py
@@ -71,6 +71,13 @@ def main() -> None:
     require(workflow, "runtime/bin/server/jvm.dll", "build-windows-release.yml")
     require(workflow, "^jdk.accessibility@", "build-windows-release.yml")
     require(
+        workflow,
+        "windows-x64/z.dll",
+        "build-windows-release.yml",
+    )
+    if "windows-x64/libz.dll" in workflow:
+        raise AssertionError("KataGo 1.17 Windows bundles use z.dll, not the legacy libz.dll name")
+    require(
         package_script,
         'LIZZIE_RELEASE_PRERELEASE:-false',
         "package_windows_exe.sh",

--- a/src/main/java/featurecat/lizzie/util/KataGoRuntimeHelper.java
+++ b/src/main/java/featurecat/lizzie/util/KataGoRuntimeHelper.java
@@ -159,7 +159,7 @@ public final class KataGoRuntimeHelper {
           Arrays.asList("cublasLt64_12.dll"),
           Arrays.asList("cudnn64_8.dll"),
           Arrays.asList("nvJitLink*.dll"),
-          Arrays.asList("zlibwapi.dll", "libz.dll"));
+          Arrays.asList("zlibwapi.dll", "libz.dll", "z.dll"));
   private static final List<List<String>> REQUIRED_NVIDIA_CUDA12_1_CUDNN9_RUNTIME_DLL_GROUPS =
       Arrays.asList(
           Arrays.asList("cudart64_12.dll"),
@@ -167,7 +167,7 @@ public final class KataGoRuntimeHelper {
           Arrays.asList("cublasLt64_12.dll"),
           Arrays.asList("cudnn64_9.dll"),
           Arrays.asList("nvJitLink*.dll"),
-          Arrays.asList("zlibwapi.dll", "libz.dll"));
+          Arrays.asList("zlibwapi.dll", "libz.dll", "z.dll"));
   private static final List<List<String>> REQUIRED_NVIDIA_CUDA12_8_RUNTIME_DLL_GROUPS =
       Arrays.asList(
           Arrays.asList("cudart64_12.dll"),
@@ -175,7 +175,7 @@ public final class KataGoRuntimeHelper {
           Arrays.asList("cublasLt64_12.dll"),
           Arrays.asList("cudnn64_9.dll"),
           Arrays.asList("nvJitLink*.dll"),
-          Arrays.asList("zlibwapi.dll", "libz.dll"));
+          Arrays.asList("zlibwapi.dll", "libz.dll", "z.dll"));
   private static final List<List<String>> REQUIRED_NVIDIA_TRT10_9_RUNTIME_DLL_GROUPS =
       Arrays.asList(
           Arrays.asList("cudart64_12.dll"),
@@ -185,7 +185,7 @@ public final class KataGoRuntimeHelper {
           Arrays.asList("nvJitLink*.dll"),
           Arrays.asList("nvinfer_10.dll", "nvinfer*.dll"),
           Arrays.asList("nvinfer_plugin_10.dll", "nvinfer_plugin*.dll"),
-          Arrays.asList("zlibwapi.dll", "libz.dll"));
+          Arrays.asList("zlibwapi.dll", "libz.dll", "z.dll"));
   private static final Object NVIDIA_RUNTIME_LOCK = new Object();
   private static final int BENCHMARK_VISITS = 800;
   private static final int BENCHMARK_POSITIONS = 6;

--- a/src/test/java/featurecat/lizzie/util/KataGoRuntimeHelperTest.java
+++ b/src/test/java/featurecat/lizzie/util/KataGoRuntimeHelperTest.java
@@ -403,6 +403,38 @@ public class KataGoRuntimeHelperTest {
   }
 
   @Test
+  void standardNvidia117RuntimeAcceptsOfficialZDllName() throws Exception {
+    withOsName(
+        WINDOWS_OS_NAME,
+        () -> {
+          Path tempRoot = Files.createTempDirectory("katago-helper-nvidia117-zdll");
+          Path engineDir =
+              Files.createDirectories(
+                  tempRoot.resolve("engines").resolve("katago").resolve("windows-x64"));
+          Files.writeString(engineDir.resolve("lizzieyzy-next-engine-backend.txt"), "nvidia");
+          Files.writeString(
+              engineDir.resolve("lizzieyzy-next-nvidia-runtime-manifest.txt"),
+              "Profile: cuda12.1-cudnn9\n");
+          Path enginePath = touch(engineDir.resolve("katago.exe"));
+          touchCommonCuda12Dlls(engineDir);
+          touch(engineDir.resolve("cudnn64_9.dll"));
+          touch(engineDir.resolve("z.dll"));
+          Path runtimeWorkDirectory = Files.createDirectories(tempRoot.resolve("runtime-root"));
+
+          withConfig(
+              runtimeWorkDirectory,
+              () -> {
+                KataGoRuntimeHelper.NvidiaRuntimeStatus status =
+                    KataGoRuntimeHelper.inspectNvidiaRuntime(enginePath);
+
+                assertTrue(status.applicable);
+                assertTrue(status.ready, "KataGo 1.17's official z.dll must satisfy the runtime check.");
+                assertTrue(status.missingDlls.isEmpty());
+              });
+        });
+  }
+
+  @Test
   void legacyStandardNvidiaRuntimeStillAcceptsCudnn8() throws Exception {
     withOsName(
         WINDOWS_OS_NAME,
@@ -1720,7 +1752,7 @@ public class KataGoRuntimeHelperTest {
   private static void touchRequiredCuda12_8Dlls(Path directory) throws IOException {
     touchCommonCuda12Dlls(directory);
     touch(directory.resolve("cudnn64_9.dll"));
-    touch(directory.resolve("libz.dll"));
+    touch(directory.resolve("z.dll"));
   }
 
   private static void writeCurrentTensorRtEngineManifest(Path directory) throws IOException {


### PR DESCRIPTION
## Summary

- Updates the Windows release audit for the official KataGo 1.17 `z.dll` dependency name.
- Accepts `z.dll` in NVIDIA runtime detection while preserving compatibility with `libz.dll` and `zlibwapi.dll`.
- Adds a regression test and command tracing so future package audit failures identify the exact assertion.

## Root cause

The release packages were generated successfully, but the fail-closed audit still required the legacy `libz.dll` filename. KataGo 1.17 ships `z.dll`, so the pre-release correctly remained a draft.

## Validation

- `python3 scripts/test_windows_launcher_packaging.py`
- `mvn -B -Dfmt.skip=true -Dtest=KataGoRuntimeHelperTest test` (47 tests)
- `mvn -B -Dfmt.skip=true test` (1786 tests)
- `mvn -B -Dfmt.skip=true -DskipTests package`
- `git diff --check`

All listed checks passed in a clean worktree.