### PR TITLE
Harden cross-platform release validation

### DIFF
--- a/.github/workflows/build-windows-release.yml
+++ b/.github/workflows/build-windows-release.yml
@@ -311,21 +311,30 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          for engine in \
-            "dist/windows/app-image-with-katago/LizzieYzy Next/app/engines/katago/windows-x64/katago.exe" \
-            "dist/windows/app-image-opencl/LizzieYzy Next OpenCL/app/engines/katago/windows-x64/katago.exe" \
-            "dist/windows/app-image-nvidia/LizzieYzy Next NVIDIA/app/engines/katago/windows-x64/katago.exe" \
-            "dist/windows/app-image-nvidia50.cuda/LizzieYzy Next NVIDIA 50 CUDA/app/engines/katago/windows-x64/katago.exe" \
-            "dist/windows/app-image-nvidia.tensorrt/LizzieYzy Next NVIDIA TensorRT/app/engines/katago/windows-x64/katago.exe"; do
+          runnable_engines=(
+            "dist/windows/app-image-with-katago/LizzieYzy Next/app/engines/katago/windows-x64/katago.exe"
+            "dist/windows/app-image-opencl/LizzieYzy Next OpenCL/app/engines/katago/windows-x64/katago.exe"
+          )
+          packaged_engines=(
+            "${runnable_engines[@]}"
+            "dist/windows/app-image-nvidia/LizzieYzy Next NVIDIA/app/engines/katago/windows-x64/katago.exe"
+            "dist/windows/app-image-nvidia50.cuda/LizzieYzy Next NVIDIA 50 CUDA/app/engines/katago/windows-x64/katago.exe"
+            "dist/windows/app-image-nvidia.tensorrt/LizzieYzy Next NVIDIA TensorRT/app/engines/katago/windows-x64/katago.exe"
+          )
+          for engine in "${runnable_engines[@]}"; do
             test -f "$engine"
             version_output="$("$engine" version 2>&1)"
             printf '%s\n%s\n' "$engine" "$version_output"
             grep -q 'KataGo v1\.17\.1' <<<"$version_output"
-            if grep -q 'KataGo v1\.17\.0' <<<"$version_output"; then
-              echo "Packaged KataGo unexpectedly contains the old v1.17.0 binary: $engine" >&2
-              exit 1
-            fi
           done
+          # GitHub-hosted Windows runners do not have an NVIDIA display driver, so
+          # CUDA/TensorRT executables cannot pass the Windows loader even when every
+          # redistributable DLL is bundled. Audit their embedded version marker after
+          # the runtime-file checks above; real NVIDIA execution is a hardware gate.
+          python3 scripts/audit_katago_binary_version.py \
+            --expected-version 1.17.1 \
+            --reject-version 1.17.0 \
+            "${packaged_engines[@]}"
 
       - name: Smoke test bundled Windows app images
         shell: powershell

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,7 @@ jobs:
       - name: Verify release packaging helpers
         run: |
           python3 -m py_compile \
+            scripts/audit_katago_binary_version.py \
             scripts/generate_release_notes.py \
             scripts/macos_bundle_version.py \
             scripts/macos_katago_bundle.py \
@@ -43,11 +44,15 @@ jobs:
             scripts/publish_release_request.py \
             scripts/summarize_jfr.py \
             scripts/test_generate_release_notes.py \
+            scripts/test_audit_katago_binary_version.py \
+            scripts/test_macos_drag_dmg_script.py \
             scripts/test_macos_bundle_version.py \
             scripts/test_macos_katago_bundle.py \
             scripts/test_publish_release_request.py \
             scripts/test_windows_launcher_packaging.py
           python3 scripts/test_generate_release_notes.py
+          python3 scripts/test_audit_katago_binary_version.py
+          python3 scripts/test_macos_drag_dmg_script.py
           python3 scripts/test_macos_bundle_version.py
           python3 scripts/test_macos_katago_bundle.py
           bash scripts/test_prepare_bundled_katago.sh
@@ -55,6 +60,7 @@ jobs:
           python3 scripts/test_publish_release_request.py
           python3 scripts/test_windows_launcher_packaging.py
           bash -n \
+            scripts/create_macos_drag_dmg.sh \
             scripts/prepare_bundled_katago.sh \
             scripts/test_prepare_bundled_katago.sh \
             scripts/package_macos_dmg.sh \

--- a/scripts/audit_katago_binary_version.py
+++ b/scripts/audit_katago_binary_version.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""Audit embedded KataGo version markers without loading GPU driver DLLs."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import sys
+
+
+class BinaryVersionAuditError(RuntimeError):
+    pass
+
+
+def audit_binary(path: Path, expected_version: str, rejected_versions: list[str]) -> None:
+    if not path.is_file():
+        raise BinaryVersionAuditError(f"KataGo binary not found: {path}")
+    data = path.read_bytes()
+    expected_marker = f"KataGo v{expected_version}".encode("ascii")
+    if expected_marker not in data:
+        raise BinaryVersionAuditError(
+            f"{path} does not contain the expected marker {expected_marker.decode('ascii')}"
+        )
+    for version in rejected_versions:
+        rejected_marker = f"KataGo v{version}".encode("ascii")
+        if rejected_marker in data:
+            raise BinaryVersionAuditError(
+                f"{path} contains rejected marker {rejected_marker.decode('ascii')}"
+            )
+    print(f"{path}: embedded KataGo v{expected_version} marker verified")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--expected-version", required=True)
+    parser.add_argument("--reject-version", action="append", default=[])
+    parser.add_argument("binaries", nargs="+", type=Path)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    for binary in args.binaries:
+        audit_binary(binary, args.expected_version, args.reject_version)
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except (OSError, BinaryVersionAuditError) as exc:
+        print(f"KataGo binary version audit failed: {exc}", file=sys.stderr)
+        raise SystemExit(1)

--- a/scripts/create_macos_drag_dmg.sh
+++ b/scripts/create_macos_drag_dmg.sh
@@ -84,6 +84,27 @@ cleanup() {
 }
 trap cleanup EXIT
 
+create_writable_dmg() {
+  local attempt
+  for attempt in 1 2 3; do
+    rm -f "$RW_DMG"
+    echo "Creating writable DMG (attempt $attempt/3)..." >&2
+    if hdiutil create \
+      -volname "$BUILD_VOLUME_NAME" \
+      -fs HFS+ \
+      -srcfolder "$STAGING_DIR" \
+      -format UDRW \
+      -ov \
+      "$RW_DMG"; then
+      return 0
+    fi
+    echo "Writable DMG creation attempt $attempt/3 failed; retrying..." >&2
+    sleep "$attempt"
+  done
+  echo "Unable to create the writable DMG after 3 attempts." >&2
+  exit 1
+}
+
 mkdir -p "$STAGING_DIR" "$MOUNT_POINT"
 ditto "$SOURCE_FOLDER" "$STAGING_DIR"
 rm -f "$STAGING_DIR/.DS_Store"
@@ -152,14 +173,7 @@ output_path.write_text(
 )
 PY
 
-hdiutil create \
-  -quiet \
-  -volname "$BUILD_VOLUME_NAME" \
-  -fs HFS+ \
-  -srcfolder "$STAGING_DIR" \
-  -format UDRW \
-  -ov \
-  "$RW_DMG"
+create_writable_dmg
 
 hdiutil attach "$RW_DMG" \
   -mountpoint "$MOUNT_POINT" \

--- a/scripts/test_audit_katago_binary_version.py
+++ b/scripts/test_audit_katago_binary_version.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+
+from pathlib import Path
+import tempfile
+import unittest
+
+from audit_katago_binary_version import BinaryVersionAuditError, audit_binary
+
+
+class AuditKataGoBinaryVersionTest(unittest.TestCase):
+    def write_fixture(self, payload: bytes) -> Path:
+        temp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(temp_dir.cleanup)
+        binary = Path(temp_dir.name) / "katago.exe"
+        binary.write_bytes(payload)
+        return binary
+
+    def test_accepts_expected_marker(self) -> None:
+        binary = self.write_fixture(b"PE fixture\0KataGo v1.17.1\0")
+        audit_binary(binary, "1.17.1", ["1.17.0"])
+
+    def test_rejects_missing_expected_marker(self) -> None:
+        binary = self.write_fixture(b"PE fixture without a version")
+        with self.assertRaises(BinaryVersionAuditError):
+            audit_binary(binary, "1.17.1", ["1.17.0"])
+
+    def test_rejects_stale_marker(self) -> None:
+        binary = self.write_fixture(b"KataGo v1.17.1\0KataGo v1.17.0\0")
+        with self.assertRaises(BinaryVersionAuditError):
+            audit_binary(binary, "1.17.1", ["1.17.0"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_macos_drag_dmg_script.py
+++ b/scripts/test_macos_drag_dmg_script.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+
+from pathlib import Path
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class MacosDragDmgScriptTest(unittest.TestCase):
+    def test_writable_image_creation_is_retried_with_diagnostics(self) -> None:
+        script = (ROOT / "scripts/create_macos_drag_dmg.sh").read_text(encoding="utf-8")
+        self.assertIn("create_writable_dmg()", script)
+        self.assertIn("for attempt in 1 2 3", script)
+        self.assertIn("Creating writable DMG (attempt $attempt/3)", script)
+        self.assertIn("Unable to create the writable DMG after 3 attempts.", script)
+        self.assertIn("\ncreate_writable_dmg\n", script)
+        self.assertNotIn("hdiutil create \\\n  -quiet", script)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_windows_launcher_packaging.py
+++ b/scripts/test_windows_launcher_packaging.py
@@ -88,6 +88,14 @@ def main() -> None:
     require(workflow, "^jdk.accessibility@", "build-windows-release.yml")
     require(
         workflow,
+        "scripts/audit_katago_binary_version.py",
+        "build-windows-release.yml",
+    )
+    require(workflow, 'runnable_engines=(', "build-windows-release.yml")
+    require(workflow, 'packaged_engines=(', "build-windows-release.yml")
+    require(workflow, "GitHub-hosted Windows runners do not have an NVIDIA display driver", "build-windows-release.yml")
+    require(
+        workflow,
         "windows-x64/z.dll",
         "build-windows-release.yml",
     )


### PR DESCRIPTION
## Summary

- Keeps executable KataGo version checks for CPU and OpenCL packages.
- Audits embedded KataGo 1.17.1 markers for CUDA and TensorRT packages because GitHub-hosted Windows runners have no NVIDIA display driver.
- Retries writable macOS DMG creation with visible diagnostics instead of silently failing.
- Adds CI regression guards for both release paths.

## Validation

- `git diff --check`
- `python3 scripts/test_audit_katago_binary_version.py`
- `python3 scripts/test_macos_drag_dmg_script.py`
- `python3 scripts/test_windows_launcher_packaging.py`
- `bash -n scripts/create_macos_drag_dmg.sh`
- Audited official KataGo 1.17.1 CPU, OpenCL, CUDA 12.1, CUDA 12.8, and TensorRT binaries.
- `mvn -B -Dfmt.skip=true test`: 1786 tests passed.
- `mvn -B -Dfmt.skip=true -DskipTests package`: passed.

## Hardware verification

PR #170 was validated on Windows 11 with an RTX 3070. CPU, OpenCL, CUDA 12.1, CUDA 12.8, and TensorRT all completed real inference.