### PR TITLE
Prepare next-2026-08-01.3 pre-release

### DIFF
--- a/.github/release-notes/next-2026-08-01.3.md
+++ b/.github/release-notes/next-2026-08-01.3.md
@@ -1,0 +1,329 @@
+# LizzieYzy Next next-2026-08-01.3
+
+## 中文
+
+这是 `next-2026-08-01.1` 之后的 KataGo 1.17.1 稳定性预览版。完整包统一修复 Windows DLL 混用风险，并把最终引擎版本校验固定进发布流程。
+
+### 本版主要更新
+
+- Windows、macOS、Linux 完整包统一升级到 KataGo `v1.17.1`，包含上游针对 Windows DLL 混用问题的修复。
+- 官方 CPU、OpenCL、CUDA 12.1、CUDA 12.8、TensorRT 和 Linux 资产全部固定 SHA-256，避免下载或打包时混入旧文件。
+- Windows 发布流程会实际运行 CPU/OpenCL 最终包中的 `katago.exe version`，并校验 CUDA/TensorRT 最终二进制内嵌的 1.17.1 版本标记；Linux 同样验证真实二进制版本。
+- Windows 便携包退出测试会清理同一包目录中的 JVM 与 KataGo 子进程，避免测试完成后残留后台进程。
+- GTX 10 系使用普通 NVIDIA 包前建议把驱动升级到 527.41 或更高；CUDA 仍无法启动时请改用 OpenCL 包。
+- macOS DMG 创建增加自动重试和明确诊断，降低偶发镜像生成失败导致的发布中断。
+
+### 下载前先看这几句
+
+- 从 `next-2026-08-01.1` 升级并希望获得 KataGo 1.17.1，必须下载对应平台的完整包。
+- `windows64.core-update.zip` 只更新主程序，不包含 KataGo 引擎、权重或 CUDA 运行库。
+- 普通 Windows 用户优先选择 OpenCL 免安装版；NVIDIA 新显卡可选择对应 CUDA 版。
+- GTX 1050 Ti 等 Pascal 显卡尚未完成同型号真机覆盖；请优先确认驱动版本，失败时使用 OpenCL。
+- 自定义权重、远程算力、无引擎模式和现有启动方式不会被本次升级覆盖。
+
+### 下载建议
+
+| 你的电脑 | 直接下载这个 |
+| --- | --- |
+| Windows 64 位，OpenCL 版，推荐，免安装 | [`2026-08-01-windows64.opencl.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.3/2026-08-01-windows64.opencl.portable.zip) |
+| 已有 Windows 免安装版，只更新主程序 | [`2026-08-01-windows64.core-update.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.3/2026-08-01-windows64.core-update.zip) |
+| Windows 64 位，OpenCL 安装版 | [`2026-08-01-windows64.opencl.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.3/2026-08-01-windows64.opencl.installer.exe) |
+| Windows 64 位，CPU 兼容版，免安装 | [`2026-08-01-windows64.with-katago.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.3/2026-08-01-windows64.with-katago.portable.zip) |
+| Windows 64 位，CPU 兼容安装版 | [`2026-08-01-windows64.with-katago.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.3/2026-08-01-windows64.with-katago.installer.exe) |
+| Windows 64 位，NVIDIA CUDA 版，免安装 | [`2026-08-01-windows64.nvidia.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.3/2026-08-01-windows64.nvidia.portable.zip) |
+| Windows 64 位，NVIDIA CUDA 安装版 | [`2026-08-01-windows64.nvidia.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.3/2026-08-01-windows64.nvidia.installer.exe) |
+| Windows 64 位，RTX 5070/5080/5090，免安装 | [`2026-08-01-windows64.nvidia50.cuda.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.3/2026-08-01-windows64.nvidia50.cuda.portable.zip) |
+| 高级可选：TensorRT 预装分卷包，需下载全部分卷 | [`2026-08-01-windows64.nvidia.tensorrt.portable.7z.001`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.3/2026-08-01-windows64.nvidia.tensorrt.portable.7z.001)<br>[`2026-08-01-windows64.nvidia.tensorrt.portable.7z.002`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.3/2026-08-01-windows64.nvidia.tensorrt.portable.7z.002) |
+| Windows 64 位，RTX 50 CUDA 安装版 | [`2026-08-01-windows64.nvidia50.cuda.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.3/2026-08-01-windows64.nvidia50.cuda.installer.exe) |
+| Windows 64 位，自行配置引擎，免安装 | [`2026-08-01-windows64.without.engine.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.3/2026-08-01-windows64.without.engine.portable.zip) |
+| Windows 64 位，自行配置引擎，安装版 | [`2026-08-01-windows64.without.engine.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.3/2026-08-01-windows64.without.engine.installer.exe) |
+| macOS Apple Silicon | [`2026-08-01-mac-apple-silicon.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.3/2026-08-01-mac-apple-silicon.with-katago.dmg) |
+| macOS Intel | [`2026-08-01-mac-intel.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.3/2026-08-01-mac-intel.with-katago.dmg) |
+| Linux 64 位，CPU 兼容版 | [`2026-08-01-linux64.with-katago.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.3/2026-08-01-linux64.with-katago.zip) |
+| Linux 64 位，OpenCL 版 | [`2026-08-01-linux64.opencl.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.3/2026-08-01-linux64.opencl.zip) |
+| Linux 64 位，NVIDIA CUDA 版 | [`2026-08-01-linux64.nvidia.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.3/2026-08-01-linux64.nvidia.zip) |
+
+### 这一版为什么值得测试
+
+- RTX 3070 Windows 真机已验证 CPU、OpenCL、CUDA 12.1、CUDA 12.8 与 TensorRT 五种后端均能加载默认 Transformer 并完成真实推理。
+- 便携版 EXE、实时分析、快速胜率曲线、48 局面整盘精析、一键设置和 150% 缩放界面均完成验收。
+- 完整 Maven 测试共 1786 项通过；Apple Silicon Metal 也已真实加载 KataGo 1.17.1 与默认 Transformer。
+
+### 交流
+
+- QQ 群：`299419120`
+
+---
+
+## 繁體中文
+
+這是 `next-2026-08-01.1` 之後的 KataGo 1.17.1 穩定性預覽版。完整套件統一修正 Windows DLL 混用風險，並把最終引擎版本驗證固定到發佈流程。
+
+### 本版主要更新
+
+- Windows、macOS、Linux 完整套件統一升級到 KataGo `v1.17.1`，包含上游針對 Windows DLL 混用問題的修正。
+- 官方 CPU、OpenCL、CUDA 12.1、CUDA 12.8、TensorRT 與 Linux 資產全部固定 SHA-256，避免下載或打包時混入舊檔。
+- Windows 發佈流程會實際執行 CPU/OpenCL 最終套件中的 `katago.exe version`，並驗證 CUDA/TensorRT 最終二進位內嵌的 1.17.1 版本標記；Linux 同樣驗證真實二進位版本。
+- Windows portable 結束測試會清理同一套件目錄內的 JVM 與 KataGo 子程序，避免測試後殘留背景程序。
+- GTX 10 系使用一般 NVIDIA 套件前建議將驅動升級到 527.41 或更新；CUDA 仍無法啟動時請改用 OpenCL 套件。
+- macOS DMG 建立加入自動重試與明確診斷，降低偶發映像建立失敗造成的發佈中斷。
+
+### 下載前先看這幾句
+
+- 從 `next-2026-08-01.1` 升級並希望取得 KataGo 1.17.1，必須下載對應平台的完整套件。
+- `windows64.core-update.zip` 只更新主程式，不包含 KataGo 引擎、權重或 CUDA runtime。
+- 一般 Windows 使用者優先選擇 OpenCL portable；較新的 NVIDIA 顯示卡可選對應 CUDA 版。
+- GTX 1050 Ti 等 Pascal 顯示卡尚未完成同型號實機覆蓋；請先確認驅動版本，失敗時使用 OpenCL。
+- 自訂權重、遠端算力、無引擎模式與既有啟動方式不會被本次升級覆蓋。
+
+### 下載建議
+
+| 你的電腦 | 直接下載這個 |
+| --- | --- |
+| Windows 64 位，OpenCL 推薦版，免安裝 | [`2026-08-01-windows64.opencl.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.3/2026-08-01-windows64.opencl.portable.zip) |
+| 既有 Windows portable，只更新主程式 | [`2026-08-01-windows64.core-update.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.3/2026-08-01-windows64.core-update.zip) |
+| Windows 64 位，OpenCL 安裝版 | [`2026-08-01-windows64.opencl.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.3/2026-08-01-windows64.opencl.installer.exe) |
+| Windows 64 位，CPU 相容版，免安裝 | [`2026-08-01-windows64.with-katago.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.3/2026-08-01-windows64.with-katago.portable.zip) |
+| Windows 64 位，CPU 相容安裝版 | [`2026-08-01-windows64.with-katago.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.3/2026-08-01-windows64.with-katago.installer.exe) |
+| Windows 64 位，NVIDIA CUDA，免安裝 | [`2026-08-01-windows64.nvidia.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.3/2026-08-01-windows64.nvidia.portable.zip) |
+| Windows 64 位，NVIDIA CUDA 安裝版 | [`2026-08-01-windows64.nvidia.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.3/2026-08-01-windows64.nvidia.installer.exe) |
+| Windows 64 位，RTX 5070/5080/5090，免安裝 | [`2026-08-01-windows64.nvidia50.cuda.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.3/2026-08-01-windows64.nvidia50.cuda.portable.zip) |
+| 進階可選：TensorRT 預裝分卷，需下載全部檔案 | [`2026-08-01-windows64.nvidia.tensorrt.portable.7z.001`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.3/2026-08-01-windows64.nvidia.tensorrt.portable.7z.001)<br>[`2026-08-01-windows64.nvidia.tensorrt.portable.7z.002`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.3/2026-08-01-windows64.nvidia.tensorrt.portable.7z.002) |
+| Windows 64 位，RTX 50 CUDA 安裝版 | [`2026-08-01-windows64.nvidia50.cuda.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.3/2026-08-01-windows64.nvidia50.cuda.installer.exe) |
+| Windows 64 位，自行設定引擎，免安裝 | [`2026-08-01-windows64.without.engine.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.3/2026-08-01-windows64.without.engine.portable.zip) |
+| Windows 64 位，自行設定引擎，安裝版 | [`2026-08-01-windows64.without.engine.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.3/2026-08-01-windows64.without.engine.installer.exe) |
+| macOS Apple Silicon | [`2026-08-01-mac-apple-silicon.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.3/2026-08-01-mac-apple-silicon.with-katago.dmg) |
+| macOS Intel | [`2026-08-01-mac-intel.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.3/2026-08-01-mac-intel.with-katago.dmg) |
+| Linux 64 位，CPU 相容版 | [`2026-08-01-linux64.with-katago.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.3/2026-08-01-linux64.with-katago.zip) |
+| Linux 64 位，OpenCL 版 | [`2026-08-01-linux64.opencl.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.3/2026-08-01-linux64.opencl.zip) |
+| Linux 64 位，NVIDIA CUDA 版 | [`2026-08-01-linux64.nvidia.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.3/2026-08-01-linux64.nvidia.zip) |
+
+### 這一版為什麼值得測試
+
+- RTX 3070 Windows 實機已驗證 CPU、OpenCL、CUDA 12.1、CUDA 12.8 與 TensorRT 五種後端都能載入預設 Transformer 並完成真實推理。
+- Portable EXE、即時分析、快速勝率曲線、48 局面整盤精析、一鍵設定與 150% 縮放介面都已完成驗收。
+- 完整 Maven 測試共 1786 項通過；Apple Silicon Metal 也已實機載入 KataGo 1.17.1 與預設 Transformer。
+
+### 交流
+
+- QQ 群：`299419120`
+
+---
+
+## English
+
+This stability pre-release follows `next-2026-08-01.1`. Complete packages now use KataGo 1.17.1, address Windows DLL mixing, and verify the final bundled engine version during publishing.
+
+### Release Highlights
+
+- Upgrades complete Windows, macOS, and Linux packages to KataGo `v1.17.1`, including the upstream Windows DLL-loading fix.
+- Pins SHA-256 for the official CPU, OpenCL, CUDA 12.1, CUDA 12.8, TensorRT, and Linux assets so stale files cannot enter a package.
+- The Windows release workflow executes `katago.exe version` for final CPU/OpenCL packages and audits the embedded 1.17.1 marker in final CUDA/TensorRT binaries; Linux also validates the actual binary.
+- Windows portable smoke cleanup now removes JVM and KataGo children owned by the exact package directory, preventing background process leaks.
+- GTX 10-series users should update to driver 527.41 or newer before using the standard NVIDIA package; use the OpenCL package if CUDA still fails.
+- macOS DMG creation now retries transient failures with visible diagnostics instead of interrupting a release without context.
+
+### Read Before Downloading
+
+- To upgrade from `next-2026-08-01.1` to KataGo 1.17.1, download the complete package for your platform.
+- `windows64.core-update.zip` updates only the application and contains no KataGo engine, weight, or CUDA runtime.
+- Most Windows users should choose the OpenCL portable package; newer NVIDIA GPUs may use the matching CUDA package.
+- Physical GTX 1050 Ti/Pascal coverage is still pending. Check the driver first and use OpenCL if CUDA cannot start.
+- Custom weights, remote compute, no-engine mode, and existing startup preferences remain unchanged.
+
+### Download Guide
+
+| Your computer | Download this file |
+| --- | --- |
+| Windows 64-bit, OpenCL, recommended, portable | [`2026-08-01-windows64.opencl.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.3/2026-08-01-windows64.opencl.portable.zip) |
+| Existing Windows portable install, application-only update | [`2026-08-01-windows64.core-update.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.3/2026-08-01-windows64.core-update.zip) |
+| Windows 64-bit, OpenCL installer | [`2026-08-01-windows64.opencl.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.3/2026-08-01-windows64.opencl.installer.exe) |
+| Windows 64-bit, CPU fallback, portable | [`2026-08-01-windows64.with-katago.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.3/2026-08-01-windows64.with-katago.portable.zip) |
+| Windows 64-bit, CPU fallback installer | [`2026-08-01-windows64.with-katago.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.3/2026-08-01-windows64.with-katago.installer.exe) |
+| Windows 64-bit, NVIDIA CUDA, portable | [`2026-08-01-windows64.nvidia.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.3/2026-08-01-windows64.nvidia.portable.zip) |
+| Windows 64-bit, NVIDIA CUDA installer | [`2026-08-01-windows64.nvidia.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.3/2026-08-01-windows64.nvidia.installer.exe) |
+| Windows 64-bit, RTX 5070/5080/5090, portable | [`2026-08-01-windows64.nvidia50.cuda.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.3/2026-08-01-windows64.nvidia50.cuda.portable.zip) |
+| Advanced optional TensorRT split package; download every part | [`2026-08-01-windows64.nvidia.tensorrt.portable.7z.001`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.3/2026-08-01-windows64.nvidia.tensorrt.portable.7z.001)<br>[`2026-08-01-windows64.nvidia.tensorrt.portable.7z.002`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.3/2026-08-01-windows64.nvidia.tensorrt.portable.7z.002) |
+| Windows 64-bit, RTX 50 CUDA installer | [`2026-08-01-windows64.nvidia50.cuda.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.3/2026-08-01-windows64.nvidia50.cuda.installer.exe) |
+| Windows 64-bit, configure your own engine, portable | [`2026-08-01-windows64.without.engine.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.3/2026-08-01-windows64.without.engine.portable.zip) |
+| Windows 64-bit, configure your own engine, installer | [`2026-08-01-windows64.without.engine.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.3/2026-08-01-windows64.without.engine.installer.exe) |
+| macOS Apple Silicon | [`2026-08-01-mac-apple-silicon.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.3/2026-08-01-mac-apple-silicon.with-katago.dmg) |
+| macOS Intel | [`2026-08-01-mac-intel.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.3/2026-08-01-mac-intel.with-katago.dmg) |
+| Linux 64-bit, CPU fallback | [`2026-08-01-linux64.with-katago.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.3/2026-08-01-linux64.with-katago.zip) |
+| Linux 64-bit, OpenCL | [`2026-08-01-linux64.opencl.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.3/2026-08-01-linux64.opencl.zip) |
+| Linux 64-bit, NVIDIA CUDA | [`2026-08-01-linux64.nvidia.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.3/2026-08-01-linux64.nvidia.zip) |
+
+### Why Test This Release
+
+- Real RTX 3070 Windows testing loaded the default Transformer and completed inference with CPU, OpenCL, CUDA 12.1, CUDA 12.8, and TensorRT.
+- The portable EXE, live analysis, quick winrate overview, 48-position whole-game analysis, one-click setup, and 150% UI scaling all passed acceptance.
+- All 1,786 Maven tests passed, and a real Apple Silicon Mac loaded KataGo 1.17.1 and the default Transformer through Metal.
+
+### Contact
+
+- QQ group: `299419120`
+
+---
+
+## 日本語
+
+`next-2026-08-01.1` に続く KataGo 1.17.1 安定性プレリリースです。完全版 package は Windows DLL 混在問題を修正し、発行時に最終 engine の実バージョンを検証します。
+
+### 主な更新
+
+- Windows、macOS、Linux の完全版 package を KataGo `v1.17.1` に統一し、Windows DLL loading の upstream 修正を含めました。
+- 公式 CPU、OpenCL、CUDA 12.1、CUDA 12.8、TensorRT、Linux asset の SHA-256 を固定し、古いファイルの混入を防ぎます。
+- Windows release workflow は CPU/OpenCL の最終 package で `katago.exe version` を実行し、CUDA/TensorRT の最終 binary では内蔵された 1.17.1 marker を検証します。Linux も実 binary を検証します。
+- Windows portable smoke test は同じ package directory の JVM と KataGo child process を終了し、background process の残留を防ぎます。
+- GTX 10 series は通常 NVIDIA package の前に driver 527.41 以上へ更新してください。CUDA が失敗する場合は OpenCL package を使用してください。
+- macOS DMG の作成は一時的な失敗を自動 retry し、明確な診断を表示するようになりました。
+
+### ダウンロード前に
+
+- `next-2026-08-01.1` から KataGo 1.17.1 へ更新する場合は、対応する完全版 package が必要です。
+- `windows64.core-update.zip` はアプリ本体のみで、KataGo engine、weight、CUDA runtime は含みません。
+- 一般的な Windows は OpenCL portable、新しい NVIDIA GPU は対応する CUDA package を推奨します。
+- GTX 1050 Ti/Pascal の同型実機検証は未完了です。driver を確認し、起動できない場合は OpenCL を使用してください。
+- Custom weight、remote compute、no-engine mode、既存の起動設定は変更しません。
+
+### ダウンロード案内
+
+| お使いの環境 | ダウンロードするファイル |
+| --- | --- |
+| Windows 64-bit、OpenCL 推奨 portable | [`2026-08-01-windows64.opencl.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.3/2026-08-01-windows64.opencl.portable.zip) |
+| 既存 Windows portable、アプリ本体のみ更新 | [`2026-08-01-windows64.core-update.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.3/2026-08-01-windows64.core-update.zip) |
+| Windows 64-bit、OpenCL installer | [`2026-08-01-windows64.opencl.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.3/2026-08-01-windows64.opencl.installer.exe) |
+| Windows 64-bit、CPU fallback portable | [`2026-08-01-windows64.with-katago.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.3/2026-08-01-windows64.with-katago.portable.zip) |
+| Windows 64-bit、CPU fallback installer | [`2026-08-01-windows64.with-katago.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.3/2026-08-01-windows64.with-katago.installer.exe) |
+| Windows 64-bit、NVIDIA CUDA portable | [`2026-08-01-windows64.nvidia.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.3/2026-08-01-windows64.nvidia.portable.zip) |
+| Windows 64-bit、NVIDIA CUDA installer | [`2026-08-01-windows64.nvidia.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.3/2026-08-01-windows64.nvidia.installer.exe) |
+| Windows 64-bit、RTX 5070/5080/5090 portable | [`2026-08-01-windows64.nvidia50.cuda.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.3/2026-08-01-windows64.nvidia50.cuda.portable.zip) |
+| 上級者向け TensorRT 分割 package、全 part が必要 | [`2026-08-01-windows64.nvidia.tensorrt.portable.7z.001`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.3/2026-08-01-windows64.nvidia.tensorrt.portable.7z.001)<br>[`2026-08-01-windows64.nvidia.tensorrt.portable.7z.002`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.3/2026-08-01-windows64.nvidia.tensorrt.portable.7z.002) |
+| Windows 64-bit、RTX 50 CUDA installer | [`2026-08-01-windows64.nvidia50.cuda.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.3/2026-08-01-windows64.nvidia50.cuda.installer.exe) |
+| Windows 64-bit、engine を自分で設定、portable | [`2026-08-01-windows64.without.engine.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.3/2026-08-01-windows64.without.engine.portable.zip) |
+| Windows 64-bit、engine を自分で設定、installer | [`2026-08-01-windows64.without.engine.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.3/2026-08-01-windows64.without.engine.installer.exe) |
+| macOS Apple Silicon | [`2026-08-01-mac-apple-silicon.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.3/2026-08-01-mac-apple-silicon.with-katago.dmg) |
+| macOS Intel | [`2026-08-01-mac-intel.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.3/2026-08-01-mac-intel.with-katago.dmg) |
+| Linux 64-bit、CPU fallback | [`2026-08-01-linux64.with-katago.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.3/2026-08-01-linux64.with-katago.zip) |
+| Linux 64-bit、OpenCL | [`2026-08-01-linux64.opencl.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.3/2026-08-01-linux64.opencl.zip) |
+| Linux 64-bit、NVIDIA CUDA | [`2026-08-01-linux64.nvidia.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.3/2026-08-01-linux64.nvidia.zip) |
+
+### このリリースを試す理由
+
+- RTX 3070 Windows 実機で CPU、OpenCL、CUDA 12.1、CUDA 12.8、TensorRT の全 backend が既定 Transformer を読み込み、実推論を完了しました。
+- Portable EXE、live analysis、quick winrate overview、48-position whole-game analysis、一鍵設定、150% UI scaling を検証しました。
+- Maven 1,786 tests が通過し、Apple Silicon 実機でも Metal で KataGo 1.17.1 と既定 Transformer を読み込みました。
+
+### 連絡先
+
+- QQ group: `299419120`
+
+---
+
+## 한국어
+
+`next-2026-08-01.1` 이후의 KataGo 1.17.1 안정성 프리릴리스입니다. 전체 패키지는 Windows DLL 혼용 문제를 수정하고 배포 시 최종 engine의 실제 버전을 검증합니다.
+
+### 주요 업데이트
+
+- Windows, macOS, Linux 전체 패키지를 KataGo `v1.17.1`로 통일하고 upstream Windows DLL loading 수정을 포함했습니다.
+- 공식 CPU, OpenCL, CUDA 12.1, CUDA 12.8, TensorRT, Linux asset의 SHA-256을 고정하여 오래된 파일이 패키지에 섞이지 않도록 했습니다.
+- Windows release workflow는 CPU/OpenCL 최종 패키지에서 `katago.exe version`을 실행하고 CUDA/TensorRT 최종 binary의 내장 1.17.1 marker를 검사합니다. Linux도 실제 binary를 검증합니다.
+- Windows portable smoke cleanup은 같은 패키지 directory의 JVM과 KataGo child process를 정리하여 background process 누수를 방지합니다.
+- GTX 10 series는 일반 NVIDIA 패키지 사용 전에 driver 527.41 이상으로 업데이트하고, CUDA가 계속 실패하면 OpenCL 패키지를 사용하세요.
+- macOS DMG 생성은 일시적 실패를 자동 재시도하고 명확한 진단을 표시하도록 보강했습니다.
+
+### 다운로드 전 확인
+
+- `next-2026-08-01.1`에서 KataGo 1.17.1로 업그레이드하려면 해당 플랫폼의 전체 패키지를 다운로드해야 합니다.
+- `windows64.core-update.zip`은 앱만 업데이트하며 KataGo engine, weight, CUDA runtime을 포함하지 않습니다.
+- 일반 Windows 사용자는 OpenCL portable을, 최신 NVIDIA GPU는 해당 CUDA 패키지를 권장합니다.
+- GTX 1050 Ti/Pascal 동일 모델 실기 검증은 아직 완료되지 않았습니다. driver를 확인하고 실패하면 OpenCL을 사용하세요.
+- Custom weight, remote compute, no-engine mode와 기존 시작 설정은 변경되지 않습니다.
+
+### 다운로드 안내
+
+| 환경 | 다운로드할 파일 |
+| --- | --- |
+| Windows 64-bit, OpenCL 권장 portable | [`2026-08-01-windows64.opencl.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.3/2026-08-01-windows64.opencl.portable.zip) |
+| 기존 Windows portable, 앱만 업데이트 | [`2026-08-01-windows64.core-update.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.3/2026-08-01-windows64.core-update.zip) |
+| Windows 64-bit, OpenCL installer | [`2026-08-01-windows64.opencl.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.3/2026-08-01-windows64.opencl.installer.exe) |
+| Windows 64-bit, CPU fallback portable | [`2026-08-01-windows64.with-katago.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.3/2026-08-01-windows64.with-katago.portable.zip) |
+| Windows 64-bit, CPU fallback installer | [`2026-08-01-windows64.with-katago.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.3/2026-08-01-windows64.with-katago.installer.exe) |
+| Windows 64-bit, NVIDIA CUDA portable | [`2026-08-01-windows64.nvidia.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.3/2026-08-01-windows64.nvidia.portable.zip) |
+| Windows 64-bit, NVIDIA CUDA installer | [`2026-08-01-windows64.nvidia.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.3/2026-08-01-windows64.nvidia.installer.exe) |
+| Windows 64-bit, RTX 5070/5080/5090 portable | [`2026-08-01-windows64.nvidia50.cuda.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.3/2026-08-01-windows64.nvidia50.cuda.portable.zip) |
+| 고급 선택: TensorRT 분할 패키지, 모든 part 필요 | [`2026-08-01-windows64.nvidia.tensorrt.portable.7z.001`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.3/2026-08-01-windows64.nvidia.tensorrt.portable.7z.001)<br>[`2026-08-01-windows64.nvidia.tensorrt.portable.7z.002`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.3/2026-08-01-windows64.nvidia.tensorrt.portable.7z.002) |
+| Windows 64-bit, RTX 50 CUDA installer | [`2026-08-01-windows64.nvidia50.cuda.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.3/2026-08-01-windows64.nvidia50.cuda.installer.exe) |
+| Windows 64-bit, 직접 engine 설정, portable | [`2026-08-01-windows64.without.engine.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.3/2026-08-01-windows64.without.engine.portable.zip) |
+| Windows 64-bit, 직접 engine 설정, installer | [`2026-08-01-windows64.without.engine.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.3/2026-08-01-windows64.without.engine.installer.exe) |
+| macOS Apple Silicon | [`2026-08-01-mac-apple-silicon.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.3/2026-08-01-mac-apple-silicon.with-katago.dmg) |
+| macOS Intel | [`2026-08-01-mac-intel.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.3/2026-08-01-mac-intel.with-katago.dmg) |
+| Linux 64-bit, CPU fallback | [`2026-08-01-linux64.with-katago.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.3/2026-08-01-linux64.with-katago.zip) |
+| Linux 64-bit, OpenCL | [`2026-08-01-linux64.opencl.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.3/2026-08-01-linux64.opencl.zip) |
+| Linux 64-bit, NVIDIA CUDA | [`2026-08-01-linux64.nvidia.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.3/2026-08-01-linux64.nvidia.zip) |
+
+### 이 릴리스를 테스트할 이유
+
+- RTX 3070 Windows 실기에서 CPU, OpenCL, CUDA 12.1, CUDA 12.8, TensorRT가 모두 기본 Transformer를 로드하고 실제 inference를 완료했습니다.
+- Portable EXE, live analysis, quick winrate overview, 48-position whole-game analysis, one-click setup, 150% UI scaling이 모두 통과했습니다.
+- Maven 1,786 tests가 통과했고 Apple Silicon 실기에서도 Metal로 KataGo 1.17.1과 기본 Transformer를 로드했습니다.
+
+### 연락처
+
+- QQ group: `299419120`
+
+---
+
+## ภาษาไทย
+
+นี่คือรุ่นทดสอบความเสถียรต่อจาก `next-2026-08-01.1` แพ็กเกจเต็มใช้ KataGo 1.17.1 แก้ปัญหา DLL ปะปนบน Windows และตรวจเวอร์ชัน engine จริงก่อนเผยแพร่
+
+### การอัปเดตหลัก
+
+- แพ็กเกจเต็ม Windows, macOS และ Linux อัปเกรดเป็น KataGo `v1.17.1` พร้อมการแก้ไข upstream สำหรับการโหลด DLL บน Windows
+- ล็อก SHA-256 ของ asset ทางการสำหรับ CPU, OpenCL, CUDA 12.1, CUDA 12.8, TensorRT และ Linux เพื่อป้องกันไฟล์เก่าปะปน
+- Workflow Windows จะรัน `katago.exe version` ในแพ็กเกจ CPU/OpenCL ขั้นสุดท้าย และตรวจ marker 1.17.1 ที่ฝังอยู่ใน binary CUDA/TensorRT ขั้นสุดท้าย ส่วน Linux ก็ตรวจ binary จริงเช่นกัน
+- การทดสอบ Windows portable จะปิด JVM และ process ลูกของ KataGo ที่อยู่ใน directory ของแพ็กเกจเดียวกัน ป้องกัน process ค้าง
+- ผู้ใช้ GTX 10 series ควรอัปเดต driver เป็น 527.41 หรือใหม่กว่าก่อนใช้แพ็กเกจ NVIDIA และใช้ OpenCL หาก CUDA ยังเปิดไม่ได้
+- การสร้าง macOS DMG จะลองใหม่อัตโนมัติเมื่อเกิดความล้มเหลวชั่วคราว พร้อมแสดงข้อมูลวินิจฉัยที่ชัดเจน
+
+### อ่านก่อนดาวน์โหลด
+
+- หากอัปเกรดจาก `next-2026-08-01.1` และต้องการ KataGo 1.17.1 ต้องดาวน์โหลดแพ็กเกจเต็มของระบบนั้น
+- `windows64.core-update.zip` อัปเดตเฉพาะโปรแกรม ไม่มี KataGo engine, weight หรือ CUDA runtime
+- ผู้ใช้ Windows ทั่วไปควรเลือก OpenCL portable ส่วน NVIDIA รุ่นใหม่เลือกแพ็กเกจ CUDA ที่ตรงกันได้
+- ยังไม่มีการทดสอบจริงบน GTX 1050 Ti/Pascal รุ่นเดียวกัน โปรดตรวจ driver ก่อน และใช้ OpenCL หาก CUDA ล้มเหลว
+- Custom weight, remote compute, โหมดไม่มี engine และการตั้งค่าเริ่มโปรแกรมเดิมจะไม่ถูกเปลี่ยน
+
+### คู่มือดาวน์โหลด
+
+| คอมพิวเตอร์ของคุณ | ดาวน์โหลดไฟล์นี้ |
+| --- | --- |
+| Windows 64-bit, OpenCL แนะนำ, portable | [`2026-08-01-windows64.opencl.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.3/2026-08-01-windows64.opencl.portable.zip) |
+| มี Windows portable แล้ว อัปเดตเฉพาะโปรแกรม | [`2026-08-01-windows64.core-update.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.3/2026-08-01-windows64.core-update.zip) |
+| Windows 64-bit, OpenCL installer | [`2026-08-01-windows64.opencl.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.3/2026-08-01-windows64.opencl.installer.exe) |
+| Windows 64-bit, CPU portable | [`2026-08-01-windows64.with-katago.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.3/2026-08-01-windows64.with-katago.portable.zip) |
+| Windows 64-bit, CPU installer | [`2026-08-01-windows64.with-katago.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.3/2026-08-01-windows64.with-katago.installer.exe) |
+| Windows 64-bit, NVIDIA CUDA portable | [`2026-08-01-windows64.nvidia.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.3/2026-08-01-windows64.nvidia.portable.zip) |
+| Windows 64-bit, NVIDIA CUDA installer | [`2026-08-01-windows64.nvidia.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.3/2026-08-01-windows64.nvidia.installer.exe) |
+| Windows 64-bit, RTX 5070/5080/5090 portable | [`2026-08-01-windows64.nvidia50.cuda.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.3/2026-08-01-windows64.nvidia50.cuda.portable.zip) |
+| ตัวเลือกขั้นสูง TensorRT แบบแบ่งส่วน ต้องดาวน์โหลดทุกส่วน | [`2026-08-01-windows64.nvidia.tensorrt.portable.7z.001`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.3/2026-08-01-windows64.nvidia.tensorrt.portable.7z.001)<br>[`2026-08-01-windows64.nvidia.tensorrt.portable.7z.002`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.3/2026-08-01-windows64.nvidia.tensorrt.portable.7z.002) |
+| Windows 64-bit, RTX 50 CUDA installer | [`2026-08-01-windows64.nvidia50.cuda.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.3/2026-08-01-windows64.nvidia50.cuda.installer.exe) |
+| Windows 64-bit, ตั้งค่า engine เอง, portable | [`2026-08-01-windows64.without.engine.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.3/2026-08-01-windows64.without.engine.portable.zip) |
+| Windows 64-bit, ตั้งค่า engine เอง, installer | [`2026-08-01-windows64.without.engine.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.3/2026-08-01-windows64.without.engine.installer.exe) |
+| macOS Apple Silicon | [`2026-08-01-mac-apple-silicon.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.3/2026-08-01-mac-apple-silicon.with-katago.dmg) |
+| macOS Intel | [`2026-08-01-mac-intel.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.3/2026-08-01-mac-intel.with-katago.dmg) |
+| Linux 64-bit, CPU | [`2026-08-01-linux64.with-katago.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.3/2026-08-01-linux64.with-katago.zip) |
+| Linux 64-bit, OpenCL | [`2026-08-01-linux64.opencl.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.3/2026-08-01-linux64.opencl.zip) |
+| Linux 64-bit, NVIDIA CUDA | [`2026-08-01-linux64.nvidia.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-01.3/2026-08-01-linux64.nvidia.zip) |
+
+### เหตุผลที่ควรทดสอบรุ่นนี้
+
+- ทดสอบจริงบน Windows RTX 3070 แล้วว่า CPU, OpenCL, CUDA 12.1, CUDA 12.8 และ TensorRT โหลด Transformer เริ่มต้นและทำ inference ได้
+- Portable EXE, live analysis, quick winrate overview, whole-game analysis 48 ตำแหน่ง, one-click setup และ UI scaling 150% ผ่านการตรวจรับ
+- Maven tests ทั้ง 1,786 รายการผ่าน และ Mac Apple Silicon จริงโหลด KataGo 1.17.1 กับ Transformer เริ่มต้นผ่าน Metal ได้
+
+### ติดต่อ
+
+- กลุ่ม QQ: `299419120`

--- a/.github/release-requests/next-2026-08-01.3.json
+++ b/.github/release-requests/next-2026-08-01.3.json
@@ -1,0 +1,7 @@
+{
+  "date_tag": "2026-08-01",
+  "release_tag": "next-2026-08-01.3",
+  "title": "LizzieYzy Next next-2026-08-01.3",
+  "prerelease": true,
+  "notes_file": ".github/release-notes/next-2026-08-01.3.md"
+}


### PR DESCRIPTION
## Summary

- Requests the `next-2026-08-01.3` pre-release from the release-validation-hardened main branch.
- Publishes the KataGo 1.17.1 upgrade and Windows process-cleanup fix already validated on real Windows hardware.
- Keeps the fixed six-language release-note structure and complete direct download guide.
- Rebuilds every platform after the Windows CUDA/TensorRT audit and macOS DMG reliability fixes.

## Validation

- Release publisher and notes tests: 24 passed.
- Markdown local-link validation: passed.
- Release-note structure: 6 languages, 30 subsections, 108 direct asset links.
- `git diff --check`: passed.

The release remains fail-closed until Windows, Linux, macOS Intel, and macOS Apple Silicon workflows all succeed.