### PR TITLE
Retry transient macOS DMG attach failures

### DIFF
--- a/scripts/create_macos_drag_dmg.sh
+++ b/scripts/create_macos_drag_dmg.sh
@@ -105,6 +105,37 @@ create_writable_dmg() {
   exit 1
 }
 
+attach_writable_dmg() {
+  local attempt
+  local attach_log="$WORK_DIR/hdiutil-attach.log"
+
+  for attempt in 1 2 3; do
+    rm -f "$attach_log"
+    rm -rf "$MOUNT_POINT"
+    mkdir -p "$MOUNT_POINT"
+    echo "Attaching writable DMG (attempt $attempt/3)..." >&2
+    if hdiutil attach "$RW_DMG" \
+      -mountpoint "$MOUNT_POINT" \
+      -readwrite \
+      -noverify \
+      -noautoopen \
+      -nobrowse \
+      >"$attach_log" 2>&1; then
+      cat "$attach_log" >&2
+      MOUNTED=1
+      return 0
+    fi
+
+    echo "Writable DMG attach attempt $attempt/3 failed:" >&2
+    cat "$attach_log" >&2
+    hdiutil detach "$MOUNT_POINT" -force -quiet >/dev/null 2>&1 || true
+    sleep "$attempt"
+  done
+
+  echo "Unable to attach the writable DMG after 3 attempts." >&2
+  exit 1
+}
+
 mkdir -p "$STAGING_DIR" "$MOUNT_POINT"
 ditto "$SOURCE_FOLDER" "$STAGING_DIR"
 rm -f "$STAGING_DIR/.DS_Store"
@@ -174,14 +205,7 @@ output_path.write_text(
 PY
 
 create_writable_dmg
-
-hdiutil attach "$RW_DMG" \
-  -mountpoint "$MOUNT_POINT" \
-  -readwrite \
-  -noverify \
-  -noautoopen \
-  -quiet
-MOUNTED=1
+attach_writable_dmg
 
 LAYOUT_CREATED=0
 for attempt in 1 2 3; do

--- a/scripts/test_macos_drag_dmg_script.py
+++ b/scripts/test_macos_drag_dmg_script.py
@@ -17,6 +17,15 @@ class MacosDragDmgScriptTest(unittest.TestCase):
         self.assertIn("\ncreate_writable_dmg\n", script)
         self.assertNotIn("hdiutil create \\\n  -quiet", script)
 
+    def test_writable_image_attach_is_retried_with_diagnostics(self) -> None:
+        script = (ROOT / "scripts/create_macos_drag_dmg.sh").read_text(encoding="utf-8")
+        self.assertIn("attach_writable_dmg()", script)
+        self.assertIn("Attaching writable DMG (attempt $attempt/3)", script)
+        self.assertIn("Writable DMG attach attempt $attempt/3 failed:", script)
+        self.assertIn("Unable to attach the writable DMG after 3 attempts.", script)
+        self.assertIn('cat "$attach_log" >&2', script)
+        self.assertIn("\nattach_writable_dmg\n", script)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

- retries writable DMG attachment up to three times on transient macOS runner failures
- prints the original `hdiutil` diagnostics instead of failing silently
- cleans stale mount points between attempts and preserves fail-closed DMG publication
- adds regression coverage for the attach retry path

## Validation

- `python3 -m unittest discover -s scripts -p 'test_*.py'` (47 passed)
- `bash -n scripts/create_macos_drag_dmg.sh`
- `mvn -B -Dfmt.skip=true test` (1786 passed)
- `git diff --check`

## Release impact

This fixes the repeated macOS Intel release failure observed while preparing `next-2026-08-01.3`. The draft release remains unpublished; a new immutable pre-release request will be created after this PR is merged.
