### PR TITLE
Fix one-click setup hit targets and navigation tooltips

### DIFF
--- a/src/main/java/featurecat/lizzie/gui/AccessibilitySupport.java
+++ b/src/main/java/featurecat/lizzie/gui/AccessibilitySupport.java
@@ -27,6 +27,7 @@ import javax.swing.text.JTextComponent;
 public final class AccessibilitySupport {
   private static final String EXPLICIT_NAME = "lizzie.a11y.explicitName";
   private static final String EXPLICIT_DESCRIPTION = "lizzie.a11y.explicitDescription";
+  private static final String VISIBLE_TOOLTIP_DISABLED = "lizzie.a11y.visibleTooltipDisabled";
   private static final int LOCALIZED_CONTROL_WIDTH_PADDING = 12;
 
   private AccessibilitySupport() {}
@@ -48,15 +49,29 @@ public final class AccessibilitySupport {
   }
 
   public static <T extends AbstractButton> T button(T button, String name, String description) {
+    return configureButton(button, name, description, true);
+  }
+
+  /** Adds button semantics without showing a tooltip that can cover rapid-repeat controls. */
+  public static <T extends AbstractButton> T buttonWithoutTooltip(
+      T button, String name, String description) {
+    return configureButton(button, name, description, false);
+  }
+
+  private static <T extends AbstractButton> T configureButton(
+      T button, String name, String description, boolean showTooltip) {
     named(button, name, description);
     if (button != null) {
+      button.putClientProperty(VISIBLE_TOOLTIP_DISABLED, !showTooltip);
       button
           .getInputMap(JComponent.WHEN_FOCUSED)
           .put(KeyStroke.getKeyStroke("pressed ENTER"), "pressed");
       button
           .getInputMap(JComponent.WHEN_FOCUSED)
           .put(KeyStroke.getKeyStroke("released ENTER"), "released");
-      if (button.getToolTipText() == null || button.getToolTipText().isBlank()) {
+      if (!showTooltip) {
+        button.setToolTipText(null);
+      } else if (button.getToolTipText() == null || button.getToolTipText().isBlank()) {
         button.setToolTipText(clean(description).isEmpty() ? clean(name) : clean(description));
       }
     }
@@ -110,7 +125,11 @@ public final class AccessibilitySupport {
                   context == null ? null : context.getAccessibleDescription(),
                   firstNonBlank(button.getToolTipText(), name)));
       if (!name.isBlank()) {
-        button(button, name, description);
+        if (Boolean.TRUE.equals(button.getClientProperty(VISIBLE_TOOLTIP_DISABLED))) {
+          buttonWithoutTooltip(button, name, description);
+        } else {
+          button(button, name, description);
+        }
       }
     } else if (root instanceof JProgressBar) {
       JProgressBar progressBar = (JProgressBar) root;

--- a/src/main/java/featurecat/lizzie/gui/AppleStyleSupport.java
+++ b/src/main/java/featurecat/lizzie/gui/AppleStyleSupport.java
@@ -44,6 +44,7 @@ public final class AppleStyleSupport {
   private static final String BUTTON_ROLE = "lizzie.apple.button.role";
   private static final String ROLE_PRIMARY = "primary";
   private static final String ROLE_DANGER = "danger";
+  private static final String CUSTOM_BUTTON_STYLE = "lizzie.apple.button.customStyle";
   private static final String LEGACY_BUTTON_UI = "lizzie.apple.legacy.button.ui";
   private static final String LEGACY_CHECKBOX_ICON = "lizzie.apple.legacy.checkbox.icon";
   private static final String LEGACY_COMBO_RENDERER = "lizzie.apple.legacy.combo.renderer";
@@ -81,6 +82,13 @@ public final class AppleStyleSupport {
   public static void markDanger(AbstractButton button) {
     if (button != null) {
       button.putClientProperty(BUTTON_ROLE, ROLE_DANGER);
+    }
+  }
+
+  /** Keeps a purpose-built button renderer from being replaced by global theme refreshes. */
+  public static void preserveCustomButtonStyle(AbstractButton button) {
+    if (button != null) {
+      button.putClientProperty(CUSTOM_BUTTON_STYLE, Boolean.TRUE);
     }
   }
 
@@ -162,6 +170,9 @@ public final class AppleStyleSupport {
 
   public static void installButtonStyle(AbstractButton button) {
     if (button == null) {
+      return;
+    }
+    if (Boolean.TRUE.equals(button.getClientProperty(CUSTOM_BUTTON_STYLE))) {
       return;
     }
     // Preserve manually set sizes (e.g. BottomToolbar buttons sized before styling)

--- a/src/main/java/featurecat/lizzie/gui/BottomToolbar.java
+++ b/src/main/java/featurecat/lizzie/gui/BottomToolbar.java
@@ -2514,27 +2514,27 @@ public class BottomToolbar extends JPanel {
   }
 
   private void configureAccessibility() {
-    AccessibilitySupport.button(
+    AccessibilitySupport.buttonWithoutTooltip(
         firstButton,
         text("Accessibility.firstMove", "First move"),
         text("Accessibility.firstMoveDescription", "Go to the first move"));
-    AccessibilitySupport.button(
+    AccessibilitySupport.buttonWithoutTooltip(
         backward10,
         text("Accessibility.previousTenMoves", "Previous ten moves"),
         text("Accessibility.previousTenMovesDescription", "Go back ten moves"));
-    AccessibilitySupport.button(
+    AccessibilitySupport.buttonWithoutTooltip(
         backward1,
         text("Accessibility.previousMove", "Previous move"),
         text("Accessibility.previousMoveDescription", "Go back one move"));
-    AccessibilitySupport.button(
+    AccessibilitySupport.buttonWithoutTooltip(
         forward1,
         text("Accessibility.nextMove", "Next move"),
         text("Accessibility.nextMoveDescription", "Go forward one move"));
-    AccessibilitySupport.button(
+    AccessibilitySupport.buttonWithoutTooltip(
         forward10,
         text("Accessibility.nextTenMoves", "Next ten moves"),
         text("Accessibility.nextTenMovesDescription", "Go forward ten moves"));
-    AccessibilitySupport.button(
+    AccessibilitySupport.buttonWithoutTooltip(
         lastButton,
         text("Accessibility.lastMove", "Last move"),
         text("Accessibility.lastMoveDescription", "Go to the last move"));

--- a/src/main/java/featurecat/lizzie/gui/KataGoAutoSetupDialog.java
+++ b/src/main/java/featurecat/lizzie/gui/KataGoAutoSetupDialog.java
@@ -41,6 +41,7 @@ import java.awt.GridBagLayout;
 import java.awt.Insets;
 import java.awt.LayoutManager;
 import java.awt.Polygon;
+import java.awt.Point;
 import java.awt.Rectangle;
 import java.awt.RenderingHints;
 import java.awt.Shape;
@@ -176,7 +177,8 @@ public class KataGoAutoSetupDialog extends JDialog {
   private final JLabel lblHumanSlModelValue = new JFontLabel();
   private final WeightStatusTagLabel lblHumanSlStatus = new WeightStatusTagLabel();
   private final JLabel lblStatus = new JFontLabel();
-  private final JList<String> sectionNav = new JList<String>();
+  private final ExactHitList<String> sectionNav = new ExactHitList<String>();
+  private final JButton btnRemoteCompute = new SidebarActionButton();
   private final ActiveCardLayout detailCardLayout = new ActiveCardLayout();
   private final JPanel detailCards = new ViewportWidthPanel(detailCardLayout);
   private final JPanel footerPanel = new JPanel(new BorderLayout(0, 10));
@@ -317,6 +319,8 @@ public class KataGoAutoSetupDialog extends JDialog {
         lblCurrentWeightName, text("AutoSetup.currentWeight"), text("AutoSetup.currentlyUsing"));
     AccessibilitySupport.named(
         sectionNav, text("AutoSetup.sidebarTitle"), text("AutoSetup.expertSubtitle"));
+    AccessibilitySupport.button(
+        btnRemoteCompute, text("Menu.remoteCompute"), text("Menu.remoteCompute"));
     AccessibilitySupport.applyToTree(content);
     AccessibilitySupport.installEscapeAction(getRootPane(), this, this::closeOrCancelActiveTask);
 
@@ -616,12 +620,12 @@ public class KataGoAutoSetupDialog extends JDialog {
           text("AutoSetup.navOverview"),
           text("AutoSetup.navWeights"),
           text("AutoSetup.navBenchmark"),
-          text("AutoSetup.navAcceleration"),
-          text("Menu.remoteCompute")
+          text("AutoSetup.navAcceleration")
         });
     sectionNav.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
     sectionNav.setSelectedIndex(0);
     sectionNav.setFixedCellHeight(58);
+    sectionNav.setVisibleRowCount(4);
     sectionNav.setOpaque(false);
     sectionNav.setBackground(new Color(0, 0, 0, 0));
     sectionNav.setForeground(SIDEBAR_TEXT);
@@ -646,20 +650,30 @@ public class KataGoAutoSetupDialog extends JDialog {
               selectedSetupSectionIndex = selectedIndex;
               showDetailCard(CARD_ACCELERATION);
               break;
-            case 4:
-              SwingUtilities.invokeLater(
-                  () -> {
-                    sectionNav.setSelectedIndex(selectedSetupSectionIndex);
-                    openRemoteComputeCenter();
-                  });
-              break;
             default:
               selectedSetupSectionIndex = 0;
               showDetailCard(CARD_OVERVIEW);
               break;
           }
         });
-    sidebar.add(sectionNav, BorderLayout.CENTER);
+
+    btnRemoteCompute.setText(text("Menu.remoteCompute"));
+    btnRemoteCompute.setIcon(new NavIcon(4, false));
+    btnRemoteCompute.addActionListener(event -> openRemoteComputeCenter());
+
+    JPanel navigation = new JPanel(new GridBagLayout());
+    navigation.setOpaque(false);
+    GridBagConstraints navigationConstraints = new GridBagConstraints();
+    navigationConstraints.gridx = 0;
+    navigationConstraints.gridy = 0;
+    navigationConstraints.weightx = 1;
+    navigationConstraints.fill = GridBagConstraints.HORIZONTAL;
+    navigationConstraints.anchor = GridBagConstraints.NORTH;
+    navigation.add(sectionNav, navigationConstraints);
+    navigationConstraints.gridy = 1;
+    navigationConstraints.insets = new Insets(8, 0, 0, 0);
+    navigation.add(btnRemoteCompute, navigationConstraints);
+    sidebar.add(navigation, BorderLayout.NORTH);
     return sidebar;
   }
 
@@ -4938,6 +4952,75 @@ public class KataGoAutoSetupDialog extends JDialog {
           int y = startY + stone[1];
           g2.setColor(stone[3] == 0 ? new Color(5, 16, 17, 150) : new Color(221, 229, 219, 135));
           g2.fillOval(stone[0], y, stone[2], stone[2]);
+        }
+      } finally {
+        g2.dispose();
+      }
+      super.paintComponent(graphics);
+    }
+  }
+
+  static final class ExactHitList<E> extends JList<E> {
+    @Override
+    public int locationToIndex(Point location) {
+      int index = super.locationToIndex(location);
+      if (index < 0) {
+        return -1;
+      }
+      Rectangle cellBounds = getCellBounds(index, index);
+      return cellBounds != null && cellBounds.contains(location) ? index : -1;
+    }
+  }
+
+  private static final class SidebarActionButton extends JFontButton {
+    private boolean hovered;
+
+    private SidebarActionButton() {
+      AppleStyleSupport.preserveCustomButtonStyle(this);
+      setUI(new BasicButtonUI());
+      setHorizontalAlignment(SwingConstants.LEFT);
+      setIconTextGap(15);
+      setForeground(SIDEBAR_TEXT);
+      setOpaque(false);
+      setContentAreaFilled(false);
+      setBorderPainted(false);
+      setFocusPainted(false);
+      setCursor(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR));
+      setBorder(BorderFactory.createEmptyBorder(0, 14, 0, 10));
+      setPreferredSize(new Dimension(190, 54));
+      addMouseListener(
+          new MouseAdapter() {
+            @Override
+            public void mouseEntered(MouseEvent event) {
+              hovered = true;
+              repaint();
+            }
+
+            @Override
+            public void mouseExited(MouseEvent event) {
+              hovered = false;
+              repaint();
+            }
+          });
+    }
+
+    @Override
+    public void updateUI() {
+      setUI(new BasicButtonUI());
+    }
+
+    @Override
+    protected void paintComponent(Graphics graphics) {
+      Graphics2D g2 = (Graphics2D) graphics.create();
+      try {
+        g2.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+        if (hovered || isFocusOwner()) {
+          g2.setColor(new Color(255, 255, 255, hovered ? 22 : 12));
+          g2.fillRoundRect(2, 3, getWidth() - 4, getHeight() - 6, 14, 14);
+        }
+        if (isFocusOwner()) {
+          g2.setColor(new Color(242, 210, 148, 150));
+          g2.drawRoundRect(3, 4, getWidth() - 7, getHeight() - 9, 12, 12);
         }
       } finally {
         g2.dispose();

--- a/src/test/java/featurecat/lizzie/gui/AccessibilitySupportTest.java
+++ b/src/test/java/featurecat/lizzie/gui/AccessibilitySupportTest.java
@@ -1,6 +1,7 @@
 package featurecat.lizzie.gui;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -53,6 +54,28 @@ class AccessibilitySupportTest {
     assertEquals(
         "released",
         button.getInputMap(JComponent.WHEN_FOCUSED).get(KeyStroke.getKeyStroke("released ENTER")));
+  }
+
+  @Test
+  void screenReaderOnlyDescriptionsNeverRegainVisibleTooltips() {
+    JPanel panel = new JPanel();
+    JButton nextMove = new JButton(">");
+    nextMove.setToolTipText("Old tooltip");
+    panel.add(nextMove);
+
+    AccessibilitySupport.buttonWithoutTooltip(
+        nextMove, "Next move", "Go forward one move");
+    AccessibilitySupport.applyToTree(panel);
+
+    assertNull(nextMove.getToolTipText());
+    assertEquals("Next move", nextMove.getAccessibleContext().getAccessibleName());
+    assertEquals(
+        "Go forward one move", nextMove.getAccessibleContext().getAccessibleDescription());
+    assertEquals(
+        "pressed",
+        nextMove
+            .getInputMap(JComponent.WHEN_FOCUSED)
+            .get(KeyStroke.getKeyStroke("pressed ENTER")));
   }
 
   @Test

--- a/src/test/java/featurecat/lizzie/gui/AppleStyleSupportTest.java
+++ b/src/test/java/featurecat/lizzie/gui/AppleStyleSupportTest.java
@@ -1,0 +1,22 @@
+package featurecat.lizzie.gui;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import javax.swing.JButton;
+import javax.swing.plaf.ButtonUI;
+import javax.swing.plaf.basic.BasicButtonUI;
+import org.junit.jupiter.api.Test;
+
+class AppleStyleSupportTest {
+  @Test
+  void globalThemeRefreshPreservesPurposeBuiltButtonUi() {
+    JButton button = new JButton("Remote compute");
+    ButtonUI customUi = new BasicButtonUI();
+    button.setUI(customUi);
+    AppleStyleSupport.preserveCustomButtonStyle(button);
+
+    AppleStyleSupport.installButtonStyle(button);
+
+    assertSame(customUi, button.getUI());
+  }
+}

--- a/src/test/java/featurecat/lizzie/gui/KataGoAutoSetupSidebarTest.java
+++ b/src/test/java/featurecat/lizzie/gui/KataGoAutoSetupSidebarTest.java
@@ -1,0 +1,20 @@
+package featurecat.lizzie.gui;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.awt.Point;
+import org.junit.jupiter.api.Test;
+
+class KataGoAutoSetupSidebarTest {
+  @Test
+  void blankSpaceBelowNavigationItemsDoesNotSelectTheLastItem() {
+    KataGoAutoSetupDialog.ExactHitList<String> navigation =
+        new KataGoAutoSetupDialog.ExactHitList<>();
+    navigation.setListData(new String[] {"Overview", "Weights", "Speed", "Acceleration"});
+    navigation.setFixedCellHeight(20);
+    navigation.setSize(180, 120);
+
+    assertEquals(3, navigation.locationToIndex(new Point(20, 70)));
+    assertEquals(-1, navigation.locationToIndex(new Point(20, 100)));
+  }
+}


### PR DESCRIPTION
## Summary

- moves Remote Compute out of the fill-height setup navigation list into a dedicated button, so blank sidebar space cannot open it
- makes list hit-testing exact instead of mapping empty space to the nearest row
- keeps screen-reader semantics and Enter-key support for rapid navigation buttons without visible tooltips blocking repeated clicks
- preserves the custom sidebar button renderer across global theme refreshes

## Validation

- `git diff --check`
- `python3 scripts/check_markdown_links.py`
- `mvn -B -Dfmt.skip=true test`
- `mvn -B -Dfmt.skip=true -DskipTests package`
- macOS real Swing smoke: launched the shaded jar in an isolated profile, opened KataGo Auto Setup, and captured/reviewed the final 1200x900 dialog

Closes #164
Closes #186