### PR TITLE
Prevent white screens from Wayland popup menus

### DIFF
--- a/docs/PACKAGES.md
+++ b/docs/PACKAGES.md
@@ -134,6 +134,13 @@
 - Windows 免安装包的用户下载权重和 TensorRT：解压目录内的 `user-data/`；TensorRT 下载缓存、CUDA/TensorRT 运行缓存会尽量保存在 `user-data/runtime/`
 - Windows 安装器版本为了避免写入 `Program Files`，运行数据可能位于 `C:\Users\Public\Documents\LizzieYzyNext` 或 `C:\ProgramData\LizzieYzyNext`；如果非常在意 C 盘空间，优先使用免安装包并解压到非 C 盘
 
+### Linux Wayland 菜单兼容
+
+- Linux Wayland 会自动使用标准 Swing 菜单栏，规避 JDK 21 下弹出菜单可能造成窗口白屏的问题；Windows、macOS 和 Linux X11 继续使用原有菜单外观。
+- 诊断包会记录桌面会话、实际菜单模式、Java 版本、显示设备以及可安全读取到的 NVIDIA 型号和驱动版本，不记录用户名、目录原文或其他个人数据。
+- 排查时可追加 JVM 参数 `-Dlizzie.menu.presentation=native` 强制标准菜单，或用 `-Dlizzie.menu.presentation=custom` 临时对照原菜单。该参数只用于诊断，不建议普通用户长期修改。
+- 相关 JDK 修复进展见 [OpenJDK JDK-8342096](https://bugs.openjdk.org/browse/JDK-8342096)。Linux 发布运行时是否升级到 JDK 25，将在 KDE Plasma Wayland 与 NVIDIA 真机验收完成后单独决定。
+
 ## 远程算力中心
 
 如果本机显卡不够，或者临时想用更强算力，可以在软件内打开 `设置 -> 远程算力中心`：

--- a/src/main/java/featurecat/lizzie/analysis/SyncDiagnosticsEnvironment.java
+++ b/src/main/java/featurecat/lizzie/analysis/SyncDiagnosticsEnvironment.java
@@ -1,6 +1,8 @@
 package featurecat.lizzie.analysis;
 
 import featurecat.lizzie.Lizzie;
+import featurecat.lizzie.util.GraphicsDriverDiagnostics;
+import java.awt.GraphicsEnvironment;
 
 public final class SyncDiagnosticsEnvironment {
   private final String appVersion;
@@ -8,6 +10,12 @@ public final class SyncDiagnosticsEnvironment {
   private final String osName;
   private final String osVersion;
   private final String osArch;
+  private final String desktopSession;
+  private final boolean waylandDisplayPresent;
+  private final String desktopName;
+  private final String menuPresentation;
+  private final String graphicsDevice;
+  private final String graphicsDriver;
   private final String userDirSanitized;
   private final long timestampMillis;
 
@@ -17,6 +25,12 @@ public final class SyncDiagnosticsEnvironment {
       String osName,
       String osVersion,
       String osArch,
+      String desktopSession,
+      boolean waylandDisplayPresent,
+      String desktopName,
+      String menuPresentation,
+      String graphicsDevice,
+      String graphicsDriver,
       String userDirSanitized,
       long timestampMillis) {
     this.appVersion = SyncDecisionTrace.normalize(appVersion, "unknown");
@@ -24,6 +38,12 @@ public final class SyncDiagnosticsEnvironment {
     this.osName = SyncDecisionTrace.normalize(osName, "unknown");
     this.osVersion = SyncDecisionTrace.normalize(osVersion, "unknown");
     this.osArch = SyncDecisionTrace.normalize(osArch, "unknown");
+    this.desktopSession = SyncDecisionTrace.normalize(desktopSession, "unknown");
+    this.waylandDisplayPresent = waylandDisplayPresent;
+    this.desktopName = SyncDecisionTrace.normalize(desktopName, "unknown");
+    this.menuPresentation = SyncDecisionTrace.normalize(menuPresentation, "unknown");
+    this.graphicsDevice = SyncDecisionTrace.normalize(graphicsDevice, "unknown");
+    this.graphicsDriver = SyncDecisionTrace.normalize(graphicsDriver, "unknown");
     this.userDirSanitized = SyncDecisionTrace.normalize(userDirSanitized, "unknown");
     this.timestampMillis = timestampMillis;
   }
@@ -35,6 +55,12 @@ public final class SyncDiagnosticsEnvironment {
         System.getProperty("os.name", "unknown"),
         System.getProperty("os.version", "unknown"),
         System.getProperty("os.arch", "unknown"),
+        safeEnvironmentValue("XDG_SESSION_TYPE"),
+        hasEnvironmentValue("WAYLAND_DISPLAY"),
+        safeEnvironmentValue("XDG_CURRENT_DESKTOP"),
+        System.getProperty("lizzie.menu.presentation.active", "unknown"),
+        captureGraphicsDevice(),
+        GraphicsDriverDiagnostics.summary(),
         sanitizePath(System.getProperty("user.dir", "")),
         System.currentTimeMillis());
   }
@@ -48,7 +74,49 @@ public final class SyncDiagnosticsEnvironment {
       String userDirSanitized,
       long timestampMillis) {
     return new SyncDiagnosticsEnvironment(
-        appVersion, javaVersion, osName, osVersion, osArch, userDirSanitized, timestampMillis);
+        appVersion,
+        javaVersion,
+        osName,
+        osVersion,
+        osArch,
+        "unknown",
+        false,
+        "unknown",
+        "unknown",
+        "unknown",
+        "not-probed",
+        userDirSanitized,
+        timestampMillis);
+  }
+
+  static SyncDiagnosticsEnvironment of(
+      String appVersion,
+      String javaVersion,
+      String osName,
+      String osVersion,
+      String osArch,
+      String desktopSession,
+      boolean waylandDisplayPresent,
+      String desktopName,
+      String menuPresentation,
+      String graphicsDevice,
+      String graphicsDriver,
+      String userDirSanitized,
+      long timestampMillis) {
+    return new SyncDiagnosticsEnvironment(
+        appVersion,
+        javaVersion,
+        osName,
+        osVersion,
+        osArch,
+        desktopSession,
+        waylandDisplayPresent,
+        desktopName,
+        menuPresentation,
+        graphicsDevice,
+        graphicsDriver,
+        userDirSanitized,
+        timestampMillis);
   }
 
   public static String sanitizePath(String path) {
@@ -101,12 +169,66 @@ public final class SyncDiagnosticsEnvironment {
     return osArch;
   }
 
+  public String getDesktopSession() {
+    return desktopSession;
+  }
+
+  public boolean isWaylandDisplayPresent() {
+    return waylandDisplayPresent;
+  }
+
+  public String getDesktopName() {
+    return desktopName;
+  }
+
+  public String getMenuPresentation() {
+    return menuPresentation;
+  }
+
+  public String getGraphicsDevice() {
+    return graphicsDevice;
+  }
+
+  public String getGraphicsDriver() {
+    return graphicsDriver;
+  }
+
   public String getUserDirSanitized() {
     return userDirSanitized;
   }
 
   public long getTimestampMillis() {
     return timestampMillis;
+  }
+
+  private static boolean hasEnvironmentValue(String name) {
+    String value = System.getenv(name);
+    return value != null && !value.isBlank();
+  }
+
+  private static String safeEnvironmentValue(String name) {
+    String value = System.getenv(name);
+    if (value == null || value.isBlank()) {
+      return "unknown";
+    }
+    String compact = value.trim().replaceAll("[^A-Za-z0-9 ._:+/-]", "");
+    if (compact.isEmpty()) {
+      return "present";
+    }
+    return compact.length() <= 80 ? compact : compact.substring(0, 80);
+  }
+
+  private static String captureGraphicsDevice() {
+    try {
+      if (GraphicsEnvironment.isHeadless()) {
+        return "headless";
+      }
+      return GraphicsEnvironment.getLocalGraphicsEnvironment()
+          .getDefaultScreenDevice()
+          .getIDstring();
+    } catch (RuntimeException e) {
+      return "unavailable";
+    }
   }
 
   private static boolean isAbsolutePath(String original, String normalized) {

--- a/src/main/java/featurecat/lizzie/analysis/SyncDiagnosticsExporter.java
+++ b/src/main/java/featurecat/lizzie/analysis/SyncDiagnosticsExporter.java
@@ -343,6 +343,22 @@ public final class SyncDiagnosticsExporter {
     text.append("osName: ").append(sanitizer.text(environment.getOsName())).append('\n');
     text.append("osVersion: ").append(sanitizer.text(environment.getOsVersion())).append('\n');
     text.append("osArch: ").append(sanitizer.text(environment.getOsArch())).append('\n');
+    text.append("desktopSession: ")
+        .append(sanitizer.text(environment.getDesktopSession()))
+        .append('\n');
+    text.append("waylandDisplayPresent: ")
+        .append(environment.isWaylandDisplayPresent())
+        .append('\n');
+    text.append("desktopName: ").append(sanitizer.text(environment.getDesktopName())).append('\n');
+    text.append("menuPresentation: ")
+        .append(sanitizer.text(environment.getMenuPresentation()))
+        .append('\n');
+    text.append("graphicsDevice: ")
+        .append(sanitizer.text(environment.getGraphicsDevice()))
+        .append('\n');
+    text.append("graphicsDriver: ")
+        .append(sanitizer.text(environment.getGraphicsDriver()))
+        .append('\n');
     text.append("userDirSanitized: ")
         .append(sanitizer.path(environment.getUserDirSanitized()))
         .append('\n');

--- a/src/main/java/featurecat/lizzie/gui/LizzieFrame.java
+++ b/src/main/java/featurecat/lizzie/gui/LizzieFrame.java
@@ -43,6 +43,7 @@ import featurecat.lizzie.rules.SGFParser;
 import featurecat.lizzie.rules.Stone;
 import featurecat.lizzie.rules.Zobrist;
 import featurecat.lizzie.theme.MorandiPalette;
+import featurecat.lizzie.util.GraphicsDriverDiagnostics;
 import featurecat.lizzie.util.KataGoRuntimeHelper;
 import featurecat.lizzie.util.Utils;
 import featurecat.lizzie.util.YikeSyncDebugLog;
@@ -321,6 +322,7 @@ public class LizzieFrame extends JFrame {
   public static Menu menu;
   public static BottomToolbar toolbar;
   public WindowMenuStrip windowMenuStrip;
+  private final MenuPresentationMode menuPresentationMode;
   private int windowMenuHeight = Config.menuHeight;
   // public static EditToolbar editToolbar;
   public Optional<List<String>> variationOpt;
@@ -733,6 +735,7 @@ public class LizzieFrame extends JFrame {
     toolbar = new BottomToolbar();
     topPanel = new TopHeaderPanel();
     menu = new Menu();
+    menuPresentationMode = MenuPresentationMode.detectCurrent();
     windowMenuStrip = new WindowMenuStrip(menu);
     RightClickMenu = new RightClickMenu();
     RightClickMenu2 = new RightClickMenu2();
@@ -1128,7 +1131,7 @@ public class LizzieFrame extends JFrame {
               }
             });
     tableTimer.start();
-    setJMenuBar(null);
+    configureWindowMenuPresentation();
     if (Lizzie.config.isDoubleEngineMode()) {
       boardRenderer2 = new BoardRenderer(false);
       boardRenderer2.setOrder(1);
@@ -1870,14 +1873,16 @@ public class LizzieFrame extends JFrame {
         text(
             "Accessibility.candidateTableDescription",
             "Candidate moves reported by the current analysis engine."));
-    AccessibilitySupport.applyToTree(windowMenuStrip);
+    JComponent activeMenuComponent =
+        menuPresentationMode.usesNativeMenuBar() ? menu : windowMenuStrip;
+    AccessibilitySupport.applyToTree(activeMenuComponent);
     AccessibilitySupport.applyToTree(topPanel);
     AccessibilitySupport.applyToTree(sidebarPanel);
     AccessibilitySupport.applyToTree(toolbar);
     AccessibilitySupport.installWindowFocusCycling(
         this,
         mainPanel,
-        windowMenuStrip,
+        activeMenuComponent,
         topPanel,
         mainPanel,
         sidebarPanel,
@@ -11851,23 +11856,49 @@ public class LizzieFrame extends JFrame {
     mainPanel.setVisible(true);
   }
 
+  private void configureWindowMenuPresentation() {
+    boolean nativeMenu = menuPresentationMode.usesNativeMenuBar();
+    GraphicsDriverDiagnostics.startAsync();
+    setJMenuBar(nativeMenu ? menu : null);
+    windowMenuStrip.setVisible(!nativeMenu);
+    windowMenuHeight = nativeMenu ? 0 : Config.menuHeight;
+    System.setProperty(MenuPresentationMode.ACTIVE_PROPERTY, menuPresentationMode.id());
+    System.out.println(
+        "Menu presentation: mode="
+            + menuPresentationMode.id()
+            + ", desktopSession="
+            + MenuPresentationMode.desktopSession(System.getenv())
+            + ", java="
+            + System.getProperty("java.version", "unknown")
+            + ", os="
+            + System.getProperty("os.name", "unknown")
+            + " "
+            + System.getProperty("os.version", "unknown"));
+  }
+
   public void reSetLoc() {
     SwingUtilities.invokeLater(
         new Thread() {
           public void run() {
             int width = getWidth() - getInsets().left - getInsets().right;
-            windowMenuStrip.rebuild();
-            windowMenuHeight =
-                windowMenuStrip.getPreferredSize().height > 0
-                    ? windowMenuStrip.getPreferredSize().height
-                    : Config.menuHeight;
-            windowMenuStrip.setBounds(0, 0, width, windowMenuHeight);
-            windowMenuStrip.setPreferredSize(new Dimension(width, windowMenuHeight));
-            windowMenuStrip.invalidate();
-            windowMenuStrip.revalidate();
-            windowMenuStrip.doLayout();
-            windowMenuStrip.repaint();
-            windowMenuStrip.setVisible(true);
+            if (menuPresentationMode.usesNativeMenuBar()) {
+              windowMenuHeight = 0;
+              windowMenuStrip.setVisible(false);
+            } else {
+              windowMenuStrip.rebuild();
+              int preferredMenuHeight =
+                  windowMenuStrip.getPreferredSize().height > 0
+                      ? windowMenuStrip.getPreferredSize().height
+                      : Config.menuHeight;
+              windowMenuHeight = menuPresentationMode.contentOffset(preferredMenuHeight);
+              windowMenuStrip.setBounds(0, 0, width, windowMenuHeight);
+              windowMenuStrip.setPreferredSize(new Dimension(width, windowMenuHeight));
+              windowMenuStrip.invalidate();
+              windowMenuStrip.revalidate();
+              windowMenuStrip.doLayout();
+              windowMenuStrip.repaint();
+              windowMenuStrip.setVisible(true);
+            }
             if (Lizzie.config.showTopToolBar) {
               if (Lizzie.config.autoWrapToolBar) {
                 // To allow FlowLayout wrapping properly, let it take its preferred height

--- a/src/main/java/featurecat/lizzie/gui/MenuPresentationMode.java
+++ b/src/main/java/featurecat/lizzie/gui/MenuPresentationMode.java
@@ -1,0 +1,74 @@
+package featurecat.lizzie.gui;
+
+import java.util.Locale;
+import java.util.Map;
+
+/** Selects the safest main-menu implementation for the current desktop session. */
+public enum MenuPresentationMode {
+  CUSTOM_STRIP("custom"),
+  NATIVE_MENU_BAR("native");
+
+  public static final String OVERRIDE_PROPERTY = "lizzie.menu.presentation";
+  public static final String ACTIVE_PROPERTY = "lizzie.menu.presentation.active";
+
+  private final String id;
+
+  MenuPresentationMode(String id) {
+    this.id = id;
+  }
+
+  public String id() {
+    return id;
+  }
+
+  public boolean usesNativeMenuBar() {
+    return this == NATIVE_MENU_BAR;
+  }
+
+  public int contentOffset(int customStripHeight) {
+    return usesNativeMenuBar() ? 0 : Math.max(0, customStripHeight);
+  }
+
+  public static MenuPresentationMode detectCurrent() {
+    return detect(
+        System.getProperty("os.name", ""),
+        System.getenv(),
+        System.getProperty(OVERRIDE_PROPERTY, "auto"));
+  }
+
+  static MenuPresentationMode detect(
+      String osName, Map<String, String> environment, String override) {
+    String requested = normalize(override);
+    if ("native".equals(requested)) {
+      return NATIVE_MENU_BAR;
+    }
+    if ("custom".equals(requested)) {
+      return CUSTOM_STRIP;
+    }
+    return isLinuxWayland(osName, environment) ? NATIVE_MENU_BAR : CUSTOM_STRIP;
+  }
+
+  static boolean isLinuxWayland(String osName, Map<String, String> environment) {
+    if (!normalize(osName).contains("linux")) {
+      return false;
+    }
+    Map<String, String> values = environment == null ? Map.of() : environment;
+    if ("wayland".equals(normalize(values.get("XDG_SESSION_TYPE")))) {
+      return true;
+    }
+    return !normalize(values.get("WAYLAND_DISPLAY")).isEmpty();
+  }
+
+  static String desktopSession(Map<String, String> environment) {
+    Map<String, String> values = environment == null ? Map.of() : environment;
+    String session = normalize(values.get("XDG_SESSION_TYPE"));
+    if (!session.isEmpty()) {
+      return session;
+    }
+    return !normalize(values.get("WAYLAND_DISPLAY")).isEmpty() ? "wayland" : "unknown";
+  }
+
+  private static String normalize(String value) {
+    return value == null ? "" : value.trim().toLowerCase(Locale.ROOT);
+  }
+}

--- a/src/main/java/featurecat/lizzie/util/GraphicsDriverDiagnostics.java
+++ b/src/main/java/featurecat/lizzie/util/GraphicsDriverDiagnostics.java
@@ -1,0 +1,88 @@
+package featurecat.lizzie.util;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Locale;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+/** Captures a small, non-personal GPU/driver summary without blocking Swing startup. */
+public final class GraphicsDriverDiagnostics {
+  private static final long PROBE_TIMEOUT_SECONDS = 2L;
+  private static final AtomicBoolean STARTED = new AtomicBoolean();
+  private static final AtomicReference<String> SUMMARY = new AtomicReference<>("not-probed");
+
+  private GraphicsDriverDiagnostics() {}
+
+  public static void startAsync() {
+    if (!isLinux() || !STARTED.compareAndSet(false, true)) {
+      return;
+    }
+    Thread probe =
+        new Thread(
+            () -> {
+              String result = probeNvidiaDriver();
+              SUMMARY.set(result);
+              System.out.println("Graphics driver diagnostics: " + result);
+            },
+            "linux-graphics-driver-diagnostics");
+    probe.setDaemon(true);
+    probe.start();
+  }
+
+  public static String summary() {
+    return SUMMARY.get();
+  }
+
+  static String sanitizeSummary(String output) {
+    if (output == null) {
+      return "unavailable";
+    }
+    String compact =
+        output
+            .replace('\r', ' ')
+            .replace('\n', ';')
+            .replaceAll("[^\\p{L}\\p{N} .,_+;()/-]", "")
+            .replaceAll("\\s+", " ")
+            .replaceAll(";+", ";")
+            .trim()
+            .replaceAll("^;+|;+$", "");
+    if (compact.isEmpty()) {
+      return "unavailable";
+    }
+    return compact.length() <= 256 ? compact : compact.substring(0, 256);
+  }
+
+  private static String probeNvidiaDriver() {
+    Process process = null;
+    try {
+      process =
+          new ProcessBuilder(
+                  "nvidia-smi",
+                  "--query-gpu=name,driver_version",
+                  "--format=csv,noheader,nounits")
+              .redirectErrorStream(true)
+              .start();
+      if (!process.waitFor(PROBE_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+        process.destroyForcibly();
+        return "timeout";
+      }
+      String output = new String(process.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+      return process.exitValue() == 0 ? sanitizeSummary(output) : "unavailable";
+    } catch (IOException e) {
+      return "unavailable";
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      return "interrupted";
+    } finally {
+      if (process != null && process.isAlive()) {
+        process.destroyForcibly();
+      }
+    }
+  }
+
+  private static boolean isLinux() {
+    return System.getProperty("os.name", "").toLowerCase(Locale.ROOT).contains("linux");
+  }
+}

--- a/src/test/java/featurecat/lizzie/analysis/SyncDiagnosticsExporterTest.java
+++ b/src/test/java/featurecat/lizzie/analysis/SyncDiagnosticsExporterTest.java
@@ -39,6 +39,19 @@ class SyncDiagnosticsExporterTest {
   }
 
   @Test
+  void environmentIncludesWaylandMenuAndGraphicsDiagnostics() throws IOException {
+    Path zip = new SyncDiagnosticsExporter(tempDir).export(sensitiveSnapshot());
+    String environment = unzipTextEntries(zip).get("environment.txt");
+
+    assertTrue(environment.contains("desktopSession: wayland"));
+    assertTrue(environment.contains("waylandDisplayPresent: true"));
+    assertTrue(environment.contains("desktopName: KDE"));
+    assertTrue(environment.contains("menuPresentation: native"));
+    assertTrue(environment.contains("graphicsDevice: screen-0"));
+    assertTrue(environment.contains("graphicsDriver: NVIDIA RTX 5080, 580.88"));
+  }
+
+  @Test
   void exportRedactsSensitiveValuesAcrossWholeZip() throws IOException {
     Path zip = new SyncDiagnosticsExporter(tempDir).export(sensitiveSnapshot());
     Map<String, String> entries = unzipTextEntries(zip);
@@ -251,6 +264,12 @@ class SyncDiagnosticsExporterTest {
             "Linux",
             "test-os",
             "x86_64",
+            "wayland",
+            true,
+            "KDE",
+            "native",
+            "screen-0",
+            "NVIDIA RTX 5080, 580.88",
             "\\\\wsl.localhost\\Ubuntu\\home\\alice\\dev",
             150L));
   }

--- a/src/test/java/featurecat/lizzie/gui/MenuPresentationModeTest.java
+++ b/src/test/java/featurecat/lizzie/gui/MenuPresentationModeTest.java
@@ -1,0 +1,53 @@
+package featurecat.lizzie.gui;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class MenuPresentationModeTest {
+  @Test
+  void linuxWaylandUsesNativeSwingMenuBar() {
+    MenuPresentationMode mode =
+        MenuPresentationMode.detect(
+            "Linux", Map.of("XDG_SESSION_TYPE", "wayland"), "auto");
+
+    assertEquals(MenuPresentationMode.NATIVE_MENU_BAR, mode);
+    assertTrue(mode.usesNativeMenuBar());
+    assertEquals(0, mode.contentOffset(34));
+  }
+
+  @Test
+  void waylandDisplayIsUsedWhenSessionTypeIsMissing() {
+    assertTrue(
+        MenuPresentationMode.isLinuxWayland(
+            "Linux", Map.of("WAYLAND_DISPLAY", "wayland-0")));
+  }
+
+  @Test
+  void x11AndNonLinuxDesktopsKeepExistingCustomStrip() {
+    assertEquals(
+        MenuPresentationMode.CUSTOM_STRIP,
+        MenuPresentationMode.detect("Linux", Map.of("XDG_SESSION_TYPE", "x11"), "auto"));
+    assertEquals(
+        MenuPresentationMode.CUSTOM_STRIP,
+        MenuPresentationMode.detect(
+            "Windows 11", Map.of("WAYLAND_DISPLAY", "wayland-0"), "auto"));
+    assertFalse(
+        MenuPresentationMode.isLinuxWayland(
+            "macOS", Map.of("XDG_SESSION_TYPE", "wayland")));
+  }
+
+  @Test
+  void explicitOverrideSupportsTroubleshootingBothRenderers() {
+    assertEquals(
+        MenuPresentationMode.CUSTOM_STRIP,
+        MenuPresentationMode.detect(
+            "Linux", Map.of("XDG_SESSION_TYPE", "wayland"), "custom"));
+    assertEquals(
+        MenuPresentationMode.NATIVE_MENU_BAR,
+        MenuPresentationMode.detect("Linux", Map.of("XDG_SESSION_TYPE", "x11"), "native"));
+  }
+}

--- a/src/test/java/featurecat/lizzie/util/GraphicsDriverDiagnosticsTest.java
+++ b/src/test/java/featurecat/lizzie/util/GraphicsDriverDiagnosticsTest.java
@@ -1,0 +1,20 @@
+package featurecat.lizzie.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+class GraphicsDriverDiagnosticsTest {
+  @Test
+  void driverSummaryKeepsOnlyCompactNonPersonalGpuData() {
+    assertEquals(
+        "NVIDIA GeForce RTX 5080, 580.88;NVIDIA RTX A4000, 570.10",
+        GraphicsDriverDiagnostics.sanitizeSummary(
+            "NVIDIA GeForce RTX 5080, 580.88\nNVIDIA RTX A4000, 570.10\n"));
+  }
+
+  @Test
+  void emptyDriverOutputIsReportedAsUnavailable() {
+    assertEquals("unavailable", GraphicsDriverDiagnostics.sanitizeSummary(" \n "));
+  }
+}


### PR DESCRIPTION
## Summary

- Uses a real Swing `JMenuBar` on Linux Wayland instead of detached popup menus, while preserving the existing menu strip on Windows, macOS, and Linux X11.
- Adds a deterministic override for troubleshooting and records the active desktop/menu mode in sync diagnostics.
- Collects a bounded, non-personal NVIDIA model/driver summary asynchronously with a strict timeout.
- Documents the Wayland fallback and the OpenJDK 21 popup issue.

## Validation

- `git diff --check`
- `python3 scripts/check_markdown_links.py`
- `mvn -B -Dfmt.skip=true test` (`1793` tests, 0 failures)
- `mvn -B -Dfmt.skip=true -DskipTests package`
- Real Swing UI smoke with both `custom` and forced `native` menu modes. The native smoke opened every visible top-level menu and verified that the custom strip stayed hidden.

## Required Linux acceptance

This PR references #176 but does not close it yet. Please validate on KDE Plasma Wayland + NVIDIA by repeatedly opening menus and submenus, minimizing/restoring the window, and checking the exported diagnostics. The issue should remain open until that real environment passes.

Refs #176