### PR TITLE
Fix fixed-handicap engine game setup

### DIFF
--- a/src/main/java/featurecat/lizzie/analysis/EngineGameInfo.java
+++ b/src/main/java/featurecat/lizzie/analysis/EngineGameInfo.java
@@ -19,6 +19,8 @@ public class EngineGameInfo {
   public int batchNumber;
   public int batchNumberCurrent;
   public boolean isExchange; // 是否交换黑白
+  public int handicap;
+  public double komi;
 
   public int firstEngineWinAsBlack;
   public int firstEngineWinAsWhite;

--- a/src/main/java/featurecat/lizzie/analysis/EngineManager.java
+++ b/src/main/java/featurecat/lizzie/analysis/EngineManager.java
@@ -265,6 +265,8 @@ public class EngineManager {
     engineGameInfo.isExchange = isExchange;
     engineGameInfo.batchNumberCurrent = 1;
     engineGameInfo.isContinueGame = isContinueGame;
+    engineGameInfo.handicap = Lizzie.config.newEngineGameHandicap;
+    engineGameInfo.komi = Lizzie.config.newEngineGameKomi;
     engineGameInfo.blackMinMove = Lizzie.config.firstEngineMinMove;
     engineGameInfo.blackResignMoveCounts = Lizzie.config.firstEngineResignMoveCounts;
     engineGameInfo.blackResignWinrate = Lizzie.config.firstEngineResignWinrate;
@@ -446,6 +448,32 @@ public class EngineManager {
       return Lizzie.frame.enginePKSgfString.get(LizzieFrame.toolbar.currentEnginePkSgfNum);
     }
     return null;
+  }
+
+  private ArrayList<Movelist> prepareEngineGameBoard(boolean firstTime, boolean analysisMode) {
+    Lizzie.board.clear(true);
+    ArrayList<Movelist> startList = getStartListForEnginePk();
+    if (startList != null) {
+      if (analysisMode) {
+        Lizzie.board.setMoveList(startList, false, true);
+      } else {
+        Lizzie.board.setlist(startList);
+      }
+    } else if (firstTime) {
+      int width = engineList.get(engineGameInfo.blackEngineIndex).width;
+      int height = engineList.get(engineGameInfo.blackEngineIndex).height;
+      if (width != Board.boardWidth || height != Board.boardHeight) {
+        Lizzie.board.reopen(width, height);
+      }
+    }
+
+    GameInfo gameInfo = Lizzie.board.getHistory().getGameInfo();
+    gameInfo.setKomiNoMenu(engineGameInfo.komi);
+    gameInfo.setHandicap(0);
+    if (startList == null && engineGameInfo.handicap >= 2) {
+      Lizzie.board.setupFixedHandicap(engineGameInfo.handicap);
+    }
+    return startList;
   }
 
   private String formateSaveString(String filename) {
@@ -1254,21 +1282,12 @@ public class EngineManager {
     }
     if (!engineGameInfo.isGenmove) {
       // 分析模式对战
-      Lizzie.board.clear(true);
-      ArrayList<Movelist> startList = getStartListForEnginePk();
-      if (startList != null) {
-        Lizzie.board.setMoveList(startList, false, true);
-      }
+      ArrayList<Movelist> startList = prepareEngineGameBoard(firstTime, true);
       if (!firstTime) {
         engineList.get(engineGameInfo.blackEngineIndex).notPondering();
         engineList.get(engineGameInfo.blackEngineIndex).clear();
         engineList.get(engineGameInfo.whiteEngineIndex).notPondering();
         engineList.get(engineGameInfo.whiteEngineIndex).clear();
-      } else if (startList == null) {
-        int width = engineList.get(engineGameInfo.blackEngineIndex).width;
-        int height = engineList.get(engineGameInfo.blackEngineIndex).height;
-        if (width != Board.boardWidth || height != Board.boardHeight)
-          Lizzie.board.reopen(width, height);
       }
       startEngineForPk(engineGameInfo.blackEngineIndex);
       startEngineForPk(engineGameInfo.whiteEngineIndex);
@@ -1350,11 +1369,6 @@ public class EngineManager {
               } else {
                 Lizzie.leelaz = engineList.get(engineGameInfo.whiteEngineIndex);
               }
-              if (Lizzie.config.newEngineGameHandicap > 0) {
-                Lizzie.board.hasStartStone = true;
-                Lizzie.board.addStartListAll();
-                Lizzie.board.flatten();
-              }
               int cmdNumberTemp = Lizzie.leelaz.cmdNumber;
               Runnable runnable1 =
                   new Runnable() {
@@ -1409,16 +1423,7 @@ public class EngineManager {
       if (engineList.get(engineGameInfo.whiteEngineIndex) != null) {
         engineList.get(engineGameInfo.whiteEngineIndex).clearBestMoves();
       }
-      Lizzie.board.clear(true);
-      ArrayList<Movelist> startList = getStartListForEnginePk();
-      if (startList != null) {
-        Lizzie.board.setlist(startList);
-      } else if (firstTime) {
-        int width = engineList.get(engineGameInfo.blackEngineIndex).width;
-        int height = engineList.get(engineGameInfo.blackEngineIndex).height;
-        if (width != Board.boardWidth || height != Board.boardHeight)
-          Lizzie.board.reopen(width, height);
-      }
+      ArrayList<Movelist> startList = prepareEngineGameBoard(firstTime, false);
       startEngineForPk(engineGameInfo.blackEngineIndex);
       startEngineForPk(engineGameInfo.whiteEngineIndex);
       Runnable runnable =
@@ -1475,11 +1480,6 @@ public class EngineManager {
                   .get(engineGameInfo.whiteEngineIndex)
                   .sendCommand("clear_cache");
               if (startList != null) {
-                if (Lizzie.config.newEngineGameHandicap > 0) {
-                  Lizzie.board.hasStartStone = true;
-                  Lizzie.board.addStartListAll();
-                  Lizzie.board.flatten();
-                }
                 try {
                   Thread.sleep(1000);
                 } catch (InterruptedException e) {

--- a/src/main/java/featurecat/lizzie/gui/BottomToolbar.java
+++ b/src/main/java/featurecat/lizzie/gui/BottomToolbar.java
@@ -164,7 +164,6 @@ public class BottomToolbar extends JPanel {
   public String batchPkNameToolbar = "";
   //  public String SF = "";
   public boolean isGenmoveToolbar = false;
-  public boolean isEngineGameHandicapToolbar = false;
   public boolean AutosavePk = true;
   public boolean exChangeToolbar = true;
   public JCheckBox chkAutoAnalyse;
@@ -4028,7 +4027,7 @@ public class BottomToolbar extends JPanel {
     boolean isBatchGame = chkenginePkBatch.isSelected();
     int batchGameNumber = Utils.parseTextToInt(txtenginePkBatch, 1);
     String batchGameName = batchPkNameToolbar;
-    boolean isContinueGame = chkenginePkContinue.isSelected() || isEngineGameHandicapToolbar;
+    boolean isContinueGame = chkenginePkContinue.isSelected();
     boolean isGenmove = isGenmoveToolbar;
     boolean isExchange = exChangeToolbar;
     return Lizzie.engineManager.startEngineGame(

--- a/src/main/java/featurecat/lizzie/gui/HumanSlGameController.java
+++ b/src/main/java/featurecat/lizzie/gui/HumanSlGameController.java
@@ -79,7 +79,7 @@ public final class HumanSlGameController {
     Lizzie.board.getHistory().getGameInfo().setKomi(komi);
     Lizzie.board.getHistory().getGameInfo().setHandicap(handicap);
     if (handicap >= 2 && Board.boardWidth == 19 && Board.boardHeight == 19) {
-      placeHandicap(handicap);
+      Lizzie.board.setupFixedHandicap(handicap);
     }
     Lizzie.board.getHistory().getGameInfo().setKomi(komi);
     String me = Lizzie.resourceBundle.getString("HumanSlGame.humanPlayer");
@@ -437,51 +437,6 @@ public final class HumanSlGameController {
 
   private String rankLabel() {
     return profile == null ? "" : profile.replace("rank_", "").toUpperCase(java.util.Locale.ROOT);
-  }
-
-  private void placeHandicap(int handicap) {
-    int[][] points = handicapPoints(handicap);
-    boolean previous = Lizzie.leelaz != null && Lizzie.leelaz.isInputCommand;
-    if (Lizzie.leelaz != null) {
-      Lizzie.leelaz.isInputCommand = true;
-    }
-    try {
-      for (int[] point : points) {
-        Lizzie.board.place(point[0], point[1], Stone.BLACK);
-      }
-    } finally {
-      if (Lizzie.leelaz != null) {
-        Lizzie.leelaz.isInputCommand = previous;
-      }
-    }
-    Lizzie.board.hasStartStone = true;
-    Lizzie.board.addStartListAll();
-    Lizzie.board.flatten();
-  }
-
-  private static int[][] handicapPoints(int handicap) {
-    switch (handicap) {
-      case 2:
-        return new int[][] {{3, 15}, {15, 3}};
-      case 3:
-        return new int[][] {{3, 3}, {15, 3}, {3, 15}};
-      case 4:
-        return new int[][] {{3, 3}, {3, 15}, {15, 3}, {15, 15}};
-      case 5:
-        return new int[][] {{3, 3}, {3, 15}, {15, 3}, {15, 15}, {9, 9}};
-      case 6:
-        return new int[][] {{3, 3}, {3, 15}, {15, 3}, {15, 15}, {3, 9}, {15, 9}};
-      case 7:
-        return new int[][] {{3, 3}, {3, 15}, {15, 3}, {15, 15}, {15, 9}, {3, 9}, {9, 9}};
-      case 8:
-        return new int[][] {{3, 3}, {3, 15}, {15, 3}, {15, 15}, {9, 3}, {9, 15}, {3, 9}, {15, 9}};
-      case 9:
-        return new int[][] {
-          {3, 3}, {3, 15}, {15, 3}, {15, 15}, {9, 3}, {9, 15}, {3, 9}, {15, 9}, {9, 9}
-        };
-      default:
-        return new int[0][];
-    }
   }
 
   public static Path resolveDefaultHumanModel() {

--- a/src/main/java/featurecat/lizzie/gui/NewEngineGameDialog.java
+++ b/src/main/java/featurecat/lizzie/gui/NewEngineGameDialog.java
@@ -7,8 +7,6 @@ package featurecat.lizzie.gui;
 import featurecat.lizzie.Config;
 import featurecat.lizzie.Lizzie;
 import featurecat.lizzie.analysis.GameInfo;
-import featurecat.lizzie.rules.Board;
-import featurecat.lizzie.rules.Stone;
 import featurecat.lizzie.util.Utils;
 import java.awt.*;
 import java.awt.event.ActionEvent;
@@ -1047,12 +1045,6 @@ public class NewEngineGameDialog extends JDialog {
 
       resetFont();
 
-      if (handicap >= 2 && Board.boardWidth == 19 && Board.boardHeight == 19) {
-        Lizzie.board.getHistory().clear();
-        placeHandicap(handicap);
-        LizzieFrame.toolbar.isEngineGameHandicapToolbar = true;
-      } else LizzieFrame.toolbar.isEngineGameHandicapToolbar = false;
-
       Lizzie.board.getHistory().setGameInfo(gameInfo);
 
       LizzieFrame.toolbar.chkenginePk.setSelected(true);
@@ -1079,72 +1071,6 @@ public class NewEngineGameDialog extends JDialog {
         new Font(Config.sysDefaultFontName, Font.PLAIN, 12));
     LizzieFrame.toolbar.txtenginePkTimeWhite.setFont(
         new Font(Config.sysDefaultFontName, Font.PLAIN, 12));
-  }
-
-  private void placeHandicap(int handicap) {
-    // TODO Auto-generated method stub
-    switch (handicap) {
-      case 2:
-        Lizzie.board.getHistory().place(3, 15, Stone.BLACK);
-        Lizzie.board.getHistory().place(15, 3, Stone.BLACK);
-        break;
-      case 3:
-        Lizzie.board.getHistory().place(3, 3, Stone.BLACK);
-        Lizzie.board.getHistory().place(15, 3, Stone.BLACK);
-        Lizzie.board.getHistory().place(3, 15, Stone.BLACK);
-        break;
-      case 4:
-        Lizzie.board.getHistory().place(3, 3, Stone.BLACK);
-        Lizzie.board.getHistory().place(3, 15, Stone.BLACK);
-        Lizzie.board.getHistory().place(15, 3, Stone.BLACK);
-        Lizzie.board.getHistory().place(15, 15, Stone.BLACK);
-        break;
-      case 5:
-        Lizzie.board.getHistory().place(3, 3, Stone.BLACK);
-        Lizzie.board.getHistory().place(3, 15, Stone.BLACK);
-        Lizzie.board.getHistory().place(15, 3, Stone.BLACK);
-        Lizzie.board.getHistory().place(15, 15, Stone.BLACK);
-        Lizzie.board.getHistory().place(9, 9, Stone.BLACK);
-        break;
-      case 6:
-        Lizzie.board.getHistory().place(3, 3, Stone.BLACK);
-        Lizzie.board.getHistory().place(3, 15, Stone.BLACK);
-        Lizzie.board.getHistory().place(15, 3, Stone.BLACK);
-        Lizzie.board.getHistory().place(15, 15, Stone.BLACK);
-        Lizzie.board.getHistory().place(3, 9, Stone.BLACK);
-        Lizzie.board.getHistory().place(15, 9, Stone.BLACK);
-        break;
-      case 7:
-        Lizzie.board.getHistory().place(3, 3, Stone.BLACK);
-        Lizzie.board.getHistory().place(3, 15, Stone.BLACK);
-        Lizzie.board.getHistory().place(15, 3, Stone.BLACK);
-        Lizzie.board.getHistory().place(15, 15, Stone.BLACK);
-        Lizzie.board.getHistory().place(15, 9, Stone.BLACK);
-        Lizzie.board.getHistory().place(3, 9, Stone.BLACK);
-        Lizzie.board.getHistory().place(9, 9, Stone.BLACK);
-        break;
-      case 8:
-        Lizzie.board.getHistory().place(3, 3, Stone.BLACK);
-        Lizzie.board.getHistory().place(3, 15, Stone.BLACK);
-        Lizzie.board.getHistory().place(15, 3, Stone.BLACK);
-        Lizzie.board.getHistory().place(15, 15, Stone.BLACK);
-        Lizzie.board.getHistory().place(9, 3, Stone.BLACK);
-        Lizzie.board.getHistory().place(9, 15, Stone.BLACK);
-        Lizzie.board.getHistory().place(3, 9, Stone.BLACK);
-        Lizzie.board.getHistory().place(15, 9, Stone.BLACK);
-        break;
-      case 9:
-        Lizzie.board.getHistory().place(3, 3, Stone.BLACK);
-        Lizzie.board.getHistory().place(3, 15, Stone.BLACK);
-        Lizzie.board.getHistory().place(15, 3, Stone.BLACK);
-        Lizzie.board.getHistory().place(15, 15, Stone.BLACK);
-        Lizzie.board.getHistory().place(9, 3, Stone.BLACK);
-        Lizzie.board.getHistory().place(9, 15, Stone.BLACK);
-        Lizzie.board.getHistory().place(3, 9, Stone.BLACK);
-        Lizzie.board.getHistory().place(15, 9, Stone.BLACK);
-        Lizzie.board.getHistory().place(9, 9, Stone.BLACK);
-        break;
-    }
   }
 
   public void setGameInfo(GameInfo gameInfo) {

--- a/src/main/java/featurecat/lizzie/rules/Board.java
+++ b/src/main/java/featurecat/lizzie/rules/Board.java
@@ -2440,6 +2440,83 @@ public class Board {
     history.setGameInfo(oldHistory.getGameInfo());
   }
 
+  /**
+   * Replaces the current position with a standard 19x19 fixed-handicap root position.
+   *
+   * <p>Handicap stones are setup stones, not a sequence of Black moves. Keeping them on the root
+   * preserves move number zero and guarantees that White is next for every handicap count.
+   *
+   * @return {@code true} when the requested fixed handicap was applied
+   */
+  public boolean setupFixedHandicap(int handicap) {
+    int[][] points = fixedHandicapPoints(handicap);
+    if (boardWidth != 19 || boardHeight != 19 || points.length == 0) {
+      return false;
+    }
+
+    Stone[] stones = new Stone[boardWidth * boardHeight];
+    Arrays.fill(stones, Stone.EMPTY);
+    Zobrist zobrist = new Zobrist();
+    for (int[] point : points) {
+      stones[getIndex(point[0], point[1])] = Stone.BLACK;
+      zobrist.toggleStone(point[0], point[1], Stone.BLACK);
+    }
+
+    GameInfo gameInfo = history == null ? new GameInfo() : history.getGameInfo();
+    gameInfo.setHandicap(handicap);
+    BoardHistoryList fixedHandicapHistory =
+        new BoardHistoryList(
+            BoardData.snapshot(
+                stones,
+                Optional.empty(),
+                Stone.EMPTY,
+                false,
+                zobrist,
+                0,
+                new int[boardWidth * boardHeight],
+                0,
+                0,
+                50,
+                0));
+    fixedHandicapHistory.setGameInfo(gameInfo);
+    history = fixedHandicapHistory;
+    hasStartStone = false;
+    startStonelist = new ArrayList<Movelist>();
+    advanceContextRevision();
+    notifyReadBoardHistoryOverwritten();
+    return true;
+  }
+
+  private static int[][] fixedHandicapPoints(int handicap) {
+    switch (handicap) {
+      case 2:
+        return new int[][] {{3, 15}, {15, 3}};
+      case 3:
+        return new int[][] {{3, 3}, {15, 3}, {3, 15}};
+      case 4:
+        return new int[][] {{3, 3}, {3, 15}, {15, 3}, {15, 15}};
+      case 5:
+        return new int[][] {{3, 3}, {3, 15}, {15, 3}, {15, 15}, {9, 9}};
+      case 6:
+        return new int[][] {{3, 3}, {3, 15}, {15, 3}, {15, 15}, {3, 9}, {15, 9}};
+      case 7:
+        return new int[][] {
+          {3, 3}, {3, 15}, {15, 3}, {15, 15}, {15, 9}, {3, 9}, {9, 9}
+        };
+      case 8:
+        return new int[][] {
+          {3, 3}, {3, 15}, {15, 3}, {15, 15}, {9, 3}, {9, 15}, {3, 9}, {15, 9}
+        };
+      case 9:
+        return new int[][] {
+          {3, 3}, {3, 15}, {15, 3}, {15, 15}, {9, 3}, {9, 15}, {3, 9}, {15, 9},
+          {9, 9}
+        };
+      default:
+        return new int[0][];
+    }
+  }
+
   public void flattenWithCondition(
       Stone[] stones,
       Zobrist zobrist,

--- a/src/test/java/featurecat/lizzie/rules/BoardNodeKindHistoryPipelineTest.java
+++ b/src/test/java/featurecat/lizzie/rules/BoardNodeKindHistoryPipelineTest.java
@@ -351,6 +351,58 @@ class BoardNodeKindHistoryPipelineTest {
   }
 
   @Test
+  void fixedHandicapSetupCreatesRootStonesAndAlwaysStartsWithWhite() throws Exception {
+    TestEnvironment env = TestEnvironment.open();
+    try {
+      Board.boardWidth = 19;
+      Board.boardHeight = 19;
+      Zobrist.init();
+      TrackingLeelaz engine = (TrackingLeelaz) Lizzie.leelaz;
+
+      for (int handicap = 2; handicap <= 9; handicap++) {
+        BoardHistoryList history = new BoardHistoryList(BoardData.empty(19, 19));
+        history.getGameInfo().setKomiNoMenu(0.5);
+        Lizzie.board.setHistory(history);
+
+        assertTrue(
+            Lizzie.board.setupFixedHandicap(handicap),
+            "standard 19x19 handicap should be accepted: " + handicap);
+
+        BoardData root = Lizzie.board.getHistory().getStart().getData();
+        assertTrue(root.isSnapshotNode(), "handicap stones should live on the root snapshot.");
+        assertEquals(0, root.moveNumber, "handicap stones must not consume move numbers.");
+        assertFalse(root.blackToPlay, "White must play first after every fixed handicap.");
+        assertEquals(
+            handicap,
+            countStones(root.stones, Stone.BLACK),
+            "the root should contain every requested handicap stone.");
+        for (int[] point : expectedFixedHandicapPoints(handicap)) {
+          assertEquals(
+              Stone.BLACK,
+              root.stones[Board.getIndex(point[0], point[1])],
+              "standard handicap point should be occupied: " + point[0] + "," + point[1]);
+        }
+        assertEquals(0, countStones(root.stones, Stone.WHITE));
+        assertEquals(handicap, Lizzie.board.getHistory().getGameInfo().getHandicap());
+        assertEquals(0.5, Lizzie.board.getHistory().getGameInfo().getKomi());
+        assertFalse(
+            Lizzie.board.hasStartStone,
+            "modern root setup should not masquerade as a legacy move prefix.");
+
+        engine.recordedCommands().clear();
+        Lizzie.board.resendMoveToEngine(engine, false);
+        assertArrayEquals(
+            root.stones,
+            engine.copyStones(),
+            "engine replay should receive the same fixed handicap position.");
+        assertFalse(engine.isBlackToPlay(), "engine replay should also leave White to play.");
+      }
+    } finally {
+      env.close();
+    }
+  }
+
+  @Test
   void liveLoadNormalHandicapRootSetupKeepsWhiteToPlayAndFixedStones() throws Exception {
     TestEnvironment env = TestEnvironment.open();
     try {
@@ -4347,6 +4399,52 @@ class BoardNodeKindHistoryPipelineTest {
       stones[index] = Stone.EMPTY;
     }
     return stones;
+  }
+
+  private static int countStones(Stone[] stones, Stone expected) {
+    int count = 0;
+    for (Stone stone : stones) {
+      if (stone == expected) {
+        count++;
+      }
+    }
+    return count;
+  }
+
+  private static int[][] expectedFixedHandicapPoints(int handicap) {
+    int[][] sequence = {
+      {3, 15}, {15, 3}, {3, 3}, {15, 15}, {9, 9}, {3, 9}, {15, 9}, {9, 3}, {9, 15}
+    };
+    switch (handicap) {
+      case 2:
+        return new int[][] {sequence[0], sequence[1]};
+      case 3:
+        return new int[][] {sequence[2], sequence[1], sequence[0]};
+      case 4:
+        return new int[][] {sequence[2], sequence[0], sequence[1], sequence[3]};
+      case 5:
+        return new int[][] {sequence[2], sequence[0], sequence[1], sequence[3], sequence[4]};
+      case 6:
+        return new int[][] {
+          sequence[2], sequence[0], sequence[1], sequence[3], sequence[5], sequence[6]
+        };
+      case 7:
+        return new int[][] {
+          sequence[2], sequence[0], sequence[1], sequence[3], sequence[6], sequence[5], sequence[4]
+        };
+      case 8:
+        return new int[][] {
+          sequence[2], sequence[0], sequence[1], sequence[3], sequence[7], sequence[8], sequence[5],
+          sequence[6]
+        };
+      case 9:
+        return new int[][] {
+          sequence[2], sequence[0], sequence[1], sequence[3], sequence[7], sequence[8], sequence[5],
+          sequence[6], sequence[4]
+        };
+      default:
+        return new int[0][];
+    }
   }
 
   private static Zobrist zobrist(Stone[] stones) {


### PR DESCRIPTION
## Summary

- represents fixed handicap stones as root setup stones instead of repeated Black moves
- guarantees White is next for 2-9 stone fixed handicaps and preserves `HA/AB/PL` SGF semantics
- shares the same setup implementation across engine games and HumanSL games
- avoids mutating the current board before the engine-game dialog is confirmed

Fixes #188

## Validation

- `mvn -B -Dfmt.skip=true -Dtest=BoardNodeKindHistoryPipelineTest test` (117 tests passed)
- `mvn -B -Dfmt.skip=true test` (1815 tests passed)
- `mvn -B -Dfmt.skip=true -DskipTests package`
- real macOS Swing smoke: started and completed a two-engine, two-stone handicap game
- saved SGF verified as `HA[2] AB[dp][pd] PL[W]`