### PR TITLE
Prevent background analysis from competing with the main engine

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,29 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  windows-script-validation:
+    runs-on: windows-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Parse RTX 50 benchmark script
+        shell: pwsh
+        run: |
+          $tokens = $null
+          $errors = $null
+          [System.Management.Automation.Language.Parser]::ParseFile(
+            (Resolve-Path 'scripts/windows_rtx50_analysis_benchmark.ps1'),
+            [ref]$tokens,
+            [ref]$errors
+          ) | Out-Null
+          if ($errors.Count -gt 0) {
+            $errors | Format-List | Out-String | Write-Error
+            exit 1
+          }
+
   build:
     runs-on: ubuntu-latest
     timeout-minutes: 20

--- a/docs/PACKAGES.md
+++ b/docs/PACKAGES.md
@@ -20,6 +20,7 @@
 - TensorRT 普通用户路径仍是软件内 `KataGo 一键设置` 按需安装，支持断点续传；RTX 20/30/40/50 用户可尝试。GTX 10 系不建议 TensorRT；普通 NVIDIA 包需要 `527.41` 或更高驱动，仍启动失败时改用 OpenCL 包
 - `KataGo 一键设置` 会检测本机 NVIDIA GPU / Compute Capability，并在安装 TensorRT 前显示推荐、可尝试、不推荐或未知状态
 - TensorRT 一键安装成功后会自动清理完整下载包缓存；首次运行产生的 CUDA/TensorRT 缓存会尽量写入软件自己的 `runtime/`，减少 C 盘额外占用
+- RTX 50 / TensorRT 吞吐与功耗对比必须固定模型、配置和缓存，并使用 [RTX 50 性能验收流程](RTX50_PERFORMANCE.md) 记录真实进程、功耗、显存和 KataGo 原始指标
 - Release 可附带高级可选 TensorRT 预装分卷包，但它不是默认推荐下载；必须下载全部 `.7z.00N` 并用 7-Zip 从 `.001` 解压
 
 如果你只想先看图再决定，先看这里：

--- a/docs/RTX50_PERFORMANCE.md
+++ b/docs/RTX50_PERFORMANCE.md
@@ -1,0 +1,66 @@
+# RTX 50 / TensorRT 分析性能验收
+
+这份文档用于排查“相同 KataGo、模型和配置下，LizzieYzy Next 比旧版吞吐低或功耗低”的问题。不能只比较界面上的瞬时 visits；必须固定模型、配置、TensorRT 缓存、局面和运行时，并同时记录 KataGo 原始指标与 GPU 状态。
+
+## 本轮资源仲裁
+
+- 未启用“预加载分析引擎”时，应用启动后不再常驻第二个隐藏 KataGo。
+- 自动快速胜率曲线按需创建独立分析进程，完成后立即退出。
+- 自动快速曲线运行期间不会同时恢复主棋盘分析；曲线完成后立即恢复。
+- 用户主动开始主棋盘分析时，空闲的第二分析进程会被释放，自动后台分析会被抢占；用户明确启动的闪电分析、整盘精析等任务不会被静默终止。
+- 诊断默认关闭，不增加正常分析 I/O。启用后会记录进程用途、PID、脱敏命令、配置哈希、动态 `kata-set-param` 和主引擎 playouts/s。
+
+## 固定参数基准
+
+在 Windows PowerShell 中运行：
+
+```powershell
+powershell -ExecutionPolicy Bypass -File scripts\windows_rtx50_analysis_benchmark.ps1 `
+  -KataGoExe "D:\KataGo\katago.exe" `
+  -Model "D:\KataGo\model.bin.gz" `
+  -Config "D:\KataGo\gtp.cfg" `
+  -OutputDirectory "$env:USERPROFILE\Desktop\lizzie-rtx50-benchmark" `
+  -Runs 3 `
+  -SecondsPerMove 30 `
+  -VisitsPerPosition 5000
+```
+
+脚本会保存：
+
+- KataGo 官方 `benchmark` 的完整 stdout/stderr
+- GPU 型号、驱动、P-State、功耗、显存、GPU/显存控制器利用率
+- 每秒计算进程 PID、名称和显存
+- 模型与配置文件 SHA-256，防止比较时实际使用了不同文件
+
+`SecondsPerMove` 对应 KataGo 官方 benchmark 的 `-time` 参数，表示典型单手思考时间，不是脚本总运行时间；完整基准会测试多个局面和线程组合。
+
+## Next 运行诊断
+
+复制一份 Windows 启动器旁的 `app\LizzieYzy Next*.cfg`，只在测试副本的 `[JavaOptions]` 末尾加入：
+
+```text
+java-options=-Dlizzie.analysis.diagnostics=true
+java-options=-Dlizzie.analysis.diagnostics.path=C:\Users\Public\Documents\LizzieYzyNext\analysis-resource-diagnostics.jsonl
+```
+
+完成测试后删除这两行。诊断文件不会记录密码、token、cookie 或完整模型路径；远程连接参数会脱敏。不要把诊断开关作为日常设置长期保留。
+
+## 对比矩阵
+
+所有行必须使用同一局面、模型、配置、KataGo 二进制、已完成预热的 TensorRT 缓存和相同运行时长。
+
+| 场景 | 自动快速曲线 | 其他 KataGo 进程 | 必须记录 |
+| --- | --- | --- | --- |
+| 官方 KataGo benchmark | 不适用 | 0 | nnEvals/s、batch、功耗、显存 |
+| Next 主棋盘单引擎 | 关闭 | 0 | visits/s、功耗、显存、最终参数 |
+| Next 自动快速曲线开启 | 开启 | 曲线完成后应为 0 | 曲线期间与完成后进程数 |
+| 旧版同局面对照 | 与 Next 一致 | 明确记录 | visits/s、功耗、显存 |
+
+每个场景至少运行三次，丢弃第一次 TensorRT 建图/缓存生成的冷启动数据。RTX 5080 真机数据未完成前，不能仅凭 CI 或其他显卡结果宣称性能问题已经解决。
+
+## 结果判读
+
+- 官方 benchmark 已慢：优先检查驱动、TensorRT/CUDA 版本、模型、配置和缓存，不属于 Swing UI 开销。
+- 官方 benchmark 正常、Next 单引擎慢：检查诊断中的最终命令、配置哈希、动态参数和进程用途。
+- Next 单引擎正常、开启自动快速曲线后持续慢：检查是否仍有第二 KataGo PID；这是资源仲裁回归。
+- 首次运行慢、第二次正常：通常是 TensorRT 引擎构建或 CUDA 缓存，不应与热缓存数据混合比较。

--- a/scripts/windows_rtx50_analysis_benchmark.ps1
+++ b/scripts/windows_rtx50_analysis_benchmark.ps1
@@ -1,0 +1,147 @@
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$KataGoExe,
+
+    [Parameter(Mandatory = $true)]
+    [string]$Model,
+
+    [Parameter(Mandatory = $true)]
+    [string]$Config,
+
+    [string]$OutputDirectory = "analysis-benchmark",
+
+    [ValidateRange(1, 20)]
+    [int]$Runs = 3,
+
+    [ValidateRange(1, 600)]
+    [int]$SecondsPerMove = 30,
+
+    [ValidateRange(1, 1000000)]
+    [int]$VisitsPerPosition = 5000
+)
+
+$ErrorActionPreference = "Stop"
+
+function Resolve-RequiredPath {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Path,
+
+        [Parameter(Mandatory = $true)]
+        [string]$Label
+    )
+
+    $resolved = Resolve-Path -LiteralPath $Path -ErrorAction SilentlyContinue
+    if (-not $resolved) {
+        throw "$Label not found: $Path"
+    }
+    return $resolved.Path
+}
+
+function Save-NvidiaSnapshot {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Destination,
+
+        [Parameter(Mandatory = $true)]
+        [string]$Phase
+    )
+
+    $timestamp = (Get-Date).ToUniversalTime().ToString("o")
+    $gpu = & nvidia-smi --query-gpu=name,driver_version,pstate,power.draw,power.limit,memory.used,memory.total,utilization.gpu,utilization.memory --format=csv,noheader,nounits 2>&1
+    $processes = & nvidia-smi --query-compute-apps=pid,process_name,used_memory --format=csv,noheader,nounits 2>&1
+    [pscustomobject]@{
+        timestamp = $timestamp
+        phase = $Phase
+        gpu = (($gpu | ForEach-Object { $_.ToString() }) -join " | ")
+        processes = (($processes | ForEach-Object { $_.ToString() }) -join " | ")
+    } | ConvertTo-Json -Compress | Add-Content -LiteralPath $Destination -Encoding utf8
+}
+
+function Quote-NativeArgument {
+    param([string]$Value)
+    return '"' + ($Value -replace '"', '\"') + '"'
+}
+
+function Invoke-BenchmarkRun {
+    param(
+        [Parameter(Mandatory = $true)]
+        [int]$RunNumber,
+
+        [Parameter(Mandatory = $true)]
+        [string]$RunDirectory
+    )
+
+    New-Item -ItemType Directory -Force -Path $RunDirectory | Out-Null
+    $stdout = Join-Path $RunDirectory "katago.stdout.log"
+    $stderr = Join-Path $RunDirectory "katago.stderr.log"
+    $telemetry = Join-Path $RunDirectory "nvidia-smi.jsonl"
+    $home = Join-Path $RunDirectory "katago-home"
+    New-Item -ItemType Directory -Force -Path $home | Out-Null
+
+    $arguments = @(
+        "benchmark",
+        "-config", (Quote-NativeArgument $script:ResolvedConfig),
+        "-model", (Quote-NativeArgument $script:ResolvedModel),
+        "-v", $VisitsPerPosition.ToString(),
+        "-time", $SecondsPerMove.ToString(),
+        "-override-config", (Quote-NativeArgument "homeDataDir=$home,logToStderr=false,logAllGTPCommunication=false")
+    )
+
+    Save-NvidiaSnapshot -Destination $telemetry -Phase "before"
+    $process = Start-Process `
+        -FilePath $script:ResolvedKataGo `
+        -ArgumentList $arguments `
+        -WorkingDirectory (Split-Path -Parent $script:ResolvedKataGo) `
+        -RedirectStandardOutput $stdout `
+        -RedirectStandardError $stderr `
+        -PassThru
+
+    while (-not $process.HasExited) {
+        Save-NvidiaSnapshot -Destination $telemetry -Phase "running"
+        Start-Sleep -Seconds 1
+        $process.Refresh()
+    }
+    Save-NvidiaSnapshot -Destination $telemetry -Phase "after"
+
+    if ($process.ExitCode -ne 0) {
+        throw "KataGo benchmark run $RunNumber exited with code $($process.ExitCode). See $stderr"
+    }
+    $combined = ((Get-Content -LiteralPath $stdout -Raw -ErrorAction SilentlyContinue) + "`n" +
+        (Get-Content -LiteralPath $stderr -Raw -ErrorAction SilentlyContinue))
+    if ($combined -notmatch "KataGo v|numSearchThreads|nnEvals") {
+        throw "Benchmark run $RunNumber did not produce expected KataGo metrics."
+    }
+}
+
+$ResolvedKataGo = Resolve-RequiredPath -Path $KataGoExe -Label "KataGo executable"
+$ResolvedModel = Resolve-RequiredPath -Path $Model -Label "KataGo model"
+$ResolvedConfig = Resolve-RequiredPath -Path $Config -Label "KataGo config"
+
+if (-not (Get-Command nvidia-smi -ErrorAction SilentlyContinue)) {
+    throw "nvidia-smi was not found. Install or repair the NVIDIA driver first."
+}
+
+$OutputDirectory = [System.IO.Path]::GetFullPath($OutputDirectory)
+New-Item -ItemType Directory -Force -Path $OutputDirectory | Out-Null
+
+$system = [pscustomobject]@{
+    timestamp = (Get-Date).ToUniversalTime().ToString("o")
+    computer = $env:COMPUTERNAME
+    os = [System.Environment]::OSVersion.VersionString
+    powershell = $PSVersionTable.PSVersion.ToString()
+    katago = (Split-Path -Leaf $ResolvedKataGo)
+    model = (Split-Path -Leaf $ResolvedModel)
+    config = (Split-Path -Leaf $ResolvedConfig)
+    modelSha256 = (Get-FileHash -Algorithm SHA256 -LiteralPath $ResolvedModel).Hash.ToLowerInvariant()
+    configSha256 = (Get-FileHash -Algorithm SHA256 -LiteralPath $ResolvedConfig).Hash.ToLowerInvariant()
+}
+$system | ConvertTo-Json -Depth 3 | Set-Content -LiteralPath (Join-Path $OutputDirectory "system.json") -Encoding utf8
+
+for ($run = 1; $run -le $Runs; $run++) {
+    Write-Host "Running fixed KataGo benchmark $run/$Runs..."
+    Invoke-BenchmarkRun -RunNumber $run -RunDirectory (Join-Path $OutputDirectory ("run-{0:D2}" -f $run))
+}
+
+Write-Host "Benchmark complete: $OutputDirectory"
+Write-Host "Keep this directory together with LizzieYzy Next analysis-resource-diagnostics.jsonl."

--- a/src/main/java/featurecat/lizzie/Lizzie.java
+++ b/src/main/java/featurecat/lizzie/Lizzie.java
@@ -802,8 +802,6 @@ public class Lizzie {
             }
             if (Lizzie.config.analysisEnginePreLoad) {
               frame.preloadConfiguredAnalysisEngineAfterStartup();
-            } else {
-              frame.scheduleQuickAnalysisEngineWarmupAfterStartup();
             }
             KataGoRuntimeHelper.startAppleSiliconAutoOptimizationAsync();
             KataGoRuntimeHelper.startFirstRunBenchmarkAsync();

--- a/src/main/java/featurecat/lizzie/analysis/AnalysisEngine.java
+++ b/src/main/java/featurecat/lizzie/analysis/AnalysisEngine.java
@@ -125,6 +125,8 @@ public class AnalysisEngine {
   private Map<BoardHistoryNode, WholeGameAnalysisPlan.PositionFingerprint>
       requestPositionFingerprints;
   private final Workload workload;
+  private final AnalysisResourceCoordinator.Purpose purpose;
+  private final boolean persistentPreload;
   private ArrayDeque<RemoteGtpAnalyzeJob> remoteGtpQueue;
   private RemoteGtpAnalyzeJob remoteGtpActiveJob;
   private boolean remoteGtpWaitingForStopAck;
@@ -161,13 +163,51 @@ public class AnalysisEngine {
   private Leelaz.ExclusiveGtpLeaseAvailability foregroundLeaseAvailability;
 
   public AnalysisEngine(boolean isPreLoad) throws IOException {
-    this(isPreLoad, Workload.STANDARD, -1);
+    this(
+        isPreLoad,
+        Workload.STANDARD,
+        -1,
+        isPreLoad
+            ? AnalysisResourceCoordinator.Purpose.PRELOADED_QUICK_ANALYSIS
+            : AnalysisResourceCoordinator.Purpose.USER_QUICK_ANALYSIS,
+        isPreLoad);
   }
 
   public AnalysisEngine(boolean isPreLoad, Workload workload, int requestedMaxVisits)
       throws IOException {
+    this(
+        isPreLoad,
+        workload,
+        requestedMaxVisits,
+        workload == Workload.WHOLE_GAME
+            ? AnalysisResourceCoordinator.Purpose.WHOLE_GAME_ANALYSIS
+            : (isPreLoad
+                ? AnalysisResourceCoordinator.Purpose.PRELOADED_QUICK_ANALYSIS
+                : AnalysisResourceCoordinator.Purpose.USER_QUICK_ANALYSIS),
+        isPreLoad);
+  }
+
+  public static AnalysisEngine createAutomaticQuickAnalysis() throws IOException {
+    return new AnalysisEngine(
+        true,
+        Workload.STANDARD,
+        -1,
+        AnalysisResourceCoordinator.Purpose.AUTO_QUICK_ANALYSIS,
+        false);
+  }
+
+  private AnalysisEngine(
+      boolean isPreLoad,
+      Workload workload,
+      int requestedMaxVisits,
+      AnalysisResourceCoordinator.Purpose purpose,
+      boolean persistentPreload)
+      throws IOException {
     this.isPreLoad = isPreLoad;
     this.workload = workload == null ? Workload.STANDARD : workload;
+    this.purpose =
+        purpose == null ? AnalysisResourceCoordinator.Purpose.OTHER : purpose;
+    this.persistentPreload = persistentPreload;
     if (Lizzie.config.analysisReuseCurrentEngine) {
       useRemoteCompute = true;
       sharedForegroundEngine = Lizzie.leelaz;
@@ -298,6 +338,7 @@ public class AnalysisEngine {
     executorErr = Executors.newSingleThreadScheduledExecutor();
     executorErr.execute(this::readError);
     isNormalEnd = false;
+    AnalysisResourceCoordinator.processStarted(this, purpose, engineCommand, process);
   }
 
   private void showErrMsg(String errMsg) {
@@ -965,9 +1006,10 @@ public class AnalysisEngine {
               == Lizzie.board.getHistory().getStart()) Lizzie.board.nextMove(true);
       Lizzie.frame.refresh();
       Lizzie.frame.requestProblemListRefresh();
-      boolean shouldKeepAlive = isPreLoad || keepAliveAfterCurrentRequest;
+      boolean shouldKeepAlive =
+          !isAutomaticBackgroundTask() && (persistentPreload || keepAliveAfterCurrentRequest);
       keepAliveAfterCurrentRequest = false;
-      if (Lizzie.config.analysisAutoQuit
+      if ((Lizzie.config.analysisAutoQuit || isAutomaticBackgroundTask())
           && !Lizzie.frame.isBatchAna
           && !shouldKeepAlive
           && sharedForegroundEngine == null) {
@@ -977,8 +1019,7 @@ public class AnalysisEngine {
       if (Lizzie.config.analysisAlwaysOverride && !preserveExistingAnalysis)
         Lizzie.config.enableLizzieCache = oriEnableLizzieCache;
     }
-    if (sharedForegroundEngine == null && shouldRePonder && !Lizzie.leelaz.isPondering())
-      Lizzie.leelaz.togglePonder();
+    resumeForegroundAnalysisIfRequested();
     Lizzie.frame.renderVarTree(0, 0, false, false);
     Runnable finishSuccessfulRequest =
         () -> {
@@ -997,6 +1038,7 @@ public class AnalysisEngine {
     // TODO Auto-generated method stub
     requestShutdown();
     isNormalEnd = true;
+    AnalysisResourceCoordinator.processStopped(this, purpose, process);
     shutdownRemoteGtpSetupAckTimeoutExecutor();
     if (sharedForegroundEngine != null) {
       requestDispatchFailed = true;
@@ -1257,9 +1299,7 @@ public class AnalysisEngine {
     if (dispatchFailed) {
       return -1;
     }
-    if (requestCount == 0 && shouldRePonder && !Lizzie.leelaz.isPondering()) {
-      Lizzie.leelaz.togglePonder();
-    }
+    if (requestCount == 0) resumeForegroundAnalysisIfRequested();
     return requestCount;
   }
 
@@ -1425,10 +1465,38 @@ public class AnalysisEngine {
     requestRulesSignature = null;
     requestPositionFingerprints().clear();
     if (!showProgressDialog) waitFrame = null;
-    if (sharedForegroundEngine == null && showProgressDialog && Lizzie.leelaz.isPondering()) {
-      Lizzie.leelaz.togglePonder();
-      shouldRePonder = true;
-    } else shouldRePonder = false;
+    pauseForegroundAnalysisForRequest(showProgressDialog);
+  }
+
+  static boolean shouldPauseForegroundAnalysisForRequest(
+      boolean sharedForegroundEngine, boolean showProgressDialog, boolean automaticBackgroundTask) {
+    return !sharedForegroundEngine && (showProgressDialog || automaticBackgroundTask);
+  }
+
+  private void pauseForegroundAnalysisForRequest(boolean showProgressDialog) {
+    shouldRePonder = false;
+    if (Lizzie.leelaz == null
+        || !shouldPauseForegroundAnalysisForRequest(
+            sharedForegroundEngine != null, showProgressDialog, isAutomaticBackgroundTask())
+        || !Lizzie.leelaz.isPondering()) {
+      return;
+    }
+    Lizzie.leelaz.notPondering();
+    Lizzie.leelaz.nameCmd();
+    AnalysisResourceCoordinator.foregroundPausedForAuxiliary(Lizzie.leelaz, purpose());
+    // Automatic requests resume through their completion/failure callback after results are stored.
+    shouldRePonder = !isAutomaticBackgroundTask();
+  }
+
+  private void resumeForegroundAnalysisIfRequested() {
+    if (sharedForegroundEngine != null
+        || !shouldRePonder
+        || Lizzie.leelaz == null
+        || Lizzie.leelaz.isPondering()) {
+      return;
+    }
+    shouldRePonder = false;
+    Lizzie.leelaz.ponder();
   }
 
   private void showRequestProgressOrContinueBatch(boolean showProgressDialog) {
@@ -1480,7 +1548,7 @@ public class AnalysisEngine {
             ? null
             : () -> javax.swing.SwingUtilities.invokeLater(failedRequestCallback);
     boolean restorePending = releaseSharedForegroundLease(deliverFailure, deliverFailure);
-    if (shouldRePonder && !Lizzie.leelaz.isPondering()) Lizzie.leelaz.togglePonder();
+    resumeForegroundAnalysisIfRequested();
     if (Lizzie.frame.isBatchAnalysisMode) Lizzie.frame.isBatchAnalysisMode = false;
     if (waitFrame != null || showProgressDialog) {
       javax.swing.SwingUtilities.invokeLater(
@@ -2310,6 +2378,22 @@ public class AnalysisEngine {
     return sharedForegroundEngine != null;
   }
 
+  public AnalysisResourceCoordinator.Purpose purpose() {
+    return purpose == null ? AnalysisResourceCoordinator.Purpose.OTHER : purpose;
+  }
+
+  public boolean isAutomaticBackgroundTask() {
+    return purpose() == AnalysisResourceCoordinator.Purpose.AUTO_QUICK_ANALYSIS;
+  }
+
+  public boolean isLocalDedicatedProcess() {
+    return sharedForegroundEngine == null
+        && !useJavaSSH
+        && !useRemoteCompute
+        && process != null
+        && process.isAlive();
+  }
+
   private enum ForegroundRequestKind {
     MAINLINE,
     ALL_BRANCHES,
@@ -2496,6 +2580,7 @@ public class AnalysisEngine {
   }
 
   public boolean sendCommand(String command) {
+    AnalysisResourceCoordinator.commandSent(this, purpose, command);
     if (sharedForegroundEngine != null) {
       return sharedForegroundEngine.sendExclusiveGtpCommand(command);
     }

--- a/src/main/java/featurecat/lizzie/analysis/AnalysisResourceCoordinator.java
+++ b/src/main/java/featurecat/lizzie/analysis/AnalysisResourceCoordinator.java
@@ -1,0 +1,370 @@
+package featurecat.lizzie.analysis;
+
+import featurecat.lizzie.Lizzie;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.json.JSONObject;
+
+/** Coordinates foreground and auxiliary KataGo processes and emits opt-in diagnostics. */
+public final class AnalysisResourceCoordinator {
+  public enum Purpose {
+    MAIN_BOARD,
+    AUTO_QUICK_ANALYSIS,
+    PRELOADED_QUICK_ANALYSIS,
+    USER_QUICK_ANALYSIS,
+    WHOLE_GAME_ANALYSIS,
+    OTHER
+  }
+
+  public enum ForegroundDecision {
+    NONE,
+    RELEASE_IDLE_SECONDARY,
+    PREEMPT_AUTOMATIC_SECONDARY,
+    KEEP_USER_TASK,
+    SHARED_ENGINE
+  }
+
+  private static final String DIAGNOSTICS_PROPERTY = "lizzie.analysis.diagnostics";
+  private static final String DIAGNOSTICS_PATH_PROPERTY = "lizzie.analysis.diagnostics.path";
+  private static final Pattern SENSITIVE_ARGUMENT =
+      Pattern.compile(
+          "(?i)(password|passwd|token|secret|authorization|session|cookie)(\\s*[=:]\\s*|\\s+)([^\\s]+)");
+  private static final Pattern URL_SECRET =
+      Pattern.compile(
+          "(?i)([?&](?:token|key|secret|password|session)=)[^&\\s]+", Pattern.CASE_INSENSITIVE);
+  private static final Pattern SET_PARAM =
+      Pattern.compile("^\\s*kata-set-param\\s+([^\\s]+)\\s+(.+?)\\s*$", Pattern.CASE_INSENSITIVE);
+  private static final Pattern FILE_OPTION =
+      Pattern.compile("(?i)(?<!\\S)(-{1,2}(?:model|config)\\s+)(\\\"[^\\\"]*\\\"|'[^']*'|[^\\s]+)");
+  private static final Pattern HOME_DATA_DIR = Pattern.compile("(?i)(homeDataDir=)([^,\\s]+)");
+  private static final Pattern LEADING_EXECUTABLE =
+      Pattern.compile("^(\\s*)(\\\"[^\\\"]*\\\"|'[^']*'|[^\\s]+)");
+  private static final Object DIAGNOSTIC_LOCK = new Object();
+  private static final Map<Object, Sample> FOREGROUND_SAMPLES = new java.util.WeakHashMap<>();
+  private static final Map<Object, Long> REGISTERED_PROCESSES = new java.util.WeakHashMap<>();
+
+  private AnalysisResourceCoordinator() {}
+
+  public static ForegroundDecision decideForegroundStart(
+      boolean sharedEngine,
+      boolean localDedicatedProcess,
+      boolean analysisInProgress,
+      boolean automaticBackgroundTask) {
+    if (sharedEngine) {
+      return ForegroundDecision.SHARED_ENGINE;
+    }
+    if (!localDedicatedProcess) {
+      return ForegroundDecision.NONE;
+    }
+    if (!analysisInProgress) {
+      return ForegroundDecision.RELEASE_IDLE_SECONDARY;
+    }
+    if (automaticBackgroundTask) {
+      return ForegroundDecision.PREEMPT_AUTOMATIC_SECONDARY;
+    }
+    return ForegroundDecision.KEEP_USER_TASK;
+  }
+
+  public static void processStarted(
+      Object owner, Purpose purpose, String command, Process process) {
+    if (!diagnosticsEnabled()) {
+      return;
+    }
+    long pid = processId(process);
+    synchronized (REGISTERED_PROCESSES) {
+      Long registered = REGISTERED_PROCESSES.get(owner);
+      if (registered != null && registered.longValue() == pid) {
+        return;
+      }
+      REGISTERED_PROCESSES.put(owner, pid);
+    }
+    JSONObject details = processDetails(owner, purpose, command, process);
+    Path config = commandPath(command, "-config");
+    Path model = commandPath(command, "-model");
+    details.put("config", config == null ? JSONObject.NULL : diagnosticFileName(config.toString()));
+    details.put("configSha256", fileSha256(config));
+    details.put("model", model == null ? JSONObject.NULL : model.getFileName().toString());
+    appendEvent("process-started", details);
+  }
+
+  public static void processStopped(Object owner, Purpose purpose, Process process) {
+    if (!diagnosticsEnabled()) {
+      return;
+    }
+    synchronized (REGISTERED_PROCESSES) {
+      if (REGISTERED_PROCESSES.remove(owner) == null) {
+        return;
+      }
+    }
+    JSONObject details = new JSONObject();
+    details.put("owner", ownerId(owner));
+    details.put("purpose", normalizedPurpose(purpose).name());
+    details.put("pid", processId(process));
+    appendEvent("process-stopped", details);
+    synchronized (FOREGROUND_SAMPLES) {
+      FOREGROUND_SAMPLES.remove(owner);
+    }
+  }
+
+  public static void commandSent(Object owner, Purpose purpose, String command) {
+    if (!diagnosticsEnabled() || command == null) {
+      return;
+    }
+    Matcher matcher = SET_PARAM.matcher(command);
+    if (!matcher.matches() && !command.trim().toLowerCase(Locale.ROOT).startsWith("kata-analyze")) {
+      return;
+    }
+    JSONObject details = new JSONObject();
+    details.put("owner", ownerId(owner));
+    details.put("purpose", normalizedPurpose(purpose).name());
+    if (matcher.matches()) {
+      details.put("parameter", matcher.group(1));
+      details.put("value", redactCommand(matcher.group(2)));
+      appendEvent("dynamic-parameter", details);
+    } else {
+      details.put("command", redactCommand(command));
+      appendEvent("analysis-started", details);
+    }
+  }
+
+  public static void foregroundPausedForAuxiliary(
+      Object foregroundOwner, Purpose auxiliaryPurpose) {
+    if (!diagnosticsEnabled()) {
+      return;
+    }
+    JSONObject details = new JSONObject();
+    details.put("foregroundOwner", ownerId(foregroundOwner));
+    details.put("auxiliaryPurpose", normalizedPurpose(auxiliaryPurpose).name());
+    appendEvent("foreground-paused", details);
+  }
+
+  public static void foregroundPlayoutSample(Object owner, int playouts) {
+    if (!diagnosticsEnabled() || owner == null || playouts < 0) {
+      return;
+    }
+    long now = System.nanoTime();
+    Sample previous;
+    synchronized (FOREGROUND_SAMPLES) {
+      previous = FOREGROUND_SAMPLES.get(owner);
+      if (previous == null || playouts <= previous.playouts) {
+        FOREGROUND_SAMPLES.put(owner, new Sample(playouts, now));
+        return;
+      }
+      if (now - previous.nanoTime < 250_000_000L) {
+        return;
+      }
+      FOREGROUND_SAMPLES.put(owner, new Sample(playouts, now));
+    }
+    double elapsedSeconds = elapsedSeconds(previous.nanoTime, now);
+    JSONObject details = new JSONObject();
+    details.put("owner", ownerId(owner));
+    details.put("purpose", Purpose.MAIN_BOARD.name());
+    details.put("playouts", playouts);
+    details.put("playoutsPerSecond", (playouts - previous.playouts) / elapsedSeconds);
+    appendEvent("foreground-throughput", details);
+  }
+
+  static double elapsedSeconds(long previousNanoTime, long currentNanoTime) {
+    return Math.max(0L, currentNanoTime - previousNanoTime) / 1_000_000_000.0;
+  }
+
+  static String redactCommand(String command) {
+    if (command == null) {
+      return "";
+    }
+    String redacted = SENSITIVE_ARGUMENT.matcher(command).replaceAll("$1$2<redacted>");
+    return URL_SECRET.matcher(redacted).replaceAll("$1<redacted>");
+  }
+
+  static String diagnosticCommand(String command) {
+    String redacted = redactCommand(command);
+    Matcher fileOptions = FILE_OPTION.matcher(redacted);
+    StringBuffer sanitized = new StringBuffer();
+    while (fileOptions.find()) {
+      fileOptions.appendReplacement(
+          sanitized,
+          Matcher.quoteReplacement(
+              fileOptions.group(1) + diagnosticFileName(unquote(fileOptions.group(2)))));
+    }
+    fileOptions.appendTail(sanitized);
+    String withoutHome = HOME_DATA_DIR.matcher(sanitized.toString()).replaceAll("$1<local-path>");
+    Matcher executable = LEADING_EXECUTABLE.matcher(withoutHome);
+    if (!executable.find()) {
+      return withoutHome;
+    }
+    String firstToken = unquote(executable.group(2));
+    if (!looksLikeLocalPath(firstToken)) {
+      return withoutHome;
+    }
+    return executable.replaceFirst(
+        Matcher.quoteReplacement(executable.group(1) + diagnosticFileName(firstToken)));
+  }
+
+  static Map<String, String> parseDynamicParameters(Iterable<String> commands) {
+    Map<String, String> parameters = new LinkedHashMap<>();
+    if (commands == null) {
+      return parameters;
+    }
+    for (String command : commands) {
+      Matcher matcher = SET_PARAM.matcher(command == null ? "" : command);
+      if (matcher.matches()) {
+        parameters.put(matcher.group(1), redactCommand(matcher.group(2)));
+      }
+    }
+    return parameters;
+  }
+
+  static String fileSha256(Path path) {
+    if (path == null || !Files.isRegularFile(path)) {
+      return "";
+    }
+    try {
+      MessageDigest digest = MessageDigest.getInstance("SHA-256");
+      byte[] buffer = new byte[64 * 1024];
+      try (java.io.InputStream input = Files.newInputStream(path)) {
+        int read;
+        while ((read = input.read(buffer)) >= 0) {
+          digest.update(buffer, 0, read);
+        }
+      }
+      StringBuilder hash = new StringBuilder();
+      for (byte value : digest.digest()) {
+        hash.append(String.format(Locale.ROOT, "%02x", value));
+      }
+      return hash.toString();
+    } catch (IOException | NoSuchAlgorithmException e) {
+      return "";
+    }
+  }
+
+  private static JSONObject processDetails(
+      Object owner, Purpose purpose, String command, Process process) {
+    JSONObject details = new JSONObject();
+    details.put("owner", ownerId(owner));
+    details.put("purpose", normalizedPurpose(purpose).name());
+    details.put("pid", processId(process));
+    details.put("command", diagnosticCommand(command));
+    return details;
+  }
+
+  private static Purpose normalizedPurpose(Purpose purpose) {
+    return purpose == null ? Purpose.OTHER : purpose;
+  }
+
+  private static String ownerId(Object owner) {
+    return owner == null
+        ? "unknown"
+        : owner.getClass().getSimpleName()
+            + "@"
+            + Integer.toHexString(System.identityHashCode(owner));
+  }
+
+  private static long processId(Process process) {
+    try {
+      return process == null ? -1L : process.pid();
+    } catch (UnsupportedOperationException e) {
+      return -1L;
+    }
+  }
+
+  private static boolean looksLikeLocalPath(String value) {
+    return value != null
+        && (value.contains("/") || value.contains("\\") || value.matches("^[A-Za-z]:.*"));
+  }
+
+  private static String diagnosticFileName(String value) {
+    if (value == null || value.isEmpty()) {
+      return "";
+    }
+    String normalized = value.replace('\\', '/');
+    int separator = normalized.lastIndexOf('/');
+    return separator >= 0 ? normalized.substring(separator + 1) : normalized;
+  }
+
+  private static String unquote(String value) {
+    if (value == null || value.length() < 2) {
+      return value == null ? "" : value;
+    }
+    char first = value.charAt(0);
+    char last = value.charAt(value.length() - 1);
+    return (first == last && (first == '\"' || first == '\''))
+        ? value.substring(1, value.length() - 1)
+        : value;
+  }
+
+  private static Path commandPath(String command, String option) {
+    if (command == null || option == null) {
+      return null;
+    }
+    java.util.List<String> parts = featurecat.lizzie.util.Utils.splitCommand(command);
+    for (int i = 0; i + 1 < parts.size(); i++) {
+      if (option.equalsIgnoreCase(parts.get(i))) {
+        try {
+          Path path = Path.of(parts.get(i + 1));
+          return path.isAbsolute() ? path.normalize() : Path.of(".").resolve(path).normalize();
+        } catch (RuntimeException e) {
+          return null;
+        }
+      }
+    }
+    return null;
+  }
+
+  private static boolean diagnosticsEnabled() {
+    return Boolean.getBoolean(DIAGNOSTICS_PROPERTY);
+  }
+
+  private static Path diagnosticsPath() {
+    String configured = System.getProperty(DIAGNOSTICS_PATH_PROPERTY, "").trim();
+    if (!configured.isEmpty()) {
+      return Path.of(configured).toAbsolutePath().normalize();
+    }
+    Path workDirectory =
+        Lizzie.config != null
+            ? Lizzie.config.getWorkDirectory().toPath()
+            : Path.of(System.getProperty("user.dir", "."));
+    return workDirectory.resolve("analysis_logs").resolve("analysis-resource-diagnostics.jsonl");
+  }
+
+  private static void appendEvent(String event, JSONObject details) {
+    JSONObject line = new JSONObject();
+    line.put("timestamp", Instant.now().toString());
+    line.put("event", event);
+    line.put("details", details == null ? new JSONObject() : details);
+    synchronized (DIAGNOSTIC_LOCK) {
+      try {
+        Path output = diagnosticsPath();
+        Files.createDirectories(output.getParent());
+        Files.writeString(
+            output,
+            line.toString() + System.lineSeparator(),
+            StandardCharsets.UTF_8,
+            StandardOpenOption.CREATE,
+            StandardOpenOption.APPEND);
+      } catch (IOException | RuntimeException e) {
+        // Diagnostics must never affect analysis availability.
+      }
+    }
+  }
+
+  private static final class Sample {
+    private final int playouts;
+    private final long nanoTime;
+
+    private Sample(int playouts, long nanoTime) {
+      this.playouts = playouts;
+      this.nanoTime = nanoTime;
+    }
+  }
+}

--- a/src/main/java/featurecat/lizzie/analysis/Leelaz.java
+++ b/src/main/java/featurecat/lizzie/analysis/Leelaz.java
@@ -1179,6 +1179,8 @@ public class Leelaz {
   }
 
   public void forceQuit() {
+    AnalysisResourceCoordinator.processStopped(
+        this, AnalysisResourceCoordinator.Purpose.MAIN_BOARD, process);
     isNormalEnd = true;
     started = false;
     isLoaded = false;
@@ -1747,6 +1749,9 @@ public class Leelaz {
       }
     }
     currentTotalPlayouts = MoveData.getPlayouts(bestMoves);
+    if (this == Lizzie.leelaz) {
+      AnalysisResourceCoordinator.foregroundPlayoutSample(this, currentTotalPlayouts);
+    }
     ArrayList<Double> estimateArray = new ArrayList<Double>();
     if (Lizzie.config.showKataGoEstimate) {
       if (hasOwnership && lineInfo != null && lineInfo.length > 1) {
@@ -4217,6 +4222,10 @@ public class Leelaz {
   }
 
   public void sendCommand(String command) {
+    if (this == Lizzie.leelaz) {
+      AnalysisResourceCoordinator.commandSent(
+          this, AnalysisResourceCoordinator.Purpose.MAIN_BOARD, command);
+    }
     if (command != null
         && (command.startsWith("clear_board") || command.startsWith("kata-analyze"))) {
       StringBuilder sb = new StringBuilder();
@@ -10091,6 +10100,8 @@ public class Leelaz {
       return;
     }
     if (this == Lizzie.leelaz && Lizzie.frame != null) {
+      AnalysisResourceCoordinator.processStarted(
+          this, AnalysisResourceCoordinator.Purpose.MAIN_BOARD, engineCommand, process);
       Lizzie.frame.onMainEnginePonder();
     }
     if (Lizzie.frame.isKeepingForce || LizzieFrame.isKeepForcing) {
@@ -10245,6 +10256,8 @@ public class Leelaz {
 
   /** End the process */
   public void shutdown() {
+    AnalysisResourceCoordinator.processStopped(
+        this, AnalysisResourceCoordinator.Purpose.MAIN_BOARD, process);
     cancelPositionEstimateRequest();
     leela0110StopPonder();
     if (this.useJavaSSH) {

--- a/src/main/java/featurecat/lizzie/gui/LizzieFrame.java
+++ b/src/main/java/featurecat/lizzie/gui/LizzieFrame.java
@@ -11,6 +11,7 @@ import featurecat.lizzie.EngineStartupStatus;
 import featurecat.lizzie.ExtraMode;
 import featurecat.lizzie.Lizzie;
 import featurecat.lizzie.analysis.AnalysisEngine;
+import featurecat.lizzie.analysis.AnalysisResourceCoordinator;
 import featurecat.lizzie.analysis.CaptureTsumeGo;
 import featurecat.lizzie.analysis.ContributeEngine;
 import featurecat.lizzie.analysis.EngineManager;
@@ -14318,11 +14319,41 @@ public class LizzieFrame extends JFrame {
   }
 
   public void onMainEnginePonder() {
+    releaseSecondaryAnalysisResourcesForForeground();
     TrackingAnalysisController controller = trackingAnalysisController;
     if (controller == null) {
       return;
     }
     controller.contextChanged(currentTrackingContext());
+  }
+
+  AnalysisResourceCoordinator.ForegroundDecision releaseSecondaryAnalysisResourcesForForeground() {
+    if (quickAnalysisEngineGeneration != null) {
+      quickAnalysisEngineGeneration.incrementAndGet();
+    }
+    stopQuickAnalysisWarmupTimer();
+    stopQuickAnalysisNavigationResumeTimer();
+    stopLoadedGameQuickAnalysisRetry();
+    if (pendingQuickAnalysisCallbacks != null) {
+      synchronized (pendingQuickAnalysisCallbacks) {
+        pendingQuickAnalysisCallbacks.clear();
+      }
+    }
+    AnalysisEngine secondary = analysisEngine;
+    AnalysisResourceCoordinator.ForegroundDecision decision =
+        AnalysisResourceCoordinator.decideForegroundStart(
+            secondary != null && secondary.usesSharedForegroundEngine(),
+            secondary != null && secondary.isLocalDedicatedProcess(),
+            secondary != null && secondary.isAnalysisInProgress(),
+            secondary != null && secondary.isAutomaticBackgroundTask());
+    if (decision == AnalysisResourceCoordinator.ForegroundDecision.RELEASE_IDLE_SECONDARY
+        || decision
+            == AnalysisResourceCoordinator.ForegroundDecision.PREEMPT_AUTOMATIC_SECONDARY) {
+      analysisEngine = null;
+      secondary.clearRequestCallbacks();
+      secondary.normalQuit();
+    }
+    return decision;
   }
 
   public void flashAnalyzeGameBatch(int firstMove, int lastMove, boolean isAllBranches) {
@@ -14501,10 +14532,12 @@ public class LizzieFrame extends JFrame {
         new Runnable() {
           public void run() {
             if (!isAnalysisEngineReusable(analysisEngine)) {
+              resumeForegroundAnalysisAfterQuickAnalysisComplete();
               return;
             }
-            analysisEngine.setKeepAliveAfterCurrentRequest(true);
             analysisEngine.setCompletionCallback(
+                LizzieFrame.this::resumeForegroundAnalysisAfterQuickAnalysisComplete);
+            analysisEngine.setFailureCallback(
                 LizzieFrame.this::resumeForegroundAnalysisAfterQuickAnalysisComplete);
             startFlashAnalyzeRequestsInBackground(analysisEngine, isAllGame, isAllBranches, true);
           }
@@ -14513,7 +14546,7 @@ public class LizzieFrame extends JFrame {
       startRequests.run();
       return;
     }
-    ensureQuickAnalysisEngineAsync(startRequests);
+    ensureQuickAnalysisEngineAsync(startRequests, false);
   }
 
   private void stopBusyQuickAnalysisEngineBeforeLoadedKifuAnalysis() {
@@ -18589,7 +18622,6 @@ public class LizzieFrame extends JFrame {
       }
       flashAnalyzeGame(true, false, true);
       scheduleLoadedGameQuickAnalysisRetry();
-      resumeForegroundAnalysisForCurrentPosition();
       return true;
     }
     stopLoadedGameQuickAnalysisRetry();
@@ -18611,7 +18643,6 @@ public class LizzieFrame extends JFrame {
         return resumeForegroundAnalysisForCurrentPosition();
       }
       flashAnalyzeGame(true, false, true);
-      resumeForegroundAnalysisForCurrentPosition();
       return true;
     }
     return ensureAnalysisResumedAfterLoad();
@@ -18690,7 +18721,6 @@ public class LizzieFrame extends JFrame {
     if (forceFullAnalysis) {
       stopLoadedGameQuickAnalysisRetry();
       flashAnalyzeGame(true, false, true);
-      resumeForegroundAnalysisForCurrentPosition();
       return;
     }
     if (++quickAnalysisLoadRetryCount > 3) {
@@ -18698,7 +18728,6 @@ public class LizzieFrame extends JFrame {
       return;
     }
     flashAnalyzeGame(true, false, true);
-    resumeForegroundAnalysisForCurrentPosition();
   }
 
   private void stopLoadedGameQuickAnalysisRetry() {
@@ -18714,13 +18743,16 @@ public class LizzieFrame extends JFrame {
       SwingUtilities.invokeLater(this::preloadQuickAnalysisEngineForKifuBrowsing);
       return;
     }
-    switch (currentQuickAnalysisWarmupAction(true)) {
+    if (Lizzie.config == null || !Lizzie.config.analysisEnginePreLoad) {
+      return;
+    }
+    switch (currentQuickAnalysisWarmupAction(false)) {
       case START:
         stopQuickAnalysisWarmupTimer();
-        ensureQuickAnalysisEngineAsync(null);
+        ensureQuickAnalysisEngineAsync(null, true);
         break;
       case WAIT_FOR_PRIMARY:
-        scheduleQuickAnalysisWarmupWhenPrimaryReady(0, true);
+        scheduleQuickAnalysisWarmupWhenPrimaryReady(0, false);
         break;
       case STOP:
         stopQuickAnalysisWarmupTimer();
@@ -18733,12 +18765,8 @@ public class LizzieFrame extends JFrame {
       SwingUtilities.invokeLater(this::scheduleQuickAnalysisEngineWarmupAfterStartup);
       return;
     }
-    if (Lizzie.config == null
-        || Lizzie.config.analysisEnginePreLoad
-        || !Lizzie.config.autoQuickAnalyzeOnLoad) {
-      return;
-    }
-    scheduleQuickAnalysisWarmupWhenPrimaryReady(1200, true);
+    // Automatic curve analysis is created on demand. Keeping a hidden KataGo resident here
+    // competes with the foreground engine for GPU memory and batch throughput.
   }
 
   /** Starts the configured analysis engine without delaying the first interactive frame. */
@@ -18765,7 +18793,7 @@ public class LizzieFrame extends JFrame {
     switch (currentQuickAnalysisWarmupAction(quickAnalysisWarmupRequiresAutoAnalyze)) {
       case START:
         stopQuickAnalysisWarmupTimer();
-        ensureQuickAnalysisEngineAsync(null);
+        ensureQuickAnalysisEngineAsync(null, !quickAnalysisWarmupRequiresAutoAnalyze);
         break;
       case WAIT_FOR_PRIMARY:
         break;
@@ -18893,7 +18921,7 @@ public class LizzieFrame extends JFrame {
     STOP
   }
 
-  private void ensureQuickAnalysisEngineAsync(Runnable onReady) {
+  private void ensureQuickAnalysisEngineAsync(Runnable onReady, boolean persistentPreload) {
     if (isAnalysisEngineReusable(analysisEngine)) {
       if (onReady != null) {
         SwingUtilities.invokeLater(onReady);
@@ -18915,7 +18943,10 @@ public class LizzieFrame extends JFrame {
               public void run() {
                 AnalysisEngine newAnalysisEngine = null;
                 try {
-                  newAnalysisEngine = new AnalysisEngine(true);
+                  newAnalysisEngine =
+                      persistentPreload
+                          ? new AnalysisEngine(true)
+                          : AnalysisEngine.createAutomaticQuickAnalysis();
                 } catch (IOException e) {
                   e.printStackTrace();
                 }
@@ -19053,7 +19084,6 @@ public class LizzieFrame extends JFrame {
             if (!isAnalysisEngineReusable(analysisEngine)) {
               return;
             }
-            analysisEngine.setKeepAliveAfterCurrentRequest(true);
             analysisEngine.setCompletionCallback(
                 LizzieFrame.this::resumeForegroundAnalysisAfterQuickAnalysisComplete);
             analysisEngine.setFailureCallback(
@@ -19070,7 +19100,7 @@ public class LizzieFrame extends JFrame {
     if (isAnalysisEngineReusable(analysisEngine)) {
       continueMissingMainline.run();
     } else {
-      ensureQuickAnalysisEngineAsync(continueMissingMainline);
+      ensureQuickAnalysisEngineAsync(continueMissingMainline, false);
     }
   }
 
@@ -19104,6 +19134,11 @@ public class LizzieFrame extends JFrame {
         && analysisEngine.usesSharedForegroundEngine()
         && analysisEngine.matchesCurrentAnalysisBackend()) {
       return;
+    }
+    if (analysisEngine != null
+        && analysisEngine.isAutomaticBackgroundTask()
+        && !analysisEngine.isRunning()) {
+      analysisEngine = null;
     }
     if (EngineManager.isEngineGame() || isPlayingAgainstLeelaz || isAnaPlayingAgainstLeelaz) {
       return;

--- a/src/test/java/featurecat/lizzie/analysis/AnalysisEngineRequestTest.java
+++ b/src/test/java/featurecat/lizzie/analysis/AnalysisEngineRequestTest.java
@@ -62,6 +62,54 @@ class AnalysisEngineRequestTest {
   private static final int BOARD_AREA = BOARD_SIZE * BOARD_SIZE;
 
   @Test
+  void automaticSilentAnalysisPausesForegroundAndLeavesResumeToItsCallback() throws Exception {
+    try (TestEnvironment env = TestEnvironment.open()) {
+      PonderTrackingLeelaz foreground = allocate(PonderTrackingLeelaz.class);
+      foreground.pondering = true;
+      Lizzie.leelaz = foreground;
+      TrackingAnalysisEngine engine = TrackingAnalysisEngine.create();
+      setField(
+          AnalysisEngine.class,
+          engine,
+          "purpose",
+          AnalysisResourceCoordinator.Purpose.AUTO_QUICK_ANALYSIS);
+
+      invokeAnalysisEnginePrepareRequestState(engine, false);
+
+      assertFalse(foreground.pondering);
+      assertEquals(1, foreground.notPonderingCalls);
+      assertEquals(1, foreground.nameCommandCalls);
+      assertFalse((boolean) getField(AnalysisEngine.class, engine, "shouldRePonder"));
+      invokeAnalysisEngineResumeForeground(engine);
+      assertEquals(0, foreground.ponderCalls);
+    }
+  }
+
+  @Test
+  void visibleUserAnalysisPausesAndRestoresForegroundExactlyOnce() throws Exception {
+    try (TestEnvironment env = TestEnvironment.open()) {
+      PonderTrackingLeelaz foreground = allocate(PonderTrackingLeelaz.class);
+      foreground.pondering = true;
+      Lizzie.leelaz = foreground;
+      TrackingAnalysisEngine engine = TrackingAnalysisEngine.create();
+      setField(
+          AnalysisEngine.class,
+          engine,
+          "purpose",
+          AnalysisResourceCoordinator.Purpose.USER_QUICK_ANALYSIS);
+
+      invokeAnalysisEnginePrepareRequestState(engine, true);
+      invokeAnalysisEngineResumeForeground(engine);
+      invokeAnalysisEngineResumeForeground(engine);
+
+      assertEquals(1, foreground.notPonderingCalls);
+      assertEquals(1, foreground.nameCommandCalls);
+      assertEquals(1, foreground.ponderCalls);
+      assertTrue(foreground.pondering);
+    }
+  }
+
+  @Test
   void reuseModeBindsCurrentForegroundKatagoWithoutStartingAProcess() throws Exception {
     try (TestEnvironment env = TestEnvironment.open()) {
       Leelaz foreground = reusableForegroundEngine(true);
@@ -1815,6 +1863,7 @@ class AnalysisEngineRequestTest {
       BoardHistoryNode node = singleUnanalyzedMoveNode();
       TrackingAnalysisEngine engine = TrackingAnalysisEngine.create();
       setField(AnalysisEngine.class, engine, "isPreLoad", true);
+      setField(AnalysisEngine.class, engine, "persistentPreload", true);
       engine.trackPending(1, node);
 
       engine.parseResult(analysisResult(1, 200, 62.0));
@@ -3238,6 +3287,21 @@ class AnalysisEngineRequestTest {
     method.invoke(engine, false);
   }
 
+  private static void invokeAnalysisEnginePrepareRequestState(
+      AnalysisEngine engine, boolean showProgressDialog) throws Exception {
+    Method method =
+        AnalysisEngine.class.getDeclaredMethod("prepareRequestState", boolean.class);
+    method.setAccessible(true);
+    method.invoke(engine, showProgressDialog);
+  }
+
+  private static void invokeAnalysisEngineResumeForeground(AnalysisEngine engine) throws Exception {
+    Method method =
+        AnalysisEngine.class.getDeclaredMethod("resumeForegroundAnalysisIfRequested");
+    method.setAccessible(true);
+    method.invoke(engine);
+  }
+
   private static int countCommand(List<String> commands, String expected) {
     int count = 0;
     for (String command : commands) {
@@ -3509,6 +3573,39 @@ class AnalysisEngineRequestTest {
 
     @Override
     public void addCommand(String command, int commandNumber, String engineName) {}
+  }
+
+  private static final class PonderTrackingLeelaz extends Leelaz {
+    private boolean pondering;
+    private int notPonderingCalls;
+    private int nameCommandCalls;
+    private int ponderCalls;
+
+    private PonderTrackingLeelaz() throws IOException {
+      super("");
+    }
+
+    @Override
+    public boolean isPondering() {
+      return pondering;
+    }
+
+    @Override
+    public void notPondering() {
+      notPonderingCalls++;
+      pondering = false;
+    }
+
+    @Override
+    public void nameCmd() {
+      nameCommandCalls++;
+    }
+
+    @Override
+    public void ponder() {
+      ponderCalls++;
+      pondering = true;
+    }
   }
 
   private static final class DeferredRestoreLeelaz extends Leelaz {

--- a/src/test/java/featurecat/lizzie/analysis/AnalysisResourceCoordinatorTest.java
+++ b/src/test/java/featurecat/lizzie/analysis/AnalysisResourceCoordinatorTest.java
@@ -1,0 +1,121 @@
+package featurecat.lizzie.analysis;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class AnalysisResourceCoordinatorTest {
+  @TempDir Path tempDir;
+
+  @Test
+  void foregroundReleasesOnlyIdleOrAutomaticDedicatedProcesses() {
+    assertEquals(
+        AnalysisResourceCoordinator.ForegroundDecision.SHARED_ENGINE,
+        AnalysisResourceCoordinator.decideForegroundStart(true, false, true, true));
+    assertEquals(
+        AnalysisResourceCoordinator.ForegroundDecision.NONE,
+        AnalysisResourceCoordinator.decideForegroundStart(false, false, true, true));
+    assertEquals(
+        AnalysisResourceCoordinator.ForegroundDecision.RELEASE_IDLE_SECONDARY,
+        AnalysisResourceCoordinator.decideForegroundStart(false, true, false, false));
+    assertEquals(
+        AnalysisResourceCoordinator.ForegroundDecision.PREEMPT_AUTOMATIC_SECONDARY,
+        AnalysisResourceCoordinator.decideForegroundStart(false, true, true, true));
+    assertEquals(
+        AnalysisResourceCoordinator.ForegroundDecision.KEEP_USER_TASK,
+        AnalysisResourceCoordinator.decideForegroundStart(false, true, true, false));
+  }
+
+  @Test
+  void diagnosticCommandsRedactCredentialsAndKeepTuningParameters() {
+    String redacted =
+        AnalysisResourceCoordinator.redactCommand(
+            "remote --token=secret-token --password hunter2 wss://host/path?token=query-token");
+
+    assertFalse(redacted.contains("secret-token"));
+    assertFalse(redacted.contains("hunter2"));
+    assertFalse(redacted.contains("query-token"));
+    assertTrue(redacted.contains("<redacted>"));
+
+    String diagnosticCommand =
+        AnalysisResourceCoordinator.diagnosticCommand(
+            "\"C:\\\\Users\\\\Player\\\\KataGo\\\\katago.exe\" gtp "
+                + "-model \"C:\\\\Users\\\\Player\\\\weights\\\\model.bin.gz\" "
+                + "-config \"C:\\\\Users\\\\Player\\\\configs\\\\gtp.cfg\" "
+                + "-override-config homeDataDir=C:\\\\Users\\\\Player\\\\cache");
+    assertFalse(diagnosticCommand.contains("Player"));
+    assertTrue(diagnosticCommand.startsWith("katago.exe gtp"));
+    assertTrue(diagnosticCommand.contains("-model model.bin.gz"));
+    assertTrue(diagnosticCommand.contains("-config gtp.cfg"));
+    assertTrue(diagnosticCommand.contains("homeDataDir=<local-path>"));
+
+    Map<String, String> parameters =
+        AnalysisResourceCoordinator.parseDynamicParameters(
+            List.of(
+                "kata-set-param numSearchThreads 12", "kata-set-param nnMaxBatchSize 64", "name"));
+    assertEquals(Map.of("numSearchThreads", "12", "nnMaxBatchSize", "64"), parameters);
+  }
+
+  @Test
+  void configHashIsStableAndMissingFilesStayEmpty() throws Exception {
+    Path config = tempDir.resolve("gtp.cfg");
+    Files.writeString(config, "numSearchThreads = 12\n", StandardCharsets.UTF_8);
+
+    assertEquals(
+        AnalysisResourceCoordinator.fileSha256(config),
+        AnalysisResourceCoordinator.fileSha256(config));
+    assertEquals(64, AnalysisResourceCoordinator.fileSha256(config).length());
+    assertEquals("", AnalysisResourceCoordinator.fileSha256(tempDir.resolve("missing.cfg")));
+  }
+
+  @Test
+  void throughputElapsedTimeUsesAStableNanosecondWindow() {
+    assertEquals(0.25, AnalysisResourceCoordinator.elapsedSeconds(1_000L, 250_001_000L));
+    assertEquals(0.0, AnalysisResourceCoordinator.elapsedSeconds(2_000L, 1_000L));
+  }
+
+  @Test
+  void optInDiagnosticsAreStructuredAndNeverPersistSecrets() throws Exception {
+    Path output = tempDir.resolve("analysis-resource-diagnostics.jsonl");
+    System.setProperty("lizzie.analysis.diagnostics", "true");
+    System.setProperty("lizzie.analysis.diagnostics.path", output.toString());
+    Object owner = new Object();
+    try {
+      AnalysisResourceCoordinator.processStarted(
+          owner,
+          AnalysisResourceCoordinator.Purpose.MAIN_BOARD,
+          "/Users/private-user/KataGo/katago gtp --token=private-value "
+              + "-model /Users/private-user/weights/model.bin.gz",
+          null);
+      AnalysisResourceCoordinator.commandSent(
+          owner,
+          AnalysisResourceCoordinator.Purpose.MAIN_BOARD,
+          "kata-set-param numSearchThreads 12");
+      AnalysisResourceCoordinator.foregroundPausedForAuxiliary(
+          owner, AnalysisResourceCoordinator.Purpose.AUTO_QUICK_ANALYSIS);
+      AnalysisResourceCoordinator.processStopped(
+          owner, AnalysisResourceCoordinator.Purpose.MAIN_BOARD, null);
+
+      String diagnostics = Files.readString(output, StandardCharsets.UTF_8);
+      assertTrue(diagnostics.contains("process-started"));
+      assertTrue(diagnostics.contains("dynamic-parameter"));
+      assertTrue(diagnostics.contains("foreground-paused"));
+      assertTrue(diagnostics.contains("AUTO_QUICK_ANALYSIS"));
+      assertTrue(diagnostics.contains("process-stopped"));
+      assertTrue(diagnostics.contains("numSearchThreads"));
+      assertFalse(diagnostics.contains("private-value"));
+      assertFalse(diagnostics.contains("private-user"));
+    } finally {
+      System.clearProperty("lizzie.analysis.diagnostics");
+      System.clearProperty("lizzie.analysis.diagnostics.path");
+    }
+  }
+}

--- a/src/test/java/featurecat/lizzie/gui/LizzieFrameRegressionTest.java
+++ b/src/test/java/featurecat/lizzie/gui/LizzieFrameRegressionTest.java
@@ -223,6 +223,49 @@ class LizzieFrameRegressionTest {
   }
 
   @Test
+  void foregroundAnalysisReleasesIdleDedicatedQuickEngine() throws Exception {
+    LizzieFrame frame = allocate(LizzieFrame.class);
+    ResourceTrackingAnalysisEngine engine = allocate(ResourceTrackingAnalysisEngine.class);
+    engine.localDedicated = true;
+    frame.analysisEngine = engine;
+
+    assertEquals(
+        featurecat.lizzie.analysis.AnalysisResourceCoordinator.ForegroundDecision
+            .RELEASE_IDLE_SECONDARY,
+        frame.releaseSecondaryAnalysisResourcesForForeground());
+    assertNull(frame.analysisEngine);
+    assertEquals(1, engine.normalQuitCount);
+  }
+
+  @Test
+  void foregroundAnalysisPreemptsOnlyAutomaticRunningQuickEngine() throws Exception {
+    LizzieFrame frame = allocate(LizzieFrame.class);
+    ResourceTrackingAnalysisEngine automatic = allocate(ResourceTrackingAnalysisEngine.class);
+    automatic.localDedicated = true;
+    automatic.analysisInProgress = true;
+    automatic.automatic = true;
+    frame.analysisEngine = automatic;
+
+    assertEquals(
+        featurecat.lizzie.analysis.AnalysisResourceCoordinator.ForegroundDecision
+            .PREEMPT_AUTOMATIC_SECONDARY,
+        frame.releaseSecondaryAnalysisResourcesForForeground());
+    assertNull(frame.analysisEngine);
+    assertEquals(1, automatic.normalQuitCount);
+
+    ResourceTrackingAnalysisEngine userTask = allocate(ResourceTrackingAnalysisEngine.class);
+    userTask.localDedicated = true;
+    userTask.analysisInProgress = true;
+    frame.analysisEngine = userTask;
+
+    assertEquals(
+        featurecat.lizzie.analysis.AnalysisResourceCoordinator.ForegroundDecision.KEEP_USER_TASK,
+        frame.releaseSecondaryAnalysisResourcesForForeground());
+    assertSame(userTask, frame.analysisEngine);
+    assertEquals(0, userTask.normalQuitCount);
+  }
+
+  @Test
   void startNewGameStopsBeforeMutatingStateWhenForegroundEngineIsReserved() throws Exception {
     LizzieFrame previousFrame = Lizzie.frame;
     Leelaz previousEngine = Lizzie.leelaz;
@@ -949,7 +992,7 @@ class LizzieFrameRegressionTest {
   }
 
   @Test
-  void loadedGameStartsSilentQuickAnalyzeAndForegroundAnalysisForUnanalyzedMoves()
+  void loadedGameDefersForegroundAnalysisUntilSilentQuickAnalysisCompletes()
       throws Exception {
     TestEnvironment env = TestEnvironment.open();
     try {
@@ -969,11 +1012,11 @@ class LizzieFrameRegressionTest {
       assertTrue(frame.lastIsAllGame);
       assertFalse(frame.lastIsAllBranches);
       assertTrue(frame.lastSilentAnalyze);
-      assertEquals(1, frame.refreshCount);
+      assertEquals(0, frame.refreshCount);
       assertEquals(
-          1,
+          0,
           leelaz.ponderCount,
-          "fast curve completion must not replace foreground candidate analysis.");
+          "foreground analysis must not contend with the automatic quick-curve process.");
     } finally {
       env.close();
     }
@@ -1169,7 +1212,7 @@ class LizzieFrameRegressionTest {
   }
 
   @Test
-  void downloadedKifuStartsSilentQuickAnalyzeAndForegroundAnalysis() throws Exception {
+  void downloadedKifuDefersForegroundAnalysisUntilSilentQuickAnalysisCompletes() throws Exception {
     TestEnvironment env = TestEnvironment.open();
     try {
       Lizzie.config = configWithAutoQuickAnalyze();
@@ -1187,8 +1230,8 @@ class LizzieFrameRegressionTest {
       assertTrue(frame.lastIsAllGame);
       assertFalse(frame.lastIsAllBranches);
       assertTrue(frame.lastSilentAnalyze);
-      assertEquals(1, frame.refreshCount);
-      assertEquals(1, leelaz.ponderCount);
+      assertEquals(0, frame.refreshCount);
+      assertEquals(0, leelaz.ponderCount);
     } finally {
       env.close();
     }
@@ -1213,9 +1256,9 @@ class LizzieFrameRegressionTest {
       SwingUtilities.invokeAndWait(frame::continueQuickAnalysisAfterHistoryNavigationWhenIdle);
 
       assertEquals(
-          1,
+          0,
           engine.keepAliveCount,
-          "navigation continuation should keep the warmed quick-analysis engine reusable.");
+          "automatic curve completion must release its dedicated engine instead of keeping it resident.");
       assertEquals(
           1,
           engine.missingMainlineRequestCount,
@@ -1388,7 +1431,10 @@ class LizzieFrameRegressionTest {
           2,
           frame.flashAnalyzeGameCount,
           "if the first silent quick-curve dispatch vanishes, the load guard should retry it.");
-      assertEquals(2, leelaz.ponderCount);
+      assertEquals(
+          0,
+          leelaz.ponderCount,
+          "a retry must not resume the foreground engine while quick analysis is still pending.");
       invokeStopLoadedGameQuickAnalysisRetry(frame);
     } finally {
       env.close();
@@ -2188,6 +2234,46 @@ class LizzieFrameRegressionTest {
     @Override
     public void refresh() {
       refreshCount++;
+    }
+  }
+
+  private static final class ResourceTrackingAnalysisEngine extends AnalysisEngine {
+    private boolean localDedicated;
+    private boolean analysisInProgress;
+    private boolean automatic;
+    private int normalQuitCount;
+
+    @SuppressWarnings("unused")
+    private ResourceTrackingAnalysisEngine() throws java.io.IOException {
+      super(false);
+    }
+
+    @Override
+    public boolean usesSharedForegroundEngine() {
+      return false;
+    }
+
+    @Override
+    public boolean isLocalDedicatedProcess() {
+      return localDedicated;
+    }
+
+    @Override
+    public synchronized boolean isAnalysisInProgress() {
+      return analysisInProgress;
+    }
+
+    @Override
+    public boolean isAutomaticBackgroundTask() {
+      return automatic;
+    }
+
+    @Override
+    public void clearRequestCallbacks() {}
+
+    @Override
+    public void normalQuit() {
+      normalQuitCount++;
     }
   }
 


### PR DESCRIPTION
## Summary

- Adds analysis-resource coordination so hidden automatic quick-curve work no longer competes with the foreground KataGo process.
- Starts automatic quick analysis only on demand, pauses foreground pondering while it runs, exits the auxiliary process after completion, and resumes the current board immediately.
- Preserves explicit user-started quick analysis and whole-game analysis instead of terminating them silently.
- Adds opt-in, credential-redacted process and throughput diagnostics plus a repeatable RTX 50 / TensorRT Windows benchmark script.

## Validation

- `git diff --check`
- `python3 scripts/check_markdown_links.py`
- focused formatter check for the two new coordinator files
- focused regression suite: 171 tests passed
- complete Maven suite: 1,824 tests passed, 0 failures/errors/skips
- `mvn -B -Dfmt.skip=true -DskipTests package`
- real macOS Swing smoke with bundled Metal KataGo: loading an SGF produced `AUTO_QUICK_ANALYSIS` -> `foreground-paused` -> auxiliary process exit -> foreground `kata-analyze`; stable state contained one KataGo process and application exit left none

## Remaining hardware validation

Issue #177 must remain open until the supplied Windows benchmark is run repeatedly on the affected RTX 5080 with identical model, config, cache, position, and runtime. This PR removes a confirmed contention source and adds evidence collection, but does not claim the RTX 5080 result before that test.

Refs #177