### PR TITLE
Remove bottom toolbar button tooltips

### DIFF
--- a/src/main/java/featurecat/lizzie/gui/AccessibilitySupport.java
+++ b/src/main/java/featurecat/lizzie/gui/AccessibilitySupport.java
@@ -154,6 +154,40 @@ public final class AccessibilitySupport {
     }
   }
 
+  /** Keeps screen-reader semantics while suppressing visible tooltips for every button in a tree. */
+  public static void disableVisibleButtonTooltips(Component root) {
+    if (root == null) {
+      return;
+    }
+    if (root instanceof AbstractButton) {
+      AbstractButton button = (AbstractButton) root;
+      AccessibleContext context = button.getAccessibleContext();
+      String name =
+          firstNonBlank(
+              (String) button.getClientProperty(EXPLICIT_NAME),
+              firstNonBlank(
+                  context == null ? null : context.getAccessibleName(),
+                  firstNonBlank(button.getText(), button.getToolTipText())));
+      String description =
+          firstNonBlank(
+              (String) button.getClientProperty(EXPLICIT_DESCRIPTION),
+              firstNonBlank(
+                  context == null ? null : context.getAccessibleDescription(),
+                  firstNonBlank(button.getToolTipText(), name)));
+      if (!name.isBlank()) {
+        buttonWithoutTooltip(button, name, description);
+      } else {
+        button.putClientProperty(VISIBLE_TOOLTIP_DISABLED, Boolean.TRUE);
+        button.setToolTipText(null);
+      }
+    }
+    if (root instanceof Container) {
+      for (Component child : ((Container) root).getComponents()) {
+        disableVisibleButtonTooltips(child);
+      }
+    }
+  }
+
   public static void installWindowFocusCycling(
       Window window, JComponent board, JComponent... focusZones) {
     if (window == null || board == null || focusZones == null || focusZones.length == 0) {

--- a/src/main/java/featurecat/lizzie/gui/BottomToolbar.java
+++ b/src/main/java/featurecat/lizzie/gui/BottomToolbar.java
@@ -509,6 +509,13 @@ public class BottomToolbar extends JPanel {
     if (text != null && !text.trim().isEmpty()) {
       return text;
     }
+    String accessibleName =
+        button.getAccessibleContext() == null
+            ? null
+            : button.getAccessibleContext().getAccessibleName();
+    if (accessibleName != null && !accessibleName.trim().isEmpty()) {
+      return accessibleName;
+    }
     String toolTip = button.getToolTipText();
     return toolTip == null ? "" : toolTip;
   }
@@ -2554,6 +2561,7 @@ public class BottomToolbar extends JPanel {
         text("Accessibility.moveNumber", "Move number"),
         text("Accessibility.moveNumberDescription", "Enter a move number and press Enter to jump"));
     AccessibilitySupport.applyToTree(this);
+    AccessibilitySupport.disableVisibleButtonTooltips(this);
   }
 
   private String text(String key, String fallback) {

--- a/src/test/java/featurecat/lizzie/gui/AccessibilitySupportTest.java
+++ b/src/test/java/featurecat/lizzie/gui/AccessibilitySupportTest.java
@@ -79,6 +79,33 @@ class AccessibilitySupportTest {
   }
 
   @Test
+  void treeWideTooltipSuppressionPreservesButtonSemanticsAfterAnotherTreePass() {
+    JPanel toolbar = new JPanel();
+    JPanel details = new JPanel();
+    JButton labeled = new JButton("Auto analyze");
+    labeled.setToolTipText("Analyze every move");
+    JButton iconOnly = new JButton("...");
+    AccessibilitySupport.button(iconOnly, "More actions", "Show hidden toolbar actions");
+    details.add(labeled);
+    details.add(iconOnly);
+    toolbar.add(details);
+
+    AccessibilitySupport.applyToTree(toolbar);
+    AccessibilitySupport.disableVisibleButtonTooltips(toolbar);
+    AccessibilitySupport.applyToTree(toolbar);
+
+    assertNull(labeled.getToolTipText());
+    assertNull(iconOnly.getToolTipText());
+    assertEquals("Auto analyze", labeled.getAccessibleContext().getAccessibleName());
+    assertEquals(
+        "Analyze every move", labeled.getAccessibleContext().getAccessibleDescription());
+    assertEquals("More actions", iconOnly.getAccessibleContext().getAccessibleName());
+    assertEquals(
+        "Show hidden toolbar actions",
+        iconOnly.getAccessibleContext().getAccessibleDescription());
+  }
+
+  @Test
   void labelsAreAssociatedWithTheirInput() {
     JLabel label = new JLabel("Account");
     JTextField field = new JTextField();


### PR DESCRIPTION
## Summary

- removes visible tooltip popups from every bottom-toolbar button and option
- preserves accessible names and descriptions for screen readers
- keeps overflow-menu labels available even when tooltips are disabled

感谢 @semanym 提交反馈并清楚说明悬浮提示会遮挡连续操作的问题。

## Validation

- `git diff --check`
- `mvn -B -Dfmt.skip=true -Dtest=AccessibilitySupportTest,AutoAnalyzeMenuTest,BottomToolbarPassDetectionTest test` (14 tests passed)
- `mvn -B -Dfmt.skip=true test` (1,825 tests passed)
- `mvn -B -Dfmt.skip=true -DskipTests package`
- `python3 scripts/check_markdown_links.py`
- macOS signed Swing smoke: hover/wait over the bottom Next button, then click repeatedly; no visible tooltip blocks interaction and accessibility descriptions remain available

Closes #192
