### PR TITLE
Fix KataGo discovery across multiple installations

### DIFF
--- a/src/main/java/featurecat/lizzie/Config.java
+++ b/src/main/java/featurecat/lizzie/Config.java
@@ -596,6 +596,13 @@ public class Config {
   }
 
   private static Optional<Path> findBundledAppRoot() {
+    Path configuredWorkingDirectory =
+        Path.of(System.getProperty("user.dir", ".")).toAbsolutePath().normalize();
+    if (hasAppRootMarker(configuredWorkingDirectory)
+        && hasCompleteBundledKataGoAssets(configuredWorkingDirectory)) {
+      return Optional.of(configuredWorkingDirectory);
+    }
+
     LinkedHashSet<Path> seedPaths = new LinkedHashSet<>();
     try {
       File codeSource =
@@ -617,6 +624,16 @@ public class Config {
       }
     }
     return Optional.empty();
+  }
+
+  private static boolean hasAppRootMarker(Path directory) {
+    return directory != null
+        && (Files.isRegularFile(directory.resolve(WINDOWS_PORTABLE_MARKER_NAME))
+            || Files.isRegularFile(directory.resolve("PROJECT_INFO.txt"))
+            || Files.isRegularFile(directory.resolve("lizzieyzy-next-installed-manifest.json"))
+            || Files.isRegularFile(directory.resolve("app").resolve("PROJECT_INFO.txt"))
+            || Files.isRegularFile(
+                directory.resolve("app").resolve("lizzieyzy-next-installed-manifest.json")));
   }
 
   private static boolean hasCompleteBundledKataGoAssets(Path appRoot) {

--- a/src/main/java/featurecat/lizzie/util/KataGoAutoSetupHelper.java
+++ b/src/main/java/featurecat/lizzie/util/KataGoAutoSetupHelper.java
@@ -2651,11 +2651,28 @@ public final class KataGoAutoSetupHelper {
     if (Utils.isBlank(value)) {
       return null;
     }
+    Path contextual = resolvePath(value, workingDir, appRoot, null);
+    if (isRegularFile(contextual)) {
+      return contextual;
+    }
+    try {
+      Path raw = Paths.get(value.trim());
+      boolean qualifiedPath =
+          raw.isAbsolute()
+              || raw.getNameCount() > 1
+              || value.indexOf('/') >= 0
+              || value.indexOf('\\') >= 0;
+      if (qualifiedPath) {
+        return contextual;
+      }
+    } catch (RuntimeException e) {
+      return contextual;
+    }
     Path onPath = Utils.resolveExistingExecutable(value);
     if (isRegularFile(onPath)) {
       return normalize(onPath);
     }
-    return resolvePath(value, workingDir, appRoot, null);
+    return contextual;
   }
 
   private static Path resolveCommandOption(

--- a/src/test/java/featurecat/lizzie/ConfigBundledKataGoDefaultsTest.java
+++ b/src/test/java/featurecat/lizzie/ConfigBundledKataGoDefaultsTest.java
@@ -549,6 +549,7 @@ public class ConfigBundledKataGoDefaultsTest {
   }
 
   private static void createBundledKataGoAssets(Path root, String modelSource) throws Exception {
+    Files.writeString(root.resolve(".lizzie-portable"), "");
     Path katagoRoot = root.resolve("engines").resolve("katago");
     String[] platformDirs = {
       "macos-arm64", "macos-amd64", "linux-x64", "linux-x86", "windows-x64", "windows-x86"

--- a/src/test/java/featurecat/lizzie/util/KataGoAutoSetupHelperTest.java
+++ b/src/test/java/featurecat/lizzie/util/KataGoAutoSetupHelperTest.java
@@ -231,6 +231,7 @@ public class KataGoAutoSetupHelperTest {
   @Test
   void doesNotTreatAnotherGtpEngineAsLocalKataGo() throws Exception {
     Path root = Files.createTempDirectory("katago-discovery-non-katago");
+    touch(root.resolve("PROJECT_INFO.txt"));
     Path engine = touch(root.resolve("other-engine").resolve("leela-zero"));
     Path config = touch(root.resolve("other-engine").resolve("configs").resolve("gtp.cfg"));
     touch(root.resolve("other-engine").resolve("configs").resolve("analysis.cfg"));
@@ -448,6 +449,59 @@ public class KataGoAutoSetupHelperTest {
           assertEquals(analysis, result.analysisConfigPath);
           assertEquals(weight, result.activeWeightPath);
         });
+  }
+
+  @Test
+  void relativeEngineCommandDoesNotLeakFromJvmWorkingDirectory() throws Exception {
+    Path jvmWorkingDirectory = Path.of("").toAbsolutePath().normalize();
+    Path shadowDirectory =
+        Files.createTempDirectory(
+                Files.createDirectories(jvmWorkingDirectory.resolve("target")),
+                "katago-cwd-shadow-")
+            .toAbsolutePath()
+            .normalize();
+    Path shadowEngine = touch(shadowDirectory.resolve(testKataGoBinaryName()));
+    Path relativeEngine = jvmWorkingDirectory.relativize(shadowEngine);
+
+    try {
+      Path packageRoot = Files.createTempDirectory("katago-contextual-relative-command");
+      touch(packageRoot.resolve("PROJECT_INFO.txt"));
+      Path workDir = Files.createDirectories(packageRoot.resolve("user-data"));
+      Path packagedEngine = touch(packageRoot.resolve(relativeEngine));
+      Path configs = Files.createDirectories(packageRoot.resolve("configs"));
+      Path gtp = touch(configs.resolve("gtp.cfg"));
+      Path analysis = touch(configs.resolve("analysis.cfg"));
+      Path weight = touch(packageRoot.resolve("weights").resolve("default.bin.gz"));
+
+      withProcessDirAndConfig(
+          packageRoot,
+          workDir,
+          () -> {
+            EngineData relative = new EngineData();
+            relative.name = "KataGo contextual relative";
+            relative.commands =
+                quoteLiteral(relativeEngine)
+                    + " gtp -model "
+                    + quote(weight)
+                    + " -config "
+                    + quote(gtp);
+            relative.isDefault = true;
+            Utils.saveEngineSettings(new ArrayList<>(List.of(relative)));
+
+            KataGoAutoSetupHelper.LocalKataGoDiscoveryResult result =
+                KataGoAutoSetupHelper.inspectLocalKataGo();
+
+            assertTrue(result.isComplete());
+            assertEquals(KataGoAutoSetupHelper.DiscoverySource.DEFAULT_ENGINE, result.source);
+            assertEquals(packagedEngine, result.enginePath);
+            assertEquals(gtp, result.gtpConfigPath);
+            assertEquals(analysis, result.analysisConfigPath);
+            assertEquals(weight, result.activeWeightPath);
+          });
+    } finally {
+      Files.deleteIfExists(shadowEngine);
+      Files.deleteIfExists(shadowDirectory);
+    }
   }
 
   @Test


### PR DESCRIPTION
## Summary

- prefer an explicitly marked portable/install root before code-source fallback
- resolve path-qualified KataGo commands against the configured work and app roots before the JVM working directory
- prevent a second installation with the same relative engine path from being selected accidentally
- make bundled and non-KataGo discovery tests independent of developer-local engine assets

## Validation

- `git diff --check`
- `python3 scripts/check_markdown_links.py`
- `mvn -B -Dfmt.skip=true -Dtest=ConfigBundledKataGoDefaultsTest,KataGoAutoSetupHelperTest test` (64 tests)
- `mvn -B -Dfmt.skip=true test` (1,844 tests)
- `mvn -B -Dfmt.skip=true -DskipTests package`

All checks passed locally with JDK 21.