### PR TITLE
Harden R2 stable channel verification

### DIFF
--- a/docs/R2_RELEASES.md
+++ b/docs/R2_RELEASES.md
@@ -20,6 +20,11 @@ Windows 安装器、Linux 包、pre-release 和历史版本不占用 R2。版本
 - `channels/stable/catalog.json`
 - `index.html`
 
+R2 自定义域名本身不会把 `/` 自动映射到 `index.html`。Cloudflare URL 重写规则必须使用
+`URI Path equals /`，将路径重写为 `/index.html`，并保留原查询字符串。不要按完整 URL
+精确匹配，否则 `/?source=...` 这类正常链接会返回 404。发布器会用带缓存穿透参数的根地址
+验证这条规则。
+
 镜像资产总量不得超过 `9,000,000,000` 字节。门禁失败、旧版本对象清理失败或任一 SHA-256
 不一致时，GitHub Release 保持原状态，不会被晋升为正式版。
 
@@ -32,10 +37,11 @@ Windows 安装器、Linux 包、pre-release 和历史版本不占用 R2。版本
 2. 先把下载首页切换到 GitHub 维护模式，再删除旧 R2 正式版对象。
 3. 使用 GitHub HTTP Range 与 R2 multipart 流式上传，不在 runner 保存完整大包。
 4. 上传过程中计算完整 SHA-256；上传后再核对 R2 对象大小和 SHA 元数据。
-5. 通过自定义域名检查 HTTPS、长度、Range、缓存和下载响应头。
+5. 通过自定义域名检查 HTTPS、长度、Range、缓存、下载响应头和根首页重写。
 6. 发布 catalog 与下载首页，最后发布签名 envelope 作为稳定频道的激活指针。
-7. 将 v2 签名清单、catalog 和旧客户端使用的 v1 GitHub 清单上传到 Release。
-8. 最后才把 GitHub pre-release 改为正式版和 latest。
+7. 使用缓存穿透参数逐字节核对公网首页、catalog 和 envelope 与本次上传内容一致。
+8. 将 v2 签名清单、catalog 和旧客户端使用的 v1 GitHub 清单上传到 Release。
+9. 最后才把 GitHub pre-release 改为正式版和 latest。
 
 重复执行同一 tag 会复用大小与 SHA 已匹配的 R2 对象。已是正式版时，只有明确启用
 `allow_stable_recovery` 才能恢复稳定频道。

--- a/scripts/r2_release.py
+++ b/scripts/r2_release.py
@@ -32,6 +32,7 @@ MULTIPART_PART_SIZE = 64 * 1024 * 1024
 SMALL_OBJECT_LIMIT = 16 * 1024 * 1024
 PUBLIC_VERIFY_ATTEMPTS = 5
 PUBLIC_VERIFY_BACKOFF_SECONDS = (2, 4, 8, 16)
+MAX_PUBLIC_METADATA_BYTES = 2 * 1024 * 1024
 
 WINDOWS_PORTABLE = re.compile(
     r"^(?P<date>\d{4}-\d{2}-\d{2})-windows64\."
@@ -852,6 +853,146 @@ def verify_public_objects(public_base: str, assets: Iterable[Asset]) -> None:
                 time.sleep(delay)
 
 
+def _cache_busted_url(url: str, attempt: int) -> str:
+    separator = "&" if "?" in url else "?"
+    return f"{url}{separator}r2-verify={int(time.time())}-{attempt}"
+
+
+def _verify_public_document(
+    requests,
+    url: str,
+    *,
+    expected_content_type: str,
+    expected_body: bytes | None = None,
+    required_marker: bytes | None = None,
+) -> None:
+    response = requests.get(
+        url,
+        headers={
+            "Accept-Encoding": "identity",
+            "Cache-Control": "no-cache",
+            "Pragma": "no-cache",
+        },
+        allow_redirects=True,
+        timeout=60,
+        stream=True,
+    )
+    try:
+        if response.status_code != 200:
+            raise ReleaseError(f"GET returned HTTP {response.status_code}")
+        expected_host = urllib.parse.urlparse(url).hostname
+        final_host = urllib.parse.urlparse(str(response.url)).hostname
+        if final_host != expected_host:
+            raise ReleaseError(
+                f"request redirected from {expected_host} to {final_host}"
+            )
+        actual_type = response.headers.get("Content-Type", "").lower()
+        if not actual_type.startswith(expected_content_type.lower()):
+            raise ReleaseError(
+                f"Content-Type is {actual_type!r}, expected {expected_content_type!r}"
+            )
+
+        body = bytearray()
+        for chunk in response.iter_content(chunk_size=64 * 1024):
+            if not chunk:
+                continue
+            body.extend(chunk)
+            if len(body) > MAX_PUBLIC_METADATA_BYTES:
+                raise ReleaseError(
+                    f"response exceeds {MAX_PUBLIC_METADATA_BYTES} bytes"
+                )
+        actual_body = bytes(body)
+        if expected_body is not None and actual_body != expected_body:
+            actual_sha = hashlib.sha256(actual_body).hexdigest()[:12]
+            expected_sha = hashlib.sha256(expected_body).hexdigest()[:12]
+            raise ReleaseError(
+                "public body differs from the uploaded object "
+                f"({len(actual_body)} bytes, sha256 {actual_sha}; expected "
+                f"{len(expected_body)} bytes, sha256 {expected_sha})"
+            )
+        if required_marker is not None and required_marker not in actual_body:
+            raise ReleaseError("public body is missing the expected page marker")
+    finally:
+        response.close()
+
+
+def _verify_public_with_retry(requests, description: str, url: str, **kwargs) -> None:
+    for attempt in range(1, PUBLIC_VERIFY_ATTEMPTS + 1):
+        request_url = _cache_busted_url(url, attempt)
+        try:
+            _verify_public_document(requests, request_url, **kwargs)
+            return
+        except (ReleaseError, requests.RequestException) as exc:
+            if attempt == PUBLIC_VERIFY_ATTEMPTS:
+                raise ReleaseError(
+                    f"Public R2 verification failed for {description} after "
+                    f"{PUBLIC_VERIFY_ATTEMPTS} attempts: {exc}"
+                ) from exc
+            delay = PUBLIC_VERIFY_BACKOFF_SECONDS[attempt - 1]
+            print(
+                f"Public R2 verification retry {attempt}/"
+                f"{PUBLIC_VERIFY_ATTEMPTS} for {description} in {delay}s: {exc}",
+                file=sys.stderr,
+            )
+            time.sleep(delay)
+
+
+def verify_public_homepage(public_base: str) -> None:
+    try:
+        import requests
+    except ImportError as exc:
+        raise ReleaseError("requests is required for public R2 verification") from exc
+    if not public_base.lower().startswith("https://"):
+        raise ReleaseError("Public R2 base URL must use HTTPS")
+    _verify_public_with_retry(
+        requests,
+        "download homepage route",
+        public_base.rstrip("/") + "/",
+        expected_content_type="text/html",
+        required_marker=b"LizzieYzy Next",
+    )
+
+
+def verify_public_stable_channel(
+    public_base: str,
+    *,
+    index_body: bytes,
+    catalog_body: bytes,
+    envelope_body: bytes,
+) -> None:
+    try:
+        import requests
+    except ImportError as exc:
+        raise ReleaseError("requests is required for public R2 verification") from exc
+    if not public_base.lower().startswith("https://"):
+        raise ReleaseError("Public R2 base URL must use HTTPS")
+    base = public_base.rstrip("/")
+    documents = (
+        ("download homepage", base + "/", "text/html", index_body),
+        ("download index", base + "/index.html", "text/html", index_body),
+        (
+            "stable catalog",
+            base + "/channels/stable/catalog.json",
+            "application/json",
+            catalog_body,
+        ),
+        (
+            "stable update envelope",
+            base + "/channels/stable/update-envelope.json",
+            "application/json",
+            envelope_body,
+        ),
+    )
+    for description, url, content_type, expected_body in documents:
+        _verify_public_with_retry(
+            requests,
+            description,
+            url,
+            expected_content_type=content_type,
+            expected_body=expected_body,
+        )
+
+
 def verify_and_activate_stable_channel(
     client,
     bucket: str,
@@ -865,6 +1006,7 @@ def verify_and_activate_stable_channel(
     asset_list = list(assets)
     if not skip_public_verify:
         verify_public_objects(public_base, asset_list)
+        verify_public_homepage(public_base)
 
     catalog_body = json_bytes(catalog)
     envelope_body = json_bytes(envelope)
@@ -892,6 +1034,13 @@ def verify_and_activate_stable_channel(
         envelope_body,
         cache_control="public, max-age=60, must-revalidate",
     )
+    if not skip_public_verify:
+        verify_public_stable_channel(
+            public_base,
+            index_body=index_body,
+            catalog_body=catalog_body,
+            envelope_body=envelope_body,
+        )
     return catalog_body, envelope_body
 
 

--- a/scripts/test_r2_release.py
+++ b/scripts/test_r2_release.py
@@ -183,9 +183,19 @@ class R2ReleaseTest(unittest.TestCase):
         def put(client, bucket, key, body, **kwargs):
             events.append(("put", key))
 
-        with mock.patch.object(r2_release, "verify_public_objects", side_effect=verify), mock.patch.object(
-            r2_release, "put_bytes", side_effect=put
-        ):
+        with mock.patch.object(
+            r2_release, "verify_public_objects", side_effect=verify
+        ), mock.patch.object(
+            r2_release,
+            "verify_public_homepage",
+            side_effect=lambda public_base: events.append(("verify-home", public_base)),
+        ), mock.patch.object(
+            r2_release,
+            "verify_public_stable_channel",
+            side_effect=lambda public_base, **kwargs: events.append(
+                ("verify-channel", public_base)
+            ),
+        ), mock.patch.object(r2_release, "put_bytes", side_effect=put):
             catalog_body, envelope_body = r2_release.verify_and_activate_stable_channel(
                 object(),
                 "bucket",
@@ -197,12 +207,114 @@ class R2ReleaseTest(unittest.TestCase):
             )
 
         self.assertEqual("verify", events[0][0])
+        self.assertEqual("verify-home", events[1][0])
         self.assertEqual(
             "channels/stable/update-envelope.json",
-            events[-1][1],
+            [event for event in events if event[0] == "put"][-1][1],
         )
+        self.assertEqual("verify-channel", events[-1][0])
         self.assertEqual({"tag": TAG}, json.loads(catalog_body))
         self.assertEqual({"payload": "signed"}, json.loads(envelope_body))
+
+    def test_public_homepage_route_accepts_cache_busting_query(self):
+        response = mock.Mock(
+            status_code=200,
+            url=r2_release.DEFAULT_PUBLIC_BASE + "/?r2-verify=1-1",
+            headers={"Content-Type": "text/html; charset=utf-8"},
+        )
+        response.iter_content.return_value = iter([b"<title>LizzieYzy Next</title>"])
+        requests = mock.Mock()
+        requests.RequestException = RuntimeError
+        requests.get.return_value = response
+
+        with mock.patch.dict(sys.modules, {"requests": requests}), mock.patch.object(
+            r2_release.time, "time", return_value=1
+        ):
+            r2_release.verify_public_homepage(r2_release.DEFAULT_PUBLIC_BASE)
+
+        requested_url = requests.get.call_args.args[0]
+        self.assertEqual(
+            r2_release.DEFAULT_PUBLIC_BASE + "/?r2-verify=1-1", requested_url
+        )
+        self.assertTrue(requests.get.call_args.kwargs["stream"])
+        response.close.assert_called_once_with()
+
+    def test_public_stable_channel_matches_exact_uploaded_bodies(self):
+        bodies = {
+            r2_release.DEFAULT_PUBLIC_BASE + "/": b"<title>LizzieYzy Next</title>",
+            r2_release.DEFAULT_PUBLIC_BASE + "/index.html": b"<title>LizzieYzy Next</title>",
+            r2_release.DEFAULT_PUBLIC_BASE
+            + "/channels/stable/catalog.json": b'{"releaseTag":"test"}\n',
+            r2_release.DEFAULT_PUBLIC_BASE
+            + "/channels/stable/update-envelope.json": b'{"payload":"signed"}\n',
+        }
+
+        def response_for(url, **kwargs):
+            base_url = url.split("?", 1)[0]
+            response = mock.Mock(
+                status_code=200,
+                url=url,
+                headers={
+                    "Content-Type": (
+                        "text/html; charset=utf-8"
+                        if base_url.endswith("/") or base_url.endswith("index.html")
+                        else "application/json; charset=utf-8"
+                    )
+                },
+            )
+            response.iter_content.return_value = iter([bodies[base_url]])
+            return response
+
+        requests = mock.Mock()
+        requests.RequestException = RuntimeError
+        requests.get.side_effect = response_for
+        with mock.patch.dict(sys.modules, {"requests": requests}), mock.patch.object(
+            r2_release.time, "time", return_value=2
+        ):
+            r2_release.verify_public_stable_channel(
+                r2_release.DEFAULT_PUBLIC_BASE,
+                index_body=bodies[r2_release.DEFAULT_PUBLIC_BASE + "/"],
+                catalog_body=bodies[
+                    r2_release.DEFAULT_PUBLIC_BASE + "/channels/stable/catalog.json"
+                ],
+                envelope_body=bodies[
+                    r2_release.DEFAULT_PUBLIC_BASE
+                    + "/channels/stable/update-envelope.json"
+                ],
+            )
+
+        self.assertEqual(4, requests.get.call_count)
+        self.assertTrue(
+            all("?r2-verify=2-1" in call.args[0] for call in requests.get.call_args_list)
+        )
+
+    def test_public_stable_channel_rejects_body_mismatch(self):
+        def mismatched_response(url, **kwargs):
+            response = mock.Mock(
+                status_code=200,
+                url=url,
+                headers={"Content-Type": "text/html; charset=utf-8"},
+            )
+            response.iter_content.return_value = iter([b"stale homepage"])
+            return response
+
+        requests = mock.Mock()
+        requests.RequestException = RuntimeError
+        requests.get.side_effect = mismatched_response
+        with mock.patch.dict(sys.modules, {"requests": requests}), mock.patch.object(
+            r2_release.time, "time", return_value=3
+        ), mock.patch.object(r2_release.time, "sleep") as sleep, self.assertRaisesRegex(
+            r2_release.ReleaseError, "download homepage after 5 attempts"
+        ):
+            r2_release.verify_public_stable_channel(
+                r2_release.DEFAULT_PUBLIC_BASE,
+                index_body=b"fresh homepage",
+                catalog_body=b"{}\n",
+                envelope_body=b"{}\n",
+            )
+
+        self.assertEqual(r2_release.PUBLIC_VERIFY_ATTEMPTS, requests.get.call_count)
+        self.assertEqual(r2_release.PUBLIC_VERIFY_ATTEMPTS - 1, sleep.call_count)
 
     def test_public_range_verification_retries_transient_failure(self):
         selected = r2_release.select_r2_assets(


### PR DESCRIPTION
## Summary

- Verifies the public download homepage route before activating the stable channel.
- Cache-busts and byte-compares the public homepage, catalog, and signed update envelope after publication.
- Rejects cross-host redirects, wrong content types, oversized metadata, and stale or mismatched bodies.
- Documents the required Cloudflare URI-path rewrite so query-string links keep working.

## Validation

- `python3 -m unittest scripts.test_r2_release` (14 tests passed)
- `python3 scripts/check_markdown_links.py`
- `git diff --check`
- `mvn -B -Dfmt.skip=true test` (1867 tests passed)
- `mvn -B -Dfmt.skip=true -DskipTests package`
- Live R2 homepage and stable-channel byte verification passed.

## Cloudflare

The active rewrite now matches `URI Path equals /` and rewrites to `/index.html` while preserving the query string.
