### PR TITLE
Keep GitHub links in stable release notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@
 </p>
 
 > [!NOTE]
-> 当前正式版优先从 [Cloudflare R2 下载页](https://download.goagent.top/) 下载，连接异常时可回到 [GitHub Releases](https://github.com/wimi321/lizzieyzy-next/releases) 使用完整备用资产、安装器、Linux 包和历史版本。GitHub 的 Downloads 徽章不包含 R2 下载量，不能作为项目总下载量。
+> 国内用户建议从 [官网下载页面](https://download.goagent.top/) 下载正式版；需要安装器、Linux 包或历史版本时，可使用 [GitHub Releases](https://github.com/wimi321/lizzieyzy-next/releases)。
 >
 > 国内用户也可使用公开百度网盘下载：
 > [https://pan.baidu.com/s/1wthaL8YwGMxy_u0U7Mabpw?pwd=3i8w](https://pan.baidu.com/s/1wthaL8YwGMxy_u0U7Mabpw?pwd=3i8w)
@@ -90,7 +90,7 @@
 
 ## 先下载哪个
 
-当前正式版常用资产在 [Cloudflare R2 下载页](https://download.goagent.top/)；安装器、Linux、历史版本和故障备用下载仍在 [GitHub Releases](https://github.com/wimi321/lizzieyzy-next/releases)。
+国内用户建议从 [官网下载页面](https://download.goagent.top/) 选择常用正式版；安装器、Linux 包和历史版本可在 [GitHub Releases](https://github.com/wimi321/lizzieyzy-next/releases) 下载。
 
 <p align="center">
   <img src="assets/package-guide-zh.svg" alt="LizzieYzy Next 下载选择图" width="100%" />

--- a/README_EN.md
+++ b/README_EN.md
@@ -33,7 +33,7 @@
 </p>
 
 > [!NOTE]
-> Current stable packages use the [Cloudflare R2 download page](https://download.goagent.top/) as the primary source. Use [GitHub Releases](https://github.com/wimi321/lizzieyzy-next/releases) for automatic fallback, installers, Linux packages, and version history. The GitHub Downloads badge does not include R2 traffic.
+> Users in mainland China are encouraged to use the [official download page](https://download.goagent.top/) for stable builds. Installers, Linux packages, and older versions remain available from [GitHub Releases](https://github.com/wimi321/lizzieyzy-next/releases).
 >
 > For users in mainland China, a public Baidu Netdisk download is available:
 > [https://pan.baidu.com/s/1wthaL8YwGMxy_u0U7Mabpw?pwd=3i8w](https://pan.baidu.com/s/1wthaL8YwGMxy_u0U7Mabpw?pwd=3i8w)
@@ -85,7 +85,7 @@ If you are searching for these things, this is the project to check first:
 
 ## What To Download First
 
-Common stable packages are on the [Cloudflare R2 download page](https://download.goagent.top/). Installers, Linux packages, historical releases, and fallback downloads remain on [GitHub Releases](https://github.com/wimi321/lizzieyzy-next/releases).
+Users in mainland China are encouraged to choose common stable builds from the [official download page](https://download.goagent.top/). Installers, Linux packages, and older versions are available from [GitHub Releases](https://github.com/wimi321/lizzieyzy-next/releases).
 
 <p align="center">
   <img src="assets/package-guide.svg" alt="LizzieYzy Next package guide" width="100%" />

--- a/README_JA.md
+++ b/README_JA.md
@@ -33,7 +33,7 @@
 </p>
 
 > [!NOTE]
-> 現在の安定版は [Cloudflare R2 ダウンロードページ](https://download.goagent.top/) を優先します。接続できない場合、インストーラ、Linux、過去版は [GitHub Releases](https://github.com/wimi321/lizzieyzy-next/releases) を利用できます。GitHub の Downloads バッジには R2 のダウンロード数は含まれません。
+> 中国本土のユーザーには、安定版の [公式ダウンロードページ](https://download.goagent.top/) をおすすめします。インストーラ、Linux パッケージ、過去版は [GitHub Releases](https://github.com/wimi321/lizzieyzy-next/releases) からダウンロードできます。
 >
 > 中国本土から利用する場合は、公開されている Baidu Netdisk ダウンロードも使えます:
 > [https://pan.baidu.com/s/1wthaL8YwGMxy_u0U7Mabpw?pwd=3i8w](https://pan.baidu.com/s/1wthaL8YwGMxy_u0U7Mabpw?pwd=3i8w)
@@ -82,7 +82,7 @@
 
 ## まずどれをダウンロードするか
 
-現在の安定版でよく使うパッケージは [Cloudflare R2 ダウンロードページ](https://download.goagent.top/) にあります。インストーラ、Linux、過去版、予備ダウンロードは [GitHub Releases](https://github.com/wimi321/lizzieyzy-next/releases) に残ります。
+中国本土のユーザーには、よく使う安定版を [公式ダウンロードページ](https://download.goagent.top/) から選ぶことをおすすめします。インストーラ、Linux パッケージ、過去版は [GitHub Releases](https://github.com/wimi321/lizzieyzy-next/releases) からダウンロードできます。
 
 <p align="center">
   <img src="assets/package-guide.svg" alt="LizzieYzy Next package guide" width="100%" />

--- a/README_KO.md
+++ b/README_KO.md
@@ -33,7 +33,7 @@
 </p>
 
 > [!NOTE]
-> 현재 안정판은 [Cloudflare R2 다운로드 페이지](https://download.goagent.top/)를 기본 경로로 사용합니다. 연결 실패, 설치형, Linux, 이전 버전은 [GitHub Releases](https://github.com/wimi321/lizzieyzy-next/releases)를 사용할 수 있습니다. GitHub Downloads 배지에는 R2 다운로드 수가 포함되지 않습니다.
+> 중국 본토 사용자는 안정판을 [공식 다운로드 페이지](https://download.goagent.top/)에서 받는 것을 권장합니다. 설치형, Linux 패키지, 이전 버전은 [GitHub Releases](https://github.com/wimi321/lizzieyzy-next/releases)에서 받을 수 있습니다.
 >
 > 중국 본토 사용자라면 공개 Baidu Netdisk 다운로드도 바로 사용할 수 있습니다:
 > [https://pan.baidu.com/s/1wthaL8YwGMxy_u0U7Mabpw?pwd=3i8w](https://pan.baidu.com/s/1wthaL8YwGMxy_u0U7Mabpw?pwd=3i8w)
@@ -82,7 +82,7 @@
 
 ## 먼저 무엇을 다운로드할까
 
-현재 안정판의 일반 패키지는 [Cloudflare R2 다운로드 페이지](https://download.goagent.top/)에 있습니다. 설치형, Linux, 이전 버전과 예비 다운로드는 [GitHub Releases](https://github.com/wimi321/lizzieyzy-next/releases)에 남아 있습니다.
+중국 본토 사용자는 일반 안정판을 [공식 다운로드 페이지](https://download.goagent.top/)에서 선택하는 것을 권장합니다. 설치형, Linux 패키지, 이전 버전은 [GitHub Releases](https://github.com/wimi321/lizzieyzy-next/releases)에서 받을 수 있습니다.
 
 <p align="center">
   <img src="assets/package-guide.svg" alt="LizzieYzy Next package guide" width="100%" />

--- a/README_TH.md
+++ b/README_TH.md
@@ -31,7 +31,7 @@
 </p>
 
 > [!NOTE]
-> แพ็กเกจเวอร์ชันเสถียรใช้ [หน้าดาวน์โหลด Cloudflare R2](https://download.goagent.top/) เป็นแหล่งหลัก หากเชื่อมต่อไม่ได้ หรือต้องการ installer, Linux และเวอร์ชันเก่า ให้ใช้ [GitHub Releases](https://github.com/wimi321/lizzieyzy-next/releases) ตัวเลข Downloads บน GitHub ไม่รวมการดาวน์โหลดจาก R2
+> แนะนำให้ผู้ใช้ในจีนแผ่นดินใหญ่ดาวน์โหลดเวอร์ชันเสถียรจาก [หน้าดาวน์โหลดอย่างเป็นทางการ](https://download.goagent.top/) ส่วน installer, แพ็กเกจ Linux และเวอร์ชันเก่าสามารถดาวน์โหลดได้จาก [GitHub Releases](https://github.com/wimi321/lizzieyzy-next/releases)
 
 > [!IMPORTANT]
 > ถ้าคุณแค่อยากดาวน์โหลดเวอร์ชันที่ใช่ ให้จำ 6 ข้อนี้:
@@ -63,7 +63,7 @@
 
 ## เลือกดาวน์โหลดตัวไหน
 
-แพ็กเกจเวอร์ชันเสถียรที่ใช้บ่อยอยู่ใน [หน้าดาวน์โหลด Cloudflare R2](https://download.goagent.top/) ส่วน installer, Linux, เวอร์ชันเก่า และแหล่งสำรองยังอยู่ใน [GitHub Releases](https://github.com/wimi321/lizzieyzy-next/releases)
+แนะนำให้ผู้ใช้ในจีนแผ่นดินใหญ่เลือกเวอร์ชันเสถียรที่ใช้บ่อยจาก [หน้าดาวน์โหลดอย่างเป็นทางการ](https://download.goagent.top/) ส่วน installer, แพ็กเกจ Linux และเวอร์ชันเก่าสามารถดาวน์โหลดได้จาก [GitHub Releases](https://github.com/wimi321/lizzieyzy-next/releases)
 
 | สถานการณ์ของคุณ | คีย์เวิร์ดไฟล์ที่ควรหา |
 | --- | --- |

--- a/README_ZH_TW.md
+++ b/README_ZH_TW.md
@@ -36,7 +36,7 @@
 > 歡迎交流使用問題、回報 bug、分享使用體驗，或者討論接下來最想加的功能。
 
 > [!NOTE]
-> 目前正式版優先使用 [Cloudflare R2 下載頁](https://download.goagent.top/)；連線異常、安裝程式、Linux 與歷史版本仍可使用 [GitHub Releases](https://github.com/wimi321/lizzieyzy-next/releases)。GitHub Downloads 徽章不包含 R2 下載量。
+> 中國大陸使用者建議從 [官方下載頁面](https://download.goagent.top/) 下載正式版；需要安裝程式、Linux 套件或歷史版本時，可使用 [GitHub Releases](https://github.com/wimi321/lizzieyzy-next/releases)。
 
 > [!IMPORTANT]
 > 如果你只想先下對版本，先記住這 6 句：
@@ -68,7 +68,7 @@
 
 ## 先下載哪個
 
-目前正式版常用資產在 [Cloudflare R2 下載頁](https://download.goagent.top/)；安裝程式、Linux、歷史版本與備用下載仍在 [GitHub Releases](https://github.com/wimi321/lizzieyzy-next/releases)。
+中國大陸使用者建議從 [官方下載頁面](https://download.goagent.top/) 選擇常用正式版；安裝程式、Linux 套件和歷史版本可在 [GitHub Releases](https://github.com/wimi321/lizzieyzy-next/releases) 下載。
 
 | 你的情況 | 到 Releases 裡找包含這個關鍵字的檔案 |
 | --- | --- |

--- a/scripts/r2_release.py
+++ b/scripts/r2_release.py
@@ -264,7 +264,7 @@ def build_legacy_manifest(manifest: dict[str, Any]) -> dict[str, Any]:
 def stable_release_body(
     release: dict[str, Any], mirrored_assets: list[Asset], public_base: str
 ) -> str:
-    """Switch mirrored asset links to R2 while keeping one obvious GitHub fallback."""
+    """Keep GitHub asset links while recommending the official download page."""
     body = str(release.get("body") or "")
     marker_pattern = re.compile(
         re.escape(RELEASE_NOTE_START) + r".*?" + re.escape(RELEASE_NOTE_END) + r"\n*",
@@ -272,20 +272,16 @@ def stable_release_body(
     )
     body = marker_pattern.sub("", body).strip()
     for asset in mirrored_assets:
-        body = body.replace(asset.browser_url, r2_url(public_base, asset))
+        body = body.replace(r2_url(public_base, asset), asset.browser_url)
 
-    release_url = str(release.get("html_url") or "").strip()
-    fallback = (
-        f"[GitHub 全量资产与备用下载 / GitHub fallback]({release_url})"
-        if release_url
-        else "GitHub 全量资产与备用下载 / GitHub fallback"
-    )
     notice = (
         f"{RELEASE_NOTE_START}\n"
         "> [!IMPORTANT]\n"
-        f"> **正式版主下载 / Stable primary downloads:** "
-        f"[{public_base.rstrip('/')}/]({public_base.rstrip('/')}/)  \n"
-        f"> R2 连接异常时可使用 {fallback}；Linux、安装器与历史版本仍在 GitHub。\n"
+        f"> **国内用户建议从 [官网下载页面]({public_base.rstrip('/')}/) 下载；"
+        f"Users in mainland China may prefer the "
+        f"[official download page]({public_base.rstrip('/')}/).**  \n"
+        "> 本页所有文件链接均保留 GitHub 原始地址。All file links on this Release "
+        "remain on GitHub.\n"
         f"{RELEASE_NOTE_END}"
     )
     if not body:

--- a/scripts/test_r2_release.py
+++ b/scripts/test_r2_release.py
@@ -177,13 +177,13 @@ class R2ReleaseTest(unittest.TestCase):
             self.assertNotIn(hidden_entry["downloadUrl"], page)
         self.assertIn("下载页面正在更新，当前下载仍可正常使用", maintenance)
 
-    def test_stable_release_body_uses_r2_and_keeps_one_github_fallback(self):
+    def test_stable_release_body_keeps_github_links_and_recommends_official_page(self):
         source = release()
         selected = r2_release.select_r2_assets(source, r2_release.DEFAULT_PUBLIC_BASE)
         linked = selected[0]
         source["body"] = (
             "# LizzieYzy Next\n\n"
-            f"[{linked.name}]({linked.browser_url})\n"
+            f"[{linked.name}]({r2_release.r2_url(r2_release.DEFAULT_PUBLIC_BASE, linked)})\n"
         )
 
         updated = r2_release.stable_release_body(
@@ -193,10 +193,14 @@ class R2ReleaseTest(unittest.TestCase):
             {**source, "body": updated}, selected, r2_release.DEFAULT_PUBLIC_BASE
         )
 
-        self.assertIn(r2_release.r2_url(r2_release.DEFAULT_PUBLIC_BASE, linked), updated)
-        self.assertNotIn(linked.browser_url, updated)
+        self.assertIn(linked.browser_url, updated)
+        self.assertNotIn(r2_release.r2_url(r2_release.DEFAULT_PUBLIC_BASE, linked), updated)
+        self.assertIn("国内用户建议从", updated)
+        self.assertIn("official download page", updated)
+        self.assertNotIn("Cloudflare", updated)
+        self.assertNotIn("R2 连接", updated)
         self.assertEqual(1, updated.count(r2_release.RELEASE_NOTE_START))
-        self.assertEqual(1, updated.count(source["html_url"]))
+        self.assertEqual(2, updated.count(r2_release.DEFAULT_PUBLIC_BASE + "/"))
         self.assertEqual(updated, repeated)
 
     def test_public_assets_are_verified_before_envelope_activation(self):


### PR DESCRIPTION
## Summary

- Keeps every file link on GitHub Release pages pointed at the original GitHub release asset.
- Recommends the official download page to users in mainland China without exposing storage-provider terminology.
- Updates all six README languages consistently.
- Repairs older mirrored asset links during future stable-release promotion.

## Validation

- `python3 -m unittest scripts.test_r2_release`: 14 passed
- `python3 scripts/check_markdown_links.py`: passed
- `mvn -B -Dfmt.skip=true -DargLine=-Djava.awt.headless=true test`: 2001 tests, 0 failures, 0 errors, 5 skipped
- `mvn -B -Dfmt.skip=true -DskipTests package`: passed
- `git diff --check`: passed