### PR TITLE
Unify official download entry and stable download backend

### DIFF
--- a/.github/workflows/promote-stable-release.yml
+++ b/.github/workflows/promote-stable-release.yml
@@ -91,6 +91,7 @@ jobs:
             --tag "$RELEASE_TAG"
             --bucket "${R2_BUCKET:-lizzieyzy-next-downloads}"
             --public-base "${R2_PUBLIC_BASE:-https://download.goagent.top}"
+            --website-download-url "https://goagent.top/download/"
             --private-key "$key_file"
             --key-id stable-2026-08
           )

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 <p align="center">
   <a href="https://goagent.top/"><strong>官方网站</strong></a>
   ·
-  <a href="https://download.goagent.top/"><strong>正式版下载</strong></a>
+  <a href="https://goagent.top/download/"><strong>正式版下载</strong></a>
   ·
   <a href="https://pan.baidu.com/s/1wthaL8YwGMxy_u0U7Mabpw?pwd=3i8w"><strong>百度网盘下载</strong></a>
   ·
@@ -33,7 +33,7 @@
 </p>
 
 > [!NOTE]
-> 国内用户建议从 [官网下载页面](https://download.goagent.top/) 下载正式版；需要安装器、Linux 包或历史版本时，可使用 [GitHub Releases](https://github.com/wimi321/lizzieyzy-next/releases)。
+> 国内用户建议从 [官网下载页面](https://goagent.top/download/) 下载正式版；需要安装器、Linux 包或历史版本时，可使用 [GitHub Releases](https://github.com/wimi321/lizzieyzy-next/releases)。
 >
 > 国内用户也可使用公开百度网盘下载：
 > [https://pan.baidu.com/s/1wthaL8YwGMxy_u0U7Mabpw?pwd=3i8w](https://pan.baidu.com/s/1wthaL8YwGMxy_u0U7Mabpw?pwd=3i8w)
@@ -46,7 +46,7 @@
 
 > [!IMPORTANT]
 > 如果你只想先下对版本，先记住这几句：
-> - Windows 大多数用户：到 [正式版下载页](https://download.goagent.top/) 下载 `*windows64.opencl.portable.zip`
+> - Windows 大多数用户：到 [正式版下载页](https://goagent.top/download/) 下载 `*windows64.opencl.portable.zip`
 > - RTX 20/30/40 NVIDIA 显卡并且想更快：下载 `*windows64.nvidia.portable.zip`
 > - RTX 5070/5080/5090：优先下载 `*windows64.nvidia50.cuda.portable.zip`，需要 TensorRT 时再到软件内“一键设置”按需安装
 > - 已经有 Windows 免安装版：日常升级优先下载 `*windows64.core-update.zip`，关闭软件后解压到旧目录覆盖，只更新主程序和启动器配置
@@ -90,7 +90,7 @@
 
 ## 先下载哪个
 
-国内用户建议从 [官网下载页面](https://download.goagent.top/) 选择常用正式版；安装器、Linux 包和历史版本可在 [GitHub Releases](https://github.com/wimi321/lizzieyzy-next/releases) 下载。
+国内用户建议从 [官网下载页面](https://goagent.top/download/) 选择常用正式版；安装器、Linux 包和历史版本可在 [GitHub Releases](https://github.com/wimi321/lizzieyzy-next/releases) 下载。
 
 <p align="center">
   <img src="assets/package-guide-zh.svg" alt="LizzieYzy Next 下载选择图" width="100%" />
@@ -153,7 +153,7 @@ Windows `portable.zip` 是真正的免安装模式：配置、日志、保存棋
 
 ## 三步开始
 
-1. 去 [正式版下载页](https://download.goagent.top/) 下载适合自己系统的包；需要安装器、Linux 或历史版本时使用 GitHub Releases。
+1. 去 [正式版下载页](https://goagent.top/download/) 下载适合自己系统的包；需要安装器、Linux 或历史版本时使用 GitHub Releases。
 2. 打开程序后，点击 `野狐棋谱`，输入野狐昵称。
 3. 抓到棋谱后继续做快速全盘分析，用主胜率图和底部快速概览直接定位关键手。
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -23,7 +23,7 @@
 <p align="center">
   <a href="https://goagent.top/"><strong>Official Website</strong></a>
   ·
-  <a href="https://download.goagent.top/"><strong>Stable Downloads</strong></a>
+  <a href="https://goagent.top/download/"><strong>Stable Downloads</strong></a>
   ·
   <a href="https://pan.baidu.com/s/1wthaL8YwGMxy_u0U7Mabpw?pwd=3i8w"><strong>Baidu Download</strong></a>
   ·
@@ -33,7 +33,7 @@
 </p>
 
 > [!NOTE]
-> Users in mainland China are encouraged to use the [official download page](https://download.goagent.top/) for stable builds. Installers, Linux packages, and older versions remain available from [GitHub Releases](https://github.com/wimi321/lizzieyzy-next/releases).
+> Users in mainland China are encouraged to use the [official download page](https://goagent.top/download/) for stable builds. Installers, Linux packages, and older versions remain available from [GitHub Releases](https://github.com/wimi321/lizzieyzy-next/releases).
 >
 > For users in mainland China, a public Baidu Netdisk download is available:
 > [https://pan.baidu.com/s/1wthaL8YwGMxy_u0U7Mabpw?pwd=3i8w](https://pan.baidu.com/s/1wthaL8YwGMxy_u0U7Mabpw?pwd=3i8w)
@@ -46,7 +46,7 @@
 
 > [!IMPORTANT]
 > If you only want the shortest possible answer, remember these 9 points:
-> - Most Windows users should open [Stable Downloads](https://download.goagent.top/) and download `*windows64.opencl.portable.zip`
+> - Most Windows users should open [Stable Downloads](https://goagent.top/download/) and download `*windows64.opencl.portable.zip`
 > - If your PC has an RTX 20/30/40 NVIDIA GPU and you want more speed, download `*windows64.nvidia.portable.zip`
 > - RTX 5070/5080/5090 users should try `*windows64.nvidia50.cuda.portable.zip` first; install TensorRT from the in-app KataGo Auto Setup only if needed
 > - TensorRT is not RTX 50-only: RTX 20/30/40/50 NVIDIA users can install it on demand; GTX 10 series and older cards should prefer CUDA/OpenCL
@@ -85,7 +85,7 @@ If you are searching for these things, this is the project to check first:
 
 ## What To Download First
 
-Users in mainland China are encouraged to choose common stable builds from the [official download page](https://download.goagent.top/). Installers, Linux packages, and older versions are available from [GitHub Releases](https://github.com/wimi321/lizzieyzy-next/releases).
+Users in mainland China are encouraged to choose common stable builds from the [official download page](https://goagent.top/download/). Installers, Linux packages, and older versions are available from [GitHub Releases](https://github.com/wimi321/lizzieyzy-next/releases).
 
 <p align="center">
   <img src="assets/package-guide.svg" alt="LizzieYzy Next package guide" width="100%" />
@@ -136,7 +136,7 @@ Quick rule:
 
 ## Start In 3 Steps
 
-1. Download the right stable package from [Stable Downloads](https://download.goagent.top/); use GitHub Releases for installers, Linux, or older versions.
+1. Download the right stable package from [Stable Downloads](https://goagent.top/download/); use GitHub Releases for installers, Linux, or older versions.
 2. Open `Fox Kifu` and enter a Fox nickname.
 3. Fetch the games, run fast full-game analysis, and use the graph plus overview to jump to important moves.
 

--- a/README_JA.md
+++ b/README_JA.md
@@ -23,7 +23,7 @@
 <p align="center">
   <a href="https://goagent.top/"><strong>公式サイト</strong></a>
   ·
-  <a href="https://download.goagent.top/"><strong>安定版ダウンロード</strong></a>
+  <a href="https://goagent.top/download/"><strong>安定版ダウンロード</strong></a>
   ·
   <a href="https://pan.baidu.com/s/1wthaL8YwGMxy_u0U7Mabpw?pwd=3i8w"><strong>Baidu ダウンロード</strong></a>
   ·
@@ -33,7 +33,7 @@
 </p>
 
 > [!NOTE]
-> 中国本土のユーザーには、安定版の [公式ダウンロードページ](https://download.goagent.top/) をおすすめします。インストーラ、Linux パッケージ、過去版は [GitHub Releases](https://github.com/wimi321/lizzieyzy-next/releases) からダウンロードできます。
+> 中国本土のユーザーには、安定版の [公式ダウンロードページ](https://goagent.top/download/) をおすすめします。インストーラ、Linux パッケージ、過去版は [GitHub Releases](https://github.com/wimi321/lizzieyzy-next/releases) からダウンロードできます。
 >
 > 中国本土から利用する場合は、公開されている Baidu Netdisk ダウンロードも使えます:
 > [https://pan.baidu.com/s/1wthaL8YwGMxy_u0U7Mabpw?pwd=3i8w](https://pan.baidu.com/s/1wthaL8YwGMxy_u0U7Mabpw?pwd=3i8w)
@@ -46,7 +46,7 @@
 
 > [!IMPORTANT]
 > まずはこの 6 点だけ押さえれば大丈夫です:
-> - Windows 利用者の多くは [安定版ダウンロード](https://download.goagent.top/) で `*windows64.opencl.portable.zip` を選べば始めやすいです
+> - Windows 利用者の多くは [安定版ダウンロード](https://goagent.top/download/) で `*windows64.opencl.portable.zip` を選べば始めやすいです
 > - NVIDIA GPU があり、より速く解析したい場合は `*windows64.nvidia.portable.zip` を選べます
 > - OpenCL の相性が悪い場合は `*windows64.with-katago.portable.zip` に切り替えられます
 > - 野狐棋譜取得はニックネーム入力に対応しており、多くの利用者はアカウント番号を先に知らなくても大丈夫です
@@ -82,7 +82,7 @@
 
 ## まずどれをダウンロードするか
 
-中国本土のユーザーには、よく使う安定版を [公式ダウンロードページ](https://download.goagent.top/) から選ぶことをおすすめします。インストーラ、Linux パッケージ、過去版は [GitHub Releases](https://github.com/wimi321/lizzieyzy-next/releases) からダウンロードできます。
+中国本土のユーザーには、よく使う安定版を [公式ダウンロードページ](https://goagent.top/download/) から選ぶことをおすすめします。インストーラ、Linux パッケージ、過去版は [GitHub Releases](https://github.com/wimi321/lizzieyzy-next/releases) からダウンロードできます。
 
 <p align="center">
   <img src="assets/package-guide.svg" alt="LizzieYzy Next package guide" width="100%" />
@@ -127,7 +127,7 @@
 
 ## 3 ステップで開始
 
-1. [安定版ダウンロード](https://download.goagent.top/) から環境に合うものを選び、インストーラ、Linux、過去版が必要な場合は GitHub Releases を使います。
+1. [安定版ダウンロード](https://goagent.top/download/) から環境に合うものを選び、インストーラ、Linux、過去版が必要な場合は GitHub Releases を使います。
 2. `野狐棋譜` を開いて野狐のニックネームを入力します。
 3. 棋譜を取得し、全局を素早く解析して、グラフと概要から重要な手へ移動します。
 

--- a/README_KO.md
+++ b/README_KO.md
@@ -23,7 +23,7 @@
 <p align="center">
   <a href="https://goagent.top/"><strong>공식 웹사이트</strong></a>
   ·
-  <a href="https://download.goagent.top/"><strong>안정판 다운로드</strong></a>
+  <a href="https://goagent.top/download/"><strong>안정판 다운로드</strong></a>
   ·
   <a href="https://pan.baidu.com/s/1wthaL8YwGMxy_u0U7Mabpw?pwd=3i8w"><strong>Baidu 다운로드</strong></a>
   ·
@@ -33,7 +33,7 @@
 </p>
 
 > [!NOTE]
-> 중국 본토 사용자는 안정판을 [공식 다운로드 페이지](https://download.goagent.top/)에서 받는 것을 권장합니다. 설치형, Linux 패키지, 이전 버전은 [GitHub Releases](https://github.com/wimi321/lizzieyzy-next/releases)에서 받을 수 있습니다.
+> 중국 본토 사용자는 안정판을 [공식 다운로드 페이지](https://goagent.top/download/)에서 받는 것을 권장합니다. 설치형, Linux 패키지, 이전 버전은 [GitHub Releases](https://github.com/wimi321/lizzieyzy-next/releases)에서 받을 수 있습니다.
 >
 > 중국 본토 사용자라면 공개 Baidu Netdisk 다운로드도 바로 사용할 수 있습니다:
 > [https://pan.baidu.com/s/1wthaL8YwGMxy_u0U7Mabpw?pwd=3i8w](https://pan.baidu.com/s/1wthaL8YwGMxy_u0U7Mabpw?pwd=3i8w)
@@ -46,7 +46,7 @@
 
 > [!IMPORTANT]
 > 먼저 이 6가지만 기억하면 됩니다:
-> - 대부분의 Windows 사용자는 [안정판 다운로드](https://download.goagent.top/)에서 `*windows64.opencl.portable.zip` 을 받으면 가장 쉽습니다
+> - 대부분의 Windows 사용자는 [안정판 다운로드](https://goagent.top/download/)에서 `*windows64.opencl.portable.zip` 을 받으면 가장 쉽습니다
 > - NVIDIA GPU 가 있고 더 빠른 분석을 원하면 `*windows64.nvidia.portable.zip` 을 선택하면 됩니다
 > - OpenCL 이 잘 맞지 않으면 `*windows64.with-katago.portable.zip` 으로 바꿔 쓸 수 있습니다
 > - Fox 기보 가져오기는 닉네임 입력을 지원하므로, 많은 사용자는 계정 번호를 먼저 알 필요가 없습니다
@@ -82,7 +82,7 @@
 
 ## 먼저 무엇을 다운로드할까
 
-중국 본토 사용자는 일반 안정판을 [공식 다운로드 페이지](https://download.goagent.top/)에서 선택하는 것을 권장합니다. 설치형, Linux 패키지, 이전 버전은 [GitHub Releases](https://github.com/wimi321/lizzieyzy-next/releases)에서 받을 수 있습니다.
+중국 본토 사용자는 일반 안정판을 [공식 다운로드 페이지](https://goagent.top/download/)에서 선택하는 것을 권장합니다. 설치형, Linux 패키지, 이전 버전은 [GitHub Releases](https://github.com/wimi321/lizzieyzy-next/releases)에서 받을 수 있습니다.
 
 <p align="center">
   <img src="assets/package-guide.svg" alt="LizzieYzy Next package guide" width="100%" />
@@ -127,7 +127,7 @@
 
 ## 3단계로 시작
 
-1. [안정판 다운로드](https://download.goagent.top/)에서 환경에 맞는 패키지를 받고, 설치형, Linux 또는 이전 버전은 GitHub Releases를 사용합니다.
+1. [안정판 다운로드](https://goagent.top/download/)에서 환경에 맞는 패키지를 받고, 설치형, Linux 또는 이전 버전은 GitHub Releases를 사용합니다.
 2. `Fox Kifu` 를 열고 Fox 닉네임을 입력합니다.
 3. 기보를 가져온 뒤 빠른 전판 분석을 돌리고, 그래프와 개요에서 중요한 수로 바로 이동합니다.
 

--- a/README_TH.md
+++ b/README_TH.md
@@ -23,7 +23,7 @@
 <p align="center">
   <a href="https://goagent.top/"><strong>เว็บไซต์ทางการ</strong></a>
   ·
-  <a href="https://download.goagent.top/"><strong>ดาวน์โหลดเวอร์ชันเสถียร</strong></a>
+  <a href="https://goagent.top/download/"><strong>ดาวน์โหลดเวอร์ชันเสถียร</strong></a>
   ·
   <a href="docs/INSTALL.md"><strong>คู่มือติดตั้ง</strong></a>
   ·
@@ -31,11 +31,11 @@
 </p>
 
 > [!NOTE]
-> แนะนำให้ผู้ใช้ในจีนแผ่นดินใหญ่ดาวน์โหลดเวอร์ชันเสถียรจาก [หน้าดาวน์โหลดอย่างเป็นทางการ](https://download.goagent.top/) ส่วน installer, แพ็กเกจ Linux และเวอร์ชันเก่าสามารถดาวน์โหลดได้จาก [GitHub Releases](https://github.com/wimi321/lizzieyzy-next/releases)
+> แนะนำให้ผู้ใช้ในจีนแผ่นดินใหญ่ดาวน์โหลดเวอร์ชันเสถียรจาก [หน้าดาวน์โหลดอย่างเป็นทางการ](https://goagent.top/download/) ส่วน installer, แพ็กเกจ Linux และเวอร์ชันเก่าสามารถดาวน์โหลดได้จาก [GitHub Releases](https://github.com/wimi321/lizzieyzy-next/releases)
 
 > [!IMPORTANT]
 > ถ้าคุณแค่อยากดาวน์โหลดเวอร์ชันที่ใช่ ให้จำ 6 ข้อนี้:
-> - ผู้ใช้ Windows ส่วนใหญ่: ไปที่ [ดาวน์โหลดเวอร์ชันเสถียร](https://download.goagent.top/) แล้วดาวน์โหลด `*windows64.opencl.portable.zip`
+> - ผู้ใช้ Windows ส่วนใหญ่: ไปที่ [ดาวน์โหลดเวอร์ชันเสถียร](https://goagent.top/download/) แล้วดาวน์โหลด `*windows64.opencl.portable.zip`
 > - ถ้าคุณมีการ์ดจอ NVIDIA และต้องการความเร็วสูงกว่า: ดาวน์โหลด `*windows64.nvidia.portable.zip`
 > - ถ้า OpenCL ไม่เสถียรบนเครื่องของคุณ: ดาวน์โหลด `*windows64.with-katago.portable.zip`
 > - ตอนนี้รองรับการใส่ชื่อเล่น Fox โดยตรงเพื่อดึงเกมสาธารณะล่าสุด ไม่ต้องรู้เลขบัญชีก่อน
@@ -63,7 +63,7 @@
 
 ## เลือกดาวน์โหลดตัวไหน
 
-แนะนำให้ผู้ใช้ในจีนแผ่นดินใหญ่เลือกเวอร์ชันเสถียรที่ใช้บ่อยจาก [หน้าดาวน์โหลดอย่างเป็นทางการ](https://download.goagent.top/) ส่วน installer, แพ็กเกจ Linux และเวอร์ชันเก่าสามารถดาวน์โหลดได้จาก [GitHub Releases](https://github.com/wimi321/lizzieyzy-next/releases)
+แนะนำให้ผู้ใช้ในจีนแผ่นดินใหญ่เลือกเวอร์ชันเสถียรที่ใช้บ่อยจาก [หน้าดาวน์โหลดอย่างเป็นทางการ](https://goagent.top/download/) ส่วน installer, แพ็กเกจ Linux และเวอร์ชันเก่าสามารถดาวน์โหลดได้จาก [GitHub Releases](https://github.com/wimi321/lizzieyzy-next/releases)
 
 | สถานการณ์ของคุณ | คีย์เวิร์ดไฟล์ที่ควรหา |
 | --- | --- |
@@ -78,7 +78,7 @@
 
 ## เริ่มต้นใน 3 ขั้นตอน
 
-1. ไปที่ [ดาวน์โหลดเวอร์ชันเสถียร](https://download.goagent.top/) และเลือกแพ็กเกจที่เหมาะกับระบบของคุณ ส่วน installer, Linux และเวอร์ชันเก่าให้ใช้ GitHub Releases
+1. ไปที่ [ดาวน์โหลดเวอร์ชันเสถียร](https://goagent.top/download/) และเลือกแพ็กเกจที่เหมาะกับระบบของคุณ ส่วน installer, Linux และเวอร์ชันเก่าให้ใช้ GitHub Releases
 2. เปิดโปรแกรมแล้วคลิก `Fox` เพื่อใส่ชื่อเล่น Fox
 3. หลังจากดึงเกมแล้ว ให้รันการวิเคราะห์ทั้งกระดานรวดเร็ว ใช้กราฟอัตราชนะและภาพรวมด้านล่างเพื่อหาจังหวะสำคัญ
 

--- a/README_ZH_TW.md
+++ b/README_ZH_TW.md
@@ -23,7 +23,7 @@
 <p align="center">
   <a href="https://goagent.top/"><strong>官方網站</strong></a>
   ·
-  <a href="https://download.goagent.top/"><strong>正式版下載</strong></a>
+  <a href="https://goagent.top/download/"><strong>正式版下載</strong></a>
   ·
   <a href="docs/INSTALL.md"><strong>安裝說明</strong></a>
   ·
@@ -36,11 +36,11 @@
 > 歡迎交流使用問題、回報 bug、分享使用體驗，或者討論接下來最想加的功能。
 
 > [!NOTE]
-> 中國大陸使用者建議從 [官方下載頁面](https://download.goagent.top/) 下載正式版；需要安裝程式、Linux 套件或歷史版本時，可使用 [GitHub Releases](https://github.com/wimi321/lizzieyzy-next/releases)。
+> 中國大陸使用者建議從 [官方下載頁面](https://goagent.top/download/) 下載正式版；需要安裝程式、Linux 套件或歷史版本時，可使用 [GitHub Releases](https://github.com/wimi321/lizzieyzy-next/releases)。
 
 > [!IMPORTANT]
 > 如果你只想先下對版本，先記住這 6 句：
-> - Windows 大多數使用者：到 [正式版下載頁](https://download.goagent.top/) 下載 `*windows64.opencl.portable.zip`
+> - Windows 大多數使用者：到 [正式版下載頁](https://goagent.top/download/) 下載 `*windows64.opencl.portable.zip`
 > - 如果你的電腦有 NVIDIA 顯示卡並且想更快：下載 `*windows64.nvidia.portable.zip`
 > - 如果 OpenCL 在你的電腦上不穩定：下載 `*windows64.with-katago.portable.zip`
 > - 現在支援直接輸入野狐暱稱抓最近公開棋譜，不需要先查帳號數字
@@ -68,7 +68,7 @@
 
 ## 先下載哪個
 
-中國大陸使用者建議從 [官方下載頁面](https://download.goagent.top/) 選擇常用正式版；安裝程式、Linux 套件和歷史版本可在 [GitHub Releases](https://github.com/wimi321/lizzieyzy-next/releases) 下載。
+中國大陸使用者建議從 [官方下載頁面](https://goagent.top/download/) 選擇常用正式版；安裝程式、Linux 套件和歷史版本可在 [GitHub Releases](https://github.com/wimi321/lizzieyzy-next/releases) 下載。
 
 | 你的情況 | 到 Releases 裡找包含這個關鍵字的檔案 |
 | --- | --- |
@@ -83,7 +83,7 @@
 
 ## 三步開始
 
-1. 到 [正式版下載頁](https://download.goagent.top/) 下載適合自己系統的包；需要安裝程式、Linux 或歷史版本時使用 GitHub Releases。
+1. 到 [正式版下載頁](https://goagent.top/download/) 下載適合自己系統的包；需要安裝程式、Linux 或歷史版本時使用 GitHub Releases。
 2. 打開程式後，點擊 `野狐棋譜`，輸入野狐暱稱。
 3. 抓到棋譜後繼續做快速全盤分析，用主勝率圖和底部快速概覽直接定位關鍵手。
 

--- a/docs/PACKAGES.md
+++ b/docs/PACKAGES.md
@@ -22,7 +22,7 @@
 - TensorRT 一键安装成功后会自动清理完整下载包缓存；首次运行产生的 CUDA/TensorRT 缓存会尽量写入软件自己的 `runtime/`，减少 C 盘额外占用
 - RTX 50 / TensorRT 吞吐与功耗对比必须固定模型、配置和缓存，并使用 [RTX 50 性能验收流程](RTX50_PERFORMANCE.md) 记录真实进程、功耗、显存和 KataGo 原始指标
 - Release 可附带高级可选 TensorRT 预装分卷包，但它不是默认推荐下载；必须下载全部 `.7z.00N` 并用 7-Zip 从 `.001` 解压
-- 当前正式版常用下载由 `https://download.goagent.top/` 提供，GitHub 保留安装器、Linux、历史版本和自动备用；pre-release 仍只在 GitHub
+- 当前正式版常用下载统一从 [官网下载页面](https://goagent.top/download/) 进入，GitHub 保留安装器、Linux、历史版本和自动备用；pre-release 仍只在 GitHub
 
 如果你只想先看图再决定，先看这里：
 
@@ -32,7 +32,7 @@
 
 ## 第一次下载就照这个选
 
-普通用户先打开 [正式版下载页](https://download.goagent.top/)。下表中的安装器、Linux 包和历史版本继续从 [GitHub Releases](https://github.com/wimi321/lizzieyzy-next/releases) 下载。GitHub 下载量不包含 R2 流量。
+普通用户先打开 [正式版下载页](https://goagent.top/download/)。下表中的安装器、Linux 包和历史版本继续从 [GitHub Releases](https://github.com/wimi321/lizzieyzy-next/releases) 下载。GitHub 下载量只统计 GitHub 文件，不包含官网下载页面产生的下载。
 
 | 包类型 | 典型文件名 | 适合谁 |
 | --- | --- | --- |

--- a/docs/R2_RELEASES.md
+++ b/docs/R2_RELEASES.md
@@ -1,7 +1,8 @@
 # Cloudflare R2 正式版下载与升级
 
-`download.goagent.top` 是 LizzieYzy Next 当前正式版的主下载源。GitHub Release 始终保留
-完整资产、安装器、Linux 包、历史版本和自动备用下载；pre-release 不上传 R2。
+用户唯一公开入口是 `https://goagent.top/download/`。`download.goagent.top` 只作为安装包、
+公开目录和软件更新接口的技术后台；GitHub Release 始终保留完整资产、安装器、Linux 包、
+历史版本和自动备用下载，pre-release 不上传 R2。
 
 ## 固定资源范围
 
@@ -20,16 +21,12 @@ Windows 安装器、Linux 包、pre-release 和历史版本不占用 R2。版本
 - `channels/stable/catalog.json`
 - `index.html`
 
-下载首页面向普通用户，只展示可直接安装的 Windows、macOS 和主程序小更新。Windows
-区直接列出 NVIDIA、RTX 50 CUDA、TensorRT、OpenCL、CPU 与无引擎版；TensorRT 只展示
-必须下载的两个 `.7z` 分卷，README、manifest 和 SHA-256 等发布元数据不进入用户界面。
-首页也不展示 R2、镜像切换或对象存储等实现细节。
-下载页图标来自 Bootstrap Icons（MIT），已随仓库保存并内联，不依赖第三方 CDN。
+完整的普通用户下载界面由 GoAgent 官网维护，动态读取 stable catalog。R2 的 `index.html`
+仅包含跳往 `https://goagent.top/download/` 的轻量兜底，不再生成第二套下载界面。
 
-R2 自定义域名本身不会把 `/` 自动映射到 `index.html`。Cloudflare URL 重写规则必须使用
-`URI Path equals /`，将路径重写为 `/index.html`，并保留原查询字符串。不要按完整 URL
-精确匹配，否则 `/?source=...` 这类正常链接会返回 404。发布器会用带缓存穿透参数的根地址
-验证这条规则。
+Cloudflare Redirect Rule 必须仅匹配 `download.goagent.top` 的 `/` 和 `/index.html`，以 301
+跳转到 `https://goagent.top/download/` 并保留查询字符串。`/releases/*` 与 `/channels/*`
+不能被重定向。发布器会同时验证两个根入口的 301，以及目录、更新清单和安装包接口。
 
 镜像资产总量不得超过 `9,000,000,000` 字节。门禁失败、旧版本对象清理失败或任一 SHA-256
 不一致时，GitHub Release 保持原状态，不会被晋升为正式版。
@@ -40,12 +37,12 @@ R2 自定义域名本身不会把 `/` 自动映射到 `index.html`。Cloudflare 
 完全相同的 release tag。工作流按以下顺序执行：
 
 1. 从 GitHub Release API 读取资产大小和 SHA-256，执行严格白名单与 9 GB 门禁。
-2. 先把下载首页切换到 GitHub 维护模式，再删除旧 R2 正式版对象。
+2. 先把 stable catalog 切换为 GitHub 原始文件地址并验证公网可用，再删除旧 R2 正式版对象。
 3. 使用 GitHub HTTP Range 与 R2 multipart 流式上传，不在 runner 保存完整大包。
 4. 上传过程中计算完整 SHA-256；上传后再核对 R2 对象大小和 SHA 元数据。
-5. 通过自定义域名检查 HTTPS、长度、Range、缓存、下载响应头和根首页重写。
-6. 发布 catalog 与下载首页，最后发布签名 envelope 作为稳定频道的激活指针。
-7. 使用缓存穿透参数逐字节核对公网首页、catalog 和 envelope 与本次上传内容一致。
+5. 通过自定义域名检查 HTTPS、长度、Range、缓存、下载响应头和根入口 301。
+6. 发布 R2 主链接 catalog 与轻量跳转页，最后发布签名 envelope 作为稳定频道的激活指针。
+7. 使用缓存穿透参数核对公网根入口、catalog 和 envelope 与本次发布一致。
 8. 将 v2 签名清单、catalog 和旧客户端使用的 v1 GitHub 清单上传到 Release。
 9. 最后才把 GitHub pre-release 改为正式版和 latest。
 
@@ -69,6 +66,9 @@ Variables：
 - `CLOUDFLARE_R2_BUCKET=lizzieyzy-next-downloads`
 - `R2_PUBLIC_BASE_URL=https://download.goagent.top`
 
+发布脚本中的用户入口独立固定为 `https://goagent.top/download/`，不能用
+`R2_PUBLIC_BASE_URL` 代替。前者供人访问，后者供目录、安装包和更新器使用。
+
 Ed25519 私钥只能存在于 GitHub Secret；应用内只包含公钥。更换签名密钥时必须先发布同时
 信任新旧公钥的客户端，再切换发布工作流，最后在旧客户端覆盖率足够后移除旧公钥。
 
@@ -89,10 +89,12 @@ GitHub 上的签名 v2 清单，签名、版本、大小或 SHA-256 不正确时
 
 除完整 Maven 测试和打包外，正式晋升后必须确认：
 
-- `https://download.goagent.top/` 显示正确 stable tag，且没有 pre-release。
+- `https://goagent.top/download/` 显示正确 stable tag，且没有 pre-release。
+- `https://www.goagent.top/download/`、`https://download.goagent.top/` 与
+  `https://download.goagent.top/index.html` 均以 301 跳到统一官网下载页。
 - 13 个对象均返回 HTTPS 200、正确 `Content-Length`、`Accept-Ranges: bytes`、
   `Content-Disposition: attachment` 和 immutable 缓存策略。
 - `Range: bytes=0-0` 返回 206 和正确 `Content-Range`。
 - R2 对象总量小于 9 GB，`releases/` 下不存在旧正式版目录。
 - Windows 断网续传与 R2 到 GitHub 切换、macOS 两种芯片 DMG、Linux GitHub 下载均通过真机验收。
-- Release 正文中的镜像资产以 R2 为主链接，并保留 GitHub 全量备用入口。
+- Release 正文顶部指向统一官网下载页，正文中的具体文件仍全部使用 GitHub 原始链接。

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -213,8 +213,8 @@ pre-release 经过各平台真机验收后，不要直接在 GitHub 页面手工
 资产，最后发布签名更新清单并晋升 GitHub Release；R2 失败时 GitHub 状态不会改变。
 
 R2 只保留当前正式版且设有 `9,000,000,000` 字节硬门禁。完整配置、Secrets、恢复方式和
-发布后验收见 [Cloudflare R2 正式版下载与升级](R2_RELEASES.md)。正式版如果重新生成了
-Release notes，必须再运行一次 `allow_stable_recovery`，恢复 R2 主链接和签名 stable 清单。
+发布后验收见 [Cloudflare R2 正式版下载与升级](R2_RELEASES.md)。单独更新 Release notes
+不需要重新上传资产；只有 stable catalog 或签名更新清单需要恢复时才运行 `allow_stable_recovery`。
 
 六种语言的下载表统一沿用 `next-2026-07-19.1` 的直接格式：
 
@@ -222,7 +222,7 @@ Release notes，必须再运行一次 `allow_stable_recovery`，恢复 R2 主链
 - 不把免安装包和安装器压缩成同一行，也不使用 `portable / installer` 这类需要用户猜测的短标签。
 - TensorRT 的 `.7z.001` 与 `.7z.002` 是同一套分卷，可以在同一行连续列出，但必须同时显示完整文件名和直链。
 - `publish_release_request.py` 会检查六种语言的下载表；任何语言缺少完整文件名直链都不能发布。
-- pre-release 下载直链保持 GitHub；正式晋升工作流会把 R2 白名单资产改为 R2 主链接，并在正文保留 GitHub 全量备用入口。
+- pre-release 与 Release 正文中的文件直链都保持 GitHub；正式版正文顶部只额外推荐统一的官网下载页面。
 
 ## 七、上传前自查
 
@@ -247,7 +247,7 @@ Release notes，必须再运行一次 `allow_stable_recovery`，恢复 R2 主链
 - “普通 Windows 包也支持智能优化”有没有写清楚
 - “NVIDIA 包首启自动准备官方运行库”有没有写清楚
 - 下载后的应用图标、安装器图标、主窗口图标是不是同一套
-- 正式版下载页是否为 `https://download.goagent.top/`，R2 连接失败时软件是否自动续传到 GitHub
+- 正式版公开入口是否为 `https://goagent.top/download/`，下载后台连接失败时软件是否自动续传到 GitHub
 - GitHub Downloads 徽章只代表 GitHub，不得写成包含 R2 的项目总下载量
 
 ## 九、Windows 体验复查

--- a/scripts/r2_release.py
+++ b/scripts/r2_release.py
@@ -22,6 +22,7 @@ R2_SIZE_LIMIT = 9_000_000_000
 DEFAULT_REPOSITORY = "wimi321/lizzieyzy-next"
 DEFAULT_BUCKET = "lizzieyzy-next-downloads"
 DEFAULT_PUBLIC_BASE = "https://download.goagent.top"
+DEFAULT_WEBSITE_DOWNLOAD_URL = "https://goagent.top/download/"
 DEFAULT_KEY_ID = "stable-2026-08"
 UPDATE_ENVELOPE_ASSET = "lizzieyzy-next-update-envelope.json"
 LEGACY_MANIFEST_ASSET = "lizzieyzy-next-update-manifest.json"
@@ -262,7 +263,10 @@ def build_legacy_manifest(manifest: dict[str, Any]) -> dict[str, Any]:
 
 
 def stable_release_body(
-    release: dict[str, Any], mirrored_assets: list[Asset], public_base: str
+    release: dict[str, Any],
+    mirrored_assets: list[Asset],
+    public_base: str,
+    website_download_url: str = DEFAULT_WEBSITE_DOWNLOAD_URL,
 ) -> str:
     """Keep GitHub asset links while recommending the official download page."""
     body = str(release.get("body") or "")
@@ -277,9 +281,9 @@ def stable_release_body(
     notice = (
         f"{RELEASE_NOTE_START}\n"
         "> [!IMPORTANT]\n"
-        f"> **国内用户建议从 [官网下载页面]({public_base.rstrip('/')}/) 下载；"
+        f"> **国内用户建议从 [官网下载页面]({website_download_url}) 下载；"
         f"Users in mainland China may prefer the "
-        f"[official download page]({public_base.rstrip('/')}/).**  \n"
+        f"[official download page]({website_download_url}).**  \n"
         "> 本页所有文件链接均保留 GitHub 原始地址。All file links on this Release "
         "remain on GitHub.\n"
         f"{RELEASE_NOTE_END}"
@@ -313,7 +317,11 @@ def catalog_label(asset: Asset) -> tuple[str, str, bool]:
 
 
 def build_catalog(
-    release: dict[str, Any], mirrored_assets: list[Asset], public_base: str
+    release: dict[str, Any],
+    mirrored_assets: list[Asset],
+    public_base: str,
+    *,
+    github_primary: bool = False,
 ) -> dict[str, Any]:
     entries = []
     for asset in mirrored_assets:
@@ -326,8 +334,12 @@ def build_catalog(
                 "arch": asset.arch,
                 "sizeBytes": asset.size,
                 "sha256": asset.sha256,
-                "downloadUrl": r2_url(public_base, asset),
-                "mirrorUrls": [asset.browser_url],
+                "downloadUrl": (
+                    asset.browser_url
+                    if github_primary
+                    else r2_url(public_base, asset)
+                ),
+                "mirrorUrls": [] if github_primary else [asset.browser_url],
                 "labelZh": zh_label,
                 "labelEn": en_label,
                 "advanced": advanced,
@@ -646,6 +658,33 @@ def render_index(catalog: dict[str, Any], *, maintenance: bool = False) -> str:
     <a class="footer-link" href="{history_url}">{decorative_icon("clock-history", "footer-icon")}历史版本</a>
   </footer>
 </main></body></html>
+"""
+
+
+def render_redirect_index(
+    website_download_url: str = DEFAULT_WEBSITE_DOWNLOAD_URL,
+) -> str:
+    parsed = urllib.parse.urlparse(website_download_url)
+    if parsed.scheme.lower() != "https" or not parsed.hostname:
+        raise ReleaseError("Official website download URL must use HTTPS")
+    escaped = html.escape(website_download_url, quote=True)
+    javascript_target = json.dumps(website_download_url, ensure_ascii=False).replace(
+        "<", "\\u003c"
+    )
+    return f"""<!doctype html>
+<html lang="zh-CN">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <meta http-equiv="refresh" content="0; url={escaped}">
+  <link rel="canonical" href="{escaped}">
+  <title>正在前往 LizzieYzy Next 官网下载</title>
+</head>
+<body>
+  <p><a href="{escaped}">前往官网下载页面</a></p>
+  <script>window.location.replace({javascript_target});</script>
+</body>
+</html>
 """
 
 
@@ -1154,26 +1193,103 @@ def _verify_public_with_retry(requests, description: str, url: str, **kwargs) ->
             time.sleep(delay)
 
 
-def verify_public_homepage(public_base: str) -> None:
+def _verify_public_redirect(
+    requests, source_url: str, website_download_url: str
+) -> None:
+    response = requests.get(
+        source_url,
+        headers={
+            "Accept-Encoding": "identity",
+            "Cache-Control": "no-cache",
+            "Pragma": "no-cache",
+        },
+        allow_redirects=False,
+        timeout=60,
+    )
+    try:
+        if response.status_code != 301:
+            raise ReleaseError(
+                f"GET returned HTTP {response.status_code}, expected permanent redirect 301"
+            )
+        location = str(response.headers.get("Location") or "").strip()
+        if not location:
+            raise ReleaseError("redirect response has no Location header")
+        resolved = urllib.parse.urljoin(source_url, location)
+        actual = urllib.parse.urlparse(resolved)
+        expected = urllib.parse.urlparse(website_download_url)
+        if (
+            actual.scheme.lower(),
+            actual.netloc.lower(),
+            actual.path,
+        ) != (
+            expected.scheme.lower(),
+            expected.netloc.lower(),
+            expected.path,
+        ):
+            raise ReleaseError(
+                f"redirect target is {resolved!r}, expected {website_download_url!r}"
+            )
+        source_query = urllib.parse.urlparse(source_url).query
+        if source_query and actual.query != source_query:
+            raise ReleaseError("redirect did not preserve the verification query string")
+    finally:
+        response.close()
+
+
+def verify_public_download_redirects(
+    public_base: str, website_download_url: str
+) -> None:
     try:
         import requests
     except ImportError as exc:
         raise ReleaseError("requests is required for public R2 verification") from exc
     if not public_base.lower().startswith("https://"):
         raise ReleaseError("Public R2 base URL must use HTTPS")
+    if not website_download_url.lower().startswith("https://"):
+        raise ReleaseError("Official website download URL must use HTTPS")
+    base = public_base.rstrip("/")
+    for description, path in (
+        ("download backend root redirect", "/"),
+        ("download backend index redirect", "/index.html"),
+    ):
+        for attempt in range(1, PUBLIC_VERIFY_ATTEMPTS + 1):
+            request_url = _cache_busted_url(base + path, attempt)
+            try:
+                _verify_public_redirect(requests, request_url, website_download_url)
+                break
+            except (ReleaseError, requests.RequestException) as exc:
+                if attempt == PUBLIC_VERIFY_ATTEMPTS:
+                    raise ReleaseError(
+                        f"Public R2 verification failed for {description} after "
+                        f"{PUBLIC_VERIFY_ATTEMPTS} attempts: {exc}"
+                    ) from exc
+                delay = PUBLIC_VERIFY_BACKOFF_SECONDS[attempt - 1]
+                print(
+                    f"Public R2 verification retry {attempt}/"
+                    f"{PUBLIC_VERIFY_ATTEMPTS} for {description} in {delay}s: {exc}",
+                    file=sys.stderr,
+                )
+                time.sleep(delay)
+
+
+def verify_public_catalog(public_base: str, catalog_body: bytes) -> None:
+    try:
+        import requests
+    except ImportError as exc:
+        raise ReleaseError("requests is required for public R2 verification") from exc
     _verify_public_with_retry(
         requests,
-        "download homepage route",
-        public_base.rstrip("/") + "/",
-        expected_content_type="text/html",
-        required_marker=b"LizzieYzy Next",
+        "stable catalog",
+        public_base.rstrip("/") + "/channels/stable/catalog.json",
+        expected_content_type="application/json",
+        expected_body=catalog_body,
     )
 
 
 def verify_public_stable_channel(
     public_base: str,
     *,
-    index_body: bytes,
+    website_download_url: str,
     catalog_body: bytes,
     envelope_body: bytes,
 ) -> None:
@@ -1183,10 +1299,9 @@ def verify_public_stable_channel(
         raise ReleaseError("requests is required for public R2 verification") from exc
     if not public_base.lower().startswith("https://"):
         raise ReleaseError("Public R2 base URL must use HTTPS")
+    verify_public_download_redirects(public_base, website_download_url)
     base = public_base.rstrip("/")
     documents = (
-        ("download homepage", base + "/", "text/html", index_body),
-        ("download index", base + "/index.html", "text/html", index_body),
         (
             "stable catalog",
             base + "/channels/stable/catalog.json",
@@ -1214,6 +1329,7 @@ def verify_and_activate_stable_channel(
     client,
     bucket: str,
     public_base: str,
+    website_download_url: str,
     assets: Iterable[Asset],
     catalog: dict[str, Any],
     envelope: dict[str, Any],
@@ -1223,11 +1339,11 @@ def verify_and_activate_stable_channel(
     asset_list = list(assets)
     if not skip_public_verify:
         verify_public_objects(public_base, asset_list)
-        verify_public_homepage(public_base)
+        verify_public_download_redirects(public_base, website_download_url)
 
     catalog_body = json_bytes(catalog)
     envelope_body = json_bytes(envelope)
-    index_body = render_index(catalog).encode("utf-8")
+    index_body = render_redirect_index(website_download_url).encode("utf-8")
     put_bytes(
         client,
         bucket,
@@ -1254,11 +1370,41 @@ def verify_and_activate_stable_channel(
     if not skip_public_verify:
         verify_public_stable_channel(
             public_base,
-            index_body=index_body,
+            website_download_url=website_download_url,
             catalog_body=catalog_body,
             envelope_body=envelope_body,
         )
     return catalog_body, envelope_body
+
+
+def publish_maintenance_catalog(
+    client,
+    bucket: str,
+    public_base: str,
+    website_download_url: str,
+    catalog: dict[str, Any],
+    *,
+    skip_public_verify: bool,
+) -> bytes:
+    catalog_body = json_bytes(catalog)
+    put_bytes(
+        client,
+        bucket,
+        "channels/stable/catalog.json",
+        catalog_body,
+        cache_control="no-store",
+    )
+    put_bytes(
+        client,
+        bucket,
+        "index.html",
+        render_redirect_index(website_download_url).encode("utf-8"),
+        cache_control="no-store",
+    )
+    if not skip_public_verify:
+        verify_public_download_redirects(public_base, website_download_url)
+        verify_public_catalog(public_base, catalog_body)
+    return catalog_body
 
 
 def promote(args: argparse.Namespace) -> None:
@@ -1291,17 +1437,20 @@ def promote(args: argparse.Namespace) -> None:
     print(f"R2 promotion plan: {len(selected)} assets, {total:,} bytes")
     manifest = build_manifest(release, selected, args.public_base)
     catalog = build_catalog(release, selected, args.public_base)
+    maintenance_catalog = build_catalog(
+        release, selected, args.public_base, github_primary=True
+    )
     envelope = sign_manifest(manifest, private_key, args.key_id)
     legacy = build_legacy_manifest(manifest)
 
     client = r2_client(account_id, access_key, secret_key)
-    maintenance_html = render_index(catalog, maintenance=True).encode("utf-8")
-    put_bytes(
+    publish_maintenance_catalog(
         client,
         args.bucket,
-        "index.html",
-        maintenance_html,
-        cache_control="no-store",
+        args.public_base,
+        args.website_download_url,
+        maintenance_catalog,
+        skip_public_verify=args.skip_public_verify,
     )
     keep_keys = {asset.r2_key for asset in selected}
     abort_incomplete_release_uploads(client, args.bucket)
@@ -1313,6 +1462,7 @@ def promote(args: argparse.Namespace) -> None:
         client,
         args.bucket,
         args.public_base,
+        args.website_download_url,
         selected,
         catalog,
         envelope,
@@ -1322,7 +1472,12 @@ def promote(args: argparse.Namespace) -> None:
     replace_github_asset(session, release, CATALOG_ASSET, catalog_body, "application/json")
     replace_github_asset(session, release, LEGACY_MANIFEST_ASSET, json_bytes(legacy), "application/json")
 
-    release_body = stable_release_body(release, selected, args.public_base)
+    release_body = stable_release_body(
+        release,
+        selected,
+        args.public_base,
+        args.website_download_url,
+    )
     response = session.patch(
         release["url"],
         json={
@@ -1367,6 +1522,9 @@ def parser() -> argparse.ArgumentParser:
         command.add_argument("--repository", default=DEFAULT_REPOSITORY)
         command.add_argument("--tag", required=True)
         command.add_argument("--public-base", default=DEFAULT_PUBLIC_BASE)
+        command.add_argument(
+            "--website-download-url", default=DEFAULT_WEBSITE_DOWNLOAD_URL
+        )
         if name == "promote":
             command.add_argument("--bucket", default=DEFAULT_BUCKET)
             command.add_argument("--private-key", required=True)

--- a/scripts/test_r2_release.py
+++ b/scripts/test_r2_release.py
@@ -140,42 +140,45 @@ class R2ReleaseTest(unittest.TestCase):
         key.public_key().verify(signature, payload)
         self.assertEqual(manifest, json.loads(payload))
 
-    def test_download_page_has_beginner_friendly_direct_downloads(self):
+    def test_catalog_uses_github_during_maintenance_and_r2_after_activation(self):
         source = release()
         selected = r2_release.select_r2_assets(source, r2_release.DEFAULT_PUBLIC_BASE)
-        catalog = r2_release.build_catalog(source, selected, r2_release.DEFAULT_PUBLIC_BASE)
-        page = r2_release.render_index(catalog)
-        maintenance = r2_release.render_index(catalog, maintenance=True)
+        stable = r2_release.build_catalog(
+            source, selected, r2_release.DEFAULT_PUBLIC_BASE
+        )
+        maintenance = r2_release.build_catalog(
+            source,
+            selected,
+            r2_release.DEFAULT_PUBLIC_BASE,
+            github_primary=True,
+        )
 
-        self.assertIn("选择你的版本", page)
-        self.assertIn("NVIDIA 显卡", page)
-        self.assertIn("RTX 50 CUDA", page)
-        self.assertIn("TensorRT 高性能版", page)
-        self.assertIn("两个分卷都要下载", page)
-        self.assertIn("分卷 1", page)
-        self.assertIn("分卷 2", page)
-        self.assertIn("CPU 通用版", page)
-        self.assertIn("OpenCL 兼容版", page)
-        self.assertIn("下载小更新", page)
-        self.assertIn("data:image/png;base64,", page)
-        self.assertIn("data:image/webp;base64,", page)
-        self.assertIn("data:image/svg+xml;base64,", page)
-        self.assertEqual(10, page.count('class="download-action"'))
-        self.assertEqual(1, page.count('class="volume-actions"'))
-        self.assertEqual(1, page.count(".7z.001"))
-        self.assertEqual(1, page.count(".7z.002"))
-        self.assertNotIn("Cloudflare", page)
-        self.assertNotIn("GitHub 下载量", page)
-        self.assertNotIn("README.txt", page)
-        self.assertNotIn("manifest.json", page)
-        self.assertNotIn("sha256.txt", page)
-        self.assertNotIn("<details", page)
-        for hidden_suffix in ("README.txt", "manifest.json", "sha256.txt"):
-            hidden_entry = next(
-                entry for entry in catalog["assets"] if entry["name"].endswith(hidden_suffix)
+        self.assertTrue(
+            all(
+                entry["downloadUrl"].startswith("https://download.goagent.top/")
+                for entry in stable["assets"]
             )
-            self.assertNotIn(hidden_entry["downloadUrl"], page)
-        self.assertIn("下载页面正在更新，当前下载仍可正常使用", maintenance)
+        )
+        self.assertTrue(
+            all(
+                entry["downloadUrl"].startswith("https://github.com/")
+                for entry in maintenance["assets"]
+            )
+        )
+        self.assertTrue(all(entry["mirrorUrls"] for entry in stable["assets"]))
+        self.assertTrue(
+            all(entry["mirrorUrls"] == [] for entry in maintenance["assets"])
+        )
+
+    def test_backend_index_is_only_a_lightweight_official_site_redirect(self):
+        page = r2_release.render_redirect_index()
+
+        self.assertIn(r2_release.DEFAULT_WEBSITE_DOWNLOAD_URL, page)
+        self.assertIn('rel="canonical"', page)
+        self.assertIn("window.location.replace", page)
+        self.assertNotIn("选择你的版本", page)
+        self.assertNotIn("TensorRT", page)
+        self.assertNotIn("download-action", page)
 
     def test_stable_release_body_keeps_github_links_and_recommends_official_page(self):
         source = release()
@@ -187,10 +190,16 @@ class R2ReleaseTest(unittest.TestCase):
         )
 
         updated = r2_release.stable_release_body(
-            source, selected, r2_release.DEFAULT_PUBLIC_BASE
+            source,
+            selected,
+            r2_release.DEFAULT_PUBLIC_BASE,
+            r2_release.DEFAULT_WEBSITE_DOWNLOAD_URL,
         )
         repeated = r2_release.stable_release_body(
-            {**source, "body": updated}, selected, r2_release.DEFAULT_PUBLIC_BASE
+            {**source, "body": updated},
+            selected,
+            r2_release.DEFAULT_PUBLIC_BASE,
+            r2_release.DEFAULT_WEBSITE_DOWNLOAD_URL,
         )
 
         self.assertIn(linked.browser_url, updated)
@@ -200,7 +209,9 @@ class R2ReleaseTest(unittest.TestCase):
         self.assertNotIn("Cloudflare", updated)
         self.assertNotIn("R2 连接", updated)
         self.assertEqual(1, updated.count(r2_release.RELEASE_NOTE_START))
-        self.assertEqual(2, updated.count(r2_release.DEFAULT_PUBLIC_BASE + "/"))
+        self.assertEqual(
+            2, updated.count(r2_release.DEFAULT_WEBSITE_DOWNLOAD_URL)
+        )
         self.assertEqual(updated, repeated)
 
     def test_public_assets_are_verified_before_envelope_activation(self):
@@ -216,12 +227,14 @@ class R2ReleaseTest(unittest.TestCase):
             r2_release, "verify_public_objects", side_effect=verify
         ), mock.patch.object(
             r2_release,
-            "render_index",
-            return_value="<title>LizzieYzy Next</title>",
+            "render_redirect_index",
+            return_value="<title>Redirect</title>",
         ), mock.patch.object(
             r2_release,
-            "verify_public_homepage",
-            side_effect=lambda public_base: events.append(("verify-home", public_base)),
+            "verify_public_download_redirects",
+            side_effect=lambda public_base, website_url: events.append(
+                ("verify-redirect", public_base, website_url)
+            ),
         ), mock.patch.object(
             r2_release,
             "verify_public_stable_channel",
@@ -233,6 +246,7 @@ class R2ReleaseTest(unittest.TestCase):
                 object(),
                 "bucket",
                 r2_release.DEFAULT_PUBLIC_BASE,
+                r2_release.DEFAULT_WEBSITE_DOWNLOAD_URL,
                 [object()],
                 {"tag": TAG},
                 {"payload": "signed"},
@@ -240,7 +254,7 @@ class R2ReleaseTest(unittest.TestCase):
             )
 
         self.assertEqual("verify", events[0][0])
-        self.assertEqual("verify-home", events[1][0])
+        self.assertEqual("verify-redirect", events[1][0])
         self.assertEqual(
             "channels/stable/update-envelope.json",
             [event for event in events if event[0] == "put"][-1][1],
@@ -249,33 +263,93 @@ class R2ReleaseTest(unittest.TestCase):
         self.assertEqual({"tag": TAG}, json.loads(catalog_body))
         self.assertEqual({"payload": "signed"}, json.loads(envelope_body))
 
-    def test_public_homepage_route_accepts_cache_busting_query(self):
-        response = mock.Mock(
-            status_code=200,
-            url=r2_release.DEFAULT_PUBLIC_BASE + "/?r2-verify=1-1",
-            headers={"Content-Type": "text/html; charset=utf-8"},
+    def test_maintenance_catalog_is_public_before_release_assets_can_change(self):
+        source = release()
+        selected = r2_release.select_r2_assets(source, r2_release.DEFAULT_PUBLIC_BASE)
+        maintenance = r2_release.build_catalog(
+            source,
+            selected,
+            r2_release.DEFAULT_PUBLIC_BASE,
+            github_primary=True,
         )
-        response.iter_content.return_value = iter([b"<title>LizzieYzy Next</title>"])
+        events = []
+
+        def put(client, bucket, key, body, **kwargs):
+            events.append(("put", key, kwargs["cache_control"]))
+
+        with mock.patch.object(r2_release, "put_bytes", side_effect=put), mock.patch.object(
+            r2_release,
+            "verify_public_download_redirects",
+            side_effect=lambda public_base, website_url: events.append(
+                ("verify-redirect", public_base, website_url)
+            ),
+        ), mock.patch.object(
+            r2_release,
+            "verify_public_catalog",
+            side_effect=lambda public_base, body: events.append(
+                ("verify-catalog", public_base, json.loads(body))
+            ),
+        ):
+            body = r2_release.publish_maintenance_catalog(
+                object(),
+                "bucket",
+                r2_release.DEFAULT_PUBLIC_BASE,
+                r2_release.DEFAULT_WEBSITE_DOWNLOAD_URL,
+                maintenance,
+                skip_public_verify=False,
+            )
+
+        self.assertEqual("channels/stable/catalog.json", events[0][1])
+        self.assertEqual("no-store", events[0][2])
+        self.assertEqual("index.html", events[1][1])
+        self.assertEqual("verify-redirect", events[2][0])
+        self.assertEqual("verify-catalog", events[3][0])
+        self.assertTrue(
+            all(
+                entry["downloadUrl"].startswith("https://github.com/")
+                for entry in json.loads(body)["assets"]
+            )
+        )
+
+    def test_public_backend_roots_permanently_redirect_and_preserve_query(self):
+        def response_for(url, **kwargs):
+            query = url.split("?", 1)[1]
+            return mock.Mock(
+                status_code=301,
+                headers={
+                    "Location": r2_release.DEFAULT_WEBSITE_DOWNLOAD_URL + "?" + query
+                },
+            )
+
         requests = mock.Mock()
         requests.RequestException = RuntimeError
-        requests.get.return_value = response
+        requests.get.side_effect = response_for
 
         with mock.patch.dict(sys.modules, {"requests": requests}), mock.patch.object(
             r2_release.time, "time", return_value=1
         ):
-            r2_release.verify_public_homepage(r2_release.DEFAULT_PUBLIC_BASE)
+            r2_release.verify_public_download_redirects(
+                r2_release.DEFAULT_PUBLIC_BASE,
+                r2_release.DEFAULT_WEBSITE_DOWNLOAD_URL,
+            )
 
-        requested_url = requests.get.call_args.args[0]
+        self.assertEqual(2, requests.get.call_count)
         self.assertEqual(
-            r2_release.DEFAULT_PUBLIC_BASE + "/?r2-verify=1-1", requested_url
+            [
+                r2_release.DEFAULT_PUBLIC_BASE + "/?r2-verify=1-1",
+                r2_release.DEFAULT_PUBLIC_BASE + "/index.html?r2-verify=1-1",
+            ],
+            [call.args[0] for call in requests.get.call_args_list],
         )
-        self.assertTrue(requests.get.call_args.kwargs["stream"])
-        response.close.assert_called_once_with()
+        self.assertTrue(
+            all(
+                call.kwargs["allow_redirects"] is False
+                for call in requests.get.call_args_list
+            )
+        )
 
     def test_public_stable_channel_matches_exact_uploaded_bodies(self):
         bodies = {
-            r2_release.DEFAULT_PUBLIC_BASE + "/": b"<title>LizzieYzy Next</title>",
-            r2_release.DEFAULT_PUBLIC_BASE + "/index.html": b"<title>LizzieYzy Next</title>",
             r2_release.DEFAULT_PUBLIC_BASE
             + "/channels/stable/catalog.json": b'{"releaseTag":"test"}\n',
             r2_release.DEFAULT_PUBLIC_BASE
@@ -284,16 +358,20 @@ class R2ReleaseTest(unittest.TestCase):
 
         def response_for(url, **kwargs):
             base_url = url.split("?", 1)[0]
+            if base_url.endswith("/") or base_url.endswith("/index.html"):
+                query = url.split("?", 1)[1]
+                return mock.Mock(
+                    status_code=301,
+                    headers={
+                        "Location": r2_release.DEFAULT_WEBSITE_DOWNLOAD_URL
+                        + "?"
+                        + query
+                    },
+                )
             response = mock.Mock(
                 status_code=200,
                 url=url,
-                headers={
-                    "Content-Type": (
-                        "text/html; charset=utf-8"
-                        if base_url.endswith("/") or base_url.endswith("index.html")
-                        else "application/json; charset=utf-8"
-                    )
-                },
+                headers={"Content-Type": "application/json; charset=utf-8"},
             )
             response.iter_content.return_value = iter([bodies[base_url]])
             return response
@@ -306,7 +384,7 @@ class R2ReleaseTest(unittest.TestCase):
         ):
             r2_release.verify_public_stable_channel(
                 r2_release.DEFAULT_PUBLIC_BASE,
-                index_body=bodies[r2_release.DEFAULT_PUBLIC_BASE + "/"],
+                website_download_url=r2_release.DEFAULT_WEBSITE_DOWNLOAD_URL,
                 catalog_body=bodies[
                     r2_release.DEFAULT_PUBLIC_BASE + "/channels/stable/catalog.json"
                 ],
@@ -317,12 +395,21 @@ class R2ReleaseTest(unittest.TestCase):
             )
 
         self.assertEqual(4, requests.get.call_count)
-        self.assertTrue(
-            all("?r2-verify=2-1" in call.args[0] for call in requests.get.call_args_list)
-        )
+        self.assertTrue(all("?r2-verify=2-1" in call.args[0] for call in requests.get.call_args_list))
 
     def test_public_stable_channel_rejects_body_mismatch(self):
         def mismatched_response(url, **kwargs):
+            base_url = url.split("?", 1)[0]
+            if base_url.endswith("/") or base_url.endswith("/index.html"):
+                query = url.split("?", 1)[1]
+                return mock.Mock(
+                    status_code=301,
+                    headers={
+                        "Location": r2_release.DEFAULT_WEBSITE_DOWNLOAD_URL
+                        + "?"
+                        + query
+                    },
+                )
             response = mock.Mock(
                 status_code=200,
                 url=url,
@@ -337,16 +424,16 @@ class R2ReleaseTest(unittest.TestCase):
         with mock.patch.dict(sys.modules, {"requests": requests}), mock.patch.object(
             r2_release.time, "time", return_value=3
         ), mock.patch.object(r2_release.time, "sleep") as sleep, self.assertRaisesRegex(
-            r2_release.ReleaseError, "download homepage after 5 attempts"
+            r2_release.ReleaseError, "stable catalog after 5 attempts"
         ):
             r2_release.verify_public_stable_channel(
                 r2_release.DEFAULT_PUBLIC_BASE,
-                index_body=b"fresh homepage",
+                website_download_url=r2_release.DEFAULT_WEBSITE_DOWNLOAD_URL,
                 catalog_body=b"{}\n",
                 envelope_body=b"{}\n",
             )
 
-        self.assertEqual(r2_release.PUBLIC_VERIFY_ATTEMPTS, requests.get.call_count)
+        self.assertEqual(2 + r2_release.PUBLIC_VERIFY_ATTEMPTS, requests.get.call_count)
         self.assertEqual(r2_release.PUBLIC_VERIFY_ATTEMPTS - 1, sleep.call_count)
 
     def test_public_range_verification_retries_transient_failure(self):


### PR DESCRIPTION
## Summary

- points all six README languages and user-facing docs to https://goagent.top/download/
- keeps GitHub Release file links on GitHub while recommending the official download page
- separates the public website URL from the download backend URL in the stable promotion workflow
- publishes a GitHub-primary maintenance catalog before replacing R2 assets, then activates the verified backend catalog atomically
- replaces the duplicate backend homepage with a lightweight redirect fallback

## Validation

- git diff --check
- python3 -m unittest scripts.test_r2_release.py (16 passed)
- python3 scripts/check_markdown_links.py
- mvn -B -Dfmt.skip=true test (2001 tests, 0 failures, 0 errors, 5 skipped)
- mvn -B -Dfmt.skip=true -DskipTests package

## Deployment order

Merge and verify the GoAgent website redirect first, then merge this PR and update the current stable Release body without replacing assets.