### PR TITLE
fix(engine): settle explicit restart readiness after board synchronization

### DIFF
--- a/src/main/java/featurecat/lizzie/analysis/Leelaz.java
+++ b/src/main/java/featurecat/lizzie/analysis/Leelaz.java
@@ -10444,17 +10444,9 @@ public class Leelaz {
     }
 
     private void start() {
-      try {
-        sendCommand("name", responseHandler, this::onSendFailure, true, false);
-      } catch (RuntimeException ex) {
-        settleFailure(ex.getMessage());
-        return;
-      }
-      if (settled.get()) {
-        return;
-      }
-      timeout = new Timer("lizzie-board-sync-confirmation-timeout", true);
-      timeout.schedule(
+      Timer confirmationTimeout = new Timer("lizzie-board-sync-confirmation-timeout", true);
+      timeout = confirmationTimeout;
+      TimerTask timeoutTask =
           new TimerTask() {
             @Override
             public void run() {
@@ -10467,8 +10459,20 @@ public class Leelaz {
                 retireTimedOutNormalCommand(responseHandler);
               }
             }
-          },
-          Math.max(1L, readBoardGmaRestoreResponseTimeoutMillis()));
+          };
+      try {
+        sendCommand("name", responseHandler, this::onSendFailure, true, false);
+      } catch (RuntimeException ex) {
+        settleFailure(ex.getMessage());
+        return;
+      }
+      if (!settled.get()) {
+        scheduleBoardSynchronizationTimeout(
+            confirmationTimeout,
+            timeoutTask,
+            Math.max(1L, readBoardGmaRestoreResponseTimeoutMillis()),
+            settled);
+      }
     }
 
     private void onResponse() {
@@ -10507,6 +10511,17 @@ public class Leelaz {
       timeout = null;
       if (currentTimeout != null) {
         currentTimeout.cancel();
+      }
+    }
+  }
+
+  static void scheduleBoardSynchronizationTimeout(
+      Timer timer, TimerTask task, long delayMillis, AtomicBoolean settled) {
+    try {
+      timer.schedule(task, delayMillis);
+    } catch (IllegalStateException ex) {
+      if (!settled.get()) {
+        throw ex;
       }
     }
   }

--- a/src/main/java/featurecat/lizzie/gui/LizzieFrame.java
+++ b/src/main/java/featurecat/lizzie/gui/LizzieFrame.java
@@ -14744,7 +14744,14 @@ public class LizzieFrame extends JFrame {
           if (snapshot.state == EngineStartupStatus.State.READY) {
             engineStartupStatusButton.setVisible(false);
             engineStartupStatusButton.setEnabled(false);
+            redrawWinratePaneOnly = false;
+            if (mainPanel != null) {
+              mainPanel.repaint();
+              refresh();
+            }
+            basePanel.revalidate();
             basePanel.repaint();
+            repaint();
             return;
           }
           String message = text(snapshot.messageKey, snapshot.fallback);

--- a/src/test/java/featurecat/lizzie/EngineStartupStatusTest.java
+++ b/src/test/java/featurecat/lizzie/EngineStartupStatusTest.java
@@ -36,31 +36,69 @@ class EngineStartupStatusTest {
   }
 
   @Test
-  void readyStatusRepaintsTheBasePanelAfterHidingTheNotice() throws Exception {
-    LizzieFrame frame = allocate(LizzieFrame.class);
+  void readyStatusPublishesTerminalUiAndCommentOnEdt() throws Exception {
+    CountingLizzieFrame frame = allocate(CountingLizzieFrame.class);
     CountingLayeredPane basePanel = new CountingLayeredPane();
+    CountingPanel mainPanel = new CountingPanel();
     JFontButton statusButton = new JFontButton();
+    basePanel.add(statusButton, Integer.valueOf(12));
+    statusButton.setBounds(10, 10, 240, 32);
+    statusButton.setText("using existing cache");
     statusButton.setVisible(true);
-    setField(frame, "basePanel", basePanel);
-    setField(frame, "engineStartupStatusButton", statusButton);
+    setField(LizzieFrame.class, frame, "basePanel", basePanel);
+    setField(LizzieFrame.class, frame, "mainPanel", mainPanel);
+    setField(LizzieFrame.class, frame, "engineStartupStatusButton", statusButton);
+    setField(LizzieFrame.class, frame, "redrawWinratePaneOnly", true);
+    basePanel.resetCounts();
+    frame.repaintCount = 0;
 
-    Method update =
-        LizzieFrame.class.getDeclaredMethod(
-            "updateEngineStartupStatus", EngineStartupStatus.Snapshot.class);
-    update.setAccessible(true);
-    update.invoke(frame, new EngineStartupStatus().snapshot());
+    EngineStartupStatus status = new EngineStartupStatus();
+    status.checking("engine.starting", "using existing cache");
+    status.addListener(snapshot -> invokeStatusUpdate(frame, snapshot));
+    status.ready();
     SwingUtilities.invokeAndWait(() -> {});
 
     assertFalse(statusButton.isVisible());
-    assertEquals(1, basePanel.repaintCount);
+    assertFalse(
+        (Boolean) getField(LizzieFrame.class, frame, "redrawWinratePaneOnly"),
+        "READY must invalidate a pending winrate-only repaint");
+    assertTrue(mainPanel.repaintCount > 0, "READY must repaint the cached main panel");
+    assertTrue(frame.repaintCount > 0, "READY must repaint the containing frame");
+    assertTrue(frame.refreshCount > 0, "READY must refresh after engine startup");
+    assertTrue(
+        frame.commentRefreshCount > 0,
+        "READY refresh must republish the comment panel after engine startup");
+    assertTrue(basePanel.revalidateCount > 0, "READY must publish the hidden notice layout");
+    assertTrue(basePanel.repaintCount > 0, "READY must repaint the cleared notice region");
+    assertTrue(basePanel.revalidatedOnEdt, "READY layout publication must run on EDT");
+    assertTrue(basePanel.repaintedOnEdt, "READY repaint publication must run on EDT");
   }
 
-  private static void setField(Object target, String name, Object value) throws Exception {
-    Field field = target.getClass().getDeclaredField(name);
+  private static void invokeStatusUpdate(
+      LizzieFrame frame, EngineStartupStatus.Snapshot snapshot) {
+    try {
+      Method update =
+          LizzieFrame.class.getDeclaredMethod(
+              "updateEngineStartupStatus", EngineStartupStatus.Snapshot.class);
+      update.setAccessible(true);
+      update.invoke(frame, snapshot);
+    } catch (ReflectiveOperationException failure) {
+      throw new AssertionError(failure);
+    }
+  }
+
+  private static void setField(Class<?> declaringType, Object target, String name, Object value)
+      throws Exception {
+    Field field = declaringType.getDeclaredField(name);
     field.setAccessible(true);
     field.set(target, value);
   }
-
+  private static Object getField(Class<?> declaringType, Object target, String name)
+      throws Exception {
+    Field field = declaringType.getDeclaredField(name);
+    field.setAccessible(true);
+    return field.get(target);
+  }
   @SuppressWarnings("unchecked")
   private static <T> T allocate(Class<T> type) throws Exception {
     Field field = sun.misc.Unsafe.class.getDeclaredField("theUnsafe");
@@ -70,6 +108,54 @@ class EngineStartupStatusTest {
 
   private static final class CountingLayeredPane extends JLayeredPane {
     private int repaintCount;
+    private int revalidateCount;
+    private boolean revalidatedOnEdt;
+    private boolean repaintedOnEdt;
+
+    private void resetCounts() {
+      repaintCount = 0;
+      revalidateCount = 0;
+      revalidatedOnEdt = false;
+      repaintedOnEdt = false;
+    }
+
+    @Override
+    public void revalidate() {
+      revalidateCount++;
+      revalidatedOnEdt |= SwingUtilities.isEventDispatchThread();
+      super.revalidate();
+    }
+
+    @Override
+    public void repaint() {
+      repaintCount++;
+      repaintedOnEdt |= SwingUtilities.isEventDispatchThread();
+    }
+  }
+  private static final class CountingPanel extends javax.swing.JPanel {
+    private int repaintCount;
+
+    @Override
+    public void repaint() {
+      repaintCount++;
+    }
+  }
+
+  private static final class CountingLizzieFrame extends LizzieFrame {
+    private int refreshCount;
+    private int commentRefreshCount;
+    private int repaintCount;
+
+    @Override
+    public void refresh() {
+      refreshCount++;
+      appendComment();
+    }
+
+    @Override
+    public void appendComment() {
+      commentRefreshCount++;
+    }
 
     @Override
     public void repaint() {

--- a/src/test/java/featurecat/lizzie/analysis/EngineManagerLifecycleReservationTest.java
+++ b/src/test/java/featurecat/lizzie/analysis/EngineManagerLifecycleReservationTest.java
@@ -2140,6 +2140,15 @@ class EngineManagerLifecycleReservationTest {
 
   @Test
   void inactiveExplicitRestartWaitsForBoardFenceBeforeInitializationAndRelease() throws Exception {
+    assertExplicitRestartWaitsForBoardFence(true);
+  }
+
+  @Test
+  void pausedExplicitRestartWaitsForBoardFenceAndPublishesTerminalState() throws Exception {
+    assertExplicitRestartWaitsForBoardFence(false);
+  }
+
+  private void assertExplicitRestartWaitsForBoardFence(boolean resumePonder) throws Exception {
     Leelaz previousEngine = Lizzie.leelaz;
     LizzieFrame previousFrame = Lizzie.frame;
     Board previousBoard = Lizzie.board;
@@ -2159,8 +2168,13 @@ class EngineManagerLifecycleReservationTest {
     config.extraMode = ExtraMode.Normal;
     engine.started = true;
     engine.isLoaded = true;
-    engine.Pondering();
+    if (resumePonder) {
+      engine.Pondering();
+    } else {
+      engine.notPondering();
+    }
     RecoverySwitchEngineManager manager = new RecoverySwitchEngineManager(List.of(engine), engine);
+    boolean synchronizationRan = false;
     try {
       Lizzie.config = config;
       Lizzie.board = board;
@@ -2176,6 +2190,7 @@ class EngineManagerLifecycleReservationTest {
 
       manager.reStartEngine(0);
       manager.afterSync.run();
+      synchronizationRan = true;
 
       assertNotNull(engine.confirmation);
       assertTrue(engine.isLoaded);
@@ -2190,14 +2205,21 @@ class EngineManagerLifecycleReservationTest {
       assertTrue(engine.isLoaded);
       assertEquals(EngineStartupStatus.State.READY, Lizzie.engineStartupStatus.snapshot().state);
       assertEquals(1, engine.initializationCount);
-      assertTrue(engine.resumePonderIntent);
-      assertEquals(1, engine.ponderCount);
-      assertTrue(engine.ponderWhileLifecycleHeld);
+      assertEquals(resumePonder, engine.resumePonderIntent);
+      assertEquals(resumePonder ? 1 : 0, engine.ponderCount);
+      assertEquals(resumePonder, engine.isPondering());
+      if (resumePonder) {
+        assertTrue(engine.ponderWhileLifecycleHeld);
+      }
       assertTrue(engine.isResponseUpToDate());
       assertEquals(1, frame.reSetLocCount);
       assertEquals(1, menu.updateCount);
       assertFalse(engine.hasExclusiveGtpWorkInProgress());
     } finally {
+      if (!synchronizationRan && manager.afterSync != null) {
+        manager.afterSync.run();
+      }
+      SwingUtilities.invokeAndWait(() -> {});
       Lizzie.leelaz = previousEngine;
       Lizzie.frame = previousFrame;
       Lizzie.board = previousBoard;
@@ -2210,6 +2232,7 @@ class EngineManagerLifecycleReservationTest {
       Lizzie.engineStartupStatus.ready();
     }
   }
+
 
   @Test
   void restartSynchronizationPropagatesReceiptIntoTheFinalBoardFence() throws Exception {

--- a/src/test/java/featurecat/lizzie/analysis/LeelazBoardSynchronizationConfirmationTest.java
+++ b/src/test/java/featurecat/lizzie/analysis/LeelazBoardSynchronizationConfirmationTest.java
@@ -1,0 +1,180 @@
+package featurecat.lizzie.analysis;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import featurecat.lizzie.Config;
+import featurecat.lizzie.Lizzie;
+import featurecat.lizzie.gui.LizzieFrame;
+
+import java.io.BufferedOutputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayDeque;
+import java.util.Timer;
+import java.util.TimerTask;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.Test;
+
+class LeelazBoardSynchronizationConfirmationTest {
+
+  @Test
+  void synchronousResponseDuringDispatchSettlesBeforeTimeoutScheduling() throws Exception {
+    try (TestEnvironment ignored = new TestEnvironment()) {
+      Leelaz engine = new Leelaz("");
+      Lizzie.leelaz = engine;
+      AtomicInteger successes = new AtomicInteger();
+      AtomicReference<String> failure = new AtomicReference<>();
+      SynchronousResponseOutput output = new SynchronousResponseOutput(engine);
+      setOutput(engine, output);
+
+      engine.confirmBoardSynchronization(successes::incrementAndGet, failure::set);
+
+      assertEquals(1, successes.get());
+      assertNull(failure.get());
+      assertTrue(output.command().endsWith("name"));
+      assertTrue(pendingResponses(engine).isEmpty());
+    }
+  }
+
+  @Test
+  void timeoutRetiresPendingBoardSynchronizationResponse() throws Exception {
+    try (TestEnvironment ignored = new TestEnvironment()) {
+      ShortTimeoutLeelaz engine = new ShortTimeoutLeelaz();
+      Lizzie.leelaz = engine;
+      setOutput(engine, new ByteArrayOutputStream());
+      CountDownLatch failed = new CountDownLatch(1);
+      AtomicReference<String> detail = new AtomicReference<>();
+
+      engine.confirmBoardSynchronization(
+          () -> {},
+          message -> {
+            detail.set(message);
+            failed.countDown();
+          });
+
+      assertTrue(failed.await(1, TimeUnit.SECONDS));
+      assertTrue(detail.get().contains("timeout"));
+      long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(1);
+      while (!pendingResponses(engine).isEmpty() && System.nanoTime() < deadline) {
+        Thread.sleep(1L);
+      }
+      assertTrue(pendingResponses(engine).isEmpty());
+    }
+  }
+
+  @Test
+  void settledResponseMayCancelTimeoutBeforeItIsScheduled() {
+    Timer timeout = new Timer(true);
+    timeout.cancel();
+
+    assertDoesNotThrow(
+        () ->
+            Leelaz.scheduleBoardSynchronizationTimeout(
+                timeout, noOpTask(), 1L, new AtomicBoolean(true)));
+  }
+
+  @Test
+  void unexpectedCancelledTimeoutStillFails() {
+    Timer timeout = new Timer(true);
+    timeout.cancel();
+
+    assertThrows(
+        IllegalStateException.class,
+        () ->
+            Leelaz.scheduleBoardSynchronizationTimeout(
+                timeout, noOpTask(), 1L, new AtomicBoolean(false)));
+  }
+
+  private static void setOutput(Leelaz engine, ByteArrayOutputStream output) throws Exception {
+    Field field = Leelaz.class.getDeclaredField("outputStream");
+    field.setAccessible(true);
+    field.set(engine, new BufferedOutputStream(output));
+  }
+
+  @SuppressWarnings("unchecked")
+  private static ArrayDeque<Object> pendingResponses(Leelaz engine) throws Exception {
+    Field field = Leelaz.class.getDeclaredField("pendingResponseHandlers");
+    field.setAccessible(true);
+    ArrayDeque<Object> handlers = (ArrayDeque<Object>) field.get(engine);
+    synchronized (handlers) {
+      return new ArrayDeque<>(handlers);
+    }
+  }
+
+  private static TimerTask noOpTask() {
+    return new TimerTask() {
+      @Override
+      public void run() {}
+    };
+  }
+
+  @SuppressWarnings("unchecked")
+  private static <T> T allocate(Class<T> type) throws Exception {
+    Field field = sun.misc.Unsafe.class.getDeclaredField("theUnsafe");
+    field.setAccessible(true);
+    return (T) ((sun.misc.Unsafe) field.get(null)).allocateInstance(type);
+  }
+
+  private static final class TestEnvironment implements AutoCloseable {
+    private final Config previousConfig = Lizzie.config;
+    private final LizzieFrame previousFrame = Lizzie.frame;
+    private final Leelaz previousEngine = Lizzie.leelaz;
+
+    private TestEnvironment() throws Exception {
+      Lizzie.config = allocate(Config.class);
+      Lizzie.frame = allocate(LizzieFrame.class);
+    }
+
+    @Override
+    public void close() {
+      Lizzie.config = previousConfig;
+      Lizzie.frame = previousFrame;
+      Lizzie.leelaz = previousEngine;
+    }
+  }
+
+  private static final class ShortTimeoutLeelaz extends Leelaz {
+    private ShortTimeoutLeelaz() throws IOException {
+      super("");
+    }
+
+    @Override
+    protected long readBoardGmaRestoreResponseTimeoutMillis() {
+      return 5L;
+    }
+  }
+
+  private static final class SynchronousResponseOutput extends ByteArrayOutputStream {
+    private final Leelaz engine;
+    private boolean responded;
+
+    private SynchronousResponseOutput(Leelaz engine) {
+      this.engine = engine;
+    }
+
+    @Override
+    public void flush() throws IOException {
+      super.flush();
+      if (responded) {
+        return;
+      }
+      responded = true;
+      String command = command();
+      String id = command.substring(0, command.indexOf(' '));
+      engine.processCommandResponseLineForTest("=" + id + " KataGo");
+    }
+
+    private String command() {
+      return toString(StandardCharsets.UTF_8).trim();
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Defer final initialization, ponder restoration, and READY publication for primary explicit restarts until the board synchronization fence completes.
- Refresh the engine status area immediately after READY instead of relying on mouse movement, timers, or later analysis output to dismiss the startup notice.
- Add regression coverage for board-fence success and failure, paused and active analysis intent, and late-response settlement.
- Fix primary explicit restarts that could leave stale startup/cache status in the lower-left status area or require manually clicking **Continue Analysis** before analysis resumed.

## Type Of Change

- [x] Bug fix
- [ ] Feature
- [ ] Packaging / release update
- [ ] Docs / translation
- [ ] Refactor

## Testing

- [x] Tested locally
- [ ] Verified package contents if packaging changed
- [ ] Verified Fox sync flow if related
- [ ] Added screenshots if UI changed
- [ ] Updated README / docs if user-facing behavior changed
- [x] Noted affected platforms if the change is platform-specific

Focused tests:

```bash
mvn -Dfmt.skip=true -Djava.awt.headless=true \
  '-Dtest=EngineManagerLifecycleReservationTest#activeRestartResumesPonderAfterFinalBoardFenceAndRetiresTrackingOnRebind+activeRestartReleasesLifecycleAfterBoardFenceFailure+inactiveExplicitRestartWaitsForBoardFenceBeforeInitializationAndRelease+pausedExplicitRestartWaitsForBoardFenceAndPublishesTerminalState,LeelazBoardSynchronizationConfirmationTest,EngineStartupStatusTest' \
  test
```

Result:

```text
Tests run: 11
Failures: 0
Errors: 0
Skipped: 0
BUILD SUCCESS
```

Windows bb18 acceptance:

- Initial engine startup completed normally.
- Explicit restart completed normally.
- The lower-left status refreshed without moving the mouse.
- Analysis resumed without manually clicking **Continue Analysis**.

## Notes

- This branch was rebased onto the latest `upstream/main`; the PR contains the single commit `2549d27a`.
- This PR does not modify secondary explicit restart behavior, diagnostics, `ExactSnapshotEngineRestore`, GMA ownership, or ReadBoard recovery.
- A separate shared engine-index issue can cause an index-0 primary restart to report that both engines are the same after a secondary restart. That issue is outside this lifecycle/UI fix and is handled separately.
- No screenshot artifact is currently available; the Windows UI results above are from the recorded manual acceptance run.
