### PR TITLE
fix(engine): fence secondary explicit restart settlement

### DIFF
--- a/src/main/java/featurecat/lizzie/analysis/EngineManager.java
+++ b/src/main/java/featurecat/lizzie/analysis/EngineManager.java
@@ -2252,10 +2252,12 @@ public class EngineManager {
       return;
     int restartEngineIndex = currentEngineNo2;
     if (rejectSameEngineSelection(restartEngineIndex, false)) return;
+    boolean restartPonderIntent =
+        Lizzie.leelaz != null && Lizzie.leelaz.isPonderingOrWasPonderingBeforeTracking();
     Leelaz secondaryTarget = engineList.get(restartEngineIndex);
     PreparedEngineSwitch preparedSwitch;
     try {
-      preparedSwitch = prepareEngineSwitch(restartEngineIndex, false);
+      preparedSwitch = prepareEngineSwitch(restartEngineIndex, false, true);
     } catch (Leelaz.ExactSnapshotRestoreAdmissionException conflict) {
       showForegroundEngineLeaseInUse();
       return;
@@ -2287,7 +2289,7 @@ public class EngineManager {
             secondaryTarget,
             false,
             true,
-            false,
+            restartPonderIntent,
             reservations,
             preparedSwitch == null ? null : preparedSwitch.lifecycleRestore));
   }
@@ -2661,6 +2663,41 @@ public class EngineManager {
             || (!explicitRestart
                 && current != null
                 && current.hasUnrestoredReadBoardGmaState());
+    if (explicitRestart && !isMain && target != null) {
+      return () -> {
+        if (Lizzie.leelaz2 != target || !target.isStarted() || !target.isLoaded()) {
+          target.isLoaded = false;
+          target.markLifecycleBoardSynchronizationFailed(
+              "restart engine was unavailable before board synchronization", targetWasUnrestored);
+          showEngineSynchronizationFailure(target);
+          reservations.close();
+          return;
+        }
+        target.confirmBoardSynchronization(
+            () -> {
+              try {
+                target.completeSecondaryExplicitRestartBoardSynchronization();
+                if (restartPonderIntent
+                    && current != null
+                    && current == Lizzie.leelaz
+                    && current.isStarted()
+                    && current.isLoaded()
+                    && !current.isCheckingName) {
+                  current.ponder();
+                }
+                target.setResponseUpToDate();
+              } finally {
+                reservations.close();
+              }
+            },
+            detail -> {
+              target.isLoaded = false;
+              target.markLifecycleBoardSynchronizationFailed(detail, targetWasUnrestored);
+              showEngineSynchronizationFailure(target);
+              reservations.close();
+            });
+      };
+    }
     if (!isMain
         || current == null
         || target == null
@@ -2865,12 +2902,16 @@ public class EngineManager {
                 } else {
                   preparedSwitch.lifecycleRestore.executeRootReplay(Lizzie.board, false, false);
                 }
-                preparedSwitch.lifecycleRestore.initializeAfterRestore(false);
+                if (!preparedSwitch.explicitRestart) {
+                  preparedSwitch.lifecycleRestore.initializeAfterRestore(false);
+                }
                 Menu.engineMenu2.setText(
                     "[" + (currentEngineNo2 + 1) + "]: " + newEng.currentEnginename);
                 changeEngIco(2);
                 LizzieFrame.boardRenderer2.removeKataEstimateImage();
-                newEng.setResponseUpToDate();
+                if (!preparedSwitch.explicitRestart) {
+                  newEng.setResponseUpToDate();
+                }
               }
             };
         synchronizeEngineWhenReady(newEng, syncBoard, afterSync);

--- a/src/main/java/featurecat/lizzie/analysis/Leelaz.java
+++ b/src/main/java/featurecat/lizzie/analysis/Leelaz.java
@@ -789,7 +789,7 @@ public class Leelaz {
       openClFp32CompatibilityActive =
           KataGoRuntimeHelper.isOpenClFp32CompatibilityActive(launchCommands, engineExecutable);
       if (openClFp32CompatibilityActive && bundledCommand && !preload) {
-        Lizzie.engineStartupStatus.checking(
+        publishBundledStartupStatus(
             "BundledEngineStartup.status.openclCompatibility",
             "Using stable NVIDIA OpenCL compatibility mode...");
       }
@@ -1164,6 +1164,11 @@ public class Leelaz {
   void initializeAfterExplicitRestartBoardSynchronization(boolean resumePonder) {
     Lizzie.initializeAfterVersionCheck(false, this, resumePonder);
   }
+  void completeSecondaryExplicitRestartBoardSynchronization() {
+    notPondering();
+    canRestoreDymPda = true;
+  }
+
 
   void completeReadBoardGmaRecoveryAfterBoardSync() {
     synchronized (readBoardGmaLock()) {
@@ -11409,7 +11414,13 @@ public class Leelaz {
     final boolean nvidiaBundled = KataGoRuntimeHelper.isNvidiaBundledPath(engineExecutable);
     final int totalSteps = nvidiaBundled ? 4 : 3;
     String progressFallback = statusFallback + " (" + step + "/" + totalSteps + ")";
-    Lizzie.engineStartupStatus.checking(statusKey, progressFallback);
+    publishBundledStartupStatus(statusKey, progressFallback);
+  }
+
+  private void publishBundledStartupStatus(String statusKey, String statusFallback) {
+    if (this == Lizzie.leelaz) {
+      Lizzie.engineStartupStatus.checking(statusKey, statusFallback);
+    }
   }
 
   private void closeBundledStartupDialog() {

--- a/src/main/java/featurecat/lizzie/analysis/Leelaz.java
+++ b/src/main/java/featurecat/lizzie/analysis/Leelaz.java
@@ -10444,17 +10444,9 @@ public class Leelaz {
     }
 
     private void start() {
-      try {
-        sendCommand("name", responseHandler, this::onSendFailure, true, false);
-      } catch (RuntimeException ex) {
-        settleFailure(ex.getMessage());
-        return;
-      }
-      if (settled.get()) {
-        return;
-      }
-      timeout = new Timer("lizzie-board-sync-confirmation-timeout", true);
-      timeout.schedule(
+      Timer confirmationTimeout = new Timer("lizzie-board-sync-confirmation-timeout", true);
+      timeout = confirmationTimeout;
+      TimerTask timeoutTask =
           new TimerTask() {
             @Override
             public void run() {
@@ -10467,8 +10459,20 @@ public class Leelaz {
                 retireTimedOutNormalCommand(responseHandler);
               }
             }
-          },
-          Math.max(1L, readBoardGmaRestoreResponseTimeoutMillis()));
+          };
+      try {
+        sendCommand("name", responseHandler, this::onSendFailure, true, false);
+      } catch (RuntimeException ex) {
+        settleFailure(ex.getMessage());
+        return;
+      }
+      if (!settled.get()) {
+        scheduleBoardSynchronizationTimeout(
+            confirmationTimeout,
+            timeoutTask,
+            Math.max(1L, readBoardGmaRestoreResponseTimeoutMillis()),
+            settled);
+      }
     }
 
     private void onResponse() {
@@ -10507,6 +10511,17 @@ public class Leelaz {
       timeout = null;
       if (currentTimeout != null) {
         currentTimeout.cancel();
+      }
+    }
+  }
+
+  static void scheduleBoardSynchronizationTimeout(
+      Timer timer, TimerTask task, long delayMillis, AtomicBoolean settled) {
+    try {
+      timer.schedule(task, delayMillis);
+    } catch (IllegalStateException ex) {
+      if (!settled.get()) {
+        throw ex;
       }
     }
   }

--- a/src/main/java/featurecat/lizzie/gui/LizzieFrame.java
+++ b/src/main/java/featurecat/lizzie/gui/LizzieFrame.java
@@ -14744,7 +14744,14 @@ public class LizzieFrame extends JFrame {
           if (snapshot.state == EngineStartupStatus.State.READY) {
             engineStartupStatusButton.setVisible(false);
             engineStartupStatusButton.setEnabled(false);
+            redrawWinratePaneOnly = false;
+            if (mainPanel != null) {
+              mainPanel.repaint();
+              refresh();
+            }
+            basePanel.revalidate();
             basePanel.repaint();
+            repaint();
             return;
           }
           String message = text(snapshot.messageKey, snapshot.fallback);

--- a/src/test/java/featurecat/lizzie/EngineStartupStatusTest.java
+++ b/src/test/java/featurecat/lizzie/EngineStartupStatusTest.java
@@ -36,31 +36,69 @@ class EngineStartupStatusTest {
   }
 
   @Test
-  void readyStatusRepaintsTheBasePanelAfterHidingTheNotice() throws Exception {
-    LizzieFrame frame = allocate(LizzieFrame.class);
+  void readyStatusPublishesTerminalUiAndCommentOnEdt() throws Exception {
+    CountingLizzieFrame frame = allocate(CountingLizzieFrame.class);
     CountingLayeredPane basePanel = new CountingLayeredPane();
+    CountingPanel mainPanel = new CountingPanel();
     JFontButton statusButton = new JFontButton();
+    basePanel.add(statusButton, Integer.valueOf(12));
+    statusButton.setBounds(10, 10, 240, 32);
+    statusButton.setText("using existing cache");
     statusButton.setVisible(true);
-    setField(frame, "basePanel", basePanel);
-    setField(frame, "engineStartupStatusButton", statusButton);
+    setField(LizzieFrame.class, frame, "basePanel", basePanel);
+    setField(LizzieFrame.class, frame, "mainPanel", mainPanel);
+    setField(LizzieFrame.class, frame, "engineStartupStatusButton", statusButton);
+    setField(LizzieFrame.class, frame, "redrawWinratePaneOnly", true);
+    basePanel.resetCounts();
+    frame.repaintCount = 0;
 
-    Method update =
-        LizzieFrame.class.getDeclaredMethod(
-            "updateEngineStartupStatus", EngineStartupStatus.Snapshot.class);
-    update.setAccessible(true);
-    update.invoke(frame, new EngineStartupStatus().snapshot());
+    EngineStartupStatus status = new EngineStartupStatus();
+    status.checking("engine.starting", "using existing cache");
+    status.addListener(snapshot -> invokeStatusUpdate(frame, snapshot));
+    status.ready();
     SwingUtilities.invokeAndWait(() -> {});
 
     assertFalse(statusButton.isVisible());
-    assertEquals(1, basePanel.repaintCount);
+    assertFalse(
+        (Boolean) getField(LizzieFrame.class, frame, "redrawWinratePaneOnly"),
+        "READY must invalidate a pending winrate-only repaint");
+    assertTrue(mainPanel.repaintCount > 0, "READY must repaint the cached main panel");
+    assertTrue(frame.repaintCount > 0, "READY must repaint the containing frame");
+    assertTrue(frame.refreshCount > 0, "READY must refresh after engine startup");
+    assertTrue(
+        frame.commentRefreshCount > 0,
+        "READY refresh must republish the comment panel after engine startup");
+    assertTrue(basePanel.revalidateCount > 0, "READY must publish the hidden notice layout");
+    assertTrue(basePanel.repaintCount > 0, "READY must repaint the cleared notice region");
+    assertTrue(basePanel.revalidatedOnEdt, "READY layout publication must run on EDT");
+    assertTrue(basePanel.repaintedOnEdt, "READY repaint publication must run on EDT");
   }
 
-  private static void setField(Object target, String name, Object value) throws Exception {
-    Field field = target.getClass().getDeclaredField(name);
+  private static void invokeStatusUpdate(
+      LizzieFrame frame, EngineStartupStatus.Snapshot snapshot) {
+    try {
+      Method update =
+          LizzieFrame.class.getDeclaredMethod(
+              "updateEngineStartupStatus", EngineStartupStatus.Snapshot.class);
+      update.setAccessible(true);
+      update.invoke(frame, snapshot);
+    } catch (ReflectiveOperationException failure) {
+      throw new AssertionError(failure);
+    }
+  }
+
+  private static void setField(Class<?> declaringType, Object target, String name, Object value)
+      throws Exception {
+    Field field = declaringType.getDeclaredField(name);
     field.setAccessible(true);
     field.set(target, value);
   }
-
+  private static Object getField(Class<?> declaringType, Object target, String name)
+      throws Exception {
+    Field field = declaringType.getDeclaredField(name);
+    field.setAccessible(true);
+    return field.get(target);
+  }
   @SuppressWarnings("unchecked")
   private static <T> T allocate(Class<T> type) throws Exception {
     Field field = sun.misc.Unsafe.class.getDeclaredField("theUnsafe");
@@ -70,6 +108,54 @@ class EngineStartupStatusTest {
 
   private static final class CountingLayeredPane extends JLayeredPane {
     private int repaintCount;
+    private int revalidateCount;
+    private boolean revalidatedOnEdt;
+    private boolean repaintedOnEdt;
+
+    private void resetCounts() {
+      repaintCount = 0;
+      revalidateCount = 0;
+      revalidatedOnEdt = false;
+      repaintedOnEdt = false;
+    }
+
+    @Override
+    public void revalidate() {
+      revalidateCount++;
+      revalidatedOnEdt |= SwingUtilities.isEventDispatchThread();
+      super.revalidate();
+    }
+
+    @Override
+    public void repaint() {
+      repaintCount++;
+      repaintedOnEdt |= SwingUtilities.isEventDispatchThread();
+    }
+  }
+  private static final class CountingPanel extends javax.swing.JPanel {
+    private int repaintCount;
+
+    @Override
+    public void repaint() {
+      repaintCount++;
+    }
+  }
+
+  private static final class CountingLizzieFrame extends LizzieFrame {
+    private int refreshCount;
+    private int commentRefreshCount;
+    private int repaintCount;
+
+    @Override
+    public void refresh() {
+      refreshCount++;
+      appendComment();
+    }
+
+    @Override
+    public void appendComment() {
+      commentRefreshCount++;
+    }
 
     @Override
     public void repaint() {

--- a/src/test/java/featurecat/lizzie/analysis/EngineManagerLifecycleReservationTest.java
+++ b/src/test/java/featurecat/lizzie/analysis/EngineManagerLifecycleReservationTest.java
@@ -2148,6 +2148,326 @@ class EngineManagerLifecycleReservationTest {
     assertExplicitRestartWaitsForBoardFence(false);
   }
 
+  @Test
+  void secondaryActiveExplicitRestartSettlesAfterOwnerBoardFence() throws Exception {
+    assertSecondaryExplicitRestartSettlesAfterOwnerBoardFence(true);
+  }
+
+  @Test
+  void secondaryPausedExplicitRestartStaysPausedAfterOwnerBoardFence() throws Exception {
+    assertSecondaryExplicitRestartSettlesAfterOwnerBoardFence(false);
+  }
+
+  private void assertSecondaryExplicitRestartSettlesAfterOwnerBoardFence(boolean resumePonder)
+      throws Exception {
+    Leelaz previousPrimary = Lizzie.leelaz;
+    Leelaz previousSecondary = Lizzie.leelaz2;
+    Board previousBoard = Lizzie.board;
+    LizzieFrame previousFrame = Lizzie.frame;
+    Config previousConfig = Lizzie.config;
+    boolean previousEmpty = EngineManager.isEmpty;
+    int previousEngineNo = EngineManager.currentEngineNo;
+    int previousEngineNo2 = EngineManager.currentEngineNo2;
+    TrackingRestartActionLeelaz primary = new TrackingRestartActionLeelaz();
+    TrackingRestartActionLeelaz secondary = new TrackingRestartActionLeelaz();
+    DeferredSecondaryRestartEngineManager manager =
+        new DeferredSecondaryRestartEngineManager(List.of(primary, secondary), secondary);
+    List<String> terminalOrder = new ArrayList<>();
+    try {
+      Config config = allocate(Config.class);
+      config.fastChange = true;
+      config.extraMode = ExtraMode.Double_Engine;
+      Lizzie.config = config;
+      Lizzie.frame = allocate(LizzieFrame.class);
+      Lizzie.board = preparedRestoreBoard();
+      primary.started = true;
+      primary.isLoaded = true;
+      secondary.started = true;
+      secondary.isLoaded = true;
+      secondary.Pondering();
+      if (resumePonder) {
+        primary.Pondering();
+      } else {
+        primary.notPondering();
+      }
+      primary.onPonder = () -> terminalOrder.add("ponder");
+      secondary.onSecondaryTerminal = () -> terminalOrder.add("terminal");
+      secondary.onResponseWatermark = () -> terminalOrder.add("watermark");
+      setLeelazField(secondary, "currentCmdNum", 15);
+      setLeelazField(secondary, "cmdNumber", 17);
+      Lizzie.leelaz = primary;
+      Lizzie.leelaz2 = secondary;
+      EngineManager.isEmpty = false;
+      EngineManager.currentEngineNo = 0;
+      EngineManager.currentEngineNo2 = 1;
+      Lizzie.engineStartupStatus.checking("primary.still.starting", "controlled");
+
+      manager.reStartEngine2();
+      assertEquals(1, secondary.shutdownCount);
+      assertNotNull(manager.afterSync);
+      assertTrue(secondary.hasExclusiveGtpWorkInProgress());
+
+      manager.afterSync.run();
+
+      assertNotNull(
+          secondary.confirmation,
+          "secondary explicit restart must wait for its owner board synchronization fence");
+      assertTrue(secondary.hasExclusiveGtpWorkInProgress());
+      assertEquals(0, secondary.secondaryTerminalCount);
+      assertEquals(0, primary.ponderCount);
+      assertEquals(0, secondary.ponderCount);
+      assertFalse(secondary.isResponseUpToDate());
+      assertEquals(EngineStartupStatus.State.CHECKING, Lizzie.engineStartupStatus.snapshot().state);
+
+      Runnable confirmation = secondary.confirmation;
+      secondary.confirmation = null;
+      confirmation.run();
+
+      assertEquals(1, secondary.secondaryTerminalCount);
+      assertTrue(secondary.secondaryTerminalWhileLifecycleHeld);
+      assertTrue(secondary.responseWatermarkWhileLifecycleHeld);
+      assertTrue(secondary.canRestoreDymPda);
+      assertFalse(secondary.isPondering());
+      assertEquals(resumePonder ? 1 : 0, primary.ponderCount);
+      assertEquals(0, secondary.ponderCount);
+      assertEquals(
+          resumePonder
+              ? List.of("terminal", "ponder", "watermark")
+              : List.of("terminal", "watermark"),
+          terminalOrder);
+      assertTrue(secondary.isResponseUpToDate());
+      assertEquals(EngineStartupStatus.State.CHECKING, Lizzie.engineStartupStatus.snapshot().state);
+      assertFalse(secondary.hasExclusiveGtpWorkInProgress());
+    } finally {
+      if (secondary.confirmation != null) {
+        Runnable confirmation = secondary.confirmation;
+        secondary.confirmation = null;
+        confirmation.run();
+      } else if (manager.afterSync != null && secondary.secondaryTerminalCount == 0) {
+        manager.afterSync.run();
+        if (secondary.confirmation != null) {
+          Runnable confirmation = secondary.confirmation;
+          secondary.confirmation = null;
+          confirmation.run();
+        }
+      }
+      Lizzie.leelaz = previousPrimary;
+      Lizzie.leelaz2 = previousSecondary;
+      Lizzie.board = previousBoard;
+      Lizzie.frame = previousFrame;
+      Lizzie.config = previousConfig;
+      EngineManager.isEmpty = previousEmpty;
+      EngineManager.currentEngineNo = previousEngineNo;
+      EngineManager.currentEngineNo2 = previousEngineNo2;
+      Lizzie.engineStartupStatus.ready();
+    }
+  }
+
+  @Test
+  void secondaryExplicitRestartFenceFailureRetiresLifecycleFailClosed() throws Exception {
+    Leelaz previousPrimary = Lizzie.leelaz;
+    Leelaz previousSecondary = Lizzie.leelaz2;
+    Board previousBoard = Lizzie.board;
+    LizzieFrame previousFrame = Lizzie.frame;
+    Config previousConfig = Lizzie.config;
+    boolean previousEmpty = EngineManager.isEmpty;
+    int previousEngineNo = EngineManager.currentEngineNo;
+    int previousEngineNo2 = EngineManager.currentEngineNo2;
+    TrackingRestartActionLeelaz primary = new TrackingRestartActionLeelaz();
+    TrackingRestartActionLeelaz secondary = new TrackingRestartActionLeelaz();
+    DeferredSecondaryRestartEngineManager manager =
+        new DeferredSecondaryRestartEngineManager(List.of(primary, secondary), secondary);
+    boolean settled = false;
+    try {
+      Config config = allocate(Config.class);
+      config.fastChange = true;
+      config.extraMode = ExtraMode.Double_Engine;
+      Lizzie.config = config;
+      Lizzie.frame = allocate(LizzieFrame.class);
+      Lizzie.board = preparedRestoreBoard();
+      primary.started = true;
+      primary.isLoaded = true;
+      primary.notPondering();
+      secondary.started = true;
+      secondary.isLoaded = true;
+      Lizzie.leelaz = primary;
+      Lizzie.leelaz2 = secondary;
+      EngineManager.isEmpty = false;
+      EngineManager.currentEngineNo = 0;
+      EngineManager.currentEngineNo2 = 1;
+      Lizzie.engineStartupStatus.ready();
+
+      manager.reStartEngine2();
+      manager.afterSync.run();
+
+      assertNotNull(secondary.rejection);
+      assertTrue(secondary.hasExclusiveGtpWorkInProgress());
+      secondary.rejection.accept("controlled secondary board fence failure");
+      settled = true;
+
+      assertFalse(secondary.isLoaded());
+      assertEquals(0, secondary.secondaryTerminalCount);
+      assertEquals(0, primary.ponderCount);
+      assertEquals(0, secondary.ponderCount);
+      assertEquals(1, manager.failureCount);
+      assertFalse(secondary.hasExclusiveGtpWorkInProgress());
+      assertEquals(EngineStartupStatus.State.READY, Lizzie.engineStartupStatus.snapshot().state);
+    } finally {
+      if (!settled && manager.afterSync != null) {
+        manager.afterSync.run();
+        if (secondary.rejection != null) {
+          secondary.rejection.accept("controlled secondary board fence cleanup");
+        }
+      }
+      Lizzie.leelaz = previousPrimary;
+      Lizzie.leelaz2 = previousSecondary;
+      Lizzie.board = previousBoard;
+      Lizzie.frame = previousFrame;
+      Lizzie.config = previousConfig;
+      EngineManager.isEmpty = previousEmpty;
+      EngineManager.currentEngineNo = previousEngineNo;
+      EngineManager.currentEngineNo2 = previousEngineNo2;
+      Lizzie.engineStartupStatus.ready();
+    }
+  }
+
+  @Test
+  void secondaryExplicitRestartBoardFenceTimeoutRetiresLifecycleFailClosed() throws Exception {
+    assertSecondaryExplicitRestartBoardFenceFailClosed(false);
+  }
+
+  @Test
+  void secondaryExplicitRestartBoardFenceSendFailureRetiresLifecycleFailClosed() throws Exception {
+    assertSecondaryExplicitRestartBoardFenceFailClosed(true);
+  }
+
+  private void assertSecondaryExplicitRestartBoardFenceFailClosed(boolean failOnSend)
+      throws Exception {
+    Leelaz previousPrimary = Lizzie.leelaz;
+    Leelaz previousSecondary = Lizzie.leelaz2;
+    Board previousBoard = Lizzie.board;
+    LizzieFrame previousFrame = Lizzie.frame;
+    Config previousConfig = Lizzie.config;
+    boolean previousEmpty = EngineManager.isEmpty;
+    boolean previousEngineGame = EngineManager.isEngineGame;
+    boolean previousPreEngineGame = EngineManager.isPreEngineGame;
+    int previousEngineNo = EngineManager.currentEngineNo;
+    int previousEngineNo2 = EngineManager.currentEngineNo2;
+    TrackingRestartActionLeelaz primary = new TrackingRestartActionLeelaz();
+    TrackingRestartActionLeelaz secondary = new TrackingRestartActionLeelaz();
+    DeferredSecondaryRestartEngineManager manager =
+        new DeferredSecondaryRestartEngineManager(List.of(primary, secondary), secondary);
+    GatedCommandOutputStream gatedOutput = new GatedCommandOutputStream(failOnSend);
+    Thread fenceThread = null;
+    boolean fenceSettled = false;
+    try {
+      Config config = allocate(Config.class);
+      config.fastChange = true;
+      config.extraMode = ExtraMode.Double_Engine;
+      Lizzie.config = config;
+      Lizzie.frame = allocate(LizzieFrame.class);
+      Lizzie.board = preparedRestoreBoard();
+      primary.started = true;
+      primary.isLoaded = true;
+      primary.notPondering();
+      secondary.started = true;
+      secondary.isLoaded = true;
+      secondary.useRealBoardSynchronizationFence = true;
+      secondary.boardSynchronizationTimeoutMillis = 100L;
+      setLeelazField(secondary, "currentCmdNum", 15);
+      setLeelazField(secondary, "cmdNumber", 17);
+      Lizzie.leelaz = primary;
+      Lizzie.leelaz2 = secondary;
+      EngineManager.isEmpty = false;
+      EngineManager.isEngineGame = false;
+      EngineManager.isPreEngineGame = false;
+      EngineManager.currentEngineNo = 0;
+      EngineManager.currentEngineNo2 = 1;
+      Lizzie.engineStartupStatus.ready();
+
+      manager.reStartEngine2();
+      assertEquals(1, secondary.shutdownCount);
+      assertNotNull(manager.afterSync);
+      setLeelazField(secondary, "outputStream", new BufferedOutputStream(gatedOutput));
+
+      fenceThread =
+          new Thread(() -> manager.afterSync.run(), "secondary-restart-board-fence");
+      fenceThread.start();
+      assertTrue(gatedOutput.writeEntered.await(2, TimeUnit.SECONDS));
+
+      int fenceResponseCommandId = pendingFenceResponseCommandId(secondary);
+      assertEquals(0, manager.failureCount);
+      assertFalse(
+          primary.hasExclusiveGtpWorkInProgress(),
+          "secondary restart must not reserve the primary lifecycle");
+      assertTrue(secondary.hasExclusiveGtpWorkInProgress());
+      assertTrue(secondary.isLoaded());
+      assertEquals(0, secondary.secondaryTerminalCount);
+      assertEquals(0, secondary.initializationCount);
+      assertEquals(0, primary.ponderCount);
+      assertEquals(0, secondary.ponderCount);
+      assertFalse(secondary.responseWatermarkWhileLifecycleHeld);
+      assertEquals(1, pendingResponseHandlerCount(secondary));
+      assertEquals(EngineStartupStatus.State.READY, Lizzie.engineStartupStatus.snapshot().state);
+
+      gatedOutput.releaseWrite();
+      fenceThread.join(2000);
+      assertFalse(fenceThread.isAlive());
+      fenceThread = null;
+      assertTrue(manager.fenceFailureSettled.await(2, TimeUnit.SECONDS));
+      fenceSettled = true;
+
+      assertFalse(secondary.isLoaded());
+      assertEquals(0, secondary.secondaryTerminalCount);
+      assertEquals(0, secondary.initializationCount);
+      assertEquals(0, primary.ponderCount);
+      assertEquals(0, secondary.ponderCount);
+      assertFalse(secondary.responseWatermarkWhileLifecycleHeld);
+      assertFalse(secondary.isResponseUpToDate());
+      assertEquals(1, manager.failureCount);
+      assertFalse(primary.hasExclusiveGtpWorkInProgress());
+      assertFalse(secondary.hasExclusiveGtpWorkInProgress());
+      assertEquals(EngineStartupStatus.State.READY, Lizzie.engineStartupStatus.snapshot().state);
+      assertEquals(0, pendingResponseHandlerCount(secondary));
+
+      processCommandResponse(secondary, "=" + fenceResponseCommandId + " name");
+
+      assertEquals(1, manager.failureCount);
+      assertEquals(0, secondary.secondaryTerminalCount);
+      assertEquals(0, secondary.initializationCount);
+      assertEquals(0, primary.ponderCount);
+      assertEquals(0, secondary.ponderCount);
+      assertFalse(secondary.isLoaded());
+      assertFalse(primary.hasExclusiveGtpWorkInProgress());
+      assertFalse(secondary.hasExclusiveGtpWorkInProgress());
+      assertEquals(EngineStartupStatus.State.READY, Lizzie.engineStartupStatus.snapshot().state);
+      assertEquals(0, pendingResponseHandlerCount(secondary));
+    } finally {
+      gatedOutput.releaseWrite();
+      if (fenceThread != null) {
+        fenceThread.join(2000);
+      }
+      if (!fenceSettled && gatedOutput.writeEntered.getCount() == 0) {
+        try {
+          manager.fenceFailureSettled.await(2, TimeUnit.SECONDS);
+        } catch (InterruptedException interrupted) {
+          Thread.currentThread().interrupt();
+        }
+      }
+      Lizzie.leelaz = previousPrimary;
+      Lizzie.leelaz2 = previousSecondary;
+      Lizzie.board = previousBoard;
+      Lizzie.frame = previousFrame;
+      Lizzie.config = previousConfig;
+      EngineManager.isEmpty = previousEmpty;
+      EngineManager.isEngineGame = previousEngineGame;
+      EngineManager.isPreEngineGame = previousPreEngineGame;
+      EngineManager.currentEngineNo = previousEngineNo;
+      EngineManager.currentEngineNo2 = previousEngineNo2;
+      Lizzie.engineStartupStatus.ready();
+    }
+  }
+
   private void assertExplicitRestartWaitsForBoardFence(boolean resumePonder) throws Exception {
     Leelaz previousEngine = Lizzie.leelaz;
     LizzieFrame previousFrame = Lizzie.frame;
@@ -2778,6 +3098,22 @@ class EngineManagerLifecycleReservationTest {
     field.set(engine, reservation);
   }
 
+  private static int pendingResponseHandlerCount(Leelaz engine) throws Exception {
+    Object handlers = getLeelazField(engine, "pendingResponseHandlers");
+    synchronized (handlers) {
+      return ((java.util.Collection<?>) handlers).size();
+    }
+  }
+
+  private static int pendingFenceResponseCommandId(Leelaz engine) throws Exception {
+    Object handlers = getLeelazField(engine, "pendingResponseHandlers");
+    synchronized (handlers) {
+      java.util.ArrayDeque<?> pending = (java.util.ArrayDeque<?>) handlers;
+      assertEquals(1, pending.size());
+      return (Integer) getField(pending.peekFirst(), "responseCommandId");
+    }
+  }
+
   private static void awaitEngineUnavailable(Leelaz engine) throws InterruptedException {
     long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(2);
     while (System.nanoTime() < deadline
@@ -2854,6 +3190,79 @@ class EngineManagerLifecycleReservationTest {
       failureCount++;
     }
   }
+  private static final class DeferredSecondaryRestartEngineManager extends EngineManager {
+    private final Leelaz target;
+    private final CountDownLatch fenceFailureSettled = new CountDownLatch(1);
+    private Runnable afterSync;
+    private int failureCount;
+
+    private DeferredSecondaryRestartEngineManager(List<Leelaz> engines, Leelaz target) {
+      super(engines);
+      this.target = target;
+    }
+
+    @Override
+    protected void switchEngineInternal(
+        int index,
+        boolean isMain,
+        PreparedEngineSwitch preparedSwitch,
+        Runnable afterSync) {
+      Lizzie.leelaz2 = target;
+      target.started = true;
+      target.isLoaded = true;
+      this.afterSync = afterSync;
+    }
+
+    @Override
+    protected void showEngineSynchronizationFailure(Leelaz engine) {
+      failureCount++;
+      fenceFailureSettled.countDown();
+    }
+  }
+
+  private static final class GatedCommandOutputStream extends java.io.OutputStream {
+    private final CountDownLatch writeEntered = new CountDownLatch(1);
+    private final CountDownLatch releaseWrite = new CountDownLatch(1);
+    private final boolean failOnRelease;
+    private final ByteArrayOutputStream sink = new ByteArrayOutputStream();
+
+    private GatedCommandOutputStream(boolean failOnRelease) {
+      this.failOnRelease = failOnRelease;
+    }
+
+    @Override
+    public void write(int value) throws java.io.IOException {
+      awaitWriteEntry();
+      if (failOnRelease) {
+        throw new java.io.IOException("controlled board fence send failure");
+      }
+      sink.write(value);
+    }
+
+    @Override
+    public void write(byte[] bytes, int offset, int length) throws java.io.IOException {
+      awaitWriteEntry();
+      if (failOnRelease) {
+        throw new java.io.IOException("controlled board fence send failure");
+      }
+      sink.write(bytes, offset, length);
+    }
+
+    private void awaitWriteEntry() {
+      writeEntered.countDown();
+      try {
+        releaseWrite.await();
+      } catch (InterruptedException interrupted) {
+        Thread.currentThread().interrupt();
+        throw new IllegalStateException("controlled board fence stream interrupted", interrupted);
+      }
+    }
+
+    private void releaseWrite() {
+      releaseWrite.countDown();
+    }
+  }
+
 
   private static final class LifecycleConflictLeelaz extends Leelaz {
     private LifecycleConflictLeelaz() throws Exception {
@@ -2893,6 +3302,14 @@ class EngineManagerLifecycleReservationTest {
     private boolean invokeRealInitialization;
     private int initializationCount;
     private boolean resumePonderIntent;
+    private int secondaryTerminalCount;
+    private boolean secondaryTerminalWhileLifecycleHeld;
+    private boolean responseWatermarkWhileLifecycleHeld;
+    private Runnable onPonder;
+    private Runnable onSecondaryTerminal;
+    private Runnable onResponseWatermark;
+    private boolean useRealBoardSynchronizationFence;
+    private long boardSynchronizationTimeoutMillis = -1L;
 
     private TrackingRestartActionLeelaz() throws Exception {
       super("");
@@ -2912,6 +3329,9 @@ class EngineManagerLifecycleReservationTest {
     public void ponder() {
       ponderWhileLifecycleHeld = hasExclusiveGtpWorkInProgress();
       ponderCount++;
+      if (onPonder != null) {
+        onPonder.run();
+      }
       if (emitPonderCommand) {
         cmdNumber++;
       }
@@ -2919,8 +3339,38 @@ class EngineManagerLifecycleReservationTest {
 
     @Override
     void confirmBoardSynchronization(Runnable onSuccess, Consumer<String> onFailure) {
-      confirmation = onSuccess;
-      rejection = onFailure;
+      if (useRealBoardSynchronizationFence) {
+        super.confirmBoardSynchronization(onSuccess, onFailure);
+      } else {
+        confirmation = onSuccess;
+        rejection = onFailure;
+      }
+    }
+
+    @Override
+    protected long readBoardGmaRestoreResponseTimeoutMillis() {
+      return boardSynchronizationTimeoutMillis > 0
+          ? boardSynchronizationTimeoutMillis
+          : super.readBoardGmaRestoreResponseTimeoutMillis();
+    }
+
+    @Override
+    void completeSecondaryExplicitRestartBoardSynchronization() {
+      secondaryTerminalCount++;
+      secondaryTerminalWhileLifecycleHeld = hasExclusiveGtpWorkInProgress();
+      if (onSecondaryTerminal != null) {
+        onSecondaryTerminal.run();
+      }
+      super.completeSecondaryExplicitRestartBoardSynchronization();
+    }
+
+    @Override
+    public void setResponseUpToDate() {
+      responseWatermarkWhileLifecycleHeld = hasExclusiveGtpWorkInProgress();
+      if (onResponseWatermark != null) {
+        onResponseWatermark.run();
+      }
+      super.setResponseUpToDate();
     }
 
     @Override

--- a/src/test/java/featurecat/lizzie/analysis/EngineManagerLifecycleReservationTest.java
+++ b/src/test/java/featurecat/lizzie/analysis/EngineManagerLifecycleReservationTest.java
@@ -2140,6 +2140,15 @@ class EngineManagerLifecycleReservationTest {
 
   @Test
   void inactiveExplicitRestartWaitsForBoardFenceBeforeInitializationAndRelease() throws Exception {
+    assertExplicitRestartWaitsForBoardFence(true);
+  }
+
+  @Test
+  void pausedExplicitRestartWaitsForBoardFenceAndPublishesTerminalState() throws Exception {
+    assertExplicitRestartWaitsForBoardFence(false);
+  }
+
+  private void assertExplicitRestartWaitsForBoardFence(boolean resumePonder) throws Exception {
     Leelaz previousEngine = Lizzie.leelaz;
     LizzieFrame previousFrame = Lizzie.frame;
     Board previousBoard = Lizzie.board;
@@ -2159,8 +2168,13 @@ class EngineManagerLifecycleReservationTest {
     config.extraMode = ExtraMode.Normal;
     engine.started = true;
     engine.isLoaded = true;
-    engine.Pondering();
+    if (resumePonder) {
+      engine.Pondering();
+    } else {
+      engine.notPondering();
+    }
     RecoverySwitchEngineManager manager = new RecoverySwitchEngineManager(List.of(engine), engine);
+    boolean synchronizationRan = false;
     try {
       Lizzie.config = config;
       Lizzie.board = board;
@@ -2176,6 +2190,7 @@ class EngineManagerLifecycleReservationTest {
 
       manager.reStartEngine(0);
       manager.afterSync.run();
+      synchronizationRan = true;
 
       assertNotNull(engine.confirmation);
       assertTrue(engine.isLoaded);
@@ -2190,14 +2205,21 @@ class EngineManagerLifecycleReservationTest {
       assertTrue(engine.isLoaded);
       assertEquals(EngineStartupStatus.State.READY, Lizzie.engineStartupStatus.snapshot().state);
       assertEquals(1, engine.initializationCount);
-      assertTrue(engine.resumePonderIntent);
-      assertEquals(1, engine.ponderCount);
-      assertTrue(engine.ponderWhileLifecycleHeld);
+      assertEquals(resumePonder, engine.resumePonderIntent);
+      assertEquals(resumePonder ? 1 : 0, engine.ponderCount);
+      assertEquals(resumePonder, engine.isPondering());
+      if (resumePonder) {
+        assertTrue(engine.ponderWhileLifecycleHeld);
+      }
       assertTrue(engine.isResponseUpToDate());
       assertEquals(1, frame.reSetLocCount);
       assertEquals(1, menu.updateCount);
       assertFalse(engine.hasExclusiveGtpWorkInProgress());
     } finally {
+      if (!synchronizationRan && manager.afterSync != null) {
+        manager.afterSync.run();
+      }
+      SwingUtilities.invokeAndWait(() -> {});
       Lizzie.leelaz = previousEngine;
       Lizzie.frame = previousFrame;
       Lizzie.board = previousBoard;
@@ -2210,6 +2232,7 @@ class EngineManagerLifecycleReservationTest {
       Lizzie.engineStartupStatus.ready();
     }
   }
+
 
   @Test
   void restartSynchronizationPropagatesReceiptIntoTheFinalBoardFence() throws Exception {

--- a/src/test/java/featurecat/lizzie/analysis/EngineStartupDialogPolicyTest.java
+++ b/src/test/java/featurecat/lizzie/analysis/EngineStartupDialogPolicyTest.java
@@ -1,8 +1,12 @@
 package featurecat.lizzie.analysis;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import featurecat.lizzie.EngineStartupStatus;
+import featurecat.lizzie.Lizzie;
+import java.lang.reflect.Method;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
@@ -29,6 +33,62 @@ class EngineStartupDialogPolicyTest {
     assertFalse(AnalysisEngine.shouldShowGeneratedConfigNotice(true, true));
     assertFalse(AnalysisEngine.shouldShowGeneratedConfigNotice(false, false));
     assertTrue(AnalysisEngine.shouldShowGeneratedConfigNotice(false, true));
+  }
+
+  @Test
+  void secondaryBundledStartupStageDoesNotPublishPrimaryStatus() throws Exception {
+    Leelaz previousPrimary = Lizzie.leelaz;
+    Leelaz primary = new Leelaz("");
+    Leelaz secondary = new Leelaz("engines/katago/windows-x64-opencl/katago.exe");
+    try {
+      Lizzie.leelaz = primary;
+      Lizzie.engineStartupStatus.ready();
+
+      invokeBundledStartupStage(secondary);
+
+      assertEquals(EngineStartupStatus.State.READY, Lizzie.engineStartupStatus.snapshot().state);
+    } finally {
+      Lizzie.leelaz = previousPrimary;
+      Lizzie.engineStartupStatus.ready();
+    }
+  }
+
+  @Test
+  void primaryBundledStartupStagePublishesCheckingStatus() throws Exception {
+    Leelaz previousPrimary = Lizzie.leelaz;
+    Leelaz primary = new Leelaz("engines/katago/windows-x64-opencl/katago.exe");
+    try {
+      Lizzie.leelaz = primary;
+      Lizzie.engineStartupStatus.ready();
+
+      invokeBundledStartupStage(primary);
+
+      assertEquals(EngineStartupStatus.State.CHECKING, Lizzie.engineStartupStatus.snapshot().state);
+    } finally {
+      Lizzie.leelaz = previousPrimary;
+      Lizzie.engineStartupStatus.ready();
+    }
+  }
+
+  @Test
+  void secondaryOpenClCompatibilityStageDoesNotPublishPrimaryStatus() throws Exception {
+    Leelaz previousPrimary = Lizzie.leelaz;
+    Leelaz primary = new Leelaz("");
+    Leelaz secondary = new Leelaz("engines/katago/windows-x64-opencl/katago.exe");
+    try {
+      Lizzie.leelaz = primary;
+      Lizzie.engineStartupStatus.ready();
+
+      invokeBundledStartupStatus(
+          secondary,
+          "BundledEngineStartup.status.openclCompatibility",
+          "Using stable NVIDIA OpenCL compatibility mode...");
+
+      assertEquals(EngineStartupStatus.State.READY, Lizzie.engineStartupStatus.snapshot().state);
+    } finally {
+      Lizzie.leelaz = previousPrimary;
+      Lizzie.engineStartupStatus.ready();
+    }
   }
 
   @Test
@@ -71,4 +131,35 @@ class EngineStartupDialogPolicyTest {
         Leelaz.hasMissingLocalStartupAsset(
             List.of(executable.toString(), "gtp"), true, false));
   }
+
+  private static void invokeBundledStartupStage(Leelaz engine) throws Exception {
+    Method method =
+        Leelaz.class.getDeclaredMethod(
+            "updateBundledStartupStage",
+            Path.class,
+            int.class,
+            String.class,
+            String.class,
+            String.class,
+            String.class);
+    method.setAccessible(true);
+    method.invoke(
+        engine,
+        Path.of("engines/katago/windows-x64-opencl/katago.exe"),
+        1,
+        "BundledEngineStartup.status.checking",
+        "Checking built-in engine files...",
+        "BundledEngineStartup.hint",
+        "First launch may take a little longer.");
+  }
+
+  private static void invokeBundledStartupStatus(
+      Leelaz engine, String statusKey, String statusFallback) throws Exception {
+    Method method =
+        Leelaz.class.getDeclaredMethod(
+            "publishBundledStartupStatus", String.class, String.class);
+    method.setAccessible(true);
+    method.invoke(engine, statusKey, statusFallback);
+  }
+
 }

--- a/src/test/java/featurecat/lizzie/analysis/LeelazBoardSynchronizationConfirmationTest.java
+++ b/src/test/java/featurecat/lizzie/analysis/LeelazBoardSynchronizationConfirmationTest.java
@@ -1,0 +1,180 @@
+package featurecat.lizzie.analysis;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import featurecat.lizzie.Config;
+import featurecat.lizzie.Lizzie;
+import featurecat.lizzie.gui.LizzieFrame;
+
+import java.io.BufferedOutputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayDeque;
+import java.util.Timer;
+import java.util.TimerTask;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.Test;
+
+class LeelazBoardSynchronizationConfirmationTest {
+
+  @Test
+  void synchronousResponseDuringDispatchSettlesBeforeTimeoutScheduling() throws Exception {
+    try (TestEnvironment ignored = new TestEnvironment()) {
+      Leelaz engine = new Leelaz("");
+      Lizzie.leelaz = engine;
+      AtomicInteger successes = new AtomicInteger();
+      AtomicReference<String> failure = new AtomicReference<>();
+      SynchronousResponseOutput output = new SynchronousResponseOutput(engine);
+      setOutput(engine, output);
+
+      engine.confirmBoardSynchronization(successes::incrementAndGet, failure::set);
+
+      assertEquals(1, successes.get());
+      assertNull(failure.get());
+      assertTrue(output.command().endsWith("name"));
+      assertTrue(pendingResponses(engine).isEmpty());
+    }
+  }
+
+  @Test
+  void timeoutRetiresPendingBoardSynchronizationResponse() throws Exception {
+    try (TestEnvironment ignored = new TestEnvironment()) {
+      ShortTimeoutLeelaz engine = new ShortTimeoutLeelaz();
+      Lizzie.leelaz = engine;
+      setOutput(engine, new ByteArrayOutputStream());
+      CountDownLatch failed = new CountDownLatch(1);
+      AtomicReference<String> detail = new AtomicReference<>();
+
+      engine.confirmBoardSynchronization(
+          () -> {},
+          message -> {
+            detail.set(message);
+            failed.countDown();
+          });
+
+      assertTrue(failed.await(1, TimeUnit.SECONDS));
+      assertTrue(detail.get().contains("timeout"));
+      long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(1);
+      while (!pendingResponses(engine).isEmpty() && System.nanoTime() < deadline) {
+        Thread.sleep(1L);
+      }
+      assertTrue(pendingResponses(engine).isEmpty());
+    }
+  }
+
+  @Test
+  void settledResponseMayCancelTimeoutBeforeItIsScheduled() {
+    Timer timeout = new Timer(true);
+    timeout.cancel();
+
+    assertDoesNotThrow(
+        () ->
+            Leelaz.scheduleBoardSynchronizationTimeout(
+                timeout, noOpTask(), 1L, new AtomicBoolean(true)));
+  }
+
+  @Test
+  void unexpectedCancelledTimeoutStillFails() {
+    Timer timeout = new Timer(true);
+    timeout.cancel();
+
+    assertThrows(
+        IllegalStateException.class,
+        () ->
+            Leelaz.scheduleBoardSynchronizationTimeout(
+                timeout, noOpTask(), 1L, new AtomicBoolean(false)));
+  }
+
+  private static void setOutput(Leelaz engine, ByteArrayOutputStream output) throws Exception {
+    Field field = Leelaz.class.getDeclaredField("outputStream");
+    field.setAccessible(true);
+    field.set(engine, new BufferedOutputStream(output));
+  }
+
+  @SuppressWarnings("unchecked")
+  private static ArrayDeque<Object> pendingResponses(Leelaz engine) throws Exception {
+    Field field = Leelaz.class.getDeclaredField("pendingResponseHandlers");
+    field.setAccessible(true);
+    ArrayDeque<Object> handlers = (ArrayDeque<Object>) field.get(engine);
+    synchronized (handlers) {
+      return new ArrayDeque<>(handlers);
+    }
+  }
+
+  private static TimerTask noOpTask() {
+    return new TimerTask() {
+      @Override
+      public void run() {}
+    };
+  }
+
+  @SuppressWarnings("unchecked")
+  private static <T> T allocate(Class<T> type) throws Exception {
+    Field field = sun.misc.Unsafe.class.getDeclaredField("theUnsafe");
+    field.setAccessible(true);
+    return (T) ((sun.misc.Unsafe) field.get(null)).allocateInstance(type);
+  }
+
+  private static final class TestEnvironment implements AutoCloseable {
+    private final Config previousConfig = Lizzie.config;
+    private final LizzieFrame previousFrame = Lizzie.frame;
+    private final Leelaz previousEngine = Lizzie.leelaz;
+
+    private TestEnvironment() throws Exception {
+      Lizzie.config = allocate(Config.class);
+      Lizzie.frame = allocate(LizzieFrame.class);
+    }
+
+    @Override
+    public void close() {
+      Lizzie.config = previousConfig;
+      Lizzie.frame = previousFrame;
+      Lizzie.leelaz = previousEngine;
+    }
+  }
+
+  private static final class ShortTimeoutLeelaz extends Leelaz {
+    private ShortTimeoutLeelaz() throws IOException {
+      super("");
+    }
+
+    @Override
+    protected long readBoardGmaRestoreResponseTimeoutMillis() {
+      return 5L;
+    }
+  }
+
+  private static final class SynchronousResponseOutput extends ByteArrayOutputStream {
+    private final Leelaz engine;
+    private boolean responded;
+
+    private SynchronousResponseOutput(Leelaz engine) {
+      this.engine = engine;
+    }
+
+    @Override
+    public void flush() throws IOException {
+      super.flush();
+      if (responded) {
+        return;
+      }
+      responded = true;
+      String command = command();
+      String id = command.substring(0, command.indexOf(' '));
+      engine.processCommandResponseLineForTest("=" + id + " KataGo");
+    }
+
+    private String command() {
+      return toString(StandardCharsets.UTF_8).trim();
+    }
+  }
+}

--- a/src/test/java/featurecat/lizzie/analysis/LeelazBoardSynchronizationConfirmationTest.java
+++ b/src/test/java/featurecat/lizzie/analysis/LeelazBoardSynchronizationConfirmationTest.java
@@ -50,14 +50,17 @@ class LeelazBoardSynchronizationConfirmationTest {
     try (TestEnvironment ignored = new TestEnvironment()) {
       ShortTimeoutLeelaz engine = new ShortTimeoutLeelaz();
       Lizzie.leelaz = engine;
-      setOutput(engine, new ByteArrayOutputStream());
+      ByteArrayOutputStream output = new ByteArrayOutputStream();
+      setOutput(engine, output);
       CountDownLatch failed = new CountDownLatch(1);
+      AtomicInteger failures = new AtomicInteger();
       AtomicReference<String> detail = new AtomicReference<>();
 
       engine.confirmBoardSynchronization(
           () -> {},
           message -> {
             detail.set(message);
+            failures.incrementAndGet();
             failed.countDown();
           });
 
@@ -68,8 +71,44 @@ class LeelazBoardSynchronizationConfirmationTest {
         Thread.sleep(1L);
       }
       assertTrue(pendingResponses(engine).isEmpty());
+      assertEquals(1, failures.get());
+      engine.processCommandResponseLineForTest("=" + commandId(output) + " late");
+      assertEquals(1, failures.get());
+      assertTrue(pendingResponses(engine).isEmpty());
     }
   }
+  @Test
+  void sendFailureRetiresPendingBoardSynchronizationResponseAndIgnoresLateReply()
+      throws Exception {
+    try (TestEnvironment ignored = new TestEnvironment()) {
+      Leelaz engine = new Leelaz("");
+      Lizzie.leelaz = engine;
+      AtomicInteger successes = new AtomicInteger();
+      AtomicInteger failures = new AtomicInteger();
+      AtomicReference<String> detail = new AtomicReference<>();
+      FailingOutput output = new FailingOutput();
+      setOutput(engine, output);
+
+      engine.confirmBoardSynchronization(
+          successes::incrementAndGet,
+          message -> {
+            detail.set(message);
+            failures.incrementAndGet();
+          });
+
+      assertEquals(0, successes.get());
+      assertEquals(1, failures.get());
+      assertTrue(detail.get().contains("controlled board fence send failure"));
+      assertTrue(pendingResponses(engine).isEmpty());
+
+      engine.processCommandResponseLineForTest("=" + output.commandId() + " late");
+
+      assertEquals(0, successes.get());
+      assertEquals(1, failures.get());
+      assertTrue(pendingResponses(engine).isEmpty());
+    }
+  }
+
 
   @Test
   void settledResponseMayCancelTimeoutBeforeItIsScheduled() {
@@ -99,6 +138,11 @@ class LeelazBoardSynchronizationConfirmationTest {
     field.setAccessible(true);
     field.set(engine, new BufferedOutputStream(output));
   }
+  private static String commandId(ByteArrayOutputStream output) {
+    String command = output.toString(StandardCharsets.UTF_8).trim();
+    return command.substring(0, command.indexOf(' '));
+  }
+
 
   @SuppressWarnings("unchecked")
   private static ArrayDeque<Object> pendingResponses(Leelaz engine) throws Exception {
@@ -150,6 +194,18 @@ class LeelazBoardSynchronizationConfirmationTest {
     @Override
     protected long readBoardGmaRestoreResponseTimeoutMillis() {
       return 5L;
+    }
+  }
+
+  private static final class FailingOutput extends ByteArrayOutputStream {
+    @Override
+    public synchronized void write(byte[] bytes, int offset, int length) {
+      super.write(bytes, offset, length);
+      throw new IllegalStateException("controlled board fence send failure");
+    }
+
+    private String commandId() {
+      return LeelazBoardSynchronizationConfirmationTest.commandId(this);
     }
   }
 


### PR DESCRIPTION
> [!IMPORTANT]
> Depends on #214. Do not merge before #214.
>
> The current diff temporarily includes the prerequisite commit from #214.
> After #214 is merged, this branch will be rebased onto the latest
> `upstream/main`, leaving only the secondary explicit restart board-fence
> changes in this PR.

## Summary

- Mark secondary explicit restarts as lifecycle restarts and capture the primary engine's active or paused ponder intent before shutdown.
- Wait for the owner target's `confirmBoardSynchronization()` after restoring the secondary board instead of initializing terminal state or releasing lifecycle reservations early.
- Settle successful restarts in this order: secondary terminal initialization, optional primary ponder resume, secondary response watermark, then reservation release.
- Fail closed when the fence times out, command dispatch fails, or the target becomes unavailable; mark the secondary engine unavailable, retire pending response handlers, and ignore late responses without settling twice.
- Prevent secondary bundled startup stages from overwriting the primary-owned global READY/CHECKING status.

## Type Of Change

- [x] Bug fix
- [ ] Feature
- [ ] Packaging / release update
- [ ] Docs / translation
- [ ] Refactor

## Testing

- [x] Tested locally
- [ ] Verified package contents if packaging changed
- [ ] Verified Fox sync flow if related
- [ ] Added screenshots if UI changed
- [ ] Updated README / docs if user-facing behavior changed
- [x] Noted affected platforms if the change is platform-specific

Focused tests:

```bash
mvn -Dfmt.skip=true -Djava.awt.headless=true \
  '-Dtest=EngineStartupDialogPolicyTest#secondaryBundledStartupStageDoesNotPublishPrimaryStatus+primaryBundledStartupStagePublishesCheckingStatus+secondaryOpenClCompatibilityStageDoesNotPublishPrimaryStatus,EngineManagerLifecycleReservationTest#secondaryActiveExplicitRestartSettlesAfterOwnerBoardFence+secondaryPausedExplicitRestartStaysPausedAfterOwnerBoardFence+secondaryExplicitRestartFenceFailureRetiresLifecycleFailClosed+secondaryExplicitRestartBoardFenceTimeoutRetiresLifecycleFailClosed+secondaryExplicitRestartBoardFenceSendFailureRetiresLifecycleFailClosed+activeRestartResumesPonderAfterFinalBoardFenceAndRetiresTrackingOnRebind+activeRestartReleasesLifecycleAfterBoardFenceFailure+inactiveExplicitRestartWaitsForBoardFenceBeforeInitializationAndRelease+pausedExplicitRestartWaitsForBoardFenceAndPublishesTerminalState,LeelazBoardSynchronizationConfirmationTest' \
  test
```

Result:

```text
Tests run: 17
Failures: 0
Errors: 0
Skipped: 0
BUILD SUCCESS
```

Windows dual-engine acceptance:

- Secondary active explicit restart: PASS. The board was restored consistently and dual-engine analysis resumed without clicking the board or **Continue Analysis**.
- Secondary paused explicit restart: PASS. The board was restored consistently and analysis remained paused.
- Secondary completion did not leave behind or overwrite the primary engine's global waiting status.

## Notes

- This PR is currently stacked on #214. The secondary-specific change is the single commit `6c2132e6`.
- This PR does not modify `ExactSnapshotEngineRestore`, diagnostics, GMA ownership, or ReadBoard recovery.
- The shared engine-index ownership issue affecting primary restarts is handled separately on `fix/primary-restart-index-ownership`.
- No screenshot artifact is currently available; the Windows UI results above are from the recorded manual acceptance run.