### PR TITLE
fix(katago): update TensorRT KataGo to v1.17.2

### DIFF
--- a/src/main/java/featurecat/lizzie/util/KataGoRuntimeHelper.java
+++ b/src/main/java/featurecat/lizzie/util/KataGoRuntimeHelper.java
@@ -137,18 +137,18 @@ public final class KataGoRuntimeHelper {
   private static final String TENSORRT_RUNTIME_SHA256_PROPERTY = "lizzie.tensorrt.runtime.sha256";
   private static final String TENSORRT_SKIP_RUNTIME_FOR_TESTS_PROPERTY =
       "lizzie.tensorrt.skipRuntimePackagesForTests";
-  private static final String TENSORRT_KATAGO_VERSION = "v1.17.1";
+  private static final String TENSORRT_KATAGO_VERSION = "v1.17.2";
   private static final String TENSORRT_INSTALL_LOCK_NAME = "tensorrt-install.lock";
   private static final String TENSORRT_KATAGO_ASSET =
-      "katago-v1.17.1-trt10.9.0-cuda12.8-windows-x64.zip";
+      "katago-v1.17.2-trt10.9.0-cuda12.8-windows-x64.zip";
   private static final String TENSORRT_KATAGO_URL =
       "https://github.com/lightvector/KataGo/releases/download/"
           + TENSORRT_KATAGO_VERSION
           + "/"
           + TENSORRT_KATAGO_ASSET;
   private static final String TENSORRT_KATAGO_SHA256 =
-      "b5de0178194cf728c12994cf0ace8a105597e864e0d42d7c6b4e0a1e9ea7a943";
-  private static final long TENSORRT_KATAGO_SIZE_BYTES = 7_678_128L;
+      "be09c4ecc02028e2bdf98ff489683840bc9be480ba94f1cfe6f7e15018e36be6";
+  private static final long TENSORRT_KATAGO_SIZE_BYTES = 7_678_930L;
   private static final String TENSORRT_ENGINE_MANIFEST_NAME =
       "lizzieyzy-next-katago-engine-manifest.txt";
   private static final String TENSORRT_RUNTIME_URL =

--- a/src/test/java/featurecat/lizzie/util/KataGoRuntimeHelperTest.java
+++ b/src/test/java/featurecat/lizzie/util/KataGoRuntimeHelperTest.java
@@ -571,10 +571,11 @@ public class KataGoRuntimeHelperTest {
                     KataGoRuntimeHelper.buildTensorRtInstallSpec(snapshot);
 
                 assertTrue(
-                    spec.katagoUrl.endsWith("/katago-v1.17.1-trt10.9.0-cuda12.8-windows-x64.zip"));
+                    spec.katagoUrl.endsWith("/katago-v1.17.2-trt10.9.0-cuda12.8-windows-x64.zip"));
                 assertEquals(
-                    "b5de0178194cf728c12994cf0ace8a105597e864e0d42d7c6b4e0a1e9ea7a943",
+                    "be09c4ecc02028e2bdf98ff489683840bc9be480ba94f1cfe6f7e15018e36be6",
                     spec.katagoSha256);
+                assertEquals(7_678_930L, spec.katagoSizeBytes);
                 assertEquals(5, spec.runtimePackageCount);
                 assertTrue(spec.totalDownloadBytes > 3_000_000_000L);
                 assertEquals(
@@ -699,7 +700,7 @@ public class KataGoRuntimeHelperTest {
                         assertTrue(
                             Files.readString(
                                     targetDir.resolve("lizzieyzy-next-katago-engine-manifest.txt"))
-                                .contains("KataGo release: v1.17.1"));
+                                .contains("KataGo release: v1.17.2"));
                         List<EngineData> engines = Utils.getEngineData();
                         assertTrue(
                             engines.stream()
@@ -935,6 +936,11 @@ public class KataGoRuntimeHelperTest {
           Path runtimeDir = Files.createDirectories(runtimeWorkDirectory.resolve("nvidia-runtime"));
           touch(targetDir.resolve("katago.exe"));
           Files.writeString(
+              targetDir.resolve("lizzieyzy-next-katago-engine-manifest.txt"),
+              "KataGo release: v1.17.1\n"
+                  + "Asset SHA-256: "
+                  + "b5de0178194cf728c12994cf0ace8a105597e864e0d42d7c6b4e0a1e9ea7a943\n");
+          Files.writeString(
               targetDir.resolve("lizzieyzy-next-engine-backend.txt"), "nvidia-tensorrt\n");
           touchRequiredCuda12_8Dlls(runtimeDir);
           touch(runtimeDir.resolve("nvinfer_10.dll"));
@@ -974,7 +980,7 @@ public class KataGoRuntimeHelperTest {
                         assertTrue(
                             Files.readString(
                                     targetDir.resolve("lizzieyzy-next-katago-engine-manifest.txt"))
-                                .contains("KataGo release: v1.17.1"));
+                                .contains("KataGo release: v1.17.2"));
                         assertTrue(
                             KataGoRuntimeHelper.inspectTensorRtInstall(result.snapshot).active);
                       }));
@@ -1771,10 +1777,10 @@ public class KataGoRuntimeHelperTest {
   private static void writeCurrentTensorRtEngineManifest(Path directory) throws IOException {
     Files.writeString(
         directory.resolve("lizzieyzy-next-katago-engine-manifest.txt"),
-        "KataGo release: v1.17.1\n"
-            + "Asset: katago-v1.17.1-trt10.9.0-cuda12.8-windows-x64.zip\n"
+        "KataGo release: v1.17.2\n"
+            + "Asset: katago-v1.17.2-trt10.9.0-cuda12.8-windows-x64.zip\n"
             + "Asset SHA-256: "
-            + "b5de0178194cf728c12994cf0ace8a105597e864e0d42d7c6b4e0a1e9ea7a943\n");
+            + "be09c4ecc02028e2bdf98ff489683840bc9be480ba94f1cfe6f7e15018e36be6\n");
   }
 
   private static SetupSnapshot createNvidia50Snapshot(Path tempRoot) throws Exception {


### PR DESCRIPTION
> *This was generated by AI during triage.*

## Why

Fixes #218. KataGo removed the v1.17.1 TensorRT Windows asset, causing
new TensorRT installations and repairs in LizzieYZY to fail with HTTP 404.

KataGo v1.17.2 is the TensorRT-specific bugfix release. The existing
TensorRT 10.9 / CUDA 12.8 runtime remains compatible and can be reused.

## What changed

- Update the TensorRT KataGo engine asset to v1.17.2.
- Update the official SHA-256 checksum and exact archive size.
- Keep the existing TensorRT runtime, CUDA, and cuDNN download logic unchanged.
- Update install-spec and manifest regression coverage.
- Add coverage for upgrading an existing v1.17.1 engine while reusing the
  already-installed TensorRT runtime.

## Test plan

- Windows Maven tests:
  - `tensorRtInstallSpecUsesOfficialKataGoAssetAndWritableRuntimeTarget`
  - `tensorRtInstallCreatesSeparateEngineProfileFromFixture`
  - `outdatedTensorRtEngineUpgradesWithoutRedownloadingRuntime`
- Result: 3 tests passed, 0 failures, 0 errors.
- The official v1.17.2 asset returned HTTP 206 for a Range request and has
  an exact size of 7,678,930 bytes.
- The old v1.17.1 asset returned HTTP 404.

## Scope

- Do not upgrade CUDA, cuDNN, or the TensorRT runtime.
- Do not change v1.17.1 metadata for non-TensorRT KataGo backends.
- Do not refactor the existing download architecture.

Closes #218