### PR TITLE
Improve HumanSL move variety without memory

### DIFF
--- a/src/main/java/featurecat/lizzie/analysis/HumanLikeMoveSelector.java
+++ b/src/main/java/featurecat/lizzie/analysis/HumanLikeMoveSelector.java
@@ -1,0 +1,309 @@
+package featurecat.lizzie.analysis;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+/** Selects a plausible HumanSL move without retaining state between calls. */
+final class HumanLikeMoveSelector {
+  static final int MAX_CANDIDATES = 12;
+  static final double CANDIDATE_POLICY_MASS = 0.95;
+
+  private static final double MIN_RELATIVE_POLICY = 0.01;
+  private static final double MAX_QUALITY_SCALE_LOSS = 4.0;
+  private static final int OPENING_END_MOVE = 60;
+  private static final int MIDDLEGAME_END_MOVE = 160;
+  private static final double OPENING_TEMPERATURE = 1.25;
+  private static final double MIDDLEGAME_TEMPERATURE = 1.05;
+  private static final double ENDGAME_TEMPERATURE = 0.90;
+
+  private HumanLikeMoveSelector() {}
+
+  static String select(
+      List<Candidate> legalMoves,
+      JSONArray moveInfos,
+      int moveNumber,
+      String profile,
+      double randomValue) {
+    List<Candidate> pool = candidatePool(legalMoves);
+    if (pool.isEmpty()) {
+      return null;
+    }
+    if (pool.size() == 1) {
+      return pool.get(0).move;
+    }
+
+    QualityTable quality = QualityTable.from(moveInfos);
+    double qualityScale = qualityScale(profile, quality.kind);
+    double temperature = temperatureForMove(moveNumber);
+    ArrayList<WeightedMove> weighted = new ArrayList<WeightedMove>(pool.size());
+    for (Candidate candidate : pool) {
+      double qualityFactor = quality.factor(candidate.move, qualityScale);
+      if (qualityFactor <= 0.0) {
+        continue;
+      }
+      double policyWeight = Math.pow(candidate.probability, 1.0 / temperature);
+      double weight = policyWeight * qualityFactor;
+      if (Double.isFinite(weight) && weight > 0.0) {
+        weighted.add(new WeightedMove(candidate.move, weight));
+      }
+    }
+
+    if (weighted.isEmpty()) {
+      return pool.get(0).move;
+    }
+    return sampleWeighted(weighted, randomValue);
+  }
+
+  static List<Candidate> candidatePool(List<Candidate> legalMoves) {
+    ArrayList<Candidate> sorted = new ArrayList<Candidate>();
+    if (legalMoves != null) {
+      for (Candidate candidate : legalMoves) {
+        if (candidate != null
+            && candidate.move != null
+            && !candidate.move.trim().isEmpty()
+            && Double.isFinite(candidate.probability)
+            && candidate.probability > 0.0) {
+          sorted.add(candidate);
+        }
+      }
+    }
+    sorted.sort(Comparator.comparingDouble((Candidate move) -> move.probability).reversed());
+    if (sorted.isEmpty()) {
+      return sorted;
+    }
+
+    double total = 0.0;
+    for (Candidate candidate : sorted) {
+      total += candidate.probability;
+    }
+    if (!(total > 0.0) || !Double.isFinite(total)) {
+      return List.of(sorted.get(0));
+    }
+
+    double topProbability = sorted.get(0).probability;
+    double cumulative = 0.0;
+    ArrayList<Candidate> pool = new ArrayList<Candidate>(MAX_CANDIDATES);
+    for (Candidate candidate : sorted) {
+      if (pool.size() >= MAX_CANDIDATES) {
+        break;
+      }
+      if (!pool.isEmpty() && candidate.probability < topProbability * MIN_RELATIVE_POLICY) {
+        break;
+      }
+      pool.add(candidate);
+      cumulative += candidate.probability;
+      if (cumulative / total >= CANDIDATE_POLICY_MASS) {
+        break;
+      }
+    }
+    return pool;
+  }
+
+  static double temperatureForMove(int moveNumber) {
+    if (moveNumber <= OPENING_END_MOVE) {
+      return OPENING_TEMPERATURE;
+    }
+    if (moveNumber <= MIDDLEGAME_END_MOVE) {
+      return MIDDLEGAME_TEMPERATURE;
+    }
+    return ENDGAME_TEMPERATURE;
+  }
+
+  private static String sampleWeighted(List<WeightedMove> moves, double randomValue) {
+    double total = 0.0;
+    for (WeightedMove move : moves) {
+      total += move.weight;
+    }
+    if (!(total > 0.0) || !Double.isFinite(total)) {
+      return moves.get(0).move;
+    }
+
+    double boundedRandom = Math.max(0.0, Math.min(0.999999999999, randomValue));
+    double target = boundedRandom * total;
+    double cumulative = 0.0;
+    for (WeightedMove move : moves) {
+      cumulative += move.weight;
+      if (target < cumulative) {
+        return move.move;
+      }
+    }
+    return moves.get(moves.size() - 1).move;
+  }
+
+  private static double qualityScale(String profile, QualityKind kind) {
+    double rankMultiplier = rankQualityMultiplier(profile);
+    switch (kind) {
+      case UTILITY:
+        return 0.50 * rankMultiplier;
+      case SCORE:
+        return 4.0 * rankMultiplier;
+      case WINRATE:
+        return 0.12 * rankMultiplier;
+      case NONE:
+      default:
+        return 1.0;
+    }
+  }
+
+  private static double rankQualityMultiplier(String profile) {
+    if (profile == null) {
+      return 1.0;
+    }
+    String normalized = profile.trim().toLowerCase(Locale.ROOT);
+    int rank = parseRankNumber(normalized);
+    if (normalized.endsWith("d") || normalized.startsWith("proyear_")) {
+      return 0.70;
+    }
+    if (rank <= 5) {
+      return 0.90;
+    }
+    if (rank <= 10) {
+      return 1.15;
+    }
+    return 1.45;
+  }
+
+  private static int parseRankNumber(String profile) {
+    int underscore = profile.lastIndexOf('_');
+    int suffix = profile.length() - 1;
+    if (underscore < 0 || suffix <= underscore) {
+      return 10;
+    }
+    try {
+      return Integer.parseInt(profile.substring(underscore + 1, suffix));
+    } catch (NumberFormatException ignored) {
+      return 10;
+    }
+  }
+
+  static final class Candidate {
+    final String move;
+    final double probability;
+
+    Candidate(String move, double probability) {
+      this.move = move;
+      this.probability = probability;
+    }
+  }
+
+  private static final class WeightedMove {
+    private final String move;
+    private final double weight;
+
+    private WeightedMove(String move, double weight) {
+      this.move = move;
+      this.weight = weight;
+    }
+  }
+
+  private enum QualityKind {
+    UTILITY,
+    SCORE,
+    WINRATE,
+    NONE
+  }
+
+  private static final class QualityTable {
+    private final QualityKind kind;
+    private final Map<String, Double> values;
+    private final double best;
+
+    private QualityTable(QualityKind kind, Map<String, Double> values, double best) {
+      this.kind = kind;
+      this.values = values;
+      this.best = best;
+    }
+
+    private double factor(String move, double scale) {
+      if (kind == QualityKind.NONE || values.isEmpty()) {
+        return 1.0;
+      }
+      Double value = values.get(normalizeMove(move));
+      if (value == null) {
+        return 1.0;
+      }
+      double loss = Math.max(0.0, best - value.doubleValue());
+      if (loss > scale * MAX_QUALITY_SCALE_LOSS) {
+        return 0.0;
+      }
+      return Math.exp(-loss / Math.max(1.0e-9, scale * MAX_QUALITY_SCALE_LOSS));
+    }
+
+    private static QualityTable from(JSONArray moveInfos) {
+      QualityTable utility = collect(moveInfos, QualityKind.UTILITY);
+      if (!utility.values.isEmpty()) {
+        return utility;
+      }
+      QualityTable score = collect(moveInfos, QualityKind.SCORE);
+      if (!score.values.isEmpty()) {
+        return score;
+      }
+      QualityTable winrate = collect(moveInfos, QualityKind.WINRATE);
+      if (!winrate.values.isEmpty()) {
+        return winrate;
+      }
+      return new QualityTable(QualityKind.NONE, Map.of(), 0.0);
+    }
+
+    private static QualityTable collect(JSONArray moveInfos, QualityKind kind) {
+      HashMap<String, Double> values = new HashMap<String, Double>();
+      double best = Double.NEGATIVE_INFINITY;
+      if (moveInfos != null) {
+        for (int i = 0; i < moveInfos.length(); i++) {
+          JSONObject moveInfo = moveInfos.optJSONObject(i);
+          if (moveInfo == null) {
+            continue;
+          }
+          String move = normalizeMove(moveInfo.optString("move", ""));
+          Double value = qualityValue(moveInfo, kind);
+          if (move.isEmpty() || value == null || !Double.isFinite(value.doubleValue())) {
+            continue;
+          }
+          values.put(move, value);
+          best = Math.max(best, value.doubleValue());
+        }
+      }
+      return new QualityTable(kind, values, best);
+    }
+
+    private static Double qualityValue(JSONObject moveInfo, QualityKind kind) {
+      switch (kind) {
+        case UTILITY:
+          return number(moveInfo, "utility");
+        case SCORE:
+          Double scoreLead = number(moveInfo, "scoreLead");
+          return scoreLead != null ? scoreLead : number(moveInfo, "scoreMean");
+        case WINRATE:
+          Double winrate = number(moveInfo, "winrate");
+          if (winrate != null && winrate.doubleValue() > 1.0) {
+            return winrate.doubleValue() / 100.0;
+          }
+          return winrate;
+        case NONE:
+        default:
+          return null;
+      }
+    }
+
+    private static Double number(JSONObject object, String key) {
+      if (!object.has(key) || !(object.opt(key) instanceof Number)) {
+        return null;
+      }
+      return ((Number) object.opt(key)).doubleValue();
+    }
+  }
+
+  private static String normalizeMove(String move) {
+    if (move == null) {
+      return "";
+    }
+    String normalized = move.trim();
+    return "pass".equalsIgnoreCase(normalized) ? "pass" : normalized.toUpperCase(Locale.ROOT);
+  }
+}

--- a/src/main/java/featurecat/lizzie/analysis/HumanSlAnalysisRunner.java
+++ b/src/main/java/featurecat/lizzie/analysis/HumanSlAnalysisRunner.java
@@ -113,7 +113,7 @@ public class HumanSlAnalysisRunner implements AutoCloseable {
     }
   }
 
-  /** Samples a move from the HumanSL policy for the requested profile. */
+  /** Selects a plausible move from the HumanSL policy for the requested profile. */
   public Optional<String> bestHumanMove(
       BoardHistoryNode positionNode, String profile, Duration timeout) {
     if (positionNode == null || profile == null) {
@@ -124,8 +124,8 @@ public class HumanSlAnalysisRunner implements AutoCloseable {
     }
     String requestId = "humansl-genmove-" + nextRequestId.getAndIncrement();
     boolean allowPass = shouldAllowPass(positionNode);
-    int visits = allowPass ? HUMAN_LIKE_PLAY_VISITS : 1;
-    JSONObject request = buildHumanSlRequest(requestId, positionNode, profile, visits);
+    JSONObject request =
+        buildHumanSlRequest(requestId, positionNode, profile, HUMAN_LIKE_PLAY_VISITS);
     try {
       JSONObject response = request(request, timeout == null ? Duration.ofSeconds(30) : timeout);
       if (allowPass && isSearchTopMovePass(response)) {
@@ -135,14 +135,16 @@ public class HumanSlAnalysisRunner implements AutoCloseable {
       if (policy == null) {
         return Optional.empty();
       }
+      List<HumanLikeMoveSelector.Candidate> legalMoves =
+          policyMoves(
+              policy, Board.boardWidth, Board.boardHeight, positionNode.getData().stones, false);
       return Optional.ofNullable(
-          samplePolicyMove(
-              policy,
-              Board.boardWidth,
-              Board.boardHeight,
-              positionNode.getData().stones,
-              ThreadLocalRandom.current().nextDouble(),
-              allowPass));
+          HumanLikeMoveSelector.select(
+              legalMoves,
+              response.optJSONArray("moveInfos"),
+              positionNode.getData().moveNumber,
+              profile,
+              ThreadLocalRandom.current().nextDouble()));
     } catch (TimeoutException | IOException e) {
       return Optional.empty();
     }
@@ -160,12 +162,14 @@ public class HumanSlAnalysisRunner implements AutoCloseable {
       Stone[] stones,
       double randomValue,
       boolean allowPass) {
-    List<PolicyMove> moves = policyMoves(policy, boardWidth, boardHeight, stones, allowPass);
+    List<HumanLikeMoveSelector.Candidate> moves =
+        policyMoves(policy, boardWidth, boardHeight, stones, allowPass);
     if (moves.isEmpty()) {
-      return argmaxPolicyMove(policy, boardWidth, boardHeight);
+      String fallback = argmaxPolicyMove(policy, boardWidth, boardHeight);
+      return !allowPass && "pass".equalsIgnoreCase(fallback) ? null : fallback;
     }
     double total = 0.0;
-    for (PolicyMove move : moves) {
+    for (HumanLikeMoveSelector.Candidate move : moves) {
       total += move.probability;
     }
     if (total <= 0.0 || Double.isNaN(total)) {
@@ -173,7 +177,7 @@ public class HumanSlAnalysisRunner implements AutoCloseable {
     }
     double target = Math.max(0.0, Math.min(0.999999999999, randomValue)) * total;
     double cumulative = 0.0;
-    for (PolicyMove move : moves) {
+    for (HumanLikeMoveSelector.Candidate move : moves) {
       cumulative += move.probability;
       if (target < cumulative) {
         return move.move;
@@ -346,6 +350,7 @@ public class HumanSlAnalysisRunner implements AutoCloseable {
     }
     overrideSettings.put("humanSLProfile", profile);
     overrideSettings.put("ignorePreRootHistory", false);
+    overrideSettings.put("humanSLRootExploreProbWeightless", 0.5);
     request.put("overrideSettings", overrideSettings);
     return request;
   }
@@ -383,14 +388,15 @@ public class HumanSlAnalysisRunner implements AutoCloseable {
     return null;
   }
 
-  private static List<PolicyMove> policyMoves(
+  private static List<HumanLikeMoveSelector.Candidate> policyMoves(
       Object policy, int boardWidth, int boardHeight, boolean allowPass) {
     return policyMoves(policy, boardWidth, boardHeight, null, allowPass);
   }
 
-  private static List<PolicyMove> policyMoves(
+  private static List<HumanLikeMoveSelector.Candidate> policyMoves(
       Object policy, int boardWidth, int boardHeight, Stone[] stones, boolean allowPass) {
-    ArrayList<PolicyMove> moves = new ArrayList<PolicyMove>();
+    ArrayList<HumanLikeMoveSelector.Candidate> moves =
+        new ArrayList<HumanLikeMoveSelector.Candidate>();
     if (policy instanceof JSONArray) {
       JSONArray array = (JSONArray) policy;
       if (isNumericPolicy(array)) {
@@ -446,12 +452,13 @@ public class HumanSlAnalysisRunner implements AutoCloseable {
     return moves;
   }
 
-  private static void addPolicyMove(List<PolicyMove> moves, String move, Object rawProbability) {
+  private static void addPolicyMove(
+      List<HumanLikeMoveSelector.Candidate> moves, String move, Object rawProbability) {
     Double probability = coerceProbability(rawProbability);
     if (move == null || move.trim().isEmpty() || probability == null || probability <= 0.0) {
       return;
     }
-    moves.add(new PolicyMove(move.trim(), probability.doubleValue()));
+    moves.add(new HumanLikeMoveSelector.Candidate(move.trim(), probability.doubleValue()));
   }
 
   private boolean ensureStarted() {
@@ -513,7 +520,7 @@ public class HumanSlAnalysisRunner implements AutoCloseable {
     if (Double.isNaN(probability) || probability < 0.0) {
       return null;
     }
-    return Math.max(probability, 1.0e-12);
+    return probability;
   }
 
   private static int[] policyIndexToCoords(int index, int boardWidth, int boardHeight) {
@@ -552,15 +559,5 @@ public class HumanSlAnalysisRunner implements AutoCloseable {
 
   interface ProcessStarter {
     Process start(ProcessBuilder processBuilder) throws IOException;
-  }
-
-  private static final class PolicyMove {
-    private final String move;
-    private final double probability;
-
-    private PolicyMove(String move, double probability) {
-      this.move = move;
-      this.probability = probability;
-    }
   }
 }

--- a/src/test/java/featurecat/lizzie/analysis/HumanLikeMoveSelectorTest.java
+++ b/src/test/java/featurecat/lizzie/analysis/HumanLikeMoveSelectorTest.java
@@ -1,0 +1,114 @@
+package featurecat.lizzie.analysis;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.junit.jupiter.api.Test;
+
+class HumanLikeMoveSelectorTest {
+
+  @Test
+  void openingTemperatureProducesMoreVarietyThanEndgame() {
+    List<HumanLikeMoveSelector.Candidate> candidates =
+        List.of(candidate("D4", 0.70), candidate("Q16", 0.20), candidate("Q4", 0.10));
+
+    Map<String, Integer> opening = sampleCounts(candidates, null, 20, "rank_3k", 1000);
+    Map<String, Integer> endgame = sampleCounts(candidates, null, 180, "rank_3k", 1000);
+
+    assertTrue(opening.getOrDefault("D4", 0) < 680);
+    assertTrue(endgame.getOrDefault("D4", 0) > opening.getOrDefault("D4", 0) + 70);
+    assertTrue(opening.getOrDefault("Q16", 0) > 0);
+    assertTrue(opening.getOrDefault("Q4", 0) > 0);
+  }
+
+  @Test
+  void candidatePoolUsesPolicyMassAndCapsAtTwelveMoves() {
+    List<HumanLikeMoveSelector.Candidate> concentrated =
+        List.of(candidate("D4", 0.96), candidate("Q16", 0.03), candidate("Q4", 0.01));
+    assertEquals(1, HumanLikeMoveSelector.candidatePool(concentrated).size());
+
+    List<HumanLikeMoveSelector.Candidate> broad = new ArrayList<>();
+    for (int i = 0; i < 20; i++) {
+      broad.add(candidate("M" + i, 1.0));
+    }
+    List<HumanLikeMoveSelector.Candidate> pool = HumanLikeMoveSelector.candidatePool(broad);
+    assertEquals(HumanLikeMoveSelector.MAX_CANDIDATES, pool.size());
+    assertEquals("M11", pool.get(pool.size() - 1).move);
+  }
+
+  @Test
+  void qualityGuardRejectsAnExtremeMoveForStrongProfile() {
+    List<HumanLikeMoveSelector.Candidate> candidates =
+        List.of(candidate("D4", 0.50), candidate("A1", 0.50));
+    JSONArray moveInfos = new JSONArray().put(moveInfo("D4", 0.80)).put(moveInfo("A1", -1.00));
+
+    for (int i = 0; i < 1000; i++) {
+      String selected =
+          HumanLikeMoveSelector.select(candidates, moveInfos, 10, "rank_5d", (i + 0.5) / 1000.0);
+      assertEquals("D4", selected);
+    }
+  }
+
+  @Test
+  void weakerProfileRetainsMoreNaturalMistakesThanStrongProfile() {
+    List<HumanLikeMoveSelector.Candidate> candidates =
+        List.of(candidate("D4", 0.50), candidate("Q4", 0.50));
+    JSONArray moveInfos = new JSONArray().put(moveInfo("D4", 0.50)).put(moveInfo("Q4", -1.00));
+
+    Map<String, Integer> strong = sampleCounts(candidates, moveInfos, 80, "rank_5d", 1000);
+    Map<String, Integer> developing = sampleCounts(candidates, moveInfos, 80, "rank_15k", 1000);
+
+    assertTrue(
+        developing.getOrDefault("Q4", 0) > strong.getOrDefault("Q4", 0) + 300,
+        "A developing profile should preserve more plausible non-best moves.");
+  }
+
+  @Test
+  void selectorHasNoInstanceState() {
+    for (Field field : HumanLikeMoveSelector.class.getDeclaredFields()) {
+      assertTrue(
+          Modifier.isStatic(field.getModifiers()),
+          () -> "Unexpected selector state field: " + field.getName());
+    }
+  }
+
+  @Test
+  void phaseTemperaturesAreOpeningMiddleAndEndgameSpecific() {
+    assertEquals(1.25, HumanLikeMoveSelector.temperatureForMove(60), 0.0001);
+    assertEquals(1.05, HumanLikeMoveSelector.temperatureForMove(61), 0.0001);
+    assertEquals(1.05, HumanLikeMoveSelector.temperatureForMove(160), 0.0001);
+    assertEquals(0.90, HumanLikeMoveSelector.temperatureForMove(161), 0.0001);
+  }
+
+  private static Map<String, Integer> sampleCounts(
+      List<HumanLikeMoveSelector.Candidate> candidates,
+      JSONArray moveInfos,
+      int moveNumber,
+      String profile,
+      int samples) {
+    HashMap<String, Integer> counts = new HashMap<>();
+    for (int i = 0; i < samples; i++) {
+      String selected =
+          HumanLikeMoveSelector.select(
+              candidates, moveInfos, moveNumber, profile, (i + 0.5) / samples);
+      counts.merge(selected, 1, Integer::sum);
+    }
+    return counts;
+  }
+
+  private static HumanLikeMoveSelector.Candidate candidate(String move, double probability) {
+    return new HumanLikeMoveSelector.Candidate(move, probability);
+  }
+
+  private static JSONObject moveInfo(String move, double utility) {
+    return new JSONObject().put("move", move).put("utility", utility);
+  }
+}

--- a/src/test/java/featurecat/lizzie/analysis/HumanSlAnalysisRunnerTest.java
+++ b/src/test/java/featurecat/lizzie/analysis/HumanSlAnalysisRunnerTest.java
@@ -59,6 +59,10 @@ class HumanSlAnalysisRunnerTest {
       assertEquals(
           "rank_1d", request.getJSONObject("overrideSettings").getString("humanSLProfile"));
       assertFalse(request.getJSONObject("overrideSettings").getBoolean("ignorePreRootHistory"));
+      assertEquals(
+          0.5,
+          request.getJSONObject("overrideSettings").getDouble("humanSLRootExploreProbWeightless"),
+          0.0001);
       assertEquals(BOARD_SIZE, request.getInt("boardXSize"));
       assertEquals(BOARD_SIZE, request.getInt("boardYSize"));
     }
@@ -159,13 +163,102 @@ class HumanSlAnalysisRunnerTest {
 
       assertTrue(best.isPresent());
       assertFalse("pass".equals(best.get()));
-      assertEquals(1, process.sentRequests.get(0).getInt("maxVisits"));
+      assertEquals(64, process.sentRequests.get(0).getInt("maxVisits"));
+      assertFalse(process.sentRequests.get(0).has("maxTime"));
       assertFalse(
           process
               .sentRequests
               .get(0)
               .getJSONObject("overrideSettings")
               .getBoolean("ignorePreRootHistory"));
+      runner.close();
+    }
+  }
+
+  @Test
+  void bestHumanMove_doesNotInventAMoveFromAnEmptyPolicy() throws Exception {
+    try (TestEnvironment env = TestEnvironment.open()) {
+      BoardHistoryList history = new BoardHistoryList(BoardData.empty(BOARD_SIZE, BOARD_SIZE));
+      boardWithHistory(history);
+      JSONArray emptyPolicy = new JSONArray();
+      for (int i = 0; i < BOARD_AREA + 1; i++) {
+        emptyPolicy.put(0.0);
+      }
+      FakeProcess process =
+          new FakeProcess(
+              request ->
+                  new JSONObject()
+                      .put("id", request.getString("id"))
+                      .put("humanPolicy", emptyPolicy)
+                      .put("moveInfos", new JSONArray()));
+      HumanSlAnalysisRunner runner =
+          new HumanSlAnalysisRunner(List.of("katago", "analysis"), ignored -> process);
+
+      java.util.Optional<String> best =
+          runner.bestHumanMove(history.getCurrentHistoryNode(), "rank_3k", Duration.ofSeconds(1));
+
+      assertTrue(best.isEmpty());
+      runner.close();
+    }
+  }
+
+  @Test
+  void bestHumanMove_acceptsPassOnlyWhenEndgameSearchSelectsIt() throws Exception {
+    try (TestEnvironment env = TestEnvironment.open()) {
+      BoardHistoryList history = endgameHistory();
+      boardWithHistory(history);
+      FakeProcess process =
+          new FakeProcess(
+              request ->
+                  new JSONObject()
+                      .put("id", request.getString("id"))
+                      .put("humanPolicy", new JSONObject().put("C3", 0.9).put("pass", 0.1))
+                      .put(
+                          "moveInfos",
+                          new JSONArray()
+                              .put(
+                                  new JSONObject()
+                                      .put("move", "pass")
+                                      .put("order", 0)
+                                      .put("utility", 0.8))));
+      HumanSlAnalysisRunner runner =
+          new HumanSlAnalysisRunner(List.of("katago", "analysis"), ignored -> process);
+
+      java.util.Optional<String> best =
+          runner.bestHumanMove(history.getCurrentHistoryNode(), "rank_3k", Duration.ofSeconds(1));
+
+      assertEquals(java.util.Optional.of("pass"), best);
+      assertEquals(64, process.sentRequests.get(0).getInt("maxVisits"));
+      runner.close();
+    }
+  }
+
+  @Test
+  void bestHumanMove_excludesPolicyPassWhenSearchPrefersARealMove() throws Exception {
+    try (TestEnvironment env = TestEnvironment.open()) {
+      BoardHistoryList history = endgameHistory();
+      boardWithHistory(history);
+      FakeProcess process =
+          new FakeProcess(
+              request ->
+                  new JSONObject()
+                      .put("id", request.getString("id"))
+                      .put("humanPolicy", new JSONObject().put("C3", 0.1).put("pass", 100.0))
+                      .put(
+                          "moveInfos",
+                          new JSONArray()
+                              .put(
+                                  new JSONObject()
+                                      .put("move", "C3")
+                                      .put("order", 0)
+                                      .put("utility", 0.5))));
+      HumanSlAnalysisRunner runner =
+          new HumanSlAnalysisRunner(List.of("katago", "analysis"), ignored -> process);
+
+      java.util.Optional<String> best =
+          runner.bestHumanMove(history.getCurrentHistoryNode(), "rank_3k", Duration.ofSeconds(1));
+
+      assertEquals(java.util.Optional.of("C3"), best);
       runner.close();
     }
   }
@@ -177,6 +270,13 @@ class HumanSlAnalysisRunnerTest {
     board.setHistory(history);
     Lizzie.board = board;
     return board;
+  }
+
+  private static BoardHistoryList endgameHistory() {
+    Stone[] position = stones(placement(0, 0, Stone.BLACK));
+    BoardHistoryList history = new BoardHistoryList(BoardData.empty(BOARD_SIZE, BOARD_SIZE));
+    history.add(moveNode(position, new int[] {0, 0}, Stone.BLACK, false, 200));
+    return history;
   }
 
   private static BoardData moveNode(


### PR DESCRIPTION
## Summary

- Adds a stateless HumanSL move selector that samples from plausible human-policy candidates without storing game history, random seeds, or cross-game state.
- Keeps at most 12 candidates within the leading 95% HumanSL policy mass and applies a mild shallow-search quality guard to reject implausible moves.
- Uses higher variety in the opening, gradually steadier play through the middlegame, and more reliable endgame selection.
- Preserves the selected HumanSL rank, existing game entry/UI, model download flow, and stable fallback behavior.
- Handles pass safely: early pass is excluded, while late-game pass is accepted only when the shallow search also prefers pass.

## Validation

- `git diff --check`
- Targeted tests: 15 passed, 0 failed
- Full Maven test suite: 2053 tests, 0 failures, 0 errors, 5 existing environment-dependent skips
- `mvn -B -Dfmt.skip=true -DskipTests package`
- Verified the shaded jar contains the new selector and updated HumanSL runner
- Started an isolated packaged macOS build with KataGo 1.17.1 Metal and the official HumanSL model
- Confirmed a real `rank_3k`, 64-visit HumanSL request returns policy and move-quality data

## Manual follow-up

The packaged application and local analysis start correctly. The macOS accessibility tree exposes the Swing new-game popup as one combined node, so the final menu-to-game click-through should still be checked manually before merge.