### PR TITLE
Restore Zhizi login and engine settings after portable updates

### DIFF
--- a/src/main/java/featurecat/lizzie/Config.java
+++ b/src/main/java/featurecat/lizzie/Config.java
@@ -152,6 +152,10 @@ public class Config {
   private static final String WINDOWS_SHARED_WORK_DIR_NAME = "LizzieYzyNext";
   private static final String WINDOWS_PORTABLE_MARKER_NAME = ".lizzie-portable";
   private static final String WINDOWS_PORTABLE_WORK_DIR_NAME = "user-data";
+  private static final String WINDOWS_PORTABLE_STATE_MIGRATION_KEY =
+      "migrated-windows-portable-user-state-v2";
+  private static final String WINDOWS_PORTABLE_RECOVERY_BACKUP_NAME =
+      "config.before-portable-recovery.txt";
   private static final String WORK_DIR_PROPERTY = "lizzie.work.dir";
   private static final String HIDE_SUBBOARD_DEFAULT_MIGRATION_KEY =
       "migrated-hide-subboard-default-v1";
@@ -391,12 +395,7 @@ public class Config {
   }
 
   private static Path resolveWindowsSharedWorkDirCandidate() throws IOException {
-    List<Path> candidates = new ArrayList<Path>();
-    addWindowsWorkDirCandidate(
-        candidates, System.getenv("PUBLIC"), "Documents", WINDOWS_SHARED_WORK_DIR_NAME);
-    addWindowsWorkDirCandidate(candidates, System.getenv("PUBLIC"), WINDOWS_SHARED_WORK_DIR_NAME);
-    addWindowsWorkDirCandidate(
-        candidates, System.getenv("PROGRAMDATA"), WINDOWS_SHARED_WORK_DIR_NAME);
+    List<Path> candidates = windowsSharedWorkDirCandidates();
 
     for (Path candidate : candidates) {
       if (candidate == null || !isAsciiSafePath(candidate)) {
@@ -415,6 +414,16 @@ public class Config {
     Path preferred = Path.of(System.getProperty("user.home"), USER_WORK_DIR_NAME);
     Files.createDirectories(preferred.resolve("save"));
     return preferred;
+  }
+
+  private static List<Path> windowsSharedWorkDirCandidates() {
+    List<Path> candidates = new ArrayList<Path>();
+    addWindowsWorkDirCandidate(
+        candidates, System.getenv("PUBLIC"), "Documents", WINDOWS_SHARED_WORK_DIR_NAME);
+    addWindowsWorkDirCandidate(candidates, System.getenv("PUBLIC"), WINDOWS_SHARED_WORK_DIR_NAME);
+    addWindowsWorkDirCandidate(
+        candidates, System.getenv("PROGRAMDATA"), WINDOWS_SHARED_WORK_DIR_NAME);
+    return candidates;
   }
 
   private static void addWindowsWorkDirCandidate(
@@ -438,7 +447,16 @@ public class Config {
   }
 
   static Path prepareWindowsPortableWorkDirForTests(Path portableRoot) throws IOException {
-    return prepareWindowsPortableWorkDir(portableRoot);
+    return prepareWindowsPortableWorkDir(portableRoot, Collections.singletonList(portableRoot));
+  }
+
+  static Path prepareWindowsPortableWorkDirWithSourcesForTests(
+      Path portableRoot, Path... migrationSources) throws IOException {
+    return prepareWindowsPortableWorkDir(portableRoot, Arrays.asList(migrationSources));
+  }
+
+  static List<Path> windowsPortableMigrationSourcesForTests(Path portableRoot) {
+    return windowsPortableMigrationSources(portableRoot);
   }
 
   public static Path resolvedWorkDirPath() {
@@ -487,6 +505,12 @@ public class Config {
   }
 
   private static Path prepareWindowsPortableWorkDir(Path portableRoot) throws IOException {
+    return prepareWindowsPortableWorkDir(
+        portableRoot, windowsPortableMigrationSources(portableRoot));
+  }
+
+  private static Path prepareWindowsPortableWorkDir(
+      Path portableRoot, Collection<Path> migrationSources) throws IOException {
     if (portableRoot == null || !Files.isDirectory(portableRoot)) {
       return null;
     }
@@ -496,8 +520,57 @@ public class Config {
     if (!Files.isWritable(workDir)) {
       return null;
     }
-    migrateWorkDirIfNeeded(workDir, portableRoot);
+    Collection<Path> safeSources =
+        migrationSources == null ? Collections.emptyList() : migrationSources;
+    migrateWorkDirIfNeeded(workDir, safeSources.toArray(new Path[0]));
     return workDir;
+  }
+
+  private static List<Path> windowsPortableMigrationSources(Path portableRoot) {
+    LinkedHashSet<Path> sources = new LinkedHashSet<>();
+    addMigrationSource(sources, portableRoot);
+    addMigrationSource(sources, portableRoot.resolve("app"));
+
+    Path parent = portableRoot.getParent();
+    if (parent != null && Files.isDirectory(parent)) {
+      try (Stream<Path> stream = Files.list(parent)) {
+        for (Path sibling : (Iterable<Path>) stream::iterator) {
+          if (!Files.isDirectory(sibling)
+              || sibling.toAbsolutePath().normalize().equals(portableRoot)) {
+            continue;
+          }
+          if (hasAppRootMarker(sibling)) {
+            addMigrationSource(sources, sibling.resolve(WINDOWS_PORTABLE_WORK_DIR_NAME));
+            addMigrationSource(sources, sibling);
+            addMigrationSource(
+                sources, sibling.resolve("app").resolve(WINDOWS_PORTABLE_WORK_DIR_NAME));
+            addMigrationSource(sources, sibling.resolve("app"));
+          }
+        }
+      } catch (IOException e) {
+        System.out.println("Portable sibling scan skipped: " + e.getMessage());
+      }
+    }
+
+    for (Path shared : windowsSharedWorkDirCandidates()) {
+      addMigrationSource(sources, shared);
+    }
+    String userHome = System.getProperty("user.home", "").trim();
+    if (!userHome.isEmpty()) {
+      addMigrationSource(sources, Path.of(userHome, USER_WORK_DIR_NAME));
+      addMigrationSource(sources, Path.of(userHome, LEGACY_USER_WORK_DIR_NAME));
+    }
+    return new ArrayList<>(sources);
+  }
+
+  private static void addMigrationSource(Collection<Path> sources, Path source) {
+    if (sources == null || source == null) {
+      return;
+    }
+    try {
+      sources.add(source.toAbsolutePath().normalize());
+    } catch (Exception ignored) {
+    }
   }
 
   private static boolean shouldUsePortableWindowsWorkDir(Path cwd) {
@@ -533,53 +606,318 @@ public class Config {
   }
 
   private static void migrateWorkDirIfNeeded(Path target, Path... sources) throws IOException {
-    if (target == null || hasExistingWorkDirData(target)) {
+    if (target == null) {
       return;
+    }
+    Path normalizedTarget = target.toAbsolutePath().normalize();
+    Files.createDirectories(normalizedTarget);
+    List<Path> candidates = normalizedMigrationSources(normalizedTarget, sources);
+    Path configSource = selectBestConfigSource(candidates);
+    Path targetConfigFile = normalizedTarget.resolve("config.txt");
+    boolean targetHadConfig = hasUsableConfig(targetConfigFile);
+    boolean recovered = false;
+
+    if (targetHadConfig && configSource != null) {
+      recovered = recoverPortableUserStateIfNeeded(normalizedTarget, configSource);
+    } else if (!targetHadConfig && configSource != null) {
+      backupUnreadableConfig(targetConfigFile.toFile());
+      copyIfExists(
+          configSource.resolve("config.txt"), targetConfigFile, true);
+    }
+
+    Path primarySource =
+        configSource != null ? configSource : candidates.stream().findFirst().orElse(null);
+    if (primarySource != null) {
+      copyIfExists(primarySource.resolve("persist"), normalizedTarget.resolve("persist"), false);
+      Path sourceSave = primarySource.resolve("save");
+      if (Files.isDirectory(sourceSave)) {
+        copyDirectoryContents(sourceSave, normalizedTarget.resolve("save"), false);
+      }
+    }
+
+    // DPAPI files are already encrypted for the current Windows user. Copy only missing blobs from
+    // every known prior location so changing portable folders does not silently sign the user out.
+    LinkedHashSet<Path> credentialSources = new LinkedHashSet<>();
+    if (configSource != null) {
+      credentialSources.add(configSource);
+    }
+    credentialSources.addAll(candidates);
+    for (Path candidate : credentialSources) {
+      Path sourceCredentials = candidate.resolve("secure-credentials");
+      if (Files.isDirectory(sourceCredentials)) {
+        copyDirectoryContents(
+            sourceCredentials, normalizedTarget.resolve("secure-credentials"), false);
+      }
+    }
+
+    if (configSource != null && (!targetHadConfig || recovered)) {
+      System.out.println("Migrated config dir to " + normalizedTarget + " from " + configSource);
+    }
+  }
+
+  private static List<Path> normalizedMigrationSources(Path target, Path... sources) {
+    LinkedHashSet<Path> candidates = new LinkedHashSet<>();
+    if (sources == null) {
+      return new ArrayList<>();
     }
     for (Path source : sources) {
       if (source == null) {
         continue;
       }
-      Path normalizedSource = source.toAbsolutePath().normalize();
-      if (normalizedSource.equals(target) || !hasExistingWorkDirData(normalizedSource)) {
+      try {
+        Path normalized = source.toAbsolutePath().normalize();
+        if (!normalized.equals(target) && hasMigratableWorkDirData(normalized)) {
+          candidates.add(normalized);
+        }
+      } catch (Exception ignored) {
+      }
+    }
+    return new ArrayList<>(candidates);
+  }
+
+  private static boolean hasMigratableWorkDirData(Path directory) {
+    return hasExistingWorkDirData(directory)
+        || Files.isDirectory(directory.resolve("secure-credentials"));
+  }
+
+  private static Path selectBestConfigSource(List<Path> candidates) {
+    Path selected = null;
+    int selectedTier = Integer.MIN_VALUE;
+    long selectedModified = Long.MIN_VALUE;
+    for (Path candidate : candidates) {
+      Path configFile = candidate.resolve("config.txt");
+      if (!hasUsableConfig(configFile)) {
         continue;
       }
-      copyWorkDirFiles(normalizedSource, target);
-      System.out.println("Migrated config dir to " + target + " from " + normalizedSource);
-      return;
+      int tier;
+      try {
+        tier = configUserStateTier(new JSONObject(Files.readString(configFile)));
+      } catch (Exception e) {
+        continue;
+      }
+      long modified = Long.MIN_VALUE;
+      try {
+        modified = Files.getLastModifiedTime(configFile).toMillis();
+      } catch (IOException ignored) {
+      }
+      if (selected == null
+          || tier > selectedTier
+          || (tier == selectedTier && modified > selectedModified)) {
+        selected = candidate;
+        selectedTier = tier;
+        selectedModified = modified;
+      }
+    }
+    return selected;
+  }
+
+  private static int configUserStateTier(JSONObject root) {
+    JSONObject leelaz = root.optJSONObject("leelaz");
+    if (leelaz == null) {
+      return 0;
+    }
+    if (hasConfiguredRemoteProvider(leelaz)) {
+      return 2;
+    }
+    JSONArray engines = leelaz.optJSONArray("engine-settings-list");
+    if (engines != null) {
+      for (int i = 0; i < engines.length(); i++) {
+        JSONObject engine = engines.optJSONObject(i);
+        if (engine != null && !looksLikeManagedBundledEngine(engine)) {
+          return 2;
+        }
+      }
+    }
+    JSONArray legacyCommands = leelaz.optJSONArray("engine-command-list");
+    if (legacyCommands != null && legacyCommands.length() > 0) {
+      return 2;
+    }
+    return engines != null && engines.length() > 0 ? 1 : 0;
+  }
+
+  private static boolean hasUsableConfig(Path configFile) {
+    if (!Files.isRegularFile(configFile)) {
+      return false;
+    }
+    try {
+      JSONObject parsed = new JSONObject(Files.readString(configFile));
+      return parsed.optJSONObject("ui") != null || parsed.optJSONObject("leelaz") != null;
+    } catch (Exception e) {
+      return false;
     }
   }
 
-  private static void copyWorkDirFiles(Path source, Path target) throws IOException {
-    Files.createDirectories(target);
-    copyIfExists(source.resolve("config.txt"), target.resolve("config.txt"));
-    copyIfExists(source.resolve("persist"), target.resolve("persist"));
-    Path sourceSave = source.resolve("save");
-    if (Files.isDirectory(sourceSave)) {
-      copyDirectoryContents(sourceSave, target.resolve("save"));
+  private static boolean recoverPortableUserStateIfNeeded(Path target, Path source)
+      throws IOException {
+    Path targetConfigFile = target.resolve("config.txt");
+    Path sourceConfigFile = source.resolve("config.txt");
+    try {
+      JSONObject targetConfig = new JSONObject(Files.readString(targetConfigFile));
+      JSONObject sourceConfig = new JSONObject(Files.readString(sourceConfigFile));
+      JSONObject targetUi = targetConfig.optJSONObject("ui");
+      if (targetUi != null && targetUi.optBoolean(WINDOWS_PORTABLE_STATE_MIGRATION_KEY, false)) {
+        return false;
+      }
+      if (!looksLikeFreshPortableConfig(targetConfig)
+          || !containsRecoverableUserState(sourceConfig, targetConfig)) {
+        return false;
+      }
+
+      Path backup = target.resolve(WINDOWS_PORTABLE_RECOVERY_BACKUP_NAME);
+      copyIfExists(targetConfigFile, backup, false);
+      JSONObject recovered = new JSONObject(sourceConfig.toString());
+      mergeMissingJsonValues(recovered, targetConfig);
+      JSONObject recoveredUi = recovered.optJSONObject("ui");
+      if (recoveredUi == null) {
+        recoveredUi = new JSONObject();
+        recovered.put("ui", recoveredUi);
+      }
+      recoveredUi.put(WINDOWS_PORTABLE_STATE_MIGRATION_KEY, true);
+      writeJsonAtomically(targetConfigFile, recovered);
+      return true;
+    } catch (JSONException e) {
+      return false;
     }
   }
 
-  private static void copyDirectoryContents(Path source, Path target) throws IOException {
+  private static boolean looksLikeFreshPortableConfig(JSONObject root) {
+    JSONObject leelaz = root.optJSONObject("leelaz");
+    if (leelaz == null || hasConfiguredRemoteProvider(leelaz)) {
+      return false;
+    }
+    JSONArray engines = leelaz.optJSONArray("engine-settings-list");
+    if (engines == null || engines.length() == 0) {
+      return true;
+    }
+    if (engines.length() != 1) {
+      return false;
+    }
+    JSONObject engine = engines.optJSONObject(0);
+    if (engine == null) {
+      return true;
+    }
+    return looksLikeManagedBundledEngine(engine);
+  }
+
+  private static boolean looksLikeManagedBundledEngine(JSONObject engine) {
+    String name = engine.optString("name", "").trim();
+    String command = engine.optString("command", "").replace('\\', '/').toLowerCase(Locale.ROOT);
+    return (BUNDLED_ENGINE_NAME.equals(name) || "KataGo Auto Setup".equals(name))
+        && (command.isEmpty()
+            || command.contains("weights/default.bin.gz")
+            || command.contains("engines/katago/"));
+  }
+
+  private static boolean containsRecoverableUserState(JSONObject source, JSONObject target) {
+    JSONObject sourceLeelaz = source.optJSONObject("leelaz");
+    JSONObject targetLeelaz = target.optJSONObject("leelaz");
+    if (sourceLeelaz == null) {
+      return false;
+    }
+    if (hasConfiguredRemoteProvider(sourceLeelaz)
+        && (targetLeelaz == null || !hasConfiguredRemoteProvider(targetLeelaz))) {
+      return true;
+    }
+    Set<String> targetEngines = engineIdentities(targetLeelaz);
+    for (String sourceEngine : engineIdentities(sourceLeelaz)) {
+      if (!targetEngines.contains(sourceEngine)) {
+        return true;
+      }
+    }
+    JSONArray legacyCommands = sourceLeelaz.optJSONArray("engine-command-list");
+    return legacyCommands != null && legacyCommands.length() > 0;
+  }
+
+  private static boolean hasConfiguredRemoteProvider(JSONObject leelaz) {
+    if (leelaz == null) {
+      return false;
+    }
+    JSONObject remote = leelaz.optJSONObject("remote-compute");
+    if (remote == null) {
+      return false;
+    }
+    return !"local".equalsIgnoreCase(remote.optString("provider", "local"))
+        || !remote.optString("zhizi-identifier", "").isBlank()
+        || !remote.optString("custom-remote-code", "").isBlank();
+  }
+
+  private static Set<String> engineIdentities(JSONObject leelaz) {
+    LinkedHashSet<String> identities = new LinkedHashSet<>();
+    if (leelaz == null) {
+      return identities;
+    }
+    JSONArray engines = leelaz.optJSONArray("engine-settings-list");
+    if (engines == null) {
+      return identities;
+    }
+    for (int i = 0; i < engines.length(); i++) {
+      JSONObject engine = engines.optJSONObject(i);
+      if (engine == null) {
+        continue;
+      }
+      String command = engine.optString("command", "").trim().toLowerCase(Locale.ROOT);
+      String name = engine.optString("name", "").trim().toLowerCase(Locale.ROOT);
+      identities.add(command.isEmpty() ? "name:" + name : "command:" + command);
+    }
+    return identities;
+  }
+
+  private static void mergeMissingJsonValues(JSONObject target, JSONObject fallback) {
+    for (String key : fallback.keySet()) {
+      Object fallbackValue = fallback.get(key);
+      if (!target.has(key)) {
+        target.put(key, fallbackValue);
+      } else if (target.opt(key) instanceof JSONObject && fallbackValue instanceof JSONObject) {
+        mergeMissingJsonValues(target.getJSONObject(key), (JSONObject) fallbackValue);
+      }
+    }
+  }
+
+  private static void writeJsonAtomically(Path target, JSONObject value) throws IOException {
+    Files.createDirectories(target.getParent());
+    Path temporary = Files.createTempFile(target.getParent(), ".config-recovery-", ".tmp");
+    try {
+      Files.writeString(temporary, value.toString(2));
+      try {
+        Files.move(
+            temporary, target, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);
+      } catch (AtomicMoveNotSupportedException e) {
+        Files.move(temporary, target, StandardCopyOption.REPLACE_EXISTING);
+      }
+    } finally {
+      Files.deleteIfExists(temporary);
+    }
+  }
+
+  private static void copyDirectoryContents(Path source, Path target, boolean replace)
+      throws IOException {
     Files.createDirectories(target);
     try (Stream<Path> stream = Files.list(source)) {
       for (Path child : (Iterable<Path>) stream::iterator) {
         Path destination = target.resolve(child.getFileName().toString());
         if (Files.isDirectory(child)) {
-          copyDirectoryContents(child, destination);
+          copyDirectoryContents(child, destination, replace);
         } else {
-          copyIfExists(child, destination);
+          copyIfExists(child, destination, replace);
         }
       }
     }
   }
 
-  private static void copyIfExists(Path source, Path destination) throws IOException {
+  private static void copyIfExists(Path source, Path destination, boolean replace)
+      throws IOException {
     if (!Files.exists(source) || Files.isDirectory(source)) {
       return;
     }
+    if (!replace && Files.exists(destination)) {
+      return;
+    }
     Files.createDirectories(destination.getParent());
-    Files.copy(source, destination, StandardCopyOption.REPLACE_EXISTING);
+    if (replace) {
+      Files.copy(source, destination, StandardCopyOption.REPLACE_EXISTING);
+    } else {
+      Files.copy(source, destination);
+    }
   }
 
   private static boolean isAsciiSafePath(Path path) {
@@ -1754,14 +2092,8 @@ public class Config {
     try {
       this.config = loadAndMergeConfig(defaultConfig, configFilename, true);
     } catch (Exception e) {
-      try {
-        File file = new File("");
-        String courseFile = file.getCanonicalPath();
-        File fileconfig = new File(courseFile + File.separator + configFilename);
-        File wrongfileconfig = new File(courseFile + File.separator + "config_wrong.txt");
-        copyFile(fileconfig, wrongfileconfig);
-      } catch (Exception ex) {
-      }
+      e.printStackTrace();
+      backupUnreadableConfig(new File(configFilename));
       this.config = loadAndMergeConfigdef(defaultConfig, configFilename, true);
     }
     applyBundledKataGoDefaults();
@@ -2529,11 +2861,12 @@ public class Config {
       String key = keys.next();
       Object newVal = defaultsConfig.get(key);
       if (newVal instanceof JSONObject) {
-        if (!config.has(key)) {
-          config.put(key, new JSONObject());
+        Object oldVal = config.opt(key);
+        if (!(oldVal instanceof JSONObject)) {
+          config.put(key, new JSONObject(((JSONObject) newVal).toString()));
           modified = true;
+          continue;
         }
-        Object oldVal = config.get(key);
         modified |= mergeDefaults((JSONObject) oldVal, (JSONObject) newVal);
       } else {
         if (!config.has(key)) {
@@ -2543,6 +2876,28 @@ public class Config {
       }
     }
     return modified;
+  }
+
+  private static void backupUnreadableConfig(File configFile) {
+    if (configFile == null || !configFile.isFile()) {
+      return;
+    }
+    Path source = configFile.toPath().toAbsolutePath().normalize();
+    Path parent = source.getParent();
+    if (parent == null) {
+      return;
+    }
+    String fileName = configFile.getName() + ".unreadable-backup";
+    Path backup = parent.resolve(fileName);
+    for (int suffix = 1; Files.exists(backup); suffix++) {
+      backup = parent.resolve(fileName + "." + suffix);
+    }
+    try {
+      Files.copy(source, backup);
+      System.err.println("Saved unreadable config backup to " + backup);
+    } catch (IOException backupError) {
+      backupError.printStackTrace();
+    }
   }
 
   public void setClassicMode(boolean status) {

--- a/src/main/java/featurecat/lizzie/Config.java
+++ b/src/main/java/featurecat/lizzie/Config.java
@@ -459,6 +459,23 @@ public class Config {
     return windowsPortableMigrationSources(portableRoot);
   }
 
+  static List<Path> windowsPortableCredentialDirectoriesForTests(Path portableRoot) {
+    return windowsPortableCredentialDirectories(portableRoot);
+  }
+
+  /** Returns existing portable credential directories that may need one-time DPAPI migration. */
+  public static List<Path> legacyWindowsCredentialDirectories() {
+    Optional<Path> portableRoot = findWindowsPortablePackageRoot();
+    if (portableRoot.isPresent()) {
+      return windowsPortableCredentialDirectories(portableRoot.get());
+    }
+    Path credentials =
+        resolvedWorkDirPath().resolve("secure-credentials").toAbsolutePath().normalize();
+    return Files.isDirectory(credentials)
+        ? Collections.singletonList(credentials)
+        : Collections.emptyList();
+  }
+
   public static Path resolvedWorkDirPath() {
     return Path.of(WORK_DIR).toAbsolutePath().normalize();
   }
@@ -563,6 +580,30 @@ public class Config {
     return new ArrayList<>(sources);
   }
 
+  private static List<Path> windowsPortableCredentialDirectories(Path portableRoot) {
+    LinkedHashSet<Path> directories = new LinkedHashSet<>();
+    addExistingCredentialDirectory(
+        directories, portableRoot.resolve(WINDOWS_PORTABLE_WORK_DIR_NAME));
+    for (Path source : windowsPortableMigrationSources(portableRoot)) {
+      addExistingCredentialDirectory(directories, source);
+    }
+    return new ArrayList<>(directories);
+  }
+
+  private static void addExistingCredentialDirectory(Collection<Path> directories, Path source) {
+    if (directories == null || source == null) {
+      return;
+    }
+    try {
+      Path credentialDirectory =
+          source.resolve("secure-credentials").toAbsolutePath().normalize();
+      if (Files.isDirectory(credentialDirectory)) {
+        directories.add(credentialDirectory);
+      }
+    } catch (Exception ignored) {
+    }
+  }
+
   private static void addMigrationSource(Collection<Path> sources, Path source) {
     if (sources == null || source == null) {
       return;
@@ -635,21 +676,6 @@ public class Config {
       }
     }
 
-    // DPAPI files are already encrypted for the current Windows user. Copy only missing blobs from
-    // every known prior location so changing portable folders does not silently sign the user out.
-    LinkedHashSet<Path> credentialSources = new LinkedHashSet<>();
-    if (configSource != null) {
-      credentialSources.add(configSource);
-    }
-    credentialSources.addAll(candidates);
-    for (Path candidate : credentialSources) {
-      Path sourceCredentials = candidate.resolve("secure-credentials");
-      if (Files.isDirectory(sourceCredentials)) {
-        copyDirectoryContents(
-            sourceCredentials, normalizedTarget.resolve("secure-credentials"), false);
-      }
-    }
-
     if (configSource != null && (!targetHadConfig || recovered)) {
       System.out.println("Migrated config dir to " + normalizedTarget + " from " + configSource);
     }
@@ -676,8 +702,7 @@ public class Config {
   }
 
   private static boolean hasMigratableWorkDirData(Path directory) {
-    return hasExistingWorkDirData(directory)
-        || Files.isDirectory(directory.resolve("secure-credentials"));
+    return hasExistingWorkDirData(directory);
   }
 
   private static Path selectBestConfigSource(List<Path> candidates) {

--- a/src/main/java/featurecat/lizzie/analysis/remote/MigratingCredentialStore.java
+++ b/src/main/java/featurecat/lizzie/analysis/remote/MigratingCredentialStore.java
@@ -1,0 +1,137 @@
+package featurecat.lizzie.analysis.remote;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+/** Moves secrets into the system store only after a verified write, while preserving old data. */
+final class MigratingCredentialStore implements CredentialStore {
+  private final CredentialStore primary;
+  private final List<CredentialStore> legacyStores;
+
+  MigratingCredentialStore(CredentialStore primary, List<CredentialStore> legacyStores) {
+    this.primary = primary;
+    this.legacyStores =
+        legacyStores == null ? List.of() : List.copyOf(new ArrayList<>(legacyStores));
+  }
+
+  @Override
+  public String backendName() {
+    return primary.backendName();
+  }
+
+  @Override
+  public boolean isAvailable() {
+    if (primary.isAvailable()) {
+      return true;
+    }
+    for (CredentialStore legacy : legacyStores) {
+      if (legacy.isAvailable()) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  @Override
+  public Optional<String> read(Kind kind, String account) throws IOException {
+    IOException primaryFailure = null;
+    if (primary.isAvailable()) {
+      try {
+        Optional<String> stored = primary.read(kind, account);
+        if (stored.isPresent()) {
+          return stored;
+        }
+      } catch (IOException e) {
+        primaryFailure = e;
+      }
+    }
+
+    for (CredentialStore legacy : legacyStores) {
+      if (!legacy.isAvailable()) {
+        continue;
+      }
+      Optional<String> existing;
+      try {
+        existing = legacy.read(kind, account);
+      } catch (IOException ignored) {
+        continue;
+      }
+      if (existing.isEmpty()) {
+        continue;
+      }
+      String secret = existing.get();
+      if (primary.isAvailable()) {
+        try {
+          writeAndVerifyPrimary(kind, account, secret);
+          deleteLegacyAfterVerifiedWrite(kind, account);
+        } catch (IOException ignored) {
+          // The DPAPI-protected legacy copy remains usable and will be retried on the next load.
+        }
+      }
+      return Optional.of(secret);
+    }
+    if (primaryFailure != null) {
+      throw primaryFailure;
+    }
+    return Optional.empty();
+  }
+
+  @Override
+  public void write(Kind kind, String account, String secret) throws IOException {
+    if (!primary.isAvailable()) {
+      throw new IOException("System credential storage is unavailable.");
+    }
+    writeAndVerifyPrimary(kind, account, secret);
+    deleteLegacyAfterVerifiedWrite(kind, account);
+  }
+
+  @Override
+  public void delete(Kind kind, String account) throws IOException {
+    IOException failure = null;
+    try {
+      primary.delete(kind, account);
+    } catch (IOException e) {
+      failure = e;
+    }
+    for (CredentialStore legacy : legacyStores) {
+      try {
+        legacy.delete(kind, account);
+      } catch (IOException e) {
+        if (failure == null) {
+          failure = e;
+        }
+      }
+    }
+    if (failure != null) {
+      throw failure;
+    }
+  }
+
+  private void writeAndVerifyPrimary(Kind kind, String account, String secret) throws IOException {
+    primary.write(kind, account, secret);
+    Optional<String> verified = primary.read(kind, account);
+    if (verified.isEmpty() || !sameSecret(secret, verified.get())) {
+      throw new IOException("System credential storage verification failed.");
+    }
+  }
+
+  private void deleteLegacyAfterVerifiedWrite(Kind kind, String account) {
+    for (CredentialStore legacy : legacyStores) {
+      try {
+        legacy.delete(kind, account);
+      } catch (IOException ignored) {
+        // A verified system copy already exists; a later load will retry legacy cleanup.
+      }
+    }
+  }
+
+  private static boolean sameSecret(String expected, String actual) {
+    byte[] left = (expected == null ? "" : expected).getBytes(StandardCharsets.UTF_8);
+    byte[] right = (actual == null ? "" : actual).getBytes(StandardCharsets.UTF_8);
+    return MessageDigest.isEqual(left, right);
+  }
+}

--- a/src/main/java/featurecat/lizzie/analysis/remote/PlatformCredentialStore.java
+++ b/src/main/java/featurecat/lizzie/analysis/remote/PlatformCredentialStore.java
@@ -40,6 +40,9 @@ public final class PlatformCredentialStore {
       return new MacKeychainStore(runner);
     }
     if (os.contains("windows")) {
+      if (credentialDirectory == null) {
+        return new UnavailableStore("session-only");
+      }
       return new WindowsDpapiStore(credentialDirectory, runner);
     }
     if (os.contains("linux")) {
@@ -279,7 +282,7 @@ public final class PlatformCredentialStore {
 
     WindowsDpapiStore(Path directory, CredentialCommandRunner runner) {
       super(runner);
-      this.directory = directory == null ? Path.of("secure-credentials") : directory;
+      this.directory = directory;
     }
 
     @Override

--- a/src/main/java/featurecat/lizzie/analysis/remote/RemoteComputeConfig.java
+++ b/src/main/java/featurecat/lizzie/analysis/remote/RemoteComputeConfig.java
@@ -1,5 +1,6 @@
 package featurecat.lizzie.analysis.remote;
 
+import featurecat.lizzie.Config;
 import featurecat.lizzie.Lizzie;
 import featurecat.lizzie.gui.EngineData;
 import featurecat.lizzie.rules.Board;
@@ -7,10 +8,15 @@ import featurecat.lizzie.util.Utils;
 import java.io.IOException;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Base64;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import org.json.JSONObject;
 
@@ -977,25 +983,93 @@ public final class RemoteComputeConfig {
     }
     Path directory = credentialDirectory();
     CredentialStore cached = systemCredentialStore;
-    if (cached != null && directory.equals(systemCredentialDirectory)) {
+    if (cached != null && Objects.equals(directory, systemCredentialDirectory)) {
       return cached;
     }
     synchronized (CREDENTIAL_LOCK) {
-      if (systemCredentialStore == null || !directory.equals(systemCredentialDirectory)) {
+      if (systemCredentialStore == null
+          || !Objects.equals(directory, systemCredentialDirectory)) {
         systemCredentialDirectory = directory;
-        systemCredentialStore = PlatformCredentialStore.create(directory);
+        systemCredentialStore = createCredentialStore(directory);
       }
       return systemCredentialStore;
     }
   }
 
   private static Path credentialDirectory() {
-    if (Lizzie.config != null && Lizzie.config.getWorkDirectory() != null) {
-      return Lizzie.config.getWorkDirectory().toPath().resolve("secure-credentials").normalize();
+    return credentialDirectory(
+        System.getProperty("os.name", ""), System.getenv(), System.getProperty("user.home", ""));
+  }
+
+  static Path credentialDirectoryForTests(
+      String osName, Map<String, String> environment, String userHome) {
+    return credentialDirectory(osName, environment, userHome);
+  }
+
+  private static Path credentialDirectory(
+      String osName, Map<String, String> environment, String userHome) {
+    String os = osName == null ? "" : osName.toLowerCase(Locale.ROOT);
+    Map<String, String> env = environment == null ? Map.of() : environment;
+    String home = userHome == null ? "" : userHome.trim();
+    Path base = null;
+    if (os.contains("windows")) {
+      String appData = env.getOrDefault("APPDATA", "").trim();
+      if (!appData.isEmpty()) {
+        base = Path.of(appData);
+      } else if (!home.isEmpty()) {
+        base = Path.of(home, "AppData", "Roaming");
+      }
+    } else if (os.contains("mac")) {
+      if (!home.isEmpty()) {
+        base = Path.of(home, "Library", "Application Support");
+      }
+    } else if (os.contains("linux")) {
+      String xdgConfig = env.getOrDefault("XDG_CONFIG_HOME", "").trim();
+      if (!xdgConfig.isEmpty()) {
+        base = Path.of(xdgConfig);
+      } else if (!home.isEmpty()) {
+        base = Path.of(home, ".config");
+      }
+    } else if (!home.isEmpty()) {
+      base = Path.of(home, ".config");
     }
-    return Path.of(System.getProperty("user.dir", "."), "secure-credentials")
-        .toAbsolutePath()
-        .normalize();
+    return base == null
+        ? null
+        : base.resolve("LizzieYzy Next").resolve("secure-credentials").toAbsolutePath().normalize();
+  }
+
+  private static CredentialStore createCredentialStore(Path systemDirectory) {
+    CredentialStore primary = PlatformCredentialStore.create(systemDirectory);
+    if (!isWindows()) {
+      return primary;
+    }
+    LinkedHashSet<Path> legacyDirectories = new LinkedHashSet<>();
+    if (Lizzie.config != null && Lizzie.config.getWorkDirectory() != null) {
+      legacyDirectories.add(
+          Lizzie.config
+              .getWorkDirectory()
+              .toPath()
+              .resolve("secure-credentials")
+              .toAbsolutePath()
+              .normalize());
+    }
+    legacyDirectories.addAll(Config.legacyWindowsCredentialDirectories());
+    List<CredentialStore> legacyStores = new ArrayList<>();
+    for (Path legacyDirectory : legacyDirectories) {
+      if (legacyDirectory == null
+          || !Files.isDirectory(legacyDirectory)
+          || Objects.equals(legacyDirectory, systemDirectory)) {
+        continue;
+      }
+      legacyStores.add(PlatformCredentialStore.create(legacyDirectory));
+    }
+    return legacyStores.isEmpty()
+        ? primary
+        : new MigratingCredentialStore(primary, legacyStores);
+  }
+
+  private static boolean isWindows() {
+    return System.getProperty("os.name", "").toLowerCase(Locale.ROOT).contains("windows");
   }
 
   private static SecretLoad loadSecret(

--- a/src/test/java/featurecat/lizzie/ConfigBundledKataGoDefaultsTest.java
+++ b/src/test/java/featurecat/lizzie/ConfigBundledKataGoDefaultsTest.java
@@ -10,6 +10,7 @@ import java.lang.reflect.Method;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.attribute.FileTime;
+import java.util.List;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.junit.jupiter.api.Test;
@@ -39,7 +40,8 @@ public class ConfigBundledKataGoDefaultsTest {
   }
 
   @Test
-  void windowsPortableUpgradeMigratesRichestConfigCredentialsAndExistingSaves() throws Exception {
+  void windowsPortableUpgradeMigratesConfigAndSavesButLeavesCredentialsForSecureMigration()
+      throws Exception {
     Path parent = Files.createTempDirectory("lizzie-portable-upgrade");
     Path previousRoot = Files.createDirectories(parent.resolve("2026-08-01-windows64.nvidia"));
     Path previousData = Files.createDirectories(previousRoot.resolve("user-data"));
@@ -73,13 +75,10 @@ public class ConfigBundledKataGoDefaultsTest {
             .getJSONObject("leelaz")
             .getJSONObject(RemoteComputeConfig.CONFIG_KEY)
             .getString("provider"));
-    assertEquals(
-        "encrypted-token",
-        Files.readString(
-            workDir.resolve("secure-credentials").resolve("account-token-user.dpapi")));
-    assertEquals(
-        "encrypted-password",
-        Files.readString(workDir.resolve("secure-credentials").resolve("password-user.dpapi")));
+    assertFalse(Files.exists(workDir.resolve("secure-credentials")));
+    assertTrue(
+        Config.windowsPortableCredentialDirectoriesForTests(currentRoot)
+            .contains(previousCredentials.toAbsolutePath().normalize()));
     assertEquals("(;GM[1])", Files.readString(currentSave.resolve("unfinished-game.sgf")));
   }
 
@@ -99,10 +98,11 @@ public class ConfigBundledKataGoDefaultsTest {
   }
 
   @Test
-  void windowsPortableUpgradeKeepsConfigAndCredentialsFromNewestMeaningfulProfile()
-      throws Exception {
+  void windowsPortableUpgradeKeepsConfigFromNewestMeaningfulProfile() throws Exception {
     Path parent = Files.createTempDirectory("lizzie-portable-newest-profile");
-    Path olderData = Files.createDirectories(parent.resolve("older").resolve("user-data"));
+    Path olderRoot = Files.createDirectories(parent.resolve("older"));
+    Files.writeString(olderRoot.resolve(".lizzie-portable"), "portable");
+    Path olderData = Files.createDirectories(olderRoot.resolve("user-data"));
     JSONObject olderConfig = richPortableConfig();
     olderConfig
         .getJSONObject("leelaz")
@@ -121,7 +121,9 @@ public class ConfigBundledKataGoDefaultsTest {
     Files.writeString(olderCredentials.resolve("account-token-user.dpapi"), "older-token");
     Files.setLastModifiedTime(olderConfigFile, FileTime.fromMillis(1_000));
 
-    Path newerData = Files.createDirectories(parent.resolve("newer").resolve("user-data"));
+    Path newerRoot = Files.createDirectories(parent.resolve("newer"));
+    Files.writeString(newerRoot.resolve(".lizzie-portable"), "portable");
+    Path newerData = Files.createDirectories(newerRoot.resolve("user-data"));
     JSONObject newerConfig = richPortableConfig();
     newerConfig
         .getJSONObject("leelaz")
@@ -146,10 +148,11 @@ public class ConfigBundledKataGoDefaultsTest {
             .getJSONObject("leelaz")
             .getJSONObject(RemoteComputeConfig.CONFIG_KEY)
             .getString("zhizi-identifier"));
-    assertEquals(
-        "newer-token",
-        Files.readString(
-            workDir.resolve("secure-credentials").resolve("account-token-user.dpapi")));
+    assertFalse(Files.exists(workDir.resolve("secure-credentials")));
+    List<Path> legacyCredentials =
+        Config.windowsPortableCredentialDirectoriesForTests(currentRoot);
+    assertTrue(legacyCredentials.contains(olderCredentials.toAbsolutePath().normalize()));
+    assertTrue(legacyCredentials.contains(newerCredentials.toAbsolutePath().normalize()));
   }
 
   @Test

--- a/src/test/java/featurecat/lizzie/ConfigBundledKataGoDefaultsTest.java
+++ b/src/test/java/featurecat/lizzie/ConfigBundledKataGoDefaultsTest.java
@@ -4,10 +4,12 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import featurecat.lizzie.analysis.remote.RemoteComputeConfig;
 import featurecat.lizzie.util.KataGoAutoSetupHelper;
 import java.lang.reflect.Method;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.attribute.FileTime;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.junit.jupiter.api.Test;
@@ -22,7 +24,8 @@ public class ConfigBundledKataGoDefaultsTest {
     Path portableRoot = Files.createDirectories(tempRoot.resolve("LizzieYzy Next 围棋"));
     Files.writeString(portableRoot.resolve(".lizzie-portable"), "portable");
     Files.createDirectories(portableRoot.resolve("app"));
-    Files.writeString(portableRoot.resolve("config.txt"), "{\"legacy\":true}");
+    Files.writeString(
+        portableRoot.resolve("config.txt"), "{\"ui\":{},\"leelaz\":{\"legacy\":true}}");
 
     Path foundRoot =
         Config.findWindowsPortablePackageRootForTests(portableRoot.resolve("app")).orElseThrow();
@@ -36,6 +39,200 @@ public class ConfigBundledKataGoDefaultsTest {
   }
 
   @Test
+  void windowsPortableUpgradeMigratesRichestConfigCredentialsAndExistingSaves() throws Exception {
+    Path parent = Files.createTempDirectory("lizzie-portable-upgrade");
+    Path previousRoot = Files.createDirectories(parent.resolve("2026-08-01-windows64.nvidia"));
+    Path previousData = Files.createDirectories(previousRoot.resolve("user-data"));
+    Files.writeString(previousRoot.resolve(".lizzie-portable"), "portable");
+    Files.writeString(previousData.resolve("config.txt"), richPortableConfig().toString(2));
+    Files.writeString(previousData.resolve("persist"), "{\"ui-persist\":{}}");
+    Path previousCredentials = Files.createDirectories(previousData.resolve("secure-credentials"));
+    Files.writeString(previousCredentials.resolve("account-token-user.dpapi"), "encrypted-token");
+    Files.writeString(previousCredentials.resolve("password-user.dpapi"), "encrypted-password");
+
+    Path decoyRoot = Files.createDirectories(parent.resolve("2026-08-07-windows64.nvidia"));
+    Path decoyData = Files.createDirectories(decoyRoot.resolve("user-data"));
+    Files.writeString(decoyRoot.resolve(".lizzie-portable"), "portable");
+    Files.writeString(decoyData.resolve("config.txt"), freshPortableConfig().toString(2));
+
+    Path currentRoot = Files.createDirectories(parent.resolve("2026-08-08-windows64.nvidia"));
+    Files.writeString(currentRoot.resolve(".lizzie-portable"), "portable");
+    Path currentSave = Files.createDirectories(currentRoot.resolve("user-data").resolve("save"));
+    Files.writeString(currentSave.resolve("unfinished-game.sgf"), "(;GM[1])");
+
+    Path workDir =
+        Config.prepareWindowsPortableWorkDirWithSourcesForTests(
+            currentRoot, decoyData, previousData);
+
+    JSONObject migrated = new JSONObject(Files.readString(workDir.resolve("config.txt")));
+    JSONArray engines = migrated.getJSONObject("leelaz").getJSONArray("engine-settings-list");
+    assertEquals(2, engines.length());
+    assertEquals(
+        RemoteComputeConfig.PROVIDER_ZHIZI,
+        migrated
+            .getJSONObject("leelaz")
+            .getJSONObject(RemoteComputeConfig.CONFIG_KEY)
+            .getString("provider"));
+    assertEquals(
+        "encrypted-token",
+        Files.readString(
+            workDir.resolve("secure-credentials").resolve("account-token-user.dpapi")));
+    assertEquals(
+        "encrypted-password",
+        Files.readString(workDir.resolve("secure-credentials").resolve("password-user.dpapi")));
+    assertEquals("(;GM[1])", Files.readString(currentSave.resolve("unfinished-game.sgf")));
+  }
+
+  @Test
+  void windowsPortableUpgradeDiscoversSiblingUserData() throws Exception {
+    Path parent = Files.createTempDirectory("lizzie-portable-sibling-discovery");
+    Path previousRoot = Files.createDirectories(parent.resolve("previous"));
+    Path previousData = Files.createDirectories(previousRoot.resolve("user-data"));
+    Files.writeString(previousRoot.resolve(".lizzie-portable"), "portable");
+    Files.writeString(previousData.resolve("config.txt"), richPortableConfig().toString(2));
+    Path currentRoot = Files.createDirectories(parent.resolve("current"));
+    Files.writeString(currentRoot.resolve(".lizzie-portable"), "portable");
+
+    assertTrue(
+        Config.windowsPortableMigrationSourcesForTests(currentRoot)
+            .contains(previousData.toAbsolutePath().normalize()));
+  }
+
+  @Test
+  void windowsPortableUpgradeKeepsConfigAndCredentialsFromNewestMeaningfulProfile()
+      throws Exception {
+    Path parent = Files.createTempDirectory("lizzie-portable-newest-profile");
+    Path olderData = Files.createDirectories(parent.resolve("older").resolve("user-data"));
+    JSONObject olderConfig = richPortableConfig();
+    olderConfig
+        .getJSONObject("leelaz")
+        .getJSONObject(RemoteComputeConfig.CONFIG_KEY)
+        .put("zhizi-identifier", "older-user");
+    olderConfig
+        .getJSONObject("leelaz")
+        .getJSONArray("engine-settings-list")
+        .put(
+            new JSONObject()
+                .put("name", "Another Old Engine")
+                .put("command", "D:/old/katago.exe gtp"));
+    Path olderConfigFile = olderData.resolve("config.txt");
+    Files.writeString(olderConfigFile, olderConfig.toString(2));
+    Path olderCredentials = Files.createDirectories(olderData.resolve("secure-credentials"));
+    Files.writeString(olderCredentials.resolve("account-token-user.dpapi"), "older-token");
+    Files.setLastModifiedTime(olderConfigFile, FileTime.fromMillis(1_000));
+
+    Path newerData = Files.createDirectories(parent.resolve("newer").resolve("user-data"));
+    JSONObject newerConfig = richPortableConfig();
+    newerConfig
+        .getJSONObject("leelaz")
+        .getJSONObject(RemoteComputeConfig.CONFIG_KEY)
+        .put("zhizi-identifier", "newer-user");
+    Path newerConfigFile = newerData.resolve("config.txt");
+    Files.writeString(newerConfigFile, newerConfig.toString(2));
+    Path newerCredentials = Files.createDirectories(newerData.resolve("secure-credentials"));
+    Files.writeString(newerCredentials.resolve("account-token-user.dpapi"), "newer-token");
+    Files.setLastModifiedTime(newerConfigFile, FileTime.fromMillis(2_000));
+
+    Path currentRoot = Files.createDirectories(parent.resolve("current"));
+    Files.writeString(currentRoot.resolve(".lizzie-portable"), "portable");
+    Path workDir =
+        Config.prepareWindowsPortableWorkDirWithSourcesForTests(
+            currentRoot, olderData, newerData);
+
+    JSONObject migrated = new JSONObject(Files.readString(workDir.resolve("config.txt")));
+    assertEquals(
+        "newer-user",
+        migrated
+            .getJSONObject("leelaz")
+            .getJSONObject(RemoteComputeConfig.CONFIG_KEY)
+            .getString("zhizi-identifier"));
+    assertEquals(
+        "newer-token",
+        Files.readString(
+            workDir.resolve("secure-credentials").resolve("account-token-user.dpapi")));
+  }
+
+  @Test
+  void windowsPortableUpgradeBacksUpUnreadableTargetBeforeRecovery() throws Exception {
+    Path parent = Files.createTempDirectory("lizzie-portable-broken-target");
+    Path previousData = Files.createDirectories(parent.resolve("previous").resolve("user-data"));
+    Files.writeString(previousData.resolve("config.txt"), richPortableConfig().toString(2));
+    Path currentRoot = Files.createDirectories(parent.resolve("current"));
+    Files.writeString(currentRoot.resolve(".lizzie-portable"), "portable");
+    Path currentData = Files.createDirectories(currentRoot.resolve("user-data"));
+    Files.writeString(currentData.resolve("config.txt"), "{broken-json");
+
+    Config.prepareWindowsPortableWorkDirWithSourcesForTests(currentRoot, previousData);
+
+    assertEquals(
+        "{broken-json",
+        Files.readString(currentData.resolve("config.txt.unreadable-backup")));
+    JSONObject recovered = new JSONObject(Files.readString(currentData.resolve("config.txt")));
+    assertEquals(
+        2, recovered.getJSONObject("leelaz").getJSONArray("engine-settings-list").length());
+  }
+
+  @Test
+  void windowsPortableUpgradeRecoversUserStateFromGeneratedDefaultOnce() throws Exception {
+    Path parent = Files.createTempDirectory("lizzie-portable-recovery");
+    Path previousData = Files.createDirectories(parent.resolve("previous").resolve("user-data"));
+    Files.writeString(previousData.resolve("config.txt"), richPortableConfig().toString(2));
+    Path currentRoot = Files.createDirectories(parent.resolve("current"));
+    Files.writeString(currentRoot.resolve(".lizzie-portable"), "portable");
+    Path currentData = Files.createDirectories(currentRoot.resolve("user-data"));
+    Files.writeString(currentData.resolve("config.txt"), freshPortableConfig().toString(2));
+
+    Config.prepareWindowsPortableWorkDirWithSourcesForTests(currentRoot, previousData);
+
+    JSONObject recovered = new JSONObject(Files.readString(currentData.resolve("config.txt")));
+    assertEquals(
+        2, recovered.getJSONObject("leelaz").getJSONArray("engine-settings-list").length());
+    assertEquals(1, recovered.getJSONObject("ui").getInt("default-engine"));
+    assertTrue(recovered.getJSONObject("ui").getBoolean("migrated-windows-portable-user-state-v2"));
+    assertTrue(Files.isRegularFile(currentData.resolve("config.before-portable-recovery.txt")));
+
+    JSONObject userEdited = new JSONObject(Files.readString(currentData.resolve("config.txt")));
+    userEdited.getJSONObject("ui").put("default-engine", 0);
+    Files.writeString(currentData.resolve("config.txt"), userEdited.toString(2));
+    Config.prepareWindowsPortableWorkDirWithSourcesForTests(currentRoot, previousData);
+    JSONObject secondLaunch = new JSONObject(Files.readString(currentData.resolve("config.txt")));
+    assertEquals(0, secondLaunch.getJSONObject("ui").getInt("default-engine"));
+  }
+
+  @Test
+  void windowsPortableUpgradeNeverOverwritesAnExistingCustomConfig() throws Exception {
+    Path parent = Files.createTempDirectory("lizzie-portable-custom-config");
+    Path previousData = Files.createDirectories(parent.resolve("previous").resolve("user-data"));
+    Files.writeString(previousData.resolve("config.txt"), richPortableConfig().toString(2));
+    Path currentRoot = Files.createDirectories(parent.resolve("current"));
+    Files.writeString(currentRoot.resolve(".lizzie-portable"), "portable");
+    Path currentData = Files.createDirectories(currentRoot.resolve("user-data"));
+    JSONObject custom = freshPortableConfig();
+    custom
+        .getJSONObject("leelaz")
+        .put(
+            "engine-settings-list",
+            new JSONArray()
+                .put(
+                    new JSONObject()
+                        .put("name", "My External KataGo")
+                        .put("command", "D:/KataGo/katago.exe gtp -model D:/models/my.bin.gz")));
+    Files.writeString(currentData.resolve("config.txt"), custom.toString(2));
+
+    Config.prepareWindowsPortableWorkDirWithSourcesForTests(currentRoot, previousData);
+
+    JSONObject preserved = new JSONObject(Files.readString(currentData.resolve("config.txt")));
+    assertEquals(
+        "My External KataGo",
+        preserved
+            .getJSONObject("leelaz")
+            .getJSONArray("engine-settings-list")
+            .getJSONObject(0)
+            .getString("name"));
+    assertFalse(Files.exists(currentData.resolve("config.before-portable-recovery.txt")));
+  }
+
+  @Test
   void defaultConfigHidesBlunderBarWhileKeepingAutoQuickAnalyzeOnLoad() throws Exception {
     Path tempRoot = Files.createTempDirectory("lizzie-config-default-ui");
     Config config = ConfigTestHelper.createForTests(tempRoot);
@@ -46,6 +243,52 @@ public class ConfigBundledKataGoDefaultsTest {
     assertFalse(ui.getBoolean("show-blunder-bar"));
     assertTrue(ui.getBoolean("auto-quick-analyze-on-load"));
     assertFalse(ui.getBoolean("quick-analysis-lightweight-model-enabled"));
+  }
+
+  @Test
+  void configSchemaRepairKeepsExistingEngineSettings() throws Exception {
+    Path tempRoot = Files.createTempDirectory("lizzie-config-schema-repair");
+    Config config = ConfigTestHelper.createForTests(tempRoot);
+    JSONObject customEngine =
+        new JSONObject()
+            .put("name", "External KataGo")
+            .put("command", "D:/KataGo/katago.exe gtp -model D:/models/custom.bin.gz");
+    JSONObject existingLeelaz =
+        new JSONObject()
+            .put("engine-settings-list", new JSONArray().put(customEngine))
+            .put("analysis-engine-ssh-info", "legacy-invalid-value");
+    JSONObject existing =
+        new JSONObject().put("ui", new JSONObject()).put("leelaz", existingLeelaz);
+    JSONObject defaults =
+        new JSONObject()
+            .put("ui", new JSONObject().put("show-status", true))
+            .put(
+                "leelaz",
+                new JSONObject()
+                    .put("analysis-engine-ssh-info", new JSONObject().put("useJavaSSH", false)));
+
+    assertTrue(config.mergeDefaults(existing, defaults));
+
+    assertEquals(
+        "External KataGo",
+        existingLeelaz.getJSONArray("engine-settings-list").getJSONObject(0).getString("name"));
+    assertFalse(existingLeelaz.getJSONObject("analysis-engine-ssh-info").getBoolean("useJavaSSH"));
+    assertTrue(existing.getJSONObject("ui").getBoolean("show-status"));
+  }
+
+  @Test
+  void unreadableConfigIsBackedUpBesideOriginal() throws Exception {
+    Path tempRoot = Files.createTempDirectory("lizzie-config-unreadable-backup");
+    Path configFile = tempRoot.resolve("config.txt");
+    Files.writeString(configFile, "{broken-json");
+    Method method = Config.class.getDeclaredMethod("backupUnreadableConfig", java.io.File.class);
+    method.setAccessible(true);
+
+    method.invoke(null, configFile.toFile());
+
+    Path backup = tempRoot.resolve("config.txt.unreadable-backup");
+    assertTrue(Files.isRegularFile(backup));
+    assertEquals("{broken-json", Files.readString(backup));
   }
 
   @Test
@@ -528,6 +771,57 @@ public class ConfigBundledKataGoDefaultsTest {
     Method method = Config.class.getDeclaredMethod("hideBlunderBarDefaultOnce");
     method.setAccessible(true);
     method.invoke(config);
+  }
+
+  private static JSONObject richPortableConfig() {
+    JSONObject localEngine =
+        new JSONObject()
+            .put("name", "My KataGo")
+            .put("command", "D:/KataGo/katago.exe gtp -model D:/models/custom.bin.gz")
+            .put("isDefault", false);
+    JSONObject zhiziEngine =
+        new JSONObject()
+            .put("name", "Zhizi Cloud")
+            .put("command", RemoteComputeConfig.COMMAND_ZHIZI)
+            .put("isDefault", true);
+    JSONObject remote =
+        new JSONObject()
+            .put("provider", RemoteComputeConfig.PROVIDER_ZHIZI)
+            .put("zhizi-identifier", "saved-user")
+            .put("remember-zhizi-token", true)
+            .put("remember-zhizi-password", true);
+    JSONObject leelaz =
+        new JSONObject()
+            .put("engine-settings-list", new JSONArray().put(localEngine).put(zhiziEngine))
+            .put(RemoteComputeConfig.CONFIG_KEY, remote);
+    JSONObject ui =
+        new JSONObject()
+            .put("first-time-load", false)
+            .put("autoload-default", true)
+            .put("autoload-last", false)
+            .put("autoload-empty", false)
+            .put("default-engine", 1)
+            .put("last-engine", 1);
+    return new JSONObject().put("ui", ui).put("leelaz", leelaz);
+  }
+
+  private static JSONObject freshPortableConfig() {
+    JSONObject bundled =
+        new JSONObject()
+            .put("name", "KataGo Bundled")
+            .put(
+                "command",
+                "app/engines/katago/windows-x64/katago.exe gtp"
+                    + " -model app/weights/default.bin.gz")
+            .put("isDefault", true);
+    JSONObject leelaz = new JSONObject().put("engine-settings-list", new JSONArray().put(bundled));
+    JSONObject ui =
+        new JSONObject()
+            .put("first-time-load", false)
+            .put("autoload-default", true)
+            .put("default-engine", 0)
+            .put("last-engine", 0);
+    return new JSONObject().put("ui", ui).put("leelaz", leelaz);
   }
 
   private static void withUserDir(Path userDir, ThrowingRunnable action) throws Exception {

--- a/src/test/java/featurecat/lizzie/analysis/remote/MigratingCredentialStoreTest.java
+++ b/src/test/java/featurecat/lizzie/analysis/remote/MigratingCredentialStoreTest.java
@@ -1,0 +1,124 @@
+package featurecat.lizzie.analysis.remote;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+class MigratingCredentialStoreTest {
+  @Test
+  void legacySecretIsDeletedOnlyAfterPrimaryReadBackMatches() throws Exception {
+    MemoryStore primary = new MemoryStore("windows-dpapi");
+    MemoryStore legacy = new MemoryStore("windows-dpapi");
+    legacy.write(CredentialStore.Kind.PASSWORD, "user", "old-secret");
+    CredentialStore migrating = new MigratingCredentialStore(primary, List.of(legacy));
+
+    assertEquals(
+        "old-secret",
+        migrating.read(CredentialStore.Kind.PASSWORD, "user").orElseThrow());
+    assertEquals(
+        "old-secret", primary.read(CredentialStore.Kind.PASSWORD, "user").orElseThrow());
+    assertTrue(legacy.read(CredentialStore.Kind.PASSWORD, "user").isEmpty());
+  }
+
+  @Test
+  void failedPrimaryVerificationKeepsLegacySecretAvailable() throws Exception {
+    MemoryStore primary = new MemoryStore("windows-dpapi");
+    primary.readOverride = "different-secret";
+    MemoryStore legacy = new MemoryStore("windows-dpapi");
+    legacy.write(CredentialStore.Kind.ACCOUNT_TOKEN, "user", "old-token");
+    CredentialStore migrating = new MigratingCredentialStore(primary, List.of(legacy));
+
+    assertEquals(
+        "old-token",
+        migrating.read(CredentialStore.Kind.ACCOUNT_TOKEN, "user").orElseThrow());
+    assertEquals(
+        "old-token", legacy.read(CredentialStore.Kind.ACCOUNT_TOKEN, "user").orElseThrow());
+  }
+
+  @Test
+  void explicitWriteDoesNotDeleteLegacyWhenPrimaryCannotBeVerified() throws Exception {
+    MemoryStore primary = new MemoryStore("windows-dpapi");
+    primary.readOverride = "corrupt";
+    MemoryStore legacy = new MemoryStore("windows-dpapi");
+    legacy.write(CredentialStore.Kind.PASSWORD, "user", "legacy-password");
+    CredentialStore migrating = new MigratingCredentialStore(primary, List.of(legacy));
+
+    assertThrows(
+        IOException.class,
+        () -> migrating.write(CredentialStore.Kind.PASSWORD, "user", "new-password"));
+    assertEquals(
+        "legacy-password", legacy.read(CredentialStore.Kind.PASSWORD, "user").orElseThrow());
+  }
+
+  @Test
+  void deleteClearsPrimaryAndEveryLegacyCopy() throws Exception {
+    MemoryStore primary = new MemoryStore("windows-dpapi");
+    MemoryStore firstLegacy = new MemoryStore("windows-dpapi");
+    MemoryStore secondLegacy = new MemoryStore("windows-dpapi");
+    for (MemoryStore store : List.of(primary, firstLegacy, secondLegacy)) {
+      store.write(CredentialStore.Kind.ACCOUNT_TOKEN, "user", "token");
+    }
+    CredentialStore migrating =
+        new MigratingCredentialStore(primary, List.of(firstLegacy, secondLegacy));
+
+    migrating.delete(CredentialStore.Kind.ACCOUNT_TOKEN, "user");
+
+    assertFalse(primary.read(CredentialStore.Kind.ACCOUNT_TOKEN, "user").isPresent());
+    assertFalse(firstLegacy.read(CredentialStore.Kind.ACCOUNT_TOKEN, "user").isPresent());
+    assertFalse(secondLegacy.read(CredentialStore.Kind.ACCOUNT_TOKEN, "user").isPresent());
+  }
+
+  private static final class MemoryStore implements CredentialStore {
+    private final String backend;
+    private final Map<Kind, Map<String, String>> secrets = new EnumMap<>(Kind.class);
+    private boolean available = true;
+    private String readOverride;
+
+    MemoryStore(String backend) {
+      this.backend = backend;
+    }
+
+    @Override
+    public String backendName() {
+      return backend;
+    }
+
+    @Override
+    public boolean isAvailable() {
+      return available;
+    }
+
+    @Override
+    public Optional<String> read(Kind kind, String account) {
+      String stored = secrets.getOrDefault(kind, Map.of()).get(account);
+      if (readOverride != null && stored != null) {
+        return Optional.of(readOverride);
+      }
+      return Optional.ofNullable(stored);
+    }
+
+    @Override
+    public void write(Kind kind, String account, String secret) throws IOException {
+      if (!available) {
+        throw new IOException("unavailable");
+      }
+      secrets.computeIfAbsent(kind, ignored -> new java.util.HashMap<>()).put(account, secret);
+    }
+
+    @Override
+    public void delete(Kind kind, String account) {
+      Map<String, String> values = secrets.get(kind);
+      if (values != null) {
+        values.remove(account);
+      }
+    }
+  }
+}

--- a/src/test/java/featurecat/lizzie/analysis/remote/RemoteComputeConfigTest.java
+++ b/src/test/java/featurecat/lizzie/analysis/remote/RemoteComputeConfigTest.java
@@ -27,6 +27,37 @@ import org.junit.jupiter.api.Test;
 
 class RemoteComputeConfigTest {
   @Test
+  void windowsCredentialsUsePerUserAppDataInsteadOfPortableWorkDirectory() {
+    Path directory =
+        RemoteComputeConfig.credentialDirectoryForTests(
+            "Windows 11", Map.of("APPDATA", "/users/test/AppData/Roaming"), "/users/test");
+
+    assertEquals(
+        Path.of("/users/test/AppData/Roaming", "LizzieYzy Next", "secure-credentials")
+            .toAbsolutePath()
+            .normalize(),
+        directory);
+  }
+
+  @Test
+  void windowsCredentialsFallBackToUserRoamingProfileWhenAppDataIsUnavailable() {
+    Path directory =
+        RemoteComputeConfig.credentialDirectoryForTests(
+            "Windows 11", Map.of(), "/users/test");
+
+    assertEquals(
+        Path.of(
+                "/users/test",
+                "AppData",
+                "Roaming",
+                "LizzieYzy Next",
+                "secure-credentials")
+            .toAbsolutePath()
+            .normalize(),
+        directory);
+  }
+
+  @Test
   void displayNameIncludesZhiziGpuType() {
     withResourceBundle(
         AppLocale.SIMPLIFIED_CHINESE.loadBundle(),


### PR DESCRIPTION
## Summary

- restores saved engine configurations when a Windows portable update starts with a newly generated `user-data/config.txt`
- keeps ordinary portable settings and user data in the application folder
- moves Zhizi password and token storage to `%APPDATA%/LizzieYzy Next/secure-credentials` using the current Windows user DPAPI protection
- migrates legacy portable DPAPI blobs transactionally: write, read back, compare, then delete the old copy
- preserves the legacy credential when system-store migration fails so login is not lost
- discovers prior sibling portable folders, shared Windows data locations, and legacy user directories
- repairs historical JSON schema mismatches field-by-field instead of resetting the entire configuration

Closes #228.

感谢 @semanym 对便携版凭据安全边界和升级兼容问题的提醒。

## Validation

- `git diff --check`
- targeted config and credential migration tests: 60 passed, 0 failed
- full headless suite: 2058 passed, 0 failed, 5 platform skips
- `mvn -B -Dfmt.skip=true -Djava.awt.headless=true -DskipTests package`: passed
- shaded jar generated successfully

## Windows acceptance required

Please verify on a real Windows machine before merging:

1. Keep an older portable package beside the new package, with custom engines and Zhizi remember-login/password enabled.
2. Start the new package and confirm the custom engine list, default/last engine choice, Zhizi provider, and remembered login are restored.
3. Confirm password/token are stored under `%APPDATA%/LizzieYzy Next/secure-credentials`, remain DPAPI-protected, and no longer remain in the portable folder after verified migration.
4. Make the system destination temporarily unwritable and confirm the old protected credential remains usable and is not deleted.
5. Restart and confirm the selected local/remote provider follows the saved setting.
6. Confirm `config.txt`, logs, diagnostics, and the portable directory contain no plaintext or reversibly encoded password/token.
7. Verify at 100%, 150%, and 200% display scaling.

## Scope

This PR does not change portable storage for ordinary settings, SGFs, engines, weights, or TensorRT files.