### PR TITLE
Fix new game engine switching under retained mode

### DIFF
--- a/src/main/java/featurecat/lizzie/analysis/EngineManager.java
+++ b/src/main/java/featurecat/lizzie/analysis/EngineManager.java
@@ -2585,10 +2585,32 @@ public class EngineManager {
    * can report failure in their own status area instead of claiming that a switch succeeded.
    */
   public boolean switchEngineIfAvailable(int index, boolean isMain) {
-    return switchEngineIfAvailable(index, isMain, false);
+    return switchEngineIfAvailable(index, isMain, false, null);
+  }
+
+  /**
+   * Switches an engine as part of a UI flow that already owns the foreground engine mode.
+   *
+   * <p>The retained reservation is accepted only for the current foreground engine. It allows the
+   * same new-game flow to deepen its lifecycle reservation without weakening exclusion against any
+   * unrelated task.
+   */
+  public boolean switchEngineIfAvailable(
+      int index,
+      boolean isMain,
+      Leelaz.EngineModeReservation retainedForegroundReservation) {
+    return switchEngineIfAvailable(index, isMain, true, retainedForegroundReservation);
   }
 
   private boolean switchEngineIfAvailable(int index, boolean isMain, boolean showConflict) {
+    return switchEngineIfAvailable(index, isMain, showConflict, null);
+  }
+
+  private boolean switchEngineIfAvailable(
+      int index,
+      boolean isMain,
+      boolean showConflict,
+      Leelaz.EngineModeReservation retainedForegroundReservation) {
     if (engineList == null || index < 0 || index >= engineList.size()) {
       return false;
     }
@@ -2596,10 +2618,23 @@ public class EngineManager {
       return false;
     }
     Leelaz currentForegroundEngine = Lizzie.leelaz;
+    Object retainedLifecycleOwner = null;
+    if (retainedForegroundReservation != null) {
+      retainedLifecycleOwner =
+          retainedForegroundReservation.lifecycleOwnerFor(currentForegroundEngine);
+      if (!isMain || currentForegroundEngine == null || retainedLifecycleOwner == null) {
+        if (showConflict) {
+          showForegroundEngineLeaseInUse();
+        }
+        return false;
+      }
+    }
     boolean foregroundActivation = isMain && isEmpty && currentEngineNo < 0;
     PreparedEngineSwitch preparedSwitch;
     try {
-      preparedSwitch = prepareEngineSwitch(index, isMain, false, foregroundActivation);
+      preparedSwitch =
+          prepareEngineSwitch(
+              index, isMain, false, foregroundActivation, retainedLifecycleOwner);
     } catch (Leelaz.ExactSnapshotRestoreAdmissionException conflict) {
       if (showConflict) {
         showForegroundEngineLeaseInUse();
@@ -2935,6 +2970,15 @@ public class EngineManager {
 
   private PreparedEngineSwitch prepareEngineSwitch(
       int index, boolean isMain, boolean explicitRestart, boolean foregroundActivation) {
+    return prepareEngineSwitch(index, isMain, explicitRestart, foregroundActivation, null);
+  }
+
+  private PreparedEngineSwitch prepareEngineSwitch(
+      int index,
+      boolean isMain,
+      boolean explicitRestart,
+      boolean foregroundActivation,
+      Object retainedLifecycleOwner) {
     Board restoreBoard = Lizzie.board;
     if (restoreBoard == null) {
       return null;
@@ -2968,7 +3012,8 @@ public class EngineManager {
             history.getCurrentHistoryNode(),
             currentGameKomi,
             rootMoves,
-            resumePonder);
+            resumePonder,
+            retainedLifecycleOwner);
     float targetKomi =
         !isMain || history.getGameInfo().changedKomi || lifecycleRestore.exactRestore.isPresent()
             ? (float) currentGameKomi
@@ -3197,10 +3242,30 @@ public class EngineManager {
         Double komi,
         ArrayList<Movelist> rootMoves,
         boolean resumePonder) {
+      return capture(
+          previousEngine,
+          targetEngine,
+          mirrorEngine,
+          historyTarget,
+          komi,
+          rootMoves,
+          resumePonder,
+          null);
+    }
+
+    private static PreparedLifecycleRestore capture(
+        Leelaz previousEngine,
+        Leelaz targetEngine,
+        Leelaz mirrorEngine,
+        BoardHistoryNode historyTarget,
+        Double komi,
+        ArrayList<Movelist> rootMoves,
+        boolean resumePonder,
+        Object retainedLifecycleOwner) {
       if (targetEngine == null) {
         throw new IllegalArgumentException("targetEngine");
       }
-      Object owner = new Object();
+      Object owner = retainedLifecycleOwner == null ? new Object() : retainedLifecycleOwner;
       Leelaz.ExactSnapshotRestoreAdmission admission =
           targetEngine.captureExactSnapshotRestoreAdmission(
               Leelaz.ExactSnapshotRestoreOwner.LIFECYCLE, owner, mirrorEngine);

--- a/src/main/java/featurecat/lizzie/analysis/Leelaz.java
+++ b/src/main/java/featurecat/lizzie/analysis/Leelaz.java
@@ -8697,6 +8697,12 @@ public class Leelaz {
       this.owner = owner;
     }
 
+    Object lifecycleOwnerFor(Leelaz expectedEngine) {
+      synchronized (this) {
+        return engine == expectedEngine ? owner : null;
+      }
+    }
+
     @Override
     public void close() {
       Leelaz reservedEngine;

--- a/src/main/java/featurecat/lizzie/gui/LizzieFrame.java
+++ b/src/main/java/featurecat/lizzie/gui/LizzieFrame.java
@@ -3995,7 +3995,7 @@ public class LizzieFrame extends JFrame {
       Lizzie.leelaz.togglePonder();
       isPondering = true;
     }
-    NewGameDialog newGameDialog = createNewGameDialog();
+    NewGameDialog newGameDialog = createNewGameDialog(activeNewGameModeReservation);
     newGameDialog.setVisible(true);
     boolean playerIsBlack = newGameDialog.playerIsBlack();
     newGameDialog.dispose();
@@ -4092,6 +4092,24 @@ public class LizzieFrame extends JFrame {
 
   protected NewGameDialog createNewGameDialog() {
     return new NewGameDialog(this);
+  }
+
+  private transient Leelaz.EngineModeReservation activeNewGameModeReservation;
+
+  protected void startNewGameReserved(Leelaz.EngineModeReservation reservation) {
+    Leelaz.EngineModeReservation previousReservation = activeNewGameModeReservation;
+    activeNewGameModeReservation = reservation;
+    try {
+      startNewGameReserved();
+    } finally {
+      activeNewGameModeReservation = previousReservation;
+    }
+  }
+
+  protected NewGameDialog createNewGameDialog(Leelaz.EngineModeReservation reservation) {
+    NewGameDialog dialog = createNewGameDialog();
+    dialog.setRetainedEngineModeReservation(reservation);
+    return dialog;
   }
 
   protected void showForegroundEngineLeaseConflict() {
@@ -13997,7 +14015,7 @@ public class LizzieFrame extends JFrame {
   private void startRetainedEngineMode(RetainedEngineModeTarget target) {
     Leelaz currentForegroundEngine = target.engine;
     if (currentForegroundEngine == null) {
-      target.runWithoutTracking();
+      target.runWithoutTracking(null);
       return;
     }
     Leelaz.TrackingHandoffClaim claim = currentForegroundEngine.claimTrackingHandoff(target);
@@ -14014,7 +14032,7 @@ public class LizzieFrame extends JFrame {
       return;
     }
     try {
-      target.runWithoutTracking();
+      target.runWithoutTracking(reservation);
     } finally {
       reservation.close();
     }
@@ -14127,7 +14145,7 @@ public class LizzieFrame extends JFrame {
               return false;
             }
             try {
-              runAction();
+              runAction(reservation);
             } finally {
               reservation.close();
             }
@@ -14145,16 +14163,16 @@ public class LizzieFrame extends JFrame {
       }
     }
 
-    private void runWithoutTracking() {
+    private void runWithoutTracking(Leelaz.EngineModeReservation reservation) {
       if (settled.compareAndSet(false, true)) {
-        runAction();
+        runAction(reservation);
       }
     }
 
-    private void runAction() {
+    private void runAction(Leelaz.EngineModeReservation reservation) {
       switch (action) {
         case START_NEW_GAME:
-          frame.startNewGameReserved();
+          frame.startNewGameReserved(reservation);
           break;
         case START_ANALYZE_GAME:
           frame.startAnalyzeGameDialogReserved();

--- a/src/main/java/featurecat/lizzie/gui/NewGameDialog.java
+++ b/src/main/java/featurecat/lizzie/gui/NewGameDialog.java
@@ -63,6 +63,7 @@ public class NewGameDialog extends JDialog {
   JFontComboBox<String> kataTimeComboBox;
 
   private boolean cancelled = true;
+  private Leelaz.EngineModeReservation retainedEngineModeReservation;
   public GameInfo gameInfo = new GameInfo();
 
   public NewGameDialog(Window owner) {
@@ -926,18 +927,19 @@ public class NewGameDialog extends JDialog {
       DesktopTimeControl.Mode timeMode =
           DesktopTimeControl.selectedMode(chkUseAdvTime.isSelected(), chkKataTime.isSelected());
       Leelaz selectedEngine = Lizzie.engineManager.engineList.get(engine.getSelectedIndex());
-      if (!DesktopTimeControl.submitHumanSelection(
-          Lizzie.config,
-          selectedEngine,
-          timeMode,
-          kataTimeComboBox.getSelectedIndex(),
-          chkNoTime.isSelected(),
-          Lizzie.frame::showUnsupportedWebSocketAdvancedClock)) {
+      if (DesktopTimeControl.rejectsHumanGame(
+          selectedEngine, timeMode, chkNoTime.isSelected())) {
+        Lizzie.frame.showUnsupportedWebSocketAdvancedClock();
         return;
       }
+      if (EngineManager.currentEngineNo != engine.getSelectedIndex()
+          && !Lizzie.engineManager.switchEngineIfAvailable(
+              engine.getSelectedIndex(), true, retainedEngineModeReservation)) {
+        return;
+      }
+      DesktopTimeControl.commitHumanSelection(
+          Lizzie.config, timeMode, kataTimeComboBox.getSelectedIndex());
       Lizzie.frame.isPlayingAgainstLeelaz = false;
-      if (EngineManager.currentEngineNo != engine.getSelectedIndex())
-        Lizzie.engineManager.switchEngine(engine.getSelectedIndex(), true);
       double komi = 7.5;
       int handicap = 0;
       try {
@@ -1047,5 +1049,9 @@ public class NewGameDialog extends JDialog {
 
   public boolean isCancelled() {
     return cancelled;
+  }
+
+  void setRetainedEngineModeReservation(Leelaz.EngineModeReservation reservation) {
+    retainedEngineModeReservation = reservation;
   }
 }

--- a/src/test/java/featurecat/lizzie/analysis/EngineManagerLifecycleReservationTest.java
+++ b/src/test/java/featurecat/lizzie/analysis/EngineManagerLifecycleReservationTest.java
@@ -1882,6 +1882,78 @@ class EngineManagerLifecycleReservationTest {
   }
 
   @Test
+  void retainedNewGameReservationCanBeReusedForTheSameForegroundSwitch() throws Exception {
+    Leelaz previousEngine = Lizzie.leelaz;
+    Board previousBoard = Lizzie.board;
+    Config previousConfig = Lizzie.config;
+    boolean previousEmpty = EngineManager.isEmpty;
+    int previousEngineNo = EngineManager.currentEngineNo;
+    Leelaz current = new Leelaz("");
+    Leelaz target = new Leelaz("");
+    DeferredSwitchEngineManager manager = new DeferredSwitchEngineManager(List.of(current, target));
+    Leelaz.EngineModeReservation retainedReservation = null;
+    try {
+      Config config = allocate(Config.class);
+      config.extraMode = ExtraMode.Normal;
+      Lizzie.config = config;
+      Lizzie.board = preparedRestoreBoard();
+      Lizzie.leelaz = current;
+      EngineManager.isEmpty = false;
+      EngineManager.currentEngineNo = 0;
+      retainedReservation = current.beginEngineModeReservation();
+      assertNotNull(retainedReservation);
+
+      assertTrue(manager.switchEngineIfAvailable(1, true, retainedReservation));
+
+      assertEquals(1, manager.switchCount);
+      assertTrue(current.hasExclusiveGtpWorkInProgress());
+      assertTrue(target.hasExclusiveGtpWorkInProgress());
+      manager.afterSync.run();
+      assertTrue(
+          current.hasExclusiveGtpWorkInProgress(),
+          "the retained new-game reservation must remain active until its dialog flow exits");
+      assertFalse(target.hasExclusiveGtpWorkInProgress());
+    } finally {
+      if (manager.afterSync != null) {
+        manager.afterSync.run();
+      }
+      if (retainedReservation != null) {
+        retainedReservation.close();
+      }
+      Lizzie.leelaz = previousEngine;
+      Lizzie.board = previousBoard;
+      Lizzie.config = previousConfig;
+      EngineManager.isEmpty = previousEmpty;
+      EngineManager.currentEngineNo = previousEngineNo;
+    }
+  }
+
+  @Test
+  void retainedReservationFromAnotherEngineCannotBypassSwitchExclusion() throws Exception {
+    Leelaz previousEngine = Lizzie.leelaz;
+    Leelaz current = new Leelaz("");
+    Leelaz target = new Leelaz("");
+    Leelaz unrelated = new Leelaz("");
+    DeferredSwitchEngineManager manager = new DeferredSwitchEngineManager(List.of(current, target));
+    Leelaz.EngineModeReservation unrelatedReservation = unrelated.beginEngineModeReservation();
+    try {
+      Lizzie.leelaz = current;
+
+      assertFalse(manager.switchEngineIfAvailable(1, true, unrelatedReservation));
+
+      assertEquals(1, manager.conflictCount);
+      assertEquals(0, manager.switchCount);
+      assertFalse(current.hasExclusiveGtpWorkInProgress());
+      assertFalse(target.hasExclusiveGtpWorkInProgress());
+    } finally {
+      if (unrelatedReservation != null) {
+        unrelatedReservation.close();
+      }
+      Lizzie.leelaz = previousEngine;
+    }
+  }
+
+  @Test
   void switchReservesDistinctTargetBeforeTouchingCurrentOwner() throws Exception {
     Leelaz previousEngine = Lizzie.leelaz;
     List<String> reservationOrder = new java.util.ArrayList<>();


### PR DESCRIPTION
## Summary

- allows the new-game flow to reuse its existing foreground engine reservation when switching the selected engine
- keeps unrelated exclusive engine tasks isolated and unable to bypass the lifecycle lock
- validates the engine switch before committing game/time settings or closing the dialog
- preserves the retained reservation until the new-game flow exits

Closes #225.

感谢 @semanym 的清晰反馈和复现信息。

## Validation

- `git diff --check`
- targeted lifecycle/UI tests: 142 passed, 0 failed
- full headless suite: 2046 passed, 0 failed, 5 platform skips
- `mvn -B -Dfmt.skip=true -Djava.awt.headless=true -DskipTests package`: passed
- shaded jar generated successfully

## Windows acceptance required

Please verify on a real Windows machine before merging:

1. Open New Game while another configured local engine is selected.
2. Change the engine in the dialog and confirm the switch succeeds without the exclusive-task warning.
3. Confirm game/time settings are committed only after a successful switch.
4. Keep a genuinely unrelated exclusive task active and confirm the switch remains blocked.
5. Repeat at 100%, 150%, and 200% display scaling.

## Scope

Issue #223 is intentionally not included; it remains assigned to @qiyi71w.