### PR TITLE
Detect external KataGo GPUs independently of TensorRT

### DIFF
--- a/src/main/java/featurecat/lizzie/gui/KataGoAutoSetupDialog.java
+++ b/src/main/java/featurecat/lizzie/gui/KataGoAutoSetupDialog.java
@@ -1896,6 +1896,7 @@ public class KataGoAutoSetupDialog extends JDialog {
   }
 
   private void updateTensorRtInfo() {
+    maybeStartNvidiaGpuDetection();
     KataGoRuntimeHelper.TensorRtInstallStatus status =
         snapshot == null
             ? null
@@ -1909,10 +1910,10 @@ public class KataGoAutoSetupDialog extends JDialog {
       btnSwitchBackCuda.setToolTipText(null);
       btnSwitchBackCuda.setEnabled(false);
       updateTensorRtCacheButton();
-      updateNvidiaGpuInfo(null);
+      updateNvidiaGpuInfo();
       return;
     }
-    updateNvidiaGpuInfo(status);
+    updateNvidiaGpuInfo();
     if (!status.applicable) {
       String notApplicable = text("AutoSetup.tensorRtNotApplicable");
       setTensorRtLabel(lblTensorRtDownloadValue, notApplicable, Color.DARK_GRAY, status.detailText);
@@ -1925,7 +1926,6 @@ public class KataGoAutoSetupDialog extends JDialog {
       updateTensorRtCacheButton();
       return;
     }
-    maybeStartNvidiaGpuDetection(status);
     setTensorRtLabel(
         lblTensorRtDownloadValue,
         status.downloaded
@@ -1997,15 +1997,13 @@ public class KataGoAutoSetupDialog extends JDialog {
     label.revalidate();
   }
 
-  private void maybeStartNvidiaGpuDetection(KataGoRuntimeHelper.TensorRtInstallStatus status) {
-    if (status == null
-        || !status.applicable
-        || nvidiaGpuDetection != null
-        || nvidiaGpuDetectionRunning) {
+  private void maybeStartNvidiaGpuDetection() {
+    if (!shouldStartNvidiaGpuDetection(
+        System.getProperty("os.name", ""), nvidiaGpuDetection != null, nvidiaGpuDetectionRunning)) {
       return;
     }
     nvidiaGpuDetectionRunning = true;
-    updateNvidiaGpuInfo(status);
+    updateNvidiaGpuInfo();
     Thread worker =
         new Thread(
             () -> {
@@ -2022,23 +2020,32 @@ public class KataGoAutoSetupDialog extends JDialog {
     worker.start();
   }
 
-  private void updateNvidiaGpuInfo(KataGoRuntimeHelper.TensorRtInstallStatus status) {
+  static boolean shouldStartNvidiaGpuDetection(
+      String osName, boolean detectionAvailable, boolean detectionRunning) {
+    return osName != null
+        && osName.toLowerCase(Locale.ROOT).contains("win")
+        && !detectionAvailable
+        && !detectionRunning;
+  }
+
+  private void updateNvidiaGpuInfo() {
     if (nvidiaGpuDetectionRunning) {
       lblNvidiaGpuValue.setText(text("AutoSetup.gpuDetecting"));
       lblNvidiaGpuValue.setToolTipText(null);
       lblNvidiaGpuValue.setForeground(TEXT_SECONDARY);
       return;
     }
-    if (status == null || status.gpuDetection == null) {
+    if (nvidiaGpuDetection == null || !nvidiaGpuDetection.detected) {
       lblNvidiaGpuValue.setText(text("AutoSetup.gpuDetectNotFound"));
       lblNvidiaGpuValue.setToolTipText(null);
       lblNvidiaGpuValue.setForeground(Color.DARK_GRAY);
       return;
     }
-    String summary = status.gpuDetection.summaryText;
+    String summary = nvidiaGpuDetection.summaryText;
     lblNvidiaGpuValue.setText(compactInfoText(summary, GPU_INFO_TEXT_LENGTH));
     lblNvidiaGpuValue.setToolTipText(summary);
-    lblNvidiaGpuValue.setForeground(tensorRtGpuStatusColor(status.gpuRecommendation));
+    lblNvidiaGpuValue.setForeground(
+        tensorRtGpuStatusColor(nvidiaGpuDetection.recommendation));
   }
 
   private Color tensorRtGpuStatusColor(NvidiaGpuDetector.TensorRtRecommendation recommendation) {

--- a/src/test/java/featurecat/lizzie/gui/KataGoAutoSetupDialogLayoutTest.java
+++ b/src/test/java/featurecat/lizzie/gui/KataGoAutoSetupDialogLayoutTest.java
@@ -24,6 +24,14 @@ class KataGoAutoSetupDialogLayoutTest {
   }
 
   @Test
+  void windowsGpuDetectionDoesNotDependOnTensorRtInstallEligibility() {
+    assertTrue(KataGoAutoSetupDialog.shouldStartNvidiaGpuDetection("Windows 11", false, false));
+    assertFalse(KataGoAutoSetupDialog.shouldStartNvidiaGpuDetection("Windows 11", true, false));
+    assertFalse(KataGoAutoSetupDialog.shouldStartNvidiaGpuDetection("Windows 11", false, true));
+    assertFalse(KataGoAutoSetupDialog.shouldStartNvidiaGpuDetection("Mac OS X", false, false));
+  }
+
+  @Test
   void sidebarRendererFontDoesNotGrowAcrossRepaints() {
     Font listFont = new Font(Font.DIALOG, Font.PLAIN, 13);
 


### PR DESCRIPTION
## Summary

- starts Windows NVIDIA detection independently of TensorRT install eligibility
- shows GPU name, Compute Capability, driver, memory, and recommendation for externally configured KataGo engines
- keeps TensorRT installation eligibility and package restrictions unchanged
- caches the detection result and preserves the existing explicit refresh behavior

Closes #219.

感谢 @qiyi71w 提交这个边界清楚、很有价值的问题。

## Validation

- `git diff --check`
- targeted KataGo setup layout tests: 20 passed, 0 failed
- full headless suite: 2045 passed, 0 failed, 5 platform skips
- `mvn -B -Dfmt.skip=true -Djava.awt.headless=true -DskipTests package`: passed
- shaded jar generated successfully

## Windows acceptance required

Please verify on a real Windows machine before merging:

1. Configure an external KataGo executable and open KataGo Auto Setup.
2. Confirm the GPU row shows GPU model, Compute Capability, driver, and VRAM.
3. Confirm Refresh re-runs detection without freezing the UI.
4. Test one NVIDIA package and one external/without-engine setup.
5. Confirm TensorRT install availability is unchanged and is not incorrectly enabled by detection alone.