### PR TITLE
Expose AI commentary and refresh Zhizi cloud models

### DIFF
--- a/src/main/java/featurecat/lizzie/analysis/remote/RemoteComputeConfig.java
+++ b/src/main/java/featurecat/lizzie/analysis/remote/RemoteComputeConfig.java
@@ -29,20 +29,20 @@ public final class RemoteComputeConfig {
   public static final String PROVIDER_CUSTOM = "custom";
   public static final String PROVIDER_LEGACY_SSH = "legacy-ssh";
   public static final String VIP_ZHIZI_ARGS =
-      "--platform all --engine-type go --gpu-type vip-share --kata-name katago-TENSORRT --kata-weight 28bnbt";
+      "--platform all --engine-type go --gpu-type vip-share --kata-name katago-TENSORRT --kata-weight 10b512t";
   public static final String DEFAULT_ZHIZI_ARGS = VIP_ZHIZI_ARGS;
   public static final String ON_DEMAND_1X_ZHIZI_ARGS =
-      "--platform all --engine-type go --gpu-type 1x --kata-name katago-TENSORRT --kata-weight 28bnbt";
+      "--platform all --engine-type go --gpu-type 1x --kata-name katago-TENSORRT --kata-weight 10b512t";
   public static final String FASTER_ZHIZI_ARGS =
-      "--platform all --engine-type go --gpu-type 3x --kata-name katago-TENSORRT --kata-weight 28bnbt";
+      "--platform all --engine-type go --gpu-type 3x --kata-name katago-TENSORRT --kata-weight 10b512t";
   public static final String FASTEST_ZHIZI_ARGS =
-      "--platform all --engine-type go --gpu-type 6x --kata-name katago-TENSORRT --kata-weight 28bnbt";
+      "--platform all --engine-type go --gpu-type 6x --kata-name katago-TENSORRT --kata-weight 10b512t";
   public static final String TWELVE_X_ZHIZI_ARGS =
-      "--platform all --engine-type go --gpu-type 12x --kata-name katago-TENSORRT --kata-weight 28bnbt";
+      "--platform all --engine-type go --gpu-type 12x --kata-name katago-TENSORRT --kata-weight 10b512t";
   public static final String TWENTY_FOUR_X_ZHIZI_ARGS =
-      "--platform all --engine-type go --gpu-type 24x --kata-name katago-TENSORRT --kata-weight 28bnbt";
+      "--platform all --engine-type go --gpu-type 24x --kata-name katago-TENSORRT --kata-weight 10b512t";
   public static final String QUICK_START_ZHIZI_ARGS =
-      "--platform all --engine-type go --gpu-type 1x --kata-name katago-CUDA --kata-weight 28bnbt";
+      "--platform all --engine-type go --gpu-type 1x --kata-name katago-CUDA --kata-weight 10b512t";
   public static final long ZHIZI_CATALOG_REFRESH_INTERVAL_MILLIS = 6L * 60L * 60L * 1000L;
 
   private static final String LEGACY_TOKEN_KEY = "zhizi-account-token";
@@ -295,7 +295,10 @@ public final class RemoteComputeConfig {
   }
 
   public static boolean shouldRefreshZhiziCatalog(State state, long nowMillis) {
-    if (state == null || state.zhiziCatalogUpdatedAt <= 0L) {
+    if (state == null
+        || state.zhiziCatalog == null
+        || !state.zhiziCatalog.isServerAuthoritative()
+        || state.zhiziCatalogUpdatedAt <= 0L) {
       return true;
     }
     return nowMillis - state.zhiziCatalogUpdatedAt >= ZHIZI_CATALOG_REFRESH_INTERVAL_MILLIS;
@@ -502,11 +505,14 @@ public final class RemoteComputeConfig {
   }
 
   public static String kataWeightForArgs(String args) {
-    return optionValueForArgs(args, "--kata-weight", "28bnbt");
+    return optionValueForArgs(args, "--kata-weight", ZhiziEngineCatalog.DEFAULT_WEIGHT);
   }
 
   public static String withKataWeight(String args, String weight) {
-    String safeWeight = ZhiziEngineCatalog.isSelectableWeight(weight) ? weight.trim() : "28bnbt";
+    String safeWeight =
+        ZhiziEngineCatalog.isSelectableWeight(weight)
+            ? weight.trim()
+            : ZhiziEngineCatalog.DEFAULT_WEIGHT;
     return withOptionValue(
         args == null || args.trim().isEmpty() ? DEFAULT_ZHIZI_ARGS : args,
         "--kata-weight",

--- a/src/main/java/featurecat/lizzie/analysis/remote/ZhiziEngineCatalog.java
+++ b/src/main/java/featurecat/lizzie/analysis/remote/ZhiziEngineCatalog.java
@@ -14,14 +14,13 @@ import org.json.JSONObject;
 
 /** Available Zhizi engine resources together with their discovery provenance. */
 public final class ZhiziEngineCatalog {
+  public static final String DEFAULT_WEIGHT = "10b512t";
+
   private static final Pattern SAFE_OPTION_NAME =
       Pattern.compile("[A-Za-z0-9][A-Za-z0-9._+-]{0,63}");
   private static final int MAX_DESCRIPTION_LENGTH = 180;
   private static final List<Option> CURRENT_BUILT_IN_WEIGHTS =
       List.of(
-          new Option("18bnbt", "weight for 18bnbt", DiscoverySource.OFFICIAL_DOCUMENTED),
-          new Option("28bnbt", "weight for 28bnbt", DiscoverySource.OFFICIAL_DOCUMENTED),
-          new Option("fdx", "40B NBT extra-large weight", DiscoverySource.OFFICIAL_DOCUMENTED),
           new Option(
               "20b", "20B, commonly used for handicap games", DiscoverySource.BUILT_IN_CURRENT),
           new Option(
@@ -30,11 +29,8 @@ public final class ZhiziEngineCatalog {
               "10b512t", "v1.17 medium Transformer, b10c512", DiscoverySource.BUILT_IN_CURRENT),
           new Option(
               "11b768t", "v1.17 large Transformer, b11c768", DiscoverySource.BUILT_IN_CURRENT));
-  private static final List<Option> OFFICIAL_DOCUMENTED_WEIGHTS =
-      CURRENT_BUILT_IN_WEIGHTS.stream()
-          .filter(option -> option.source == DiscoverySource.OFFICIAL_DOCUMENTED)
-          .toList();
-  private static final List<String> LEGACY_COMPATIBLE_WEIGHTS = List.of("60b", "40b");
+  private static final List<String> LEGACY_COMPATIBLE_WEIGHTS =
+      List.of("18bnbt", "28bnbt", "fdx", "60b", "40b");
 
   private final String serverVersion;
   private final String defaultWeight;
@@ -84,6 +80,24 @@ public final class ZhiziEngineCatalog {
     return false;
   }
 
+  /** Returns true only when every displayed option came from the latest server response. */
+  public boolean isServerAuthoritative() {
+    return !weights.isEmpty()
+        && weights.stream()
+            .allMatch(option -> option.source == DiscoverySource.SERVER_CAPABILITIES);
+  }
+
+  /** Keeps a requested model only while the current catalog still advertises it. */
+  public String resolveSupportedWeight(String requested) {
+    String candidate = safeName(requested);
+    for (Option option : weights) {
+      if (option.name.equalsIgnoreCase(candidate)) {
+        return option.name;
+      }
+    }
+    return defaultWeight;
+  }
+
   /**
    * Adds the most recently verified built-in baseline to old caches.
    *
@@ -114,6 +128,9 @@ public final class ZhiziEngineCatalog {
                   builtIn.source));
     }
     for (Option option : reported.values()) {
+      if (isLegacyCompatibleWeight(option.name)) {
+        continue;
+      }
       DiscoverySource source = option.source;
       if (source == DiscoverySource.OFFICIAL_DOCUMENTED) {
         source = DiscoverySource.CACHED_LEGACY;
@@ -122,11 +139,9 @@ public final class ZhiziEngineCatalog {
     }
 
     String preferred =
-        reportedDefault != null
-                && reportedDefault.source == DiscoverySource.SERVER_CAPABILITIES
-                && isSelectableWeight(defaultWeight)
+        reportedDefault != null && isCurrentBuiltInWeight(defaultWeight)
             ? canonicalKnownName(defaultWeight)
-            : "28bnbt";
+            : DEFAULT_WEIGHT;
     try {
       return new ZhiziEngineCatalog(serverVersion, preferred, merged);
     } catch (IOException impossible) {
@@ -186,18 +201,49 @@ public final class ZhiziEngineCatalog {
 
   /** Parses an authoritative catalog returned by the currently connected Zhizi service. */
   public static ZhiziEngineCatalog fromServerCapabilities(String json) throws IOException {
-    ZhiziEngineCatalog parsed = fromJson(json);
-    List<Option> confirmed = new ArrayList<>();
-    for (Option option : parsed.weights) {
-      confirmed.add(
-          new Option(option.name, option.description, DiscoverySource.SERVER_CAPABILITIES));
+    try {
+      JSONObject response = new JSONObject(json == null ? "" : json);
+      JSONArray items = response.optJSONArray("supportKataWeights");
+      List<Option> confirmed = new ArrayList<>();
+      if (items != null) {
+        for (int i = 0; i < items.length(); i++) {
+          Object rawItem = items.opt(i);
+          JSONObject item = rawItem instanceof JSONObject ? (JSONObject) rawItem : null;
+          String name =
+              safeName(
+                  item == null
+                      ? (rawItem instanceof String ? (String) rawItem : "")
+                      : item.optString("name", ""));
+          if (!name.isEmpty()) {
+            confirmed.add(
+                new Option(
+                    name,
+                    item == null ? "" : item.optString("description", ""),
+                    DiscoverySource.SERVER_CAPABILITIES));
+          }
+        }
+      }
+
+      String reportedDefault = safeName(response.optString("defaultKataWeight", ""));
+      String confirmedDefault = "";
+      for (Option option : confirmed) {
+        if (option.name.equalsIgnoreCase(reportedDefault)) {
+          confirmedDefault = option.name;
+          break;
+        }
+      }
+      return new ZhiziEngineCatalog(
+          response.optString("serverVersion", ""), confirmedDefault, confirmed);
+    } catch (IOException e) {
+      throw e;
+    } catch (RuntimeException e) {
+      throw new IOException("Zhizi engine catalog is not valid JSON.", e);
     }
-    return new ZhiziEngineCatalog(parsed.serverVersion, parsed.defaultWeight, confirmed);
   }
 
   public static ZhiziEngineCatalog fallback() {
     try {
-      return new ZhiziEngineCatalog("", "28bnbt", CURRENT_BUILT_IN_WEIGHTS);
+      return new ZhiziEngineCatalog("", DEFAULT_WEIGHT, CURRENT_BUILT_IN_WEIGHTS);
     } catch (IOException impossible) {
       throw new IllegalStateException(impossible);
     }
@@ -208,13 +254,7 @@ public final class ZhiziEngineCatalog {
   }
 
   public static boolean isDocumentedWeight(String value) {
-    String safeValue = safeName(value);
-    for (Option option : OFFICIAL_DOCUMENTED_WEIGHTS) {
-      if (option.name.equalsIgnoreCase(safeValue)) {
-        return true;
-      }
-    }
-    return false;
+    return isCurrentBuiltInWeight(value);
   }
 
   public static boolean isLegacyCompatibleWeight(String value) {

--- a/src/main/java/featurecat/lizzie/gui/AppleStyleSupport.java
+++ b/src/main/java/featurecat/lizzie/gui/AppleStyleSupport.java
@@ -85,6 +85,13 @@ public final class AppleStyleSupport {
     }
   }
 
+  static void copyButtonRole(AbstractButton source, AbstractButton target) {
+    if (source == null || target == null) {
+      return;
+    }
+    target.putClientProperty(BUTTON_ROLE, source.getClientProperty(BUTTON_ROLE));
+  }
+
   /** Keeps a purpose-built button renderer from being replaced by global theme refreshes. */
   public static void preserveCustomButtonStyle(AbstractButton button) {
     if (button != null) {

--- a/src/main/java/featurecat/lizzie/gui/Menu.java
+++ b/src/main/java/featurecat/lizzie/gui/Menu.java
@@ -5486,6 +5486,30 @@ public class Menu extends JMenuBar {
     // Math.max(Lizzie.config.allFontSize, 12));
     this.add(engineMenu2);
 
+    JFontButton aiCommentaryButton =
+        new JFontButton(resourceBundle.getString("Menu.aiCommentary"));
+    aiCommentaryButton.setName("aiCommentaryToolbarButton");
+    aiCommentaryButton.setFont(baseMenuFont.deriveFont(Font.BOLD));
+    aiCommentaryButton.setMargin(new Insets(0, 10, 0, 10));
+    AppleStyleSupport.markPrimary(aiCommentaryButton);
+    Dimension commentarySize = aiCommentaryButton.getPreferredSize();
+    aiCommentaryButton.setPreferredSize(
+        new Dimension(
+            Math.max(
+                Lizzie.config.isChinese ? Config.menuHeight * 4 : Config.menuHeight * 5,
+                commentarySize.width + 16),
+            Math.max(24, Config.menuHeight - 2)));
+    aiCommentaryButton.setToolTipText(resourceBundle.getString("Menu.aiCommentary"));
+    aiCommentaryButton
+        .getAccessibleContext()
+        .setAccessibleName(resourceBundle.getString("Menu.aiCommentary"));
+    aiCommentaryButton
+        .getAccessibleContext()
+        .setAccessibleDescription(resourceBundle.getString("Teacher.subtitle"));
+    aiCommentaryButton.addActionListener(event -> TeacherDialog.show(Lizzie.frame));
+    this.add(Box.createHorizontalStrut(6));
+    this.add(aiCommentaryButton);
+
     playing = new ImageIcon();
     try {
       playing.setImage(ImageIO.read(getClass().getResourceAsStream("/assets/playing.png")));

--- a/src/main/java/featurecat/lizzie/gui/RemoteComputeDialog.java
+++ b/src/main/java/featurecat/lizzie/gui/RemoteComputeDialog.java
@@ -162,7 +162,7 @@ public class RemoteComputeDialog extends JDialog {
   private Component resetPasswordRowGap;
   private Component resetConfirmPasswordRowGap;
   private Component fastLoginHintGap;
-  private JLabel loggedInAccountLabel;
+  private JTextArea loggedInAccountLabel;
   private JLabel membershipLabel;
   private JLabel balanceLabel;
   private JLabel accountActivityLabel;
@@ -263,19 +263,13 @@ public class RemoteComputeDialog extends JDialog {
   }
 
   private JPanel buildZhiziPage() {
-    JPanel page = transparent(new GridBagLayout());
-    GridBagConstraints gbc = new GridBagConstraints();
-    gbc.gridy = 0;
-    gbc.fill = GridBagConstraints.BOTH;
-    gbc.weighty = 1;
-    gbc.insets = new Insets(0, 0, 0, 18);
-    gbc.gridx = 0;
-    gbc.weightx = 0.52;
-    page.add(buildZhiziLoginCard(), gbc);
-    gbc.gridx = 1;
-    gbc.weightx = 0.48;
-    gbc.insets = new Insets(0, 0, 0, 0);
-    page.add(buildZhiziActionCard(), gbc);
+    return createTwoColumnPage(buildZhiziLoginCard(), buildZhiziActionCard());
+  }
+
+  static JPanel createTwoColumnPage(JPanel left, JPanel right) {
+    JPanel page = transparent(new GridLayout(1, 2, 18, 0));
+    page.add(left);
+    page.add(right);
     return page;
   }
 
@@ -349,7 +343,7 @@ public class RemoteComputeDialog extends JDialog {
     loggedInPanel.add(loggedInTitle);
     loggedInPanel.add(Box.createVerticalStrut(10));
     loggedInAccountLabel =
-        smallText(
+        wrappedAccountText(
             text(
                 "RemoteCompute.loginSavedNoPassword",
                 "This login is saved. The password is not stored."));
@@ -407,20 +401,7 @@ public class RemoteComputeDialog extends JDialog {
   }
 
   private JPanel buildCustomPage() {
-    JPanel page = transparent(new GridBagLayout());
-    GridBagConstraints gbc = new GridBagConstraints();
-    gbc.gridy = 0;
-    gbc.fill = GridBagConstraints.BOTH;
-    gbc.weighty = 1;
-    gbc.insets = new Insets(0, 0, 0, 18);
-    gbc.gridx = 0;
-    gbc.weightx = 0.55;
-    page.add(buildCustomConnectCard(), gbc);
-    gbc.gridx = 1;
-    gbc.weightx = 0.45;
-    gbc.insets = new Insets(0, 0, 0, 0);
-    page.add(buildCustomActionCard(), gbc);
-    return page;
+    return createTwoColumnPage(buildCustomConnectCard(), buildCustomActionCard());
   }
 
   private JPanel buildCustomConnectCard() {
@@ -1073,22 +1054,22 @@ public class RemoteComputeDialog extends JDialog {
 
   private String selectedWeightName() {
     Object selected = weightBox.getSelectedItem();
-    return selected instanceof WeightItem ? ((WeightItem) selected).name : "28bnbt";
+    return selected instanceof WeightItem
+        ? ((WeightItem) selected).name
+        : ZhiziEngineCatalog.DEFAULT_WEIGHT;
   }
 
   private void populateWeightOptions(ZhiziEngineCatalog catalog, String preferredWeight) {
     ZhiziEngineCatalog safeCatalog =
         catalog == null ? ZhiziEngineCatalog.fallback() : catalog.withDocumentedWeights();
-    String preferred =
+    String requested =
         ZhiziEngineCatalog.isSelectableWeight(preferredWeight)
             ? preferredWeight.trim()
             : safeCatalog.defaultWeight();
+    String preferred = safeCatalog.resolveSupportedWeight(requested);
     updatingWeightOptions = true;
     try {
       weightBox.removeAllItems();
-      if (!safeCatalog.containsWeight(preferred)) {
-        weightBox.addItem(WeightItem.preserved(preferred));
-      }
       for (ZhiziEngineCatalog.Option option : safeCatalog.weights()) {
         boolean preferredOption = option.name().equalsIgnoreCase(preferred);
         boolean confirmedOption =
@@ -1165,15 +1146,26 @@ public class RemoteComputeDialog extends JDialog {
             try {
               ZhiziEngineCatalog refreshed = get();
               RemoteComputeConfig.State latest = RemoteComputeConfig.load();
+              boolean retiredSelection = !refreshed.containsWeight(preferredWeight);
+              String resolvedWeight = refreshed.resolveSupportedWeight(preferredWeight);
               latest.zhiziCatalog = refreshed;
               latest.zhiziCatalogUpdatedAt = System.currentTimeMillis();
+              latest.zhiziArgs =
+                  RemoteComputeConfig.withKataWeight(latest.zhiziArgs, resolvedWeight);
               RemoteComputeConfig.save(latest);
-              populateWeightOptions(refreshed, preferredWeight);
+              populateWeightOptions(refreshed, resolvedWeight);
               updateStatus(
-                  format(
-                      "RemoteCompute.status.weightsRefreshed",
-                      "Refreshed {0} models from Zhizi.",
-                      refreshed.weights().size()),
+                  retiredSelection
+                      ? format(
+                          "RemoteCompute.status.weightsRefreshedRetired",
+                          "Refreshed {0} models from Zhizi. {1} is no longer available; switched to {2}.",
+                          refreshed.weights().size(),
+                          preferredWeight,
+                          RemoteComputeConfig.displayNameForZhiziWeight(resolvedWeight))
+                      : format(
+                          "RemoteCompute.status.weightsRefreshed",
+                          "Refreshed {0} models from Zhizi.",
+                          refreshed.weights().size()),
                   true);
             } catch (Exception error) {
               Throwable cause = error.getCause() == null ? error : error.getCause();
@@ -1201,7 +1193,7 @@ public class RemoteComputeDialog extends JDialog {
 
   private void selectOfficialBaseline() {
     for (int i = 0; i < weightBox.getItemCount(); i++) {
-      if ("28bnbt".equalsIgnoreCase(weightBox.getItemAt(i).name)) {
+      if (ZhiziEngineCatalog.DEFAULT_WEIGHT.equalsIgnoreCase(weightBox.getItemAt(i).name)) {
         weightBox.setSelectedIndex(i);
         updateStatus(
             text(
@@ -2215,6 +2207,20 @@ public class RemoteComputeDialog extends JDialog {
     return label;
   }
 
+  private JTextArea wrappedAccountText(String value) {
+    JTextArea area = new JTextArea(value, 2, 28);
+    area.setEditable(false);
+    area.setFocusable(false);
+    area.setOpaque(false);
+    area.setLineWrap(true);
+    area.setWrapStyleWord(true);
+    area.setForeground(MUTED);
+    area.setFont(area.getFont().deriveFont(Font.BOLD, 13F));
+    area.setBorder(null);
+    area.setMaximumSize(new Dimension(Integer.MAX_VALUE, 52));
+    return area;
+  }
+
   private JTextArea multilineHint(String value) {
     JTextArea area = new JTextArea(value, 2, 24);
     area.setEditable(false);
@@ -2345,10 +2351,6 @@ public class RemoteComputeDialog extends JDialog {
       this.description = description == null ? "" : description.replaceAll("\\s+", " ").trim();
       this.defaultOption = defaultOption;
       this.source = source == null ? ZhiziEngineCatalog.DiscoverySource.CACHED_LEGACY : source;
-    }
-
-    static WeightItem preserved(String name) {
-      return new WeightItem(name, "", false, ZhiziEngineCatalog.DiscoverySource.USER_PRESERVED);
     }
 
     boolean isConfirmed() {

--- a/src/main/java/featurecat/lizzie/gui/RemoteComputeDialog.java
+++ b/src/main/java/featurecat/lizzie/gui/RemoteComputeDialog.java
@@ -381,6 +381,7 @@ public class RemoteComputeDialog extends JDialog {
     loggedInPanel.add(fullWidth(paymentButton, 44));
     loggedInPanel.add(Box.createVerticalStrut(10));
     loggedInPanel.add(fullWidth(logoutButton, 48));
+    stretchHorizontally(loggedInPanel);
     loggedInPanel.setVisible(false);
     showAccountLoadingState();
     card.add(loggedInPanel);
@@ -2219,6 +2220,11 @@ public class RemoteComputeDialog extends JDialog {
     area.setBorder(null);
     area.setMaximumSize(new Dimension(Integer.MAX_VALUE, 52));
     return area;
+  }
+
+  static void stretchHorizontally(JComponent component) {
+    Dimension preferred = component.getPreferredSize();
+    component.setMaximumSize(new Dimension(Integer.MAX_VALUE, preferred.height));
   }
 
   private JTextArea multilineHint(String value) {

--- a/src/main/java/featurecat/lizzie/gui/WindowMenuStrip.java
+++ b/src/main/java/featurecat/lizzie/gui/WindowMenuStrip.java
@@ -17,6 +17,7 @@ import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.util.ArrayList;
 import java.util.List;
+import javax.swing.AbstractButton;
 import javax.swing.JButton;
 import javax.swing.JMenu;
 import javax.swing.JMenuBar;
@@ -33,6 +34,7 @@ public class WindowMenuStrip extends JPanel {
   private static final long SAME_MENU_REOPEN_SUPPRESS_MS = 250L;
   private final JMenuBar sourceMenuBar;
   private final List<MenuButton> menuButtons = new ArrayList<>();
+  private final List<ActionButton> actionButtons = new ArrayList<>();
   private static final String POPUP_LISTENER_KEY = "lizzie.window-menu-strip.popup-listener";
   private JMenu recentlyHiddenMenu;
   private long recentlyHiddenAtMillis;
@@ -49,24 +51,41 @@ public class WindowMenuStrip extends JPanel {
     for (MenuButton button : menuButtons) {
       button.detach();
     }
+    for (ActionButton button : actionButtons) {
+      button.detach();
+    }
     removeAll();
     menuButtons.clear();
+    actionButtons.clear();
     if (sourceMenuBar == null) {
       return;
     }
-    int menuCount = sourceMenuBar.getMenuCount();
-    for (int i = 0; i < menuCount; i++) {
-      JMenu menu = sourceMenuBar.getMenu(i);
-      if (menu == null || !menu.isVisible()) {
+    for (java.awt.Component component : sourceMenuBar.getComponents()) {
+      if (!component.isVisible()) {
         continue;
       }
-      String text = menu.getText();
-      if (text == null || text.trim().isEmpty()) {
+      if (component instanceof JMenu) {
+        JMenu menu = (JMenu) component;
+        String text = menu.getText();
+        if (text == null || text.trim().isEmpty()) {
+          continue;
+        }
+        MenuButton button = new MenuButton(menu);
+        menuButtons.add(button);
+        add(button);
         continue;
       }
-      MenuButton button = new MenuButton(menu);
-      menuButtons.add(button);
-      add(button);
+      if (component instanceof AbstractButton) {
+        AbstractButton sourceButton = (AbstractButton) component;
+        String text = sourceButton.getText();
+        if ((text == null || text.trim().isEmpty()) && sourceButton.getIcon() == null) {
+          continue;
+        }
+        ActionButton button = new ActionButton(sourceButton);
+        actionButtons.add(button);
+        add(button);
+        button.installStyle();
+      }
     }
     revalidate();
     repaint();
@@ -76,6 +95,9 @@ public class WindowMenuStrip extends JPanel {
     Color fg = AppleStyleSupport.dialogTextColor();
     for (MenuButton b : menuButtons) {
       b.setForeground(fg);
+    }
+    for (ActionButton b : actionButtons) {
+      b.syncFromSource();
     }
   }
 
@@ -322,6 +344,74 @@ public class WindowMenuStrip extends JPanel {
       }
       g2.dispose();
       super.paintComponent(g);
+    }
+  }
+
+  private final class ActionButton extends JButton {
+    private final AbstractButton sourceButton;
+    private final PropertyChangeListener sourcePropertyListener = this::sourcePropertyChanged;
+
+    private ActionButton(AbstractButton sourceButton) {
+      this.sourceButton = sourceButton;
+      syncFromSource();
+      sourceButton.addPropertyChangeListener(sourcePropertyListener);
+      addActionListener(event -> sourceButton.doClick(0));
+    }
+
+    private void installStyle() {
+      AppleStyleSupport.copyButtonRole(sourceButton, this);
+      AppleStyleSupport.installButtonStyle(this);
+      setCursor(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR));
+    }
+
+    private void sourcePropertyChanged(PropertyChangeEvent event) {
+      String property = event.getPropertyName();
+      if ("visible".equals(property)) {
+        SwingUtilities.invokeLater(WindowMenuStrip.this::rebuild);
+        return;
+      }
+      if ("text".equals(property)
+          || "enabled".equals(property)
+          || "font".equals(property)
+          || "foreground".equals(property)
+          || "icon".equals(property)
+          || "toolTipText".equals(property)
+          || "name".equals(property)
+          || "preferredSize".equals(property)) {
+        syncFromSource();
+      }
+    }
+
+    private void syncFromSource() {
+      setText(sourceButton.getText());
+      setIcon(sourceButton.getIcon());
+      setEnabled(sourceButton.isEnabled());
+      setName(sourceButton.getName());
+      setToolTipText(sourceButton.getToolTipText());
+      if (sourceButton.getFont() != null) {
+        setFont(sourceButton.getFont());
+      }
+      Dimension preferred = sourceButton.getPreferredSize();
+      if (preferred != null) {
+        setPreferredSize(new Dimension(preferred));
+      }
+      if (getAccessibleContext() != null) {
+        String accessibleName = sourceButton.getAccessibleContext().getAccessibleName();
+        String accessibleDescription =
+            sourceButton.getAccessibleContext().getAccessibleDescription();
+        getAccessibleContext()
+            .setAccessibleName(
+                accessibleName == null || accessibleName.trim().isEmpty()
+                    ? sourceButton.getText()
+                    : accessibleName);
+        getAccessibleContext().setAccessibleDescription(accessibleDescription);
+      }
+      revalidate();
+      repaint();
+    }
+
+    private void detach() {
+      sourceButton.removePropertyChangeListener(sourcePropertyListener);
     }
   }
 }

--- a/src/main/resources/l10n/DisplayStrings.properties
+++ b/src/main/resources/l10n/DisplayStrings.properties
@@ -2749,6 +2749,7 @@ RemoteCompute.weightName.10b512t=Transformer 10B - Balanced
 RemoteCompute.weightName.11b768t=Transformer 11B - Flagship
 RemoteCompute.status.refreshingWeights=Refreshing the available Zhizi models...
 RemoteCompute.status.weightsRefreshed=Refreshed {0} models from Zhizi.
+RemoteCompute.status.weightsRefreshedRetired=Refreshed {0} models from Zhizi. {1} is no longer available; switched to {2}.
 RemoteCompute.status.weightsRefreshFailed=Could not refresh models. The saved list is still available.
 RemoteCompute.error.loginBeforeRefresh=Sign in before refreshing models.
 RemoteCompute.status.weightsDocumented=Loaded the current built-in model catalog. Sign in to refresh the latest list from Zhizi.

--- a/src/main/resources/l10n/DisplayStrings_en_US.properties
+++ b/src/main/resources/l10n/DisplayStrings_en_US.properties
@@ -2747,6 +2747,7 @@ RemoteCompute.weightName.10b512t=Transformer 10B - Balanced
 RemoteCompute.weightName.11b768t=Transformer 11B - Flagship
 RemoteCompute.status.refreshingWeights=Refreshing the available Zhizi models...
 RemoteCompute.status.weightsRefreshed=Refreshed {0} models from Zhizi.
+RemoteCompute.status.weightsRefreshedRetired=Refreshed {0} models from Zhizi. {1} is no longer available; switched to {2}.
 RemoteCompute.status.weightsRefreshFailed=Could not refresh models. The saved list is still available.
 RemoteCompute.error.loginBeforeRefresh=Sign in before refreshing models.
 RemoteCompute.status.weightsDocumented=Loaded the current built-in model catalog. Sign in to refresh the latest list from Zhizi.

--- a/src/main/resources/l10n/DisplayStrings_ja_JP.properties
+++ b/src/main/resources/l10n/DisplayStrings_ja_JP.properties
@@ -2747,6 +2747,7 @@ RemoteCompute.weightName.10b512t=Transformer 10B · バランス版
 RemoteCompute.weightName.11b768t=Transformer 11B · フラッグシップ版
 RemoteCompute.status.refreshingWeights=Zhizi の利用可能なモデルを更新しています...
 RemoteCompute.status.weightsRefreshed=Zhizi から {0} 個のモデルを更新しました。
+RemoteCompute.status.weightsRefreshedRetired=Zhizi から {0} 個のモデルを更新しました。{1} は提供終了のため、{2} に切り替えました。
 RemoteCompute.status.weightsRefreshFailed=モデルを更新できませんでした。保存済みの一覧を引き続き使用できます。
 RemoteCompute.error.loginBeforeRefresh=モデルを更新する前に Zhizi Cloud にログインしてください。
 RemoteCompute.status.weightsDocumented=現在の内蔵モデルカタログを読み込みました。ログイン後に Zhizi の最新一覧を更新できます。

--- a/src/main/resources/l10n/DisplayStrings_ko.properties
+++ b/src/main/resources/l10n/DisplayStrings_ko.properties
@@ -2747,6 +2747,7 @@ RemoteCompute.weightName.10b512t=Transformer 10B · 균형형
 RemoteCompute.weightName.11b768t=Transformer 11B · 플래그십
 RemoteCompute.status.refreshingWeights=사용 가능한 Zhizi 모델을 새로 고치는 중...
 RemoteCompute.status.weightsRefreshed=Zhizi에서 {0}개의 모델을 새로 고쳤습니다.
+RemoteCompute.status.weightsRefreshedRetired=Zhizi에서 {0}개의 모델을 새로 고쳤습니다. {1} 모델은 더 이상 제공되지 않아 {2}(으)로 변경했습니다.
 RemoteCompute.status.weightsRefreshFailed=모델을 새로 고칠 수 없습니다. 저장된 목록을 계속 사용할 수 있습니다.
 RemoteCompute.error.loginBeforeRefresh=모델을 새로 고치기 전에 Zhizi Cloud에 로그인하세요.
 RemoteCompute.status.weightsDocumented=현재 내장 모델 카탈로그를 불러왔습니다. 로그인 후 Zhizi의 최신 목록을 새로 고칠 수 있습니다.

--- a/src/main/resources/l10n/DisplayStrings_th_TH.properties
+++ b/src/main/resources/l10n/DisplayStrings_th_TH.properties
@@ -2747,6 +2747,7 @@ RemoteCompute.weightName.10b512t=Transformer 10B · รุ่นสมดุล
 RemoteCompute.weightName.11b768t=Transformer 11B · รุ่นเรือธง
 RemoteCompute.status.refreshingWeights=กำลังรีเฟรชโมเดล Zhizi ที่ใช้ได้...
 RemoteCompute.status.weightsRefreshed=รีเฟรชโมเดล {0} รายการจาก Zhizi แล้ว
+RemoteCompute.status.weightsRefreshedRetired=รีเฟรชโมเดล {0} รายการจาก Zhizi แล้ว รุ่น {1} ไม่มีให้บริการแล้ว จึงเปลี่ยนเป็น {2}
 RemoteCompute.status.weightsRefreshFailed=ไม่สามารถรีเฟรชโมเดลได้ ยังใช้รายการที่บันทึกไว้ได้
 RemoteCompute.error.loginBeforeRefresh=โปรดเข้าสู่ระบบ Zhizi Cloud ก่อนรีเฟรชโมเดล
 RemoteCompute.status.weightsDocumented=โหลดรายการโมเดลปัจจุบันที่มากับโปรแกรมแล้ว เข้าสู่ระบบเพื่อรีเฟรชรายการล่าสุดจาก Zhizi

--- a/src/main/resources/l10n/DisplayStrings_zh_CN.properties
+++ b/src/main/resources/l10n/DisplayStrings_zh_CN.properties
@@ -2747,6 +2747,7 @@ RemoteCompute.weightName.10b512t=Transformer 10B · 均衡版
 RemoteCompute.weightName.11b768t=Transformer 11B · 旗舰版
 RemoteCompute.status.refreshingWeights=正在刷新智子可用模型...
 RemoteCompute.status.weightsRefreshed=已从智子服务刷新 {0} 个可用模型。
+RemoteCompute.status.weightsRefreshedRetired=已从智子服务刷新 {0} 个可用模型。原模型 {1} 已不再提供，已切换为 {2}。
 RemoteCompute.status.weightsRefreshFailed=暂时无法刷新模型，继续使用已保存的列表。
 RemoteCompute.error.loginBeforeRefresh=请先登录智子云算力，再刷新模型列表。
 RemoteCompute.status.weightsDocumented=已加载当前内置模型目录；登录后可刷新智子服务的最新列表。

--- a/src/main/resources/l10n/DisplayStrings_zh_HK.properties
+++ b/src/main/resources/l10n/DisplayStrings_zh_HK.properties
@@ -2747,6 +2747,7 @@ RemoteCompute.weightName.10b512t=Transformer 10B · 均衡版
 RemoteCompute.weightName.11b768t=Transformer 11B · 旗艦版
 RemoteCompute.status.refreshingWeights=正在更新智子可用模型...
 RemoteCompute.status.weightsRefreshed=已從智子服務更新 {0} 個可用模型。
+RemoteCompute.status.weightsRefreshedRetired=已從智子服務更新 {0} 個可用模型。原模型 {1} 已不再提供，已切換為 {2}。
 RemoteCompute.status.weightsRefreshFailed=暫時無法更新模型，繼續使用已儲存的清單。
 RemoteCompute.error.loginBeforeRefresh=請先登入智子雲算力，再更新模型清單。
 RemoteCompute.status.weightsDocumented=已載入目前內置模型目錄；登入後可重新整理智子服務的最新清單。

--- a/src/main/resources/l10n/DisplayStrings_zh_TW.properties
+++ b/src/main/resources/l10n/DisplayStrings_zh_TW.properties
@@ -2747,6 +2747,7 @@ RemoteCompute.weightName.10b512t=Transformer 10B · 均衡版
 RemoteCompute.weightName.11b768t=Transformer 11B · 旗艦版
 RemoteCompute.status.refreshingWeights=正在重新整理智子可用模型...
 RemoteCompute.status.weightsRefreshed=已從智子服務重新整理 {0} 個可用模型。
+RemoteCompute.status.weightsRefreshedRetired=已從智子服務重新整理 {0} 個可用模型。原模型 {1} 已不再提供，已切換為 {2}。
 RemoteCompute.status.weightsRefreshFailed=暫時無法重新整理模型，繼續使用已儲存的清單。
 RemoteCompute.error.loginBeforeRefresh=請先登入智子雲算力，再重新整理模型清單。
 RemoteCompute.status.weightsDocumented=已載入目前內建模型目錄；登入後可重新整理智子服務的最新清單。

--- a/src/test/java/featurecat/lizzie/analysis/EngineManagerLifecycleReservationTest.java
+++ b/src/test/java/featurecat/lizzie/analysis/EngineManagerLifecycleReservationTest.java
@@ -2801,7 +2801,15 @@ class EngineManagerLifecycleReservationTest {
     RestartIndexLeelaz unrelated = new RestartIndexLeelaz("unrelated");
     try (RestartIndexTestEnvironment environment =
         new RestartIndexTestEnvironment(List.of(shared, unrelated), 0, 0)) {
-      environment.manager.reStartEngine();
+      // This path stops before any frame interaction. Avoid showing a real modal dialog from the
+      // Unsafe-allocated test frame, which is not a fully initialized AWT Window on Windows.
+      LizzieFrame testFrame = Lizzie.frame;
+      Lizzie.frame = null;
+      try {
+        environment.manager.reStartEngine();
+      } finally {
+        Lizzie.frame = testFrame;
+      }
 
       assertEquals(0, shared.shutdownCount);
       assertEquals(0, unrelated.shutdownCount);
@@ -3757,7 +3765,7 @@ class EngineManagerLifecycleReservationTest {
     private final UpdateForegroundLeelaz previousForegroundEngine;
     private final UpdateBoard board;
     private final EngineManager manager;
-    private final Path commandScript;
+    private final String commandPrefix;
     private final Path commandLog;
     private final Path startupGate;
     private final Path loadSgfFailure;
@@ -3769,14 +3777,12 @@ class EngineManagerLifecycleReservationTest {
       previousForegroundEngine.oriEnginename = "update-target";
       previousForegroundEngine.started = true;
       previousForegroundEngine.isLoaded = true;
-      commandScript = Files.createTempFile("lizzie-update-engine-", ".sh");
       commandLog = Files.createTempFile("lizzie-update-engine-", ".log");
       startupGate = Files.createTempFile("lizzie-update-engine-startup-", ".gate");
       loadSgfFailure = Files.createTempFile("lizzie-update-engine-loadsgf-", ".failure");
       Files.delete(loadSgfFailure);
       Files.delete(startupGate);
-      Files.writeString(commandScript, updateEngineScript());
-      assertTrue(commandScript.toFile().setExecutable(true));
+      commandPrefix = updateEngineCommandPrefix();
       board = allocate(UpdateBoard.class);
       board.startStonelist = new ArrayList<>();
       board.hasStartStone = false;
@@ -3798,13 +3804,13 @@ class EngineManagerLifecycleReservationTest {
                           new JSONObject()
                               .put(
                                   "command",
-                                  commandScript.toString()
+                                  commandPrefix
                                       + " "
-                                      + commandLog
+                                      + quoteCommandPath(commandLog)
                                       + " "
-                                      + startupGate
+                                      + quoteCommandPath(startupGate)
                                       + " "
-                                      + loadSgfFailure)
+                                      + quoteCommandPath(loadSgfFailure))
                               .put("name", "update-target")
                               .put("preload", false)
                               .put("width", targetWidth)
@@ -3852,7 +3858,6 @@ class EngineManagerLifecycleReservationTest {
         }
       }
       try {
-        Files.deleteIfExists(commandScript);
         Files.deleteIfExists(commandLog);
         Files.deleteIfExists(startupGate);
         Files.deleteIfExists(loadSgfFailure);
@@ -3882,55 +3887,22 @@ class EngineManagerLifecycleReservationTest {
       }
     }
 
-    private static String updateEngineScript() {
-      return "#!/bin/sh\n"
-          + "log=\"$1\"\n"
-          + "gate=\"$2\"\n"
-          + "loadsgf_failure=\"$3\"\n"
-          + "while IFS= read -r line; do\n"
-          + "  printf '%s\\n"
-          + "' \"$line\" >> \"$log\"\n"
-          + "  rest=\"$line\"\n"
-          + "  id=\"\"\n"
-          + "  case \"$line\" in\n"
-          + "    [0-9]*\\ *) id=\"${line%% *}\"; rest=\"${line#* }\" ;;\n"
-          + "  esac\n"
-          + "  case \"$rest\" in\n"
-          + "    loadsgf\\ *)\n"
-          + "      printf 'SGF:%s\\n"
-          + "' \"$(cat \"${rest#loadsgf }\")\" >> \"$log\"\n"
-          + "      if [ -f \"$loadsgf_failure\" ]; then\n"
-          + "        if [ -n \"$id\" ]; then printf '?%s controlled restore failure\\n"
-          + "\\n"
-          + "' \"$id\"; else printf '? controlled restore failure\\n"
-          + "\\n"
-          + "'; fi\n"
-          + "        continue\n"
-          + "      fi ;;\n"
-          + "  esac\n"
-          + "  case \"$rest\" in\n"
-          + "    name) while [ ! -f \"$gate\" ]; do sleep 0.01; done ;;\n"
-          + "  esac\n"
-          + "  if [ -n \"$id\" ]; then printf '=%s\\n"
-          + "\\n"
-          + "' \"$id\"; else\n"
-          + "    case \"$rest\" in\n"
-          + "      name) printf '= KataGo\\n"
-          + "\\n"
-          + "' ;;\n"
-          + "      version) printf '= 1.15\\n"
-          + "\\n"
-          + "' ;;\n"
-          + "      list_commands) printf '= protocol_version\\n"
-          + "\\n"
-          + "' ;;\n"
-          + "      *) printf '=\\n"
-          + "\\n"
-          + "' ;;\n"
-          + "    esac\n"
-          + "  fi\n"
-          + "  [ \"$rest\" = quit ] && exit 0\n"
-          + "done\n";
+    private static String updateEngineCommandPrefix() throws Exception {
+      String javaName = System.getProperty("os.name", "").startsWith("Windows")
+          ? "java.exe"
+          : "java";
+      Path javaExecutable = Path.of(System.getProperty("java.home"), "bin", javaName);
+      Path testClasses =
+          Path.of(UpdateEngineGtpFixture.class.getProtectionDomain().getCodeSource().getLocation().toURI());
+      return quoteCommandPath(javaExecutable)
+          + " -cp "
+          + quoteCommandPath(testClasses)
+          + " "
+          + UpdateEngineGtpFixture.class.getName();
+    }
+
+    private static String quoteCommandPath(Path path) {
+      return "\"" + path.toAbsolutePath().normalize() + "\"";
     }
   }
 

--- a/src/test/java/featurecat/lizzie/analysis/LeelazDisplayNameTest.java
+++ b/src/test/java/featurecat/lizzie/analysis/LeelazDisplayNameTest.java
@@ -80,7 +80,7 @@ class LeelazDisplayNameTest {
     try {
       Lizzie.resourceBundle = AppLocale.SIMPLIFIED_CHINESE.loadBundle();
       assertEquals(
-          "智子云算力 VIP 包月 · 28B NBT · TensorRT",
+          "智子云算力 VIP 包月 · Transformer 10B · 均衡版 · TensorRT",
           Leelaz.friendlyEngineName("智子云算力 28B TensorRT", RemoteComputeConfig.COMMAND_ZHIZI));
     } finally {
       Lizzie.resourceBundle = previous;

--- a/src/test/java/featurecat/lizzie/analysis/UpdateEngineGtpFixture.java
+++ b/src/test/java/featurecat/lizzie/analysis/UpdateEngineGtpFixture.java
@@ -1,0 +1,100 @@
+package featurecat.lizzie.analysis;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+
+/** Cross-platform fake GTP process used by engine lifecycle integration tests. */
+public final class UpdateEngineGtpFixture {
+  private UpdateEngineGtpFixture() {}
+
+  public static void main(String[] args) throws Exception {
+    if (args.length != 3) {
+      throw new IllegalArgumentException("expected log, startup gate, and loadsgf failure paths");
+    }
+    Path log = Path.of(args[0]);
+    Path startupGate = Path.of(args[1]);
+    Path loadSgfFailure = Path.of(args[2]);
+    try (BufferedReader input =
+            new BufferedReader(new InputStreamReader(System.in, StandardCharsets.UTF_8));
+        BufferedWriter output =
+            new BufferedWriter(new OutputStreamWriter(System.out, StandardCharsets.UTF_8))) {
+      String line;
+      while ((line = input.readLine()) != null) {
+        append(log, line);
+        ParsedCommand parsed = ParsedCommand.parse(line);
+        if (parsed.command.startsWith("loadsgf ")) {
+          Path sgf = Path.of(parsed.command.substring("loadsgf ".length()));
+          append(log, "SGF:" + Files.readString(sgf));
+          if (Files.isRegularFile(loadSgfFailure)) {
+            writeResponse(output, parsed.id, false, "controlled restore failure");
+            continue;
+          }
+        }
+        if ("name".equals(parsed.command)) {
+          while (!Files.isRegularFile(startupGate)) {
+            Thread.sleep(10L);
+          }
+        }
+        String body =
+            parsed.id.isEmpty()
+                ? switch (parsed.command) {
+                  case "name" -> "KataGo";
+                  case "version" -> "1.15";
+                  case "list_commands" -> "protocol_version";
+                  default -> "";
+                }
+                : "";
+        writeResponse(output, parsed.id, true, body);
+        if ("quit".equals(parsed.command)) {
+          return;
+        }
+      }
+    }
+  }
+
+  private static void append(Path log, String line) throws Exception {
+    Files.writeString(
+        log,
+        line + System.lineSeparator(),
+        StandardCharsets.UTF_8,
+        StandardOpenOption.CREATE,
+        StandardOpenOption.APPEND);
+  }
+
+  private static void writeResponse(
+      BufferedWriter output, String id, boolean success, String body) throws Exception {
+    output.write(success ? '=' : '?');
+    output.write(id);
+    if (!body.isEmpty()) {
+      output.write(' ');
+      output.write(body);
+    }
+    output.newLine();
+    output.newLine();
+    output.flush();
+  }
+
+  private static final class ParsedCommand {
+    private final String id;
+    private final String command;
+
+    private ParsedCommand(String id, String command) {
+      this.id = id;
+      this.command = command;
+    }
+
+    private static ParsedCommand parse(String line) {
+      int separator = line.indexOf(' ');
+      if (separator > 0 && line.substring(0, separator).chars().allMatch(Character::isDigit)) {
+        return new ParsedCommand(line.substring(0, separator), line.substring(separator + 1));
+      }
+      return new ParsedCommand("", line);
+    }
+  }
+}

--- a/src/test/java/featurecat/lizzie/analysis/remote/RemoteComputeConfigTest.java
+++ b/src/test/java/featurecat/lizzie/analysis/remote/RemoteComputeConfigTest.java
@@ -63,17 +63,17 @@ class RemoteComputeConfigTest {
         AppLocale.SIMPLIFIED_CHINESE.loadBundle(),
         () -> {
           assertEquals(
-              "智子云算力 VIP 包月 · 28B NBT · TensorRT",
+              "智子云算力 VIP 包月 · Transformer 10B · 均衡版 · TensorRT",
               RemoteComputeConfig.displayNameForZhiziArgs(RemoteComputeConfig.DEFAULT_ZHIZI_ARGS));
           assertEquals(
-              "智子云算力 按量 1x · 28B NBT · TensorRT",
+              "智子云算力 按量 1x · Transformer 10B · 均衡版 · TensorRT",
               RemoteComputeConfig.displayNameForZhiziArgs(
                   RemoteComputeConfig.ON_DEMAND_1X_ZHIZI_ARGS));
           assertEquals(
-              "智子云算力 按量 3x · 28B NBT · TensorRT",
+              "智子云算力 按量 3x · Transformer 10B · 均衡版 · TensorRT",
               RemoteComputeConfig.displayNameForZhiziArgs(RemoteComputeConfig.FASTER_ZHIZI_ARGS));
           assertEquals(
-              "智子云算力 VIP 包月 · 28B NBT · TensorRT",
+              "智子云算力 VIP 包月 · Transformer 10B · 均衡版 · TensorRT",
               RemoteComputeConfig.displayNameForZhiziArgs(RemoteComputeConfig.VIP_ZHIZI_ARGS));
         });
   }
@@ -140,7 +140,7 @@ class RemoteComputeConfigTest {
         RemoteComputeConfig.withKataWeight(
             RemoteComputeConfig.ON_DEMAND_1X_ZHIZI_ARGS, "60b --gpu-type 24x");
 
-    assertEquals("28bnbt", RemoteComputeConfig.kataWeightForArgs(selected));
+    assertEquals("10b512t", RemoteComputeConfig.kataWeightForArgs(selected));
     assertEquals("1x", RemoteComputeConfig.gpuTypeForArgs(selected));
 
     String futureServerModel =
@@ -150,7 +150,7 @@ class RemoteComputeConfigTest {
   }
 
   @Test
-  void zhiziCatalogCachePersistsAndExpiresAfterRefreshInterval() throws Exception {
+  void legacyZhiziCatalogPersistsButRefreshesImmediately() throws Exception {
     withConfig(
         () -> {
           ZhiziEngineCatalog catalog =
@@ -166,13 +166,53 @@ class RemoteComputeConfigTest {
           RemoteComputeConfig.save(state);
 
           RemoteComputeConfig.State restored = RemoteComputeConfig.load();
-          assertEquals("28bnbt", restored.zhiziCatalog.defaultWeight());
-          assertEquals(8, restored.zhiziCatalog.weights().size());
-          assertTrue(restored.zhiziCatalog.containsWeight("18bnbt"));
-          assertTrue(restored.zhiziCatalog.containsWeight("fdx"));
+          assertEquals("10b512t", restored.zhiziCatalog.defaultWeight());
+          assertEquals(4, restored.zhiziCatalog.weights().size());
+          assertFalse(restored.zhiziCatalog.containsWeight("18bnbt"));
+          assertFalse(restored.zhiziCatalog.containsWeight("28bnbt"));
+          assertFalse(restored.zhiziCatalog.containsWeight("fdx"));
           assertTrue(restored.zhiziCatalog.containsWeight("20b"));
           assertTrue(restored.zhiziCatalog.containsWeight("10b512t"));
           assertFalse(restored.zhiziCatalog.containsWeight("60b"));
+          assertTrue(
+              RemoteComputeConfig.shouldRefreshZhiziCatalog(
+                  restored,
+                  1_000L + RemoteComputeConfig.ZHIZI_CATALOG_REFRESH_INTERVAL_MILLIS - 1L));
+          assertTrue(
+              RemoteComputeConfig.shouldRefreshZhiziCatalog(
+                  restored, 1_000L + RemoteComputeConfig.ZHIZI_CATALOG_REFRESH_INTERVAL_MILLIS));
+        });
+  }
+
+  @Test
+  void serverConfirmedZhiziCatalogUsesRefreshInterval() throws Exception {
+    withConfig(
+        () -> {
+          ZhiziEngineCatalog catalog =
+              new ZhiziEngineCatalog(
+                  "9.0.0",
+                  "10b512t",
+                  List.of(
+                      new ZhiziEngineCatalog.Option(
+                          "10b512t",
+                          "balanced transformer",
+                          ZhiziEngineCatalog.DiscoverySource.SERVER_CAPABILITIES),
+                      new ZhiziEngineCatalog.Option(
+                          "11b768t",
+                          "large transformer",
+                          ZhiziEngineCatalog.DiscoverySource.SERVER_CAPABILITIES)));
+          RemoteComputeConfig.State state = RemoteComputeConfig.load();
+          state.zhiziCatalog = catalog;
+          state.zhiziCatalogUpdatedAt = 1_000L;
+          RemoteComputeConfig.save(state);
+
+          RemoteComputeConfig.State restored = RemoteComputeConfig.load();
+          assertTrue(restored.zhiziCatalog.isServerAuthoritative());
+          assertEquals(
+              List.of("10b512t", "11b768t"),
+              restored.zhiziCatalog.weights().stream()
+                  .map(ZhiziEngineCatalog.Option::name)
+                  .toList());
           assertFalse(
               RemoteComputeConfig.shouldRefreshZhiziCatalog(
                   restored,
@@ -216,7 +256,9 @@ class RemoteComputeConfigTest {
                   RemoteComputeConfig.ON_DEMAND_1X_ZHIZI_ARGS);
 
           assertEquals("การคำนวณแบบกำหนดเอง · compute.example.com", custom);
-          assertTrue(zhizi.startsWith("คลาวด์ Zhizi ตามการใช้งาน 1x · 28B NBT · "));
+          assertTrue(
+              zhizi.startsWith(
+                  "คลาวด์ Zhizi ตามการใช้งาน 1x · Transformer 10B · รุ่นสมดุล · "));
           assertFalse(custom.matches(".*\\p{IsHan}.*"));
           assertFalse(zhizi.matches(".*\\p{IsHan}.*"));
         });

--- a/src/test/java/featurecat/lizzie/analysis/remote/ZhiziEngineCatalogTest.java
+++ b/src/test/java/featurecat/lizzie/analysis/remote/ZhiziEngineCatalogTest.java
@@ -38,6 +38,7 @@ class ZhiziEngineCatalogTest {
     assertEquals(
         List.of("18bnbt", "28bnbt", "fdx", "20b", "10b384t", "10b512t", "11b768t"), names(catalog));
     assertFalse(catalog.containsWeight("../../unsafe"));
+    assertTrue(catalog.isServerAuthoritative());
     assertTrue(
         catalog.weights().stream()
             .allMatch(
@@ -66,15 +67,60 @@ class ZhiziEngineCatalogTest {
   void fallbackContainsTheCurrentVerifiedCatalog() {
     ZhiziEngineCatalog catalog = ZhiziEngineCatalog.fallback();
 
-    assertEquals("28bnbt", catalog.defaultWeight());
+    assertEquals("10b512t", catalog.defaultWeight());
     assertEquals(
-        List.of("18bnbt", "28bnbt", "fdx", "20b", "10b384t", "10b512t", "11b768t"), names(catalog));
-    assertEquals("40B NBT extra-large weight", description(catalog, "fdx"));
+        List.of("20b", "10b384t", "10b512t", "11b768t"), names(catalog));
+    assertFalse(catalog.containsWeight("28bnbt"));
+    assertFalse(catalog.containsWeight("fdx"));
     assertEquals(ZhiziEngineCatalog.DiscoverySource.BUILT_IN_CURRENT, source(catalog, "10b512t"));
+    assertFalse(catalog.isServerAuthoritative());
   }
 
   @Test
-  void documentedWeightsCompleteOldCachesWithoutMislabelingLegacyOptions() throws Exception {
+  void liveCatalogDropsRetiredSelectionAndUsesServerDefault() throws Exception {
+    JSONObject json =
+        new JSONObject()
+            .put("serverVersion", "9.0.0")
+            .put("defaultKataWeight", "10b512t")
+            .put(
+                "supportKataWeights",
+                new JSONArray()
+                    .put(option("10b512t", "balanced transformer"))
+                    .put(option("11b768t", "large transformer")));
+
+    ZhiziEngineCatalog catalog = ZhiziEngineCatalog.fromServerCapabilities(json.toString());
+    ZhiziEngineCatalog displayed = catalog.withDocumentedWeights();
+
+    assertEquals(List.of("10b512t", "11b768t"), names(displayed));
+    assertFalse(displayed.containsWeight("28bnbt"));
+    assertFalse(displayed.containsWeight("40b"));
+    assertEquals("10b512t", displayed.resolveSupportedWeight("40b"));
+    assertEquals("11b768t", displayed.resolveSupportedWeight("11B768T"));
+  }
+
+  @Test
+  void liveCatalogNeverPromotesAnUnadvertisedDefaultToASelectableWeight() throws Exception {
+    JSONObject json =
+        new JSONObject()
+            .put("serverVersion", "9.0.1")
+            .put("defaultKataWeight", "40b")
+            .put(
+                "supportKataWeights",
+                new JSONArray()
+                    .put(option("10b512t", "balanced transformer"))
+                    .put(option("11b768t", "large transformer")));
+
+    ZhiziEngineCatalog catalog = ZhiziEngineCatalog.fromServerCapabilities(json.toString());
+
+    assertEquals(List.of("10b512t", "11b768t"), names(catalog));
+    assertEquals("10b512t", catalog.defaultWeight());
+    assertFalse(catalog.containsWeight("40b"));
+    assertEquals("10b512t", catalog.resolveSupportedWeight("40b"));
+    assertTrue(catalog.isServerAuthoritative());
+  }
+
+  @Test
+  void currentBaselineReplacesRetiredOptionsInOldCaches() throws Exception {
     ZhiziEngineCatalog oldCache =
         new ZhiziEngineCatalog(
             "7.9.0",
@@ -87,13 +133,15 @@ class ZhiziEngineCatalogTest {
     ZhiziEngineCatalog completed = oldCache.withDocumentedWeights();
 
     assertEquals(
-        List.of("18bnbt", "28bnbt", "fdx", "20b", "10b384t", "10b512t", "11b768t", "40b"),
+        List.of("20b", "10b384t", "10b512t", "11b768t"),
         names(completed));
-    assertEquals("server description", description(completed, "28bnbt"));
+    assertEquals("10b512t", completed.defaultWeight());
+    assertEquals("legacy handicap network", description(completed, "20b"));
     assertEquals(
-        ZhiziEngineCatalog.DiscoverySource.OFFICIAL_DOCUMENTED, source(completed, "28bnbt"));
-    assertEquals(ZhiziEngineCatalog.DiscoverySource.CACHED_LEGACY, source(completed, "40b"));
+        ZhiziEngineCatalog.DiscoverySource.BUILT_IN_CURRENT, source(completed, "10b512t"));
     assertEquals(ZhiziEngineCatalog.DiscoverySource.BUILT_IN_CURRENT, source(completed, "20b"));
+    assertFalse(completed.containsWeight("28bnbt"));
+    assertFalse(completed.containsWeight("40b"));
   }
 
   @Test
@@ -104,17 +152,19 @@ class ZhiziEngineCatalogTest {
             .put("supportKataWeights", new JSONArray().put(option("40b", "old cached option")));
 
     ZhiziEngineCatalog migrated = ZhiziEngineCatalog.fromJson(oldCache).withDocumentedWeights();
-    assertEquals(ZhiziEngineCatalog.DiscoverySource.CACHED_LEGACY, source(migrated, "40b"));
+    assertEquals("10b512t", migrated.defaultWeight());
+    assertFalse(migrated.containsWeight("40b"));
 
     ZhiziEngineCatalog restored = ZhiziEngineCatalog.fromJson(migrated.toJson());
-    assertEquals(ZhiziEngineCatalog.DiscoverySource.CACHED_LEGACY, source(restored, "40b"));
     assertEquals(
-        ZhiziEngineCatalog.DiscoverySource.OFFICIAL_DOCUMENTED, source(restored, "28bnbt"));
+        ZhiziEngineCatalog.DiscoverySource.BUILT_IN_CURRENT, source(restored, "10b512t"));
   }
 
   @Test
   void safeFutureServerNamesAreSelectableButArgumentInjectionIsRejected() {
-    assertTrue(ZhiziEngineCatalog.isDocumentedWeight("28bnbt"));
+    assertTrue(ZhiziEngineCatalog.isDocumentedWeight("10b512t"));
+    assertFalse(ZhiziEngineCatalog.isDocumentedWeight("28bnbt"));
+    assertTrue(ZhiziEngineCatalog.isLegacyCompatibleWeight("28bnbt"));
     assertTrue(ZhiziEngineCatalog.isLegacyCompatibleWeight("60b"));
     assertTrue(ZhiziEngineCatalog.isSelectableWeight("20b"));
     assertTrue(ZhiziEngineCatalog.isSelectableWeight("future-net"));

--- a/src/test/java/featurecat/lizzie/analysis/remote/ZhiziServerCatalogClientTest.java
+++ b/src/test/java/featurecat/lizzie/analysis/remote/ZhiziServerCatalogClientTest.java
@@ -54,8 +54,8 @@ class ZhiziServerCatalogClientTest {
         client.fetchCatalog(
             new ZhiziApiClient.ConnectAccount("zz-player@example.com", "temporary-password"));
 
-    assertEquals("28bnbt", catalog.defaultWeight());
-    assertEquals(7, catalog.weights().size());
+    assertEquals("10b512t", catalog.defaultWeight());
+    assertEquals(4, catalog.weights().size());
     assertTrue(catalog.containsWeight("11b768t"));
     assertTrue(
         catalog.weights().stream()
@@ -97,13 +97,12 @@ class ZhiziServerCatalogClientTest {
 
   private static JSONObject liveCatalog() {
     JSONArray weights = new JSONArray();
-    for (String name :
-        new String[] {"18bnbt", "28bnbt", "fdx", "20b", "10b384t", "10b512t", "11b768t"}) {
+    for (String name : new String[] {"20b", "10b384t", "10b512t", "11b768t"}) {
       weights.put(new JSONObject().put("name", name).put("description", name + " weight"));
     }
     return new JSONObject()
         .put("serverVersion", "8.0.1")
-        .put("defaultKataWeight", "28bnbt")
+        .put("defaultKataWeight", "10b512t")
         .put("supportKataWeights", weights);
   }
 }

--- a/src/test/java/featurecat/lizzie/gui/RemoteComputeDialogLayoutTest.java
+++ b/src/test/java/featurecat/lizzie/gui/RemoteComputeDialogLayoutTest.java
@@ -48,6 +48,22 @@ class RemoteComputeDialogLayoutTest {
   }
 
   @Test
+  void remoteComputePagesKeepBothColumnsUsableAtWindowsHighDpi() {
+    JPanel left = new JPanel();
+    JPanel right = new JPanel();
+    JPanel page = RemoteComputeDialog.createTwoColumnPage(left, right);
+
+    page.setSize(900, 520);
+    page.doLayout();
+
+    assertEquals(left.getWidth(), right.getWidth());
+    assertEquals(18, right.getX() - left.getWidth());
+    assertTrue(left.getWidth() >= 400);
+    assertEquals(520, left.getHeight());
+    assertEquals(520, right.getHeight());
+  }
+
+  @Test
   void zhiziWebsiteCardKeepsItsActionCompactAndContentVisible() {
     JButton button = new JButton("Open official website");
     JPanel card =

--- a/src/test/java/featurecat/lizzie/gui/RemoteComputeDialogLayoutTest.java
+++ b/src/test/java/featurecat/lizzie/gui/RemoteComputeDialogLayoutTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.awt.Component;
 import java.awt.Container;
+import java.awt.Dimension;
 import java.util.concurrent.atomic.AtomicReference;
 import javax.accessibility.AccessibleContext;
 import javax.swing.JButton;
@@ -61,6 +62,17 @@ class RemoteComputeDialogLayoutTest {
     assertTrue(left.getWidth() >= 400);
     assertEquals(520, left.getHeight());
     assertEquals(520, right.getHeight());
+  }
+
+  @Test
+  void signedInAccountCardFillsItsColumnWithoutGrowingVertically() {
+    JPanel accountCard = new JPanel();
+    accountCard.setPreferredSize(new Dimension(240, 280));
+
+    RemoteComputeDialog.stretchHorizontally(accountCard);
+
+    assertEquals(Integer.MAX_VALUE, accountCard.getMaximumSize().width);
+    assertEquals(280, accountCard.getMaximumSize().height);
   }
 
   @Test

--- a/src/test/java/featurecat/lizzie/gui/WindowMenuStripTest.java
+++ b/src/test/java/featurecat/lizzie/gui/WindowMenuStripTest.java
@@ -7,6 +7,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.awt.Component;
 import java.awt.event.MouseEvent;
 import java.awt.event.MouseListener;
+import java.util.concurrent.atomic.AtomicInteger;
+import javax.swing.Box;
 import javax.swing.JButton;
 import javax.swing.JMenu;
 import javax.swing.JMenuBar;
@@ -15,6 +17,36 @@ import javax.swing.JPopupMenu;
 import org.junit.jupiter.api.Test;
 
 class WindowMenuStripTest {
+  @Test
+  void mirrorsProminentToolbarActionsAndDelegatesClicks() {
+    JMenuBar menuBar = new JMenuBar();
+    menuBar.add(new JMenu("分析"));
+    menuBar.add(Box.createHorizontalStrut(6));
+    JButton sourceButton = new JButton("AI 解说");
+    sourceButton.setName("aiCommentaryToolbarButton");
+    sourceButton.getAccessibleContext().setAccessibleName("AI 解说");
+    sourceButton.getAccessibleContext().setAccessibleDescription("生成当前棋局解说");
+    AtomicInteger invocationCount = new AtomicInteger();
+    sourceButton.addActionListener(event -> invocationCount.incrementAndGet());
+    menuBar.add(sourceButton);
+
+    WindowMenuStrip strip = new WindowMenuStrip(menuBar);
+
+    assertEquals(2, strip.getComponentCount());
+    assertTrue(strip.getComponent(1) instanceof JButton);
+    JButton mirroredButton = (JButton) strip.getComponent(1);
+    assertEquals("AI 解说", mirroredButton.getText());
+    assertEquals("aiCommentaryToolbarButton", mirroredButton.getName());
+    assertEquals("AI 解说", mirroredButton.getAccessibleContext().getAccessibleName());
+    assertEquals(
+        "生成当前棋局解说",
+        mirroredButton.getAccessibleContext().getAccessibleDescription());
+
+    mirroredButton.doClick(0);
+
+    assertEquals(1, invocationCount.get());
+  }
+
   @Test
   void mirrorsSourceMenuTextAndEnabledStateWithoutRebuild() {
     JMenuBar menuBar = new JMenuBar();


### PR DESCRIPTION
## Summary

- Adds a prominent AI commentary button beside the active engine selector and preserves it in the native menu-strip presentation.
- Treats the live Zhizi model catalog as authoritative, migrates retired selections to the supported default, and keeps legacy model names only for compatibility.
- Fixes the signed-in Zhizi account card so it fills the left column correctly under Windows high-DPI scaling.
- Replaces the Unix-only fake GTP process used by lifecycle tests with a portable Java fixture.

## Validation

- `git diff --check origin/main...HEAD`
- macOS: `mvn -B -Dfmt.skip=true test` - 2,156 tests passed.
- macOS: `mvn -B -Dfmt.skip=true -DskipTests package` - passed.
- Windows 11 at 150% scaling: full Maven suite - 2,156 tests passed, 3 platform-only skips.
- Windows package build - passed.
- Windows real UI: signed-in Zhizi account card, current four-model catalog, buttons, and status text display without clipping.
- AI commentary: the toolbar entry and dialogs open in the packaged Swing app; a live OpenAI-compatible model listing and streaming completion completed successfully, with the temporary key kept session-only and absent from configuration and logs.

## Security

No account password, API key, access token, or live-provider response is included in this branch.
