### PR TITLE
Prepare next-2026-08-09.2 pre-release

### DIFF
--- a/.github/release-notes/next-2026-08-09.2.md
+++ b/.github/release-notes/next-2026-08-09.2.md
@@ -1,0 +1,317 @@
+# LizzieYzy Next next-2026-08-09.2
+
+## 中文
+
+这是 `next-2026-08-09.1` 之后的体验与稳定性预览更新，重点完善 AI 讲棋的可见入口、生成过程和知识库刷新，并让智子云模型目录与服务端保持一致。
+
+### 本版主要更新
+
+- AI 讲棋入口固定显示在顶部引擎区域，普通布局、Windows 与 macOS 下都能直接找到。感谢 `Fly143` 持续提交并完善这一功能。
+- AI 讲棋新增区间与整局进度，生成期间能看到真实完成比例；输出支持 Markdown 标题、列表和重点内容，长讲解更易阅读。
+- 本地定式与知识库支持运行时刷新，修改知识文件后无需重启应用；知识证据标签同步补齐六种语言。
+- 智子云模型下拉框以服务端当前目录为准，刷新失败时保留上一次成功结果，不再混入已经下线的旧模型。
+- 修复智子账户卡在 Windows 高 DPI 下的裁切和错位，模型状态与操作区在不同缩放比例下保持完整。
+
+### 下载前先看这几句
+
+- 已有 Windows 免安装版可使用 `windows64.core-update.zip` 更新主程序；需要同步更新引擎、权重或运行库时请下载对应完整包。
+- 普通 Windows 用户优先选择 OpenCL 免安装版；NVIDIA 用户按显卡代际选择 NVIDIA 或 RTX 50 CUDA 版。
+- AI 讲棋不会内置或上传你的 AI 服务密钥，需要时请在功能设置中自行配置。
+- 这是预发布版。建议先覆盖到副本并备份现有 `user-data`、自定义权重和棋谱。
+
+### 下载建议
+
+| 你的电脑 | 直接下载这个 |
+| --- | --- |
+| Windows 64 位，OpenCL 版，推荐，免安装 | [`2026-08-09-windows64.opencl.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-09.2/2026-08-09-windows64.opencl.portable.zip) |
+| 已有 Windows 免安装版，只更新主程序 | [`2026-08-09-windows64.core-update.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-09.2/2026-08-09-windows64.core-update.zip) |
+| Windows 64 位，OpenCL 安装版 | [`2026-08-09-windows64.opencl.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-09.2/2026-08-09-windows64.opencl.installer.exe) |
+| Windows 64 位，CPU 兼容版，免安装 | [`2026-08-09-windows64.with-katago.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-09.2/2026-08-09-windows64.with-katago.portable.zip) |
+| Windows 64 位，CPU 兼容安装版 | [`2026-08-09-windows64.with-katago.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-09.2/2026-08-09-windows64.with-katago.installer.exe) |
+| Windows 64 位，NVIDIA CUDA 版，免安装 | [`2026-08-09-windows64.nvidia.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-09.2/2026-08-09-windows64.nvidia.portable.zip) |
+| Windows 64 位，NVIDIA CUDA 安装版 | [`2026-08-09-windows64.nvidia.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-09.2/2026-08-09-windows64.nvidia.installer.exe) |
+| Windows 64 位，RTX 5070/5080/5090，免安装 | [`2026-08-09-windows64.nvidia50.cuda.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-09.2/2026-08-09-windows64.nvidia50.cuda.portable.zip) |
+| 高级可选：TensorRT 预装分卷包，需下载全部分卷 | [`2026-08-09-windows64.nvidia.tensorrt.portable.7z.001`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-09.2/2026-08-09-windows64.nvidia.tensorrt.portable.7z.001)<br>[`2026-08-09-windows64.nvidia.tensorrt.portable.7z.002`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-09.2/2026-08-09-windows64.nvidia.tensorrt.portable.7z.002) |
+| Windows 64 位，RTX 50 CUDA 安装版 | [`2026-08-09-windows64.nvidia50.cuda.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-09.2/2026-08-09-windows64.nvidia50.cuda.installer.exe) |
+| Windows 64 位，自行配置引擎，免安装 | [`2026-08-09-windows64.without.engine.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-09.2/2026-08-09-windows64.without.engine.portable.zip) |
+| Windows 64 位，自行配置引擎，安装版 | [`2026-08-09-windows64.without.engine.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-09.2/2026-08-09-windows64.without.engine.installer.exe) |
+| macOS Apple Silicon | [`2026-08-09-mac-apple-silicon.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-09.2/2026-08-09-mac-apple-silicon.with-katago.dmg) |
+| macOS Intel | [`2026-08-09-mac-intel.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-09.2/2026-08-09-mac-intel.with-katago.dmg) |
+| Linux 64 位，CPU 兼容版 | [`2026-08-09-linux64.with-katago.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-09.2/2026-08-09-linux64.with-katago.zip) |
+| Linux 64 位，OpenCL 版 | [`2026-08-09-linux64.opencl.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-09.2/2026-08-09-linux64.opencl.zip) |
+| Linux 64 位，NVIDIA CUDA 版 | [`2026-08-09-linux64.nvidia.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-09.2/2026-08-09-linux64.nvidia.zip) |
+
+### 这一版为什么值得测试
+
+- AI 讲棋从入口、等待进度到最终排版都更清楚，知识文件也可以直接刷新生效。
+- 智子模型只展示服务端当前可用项，网络波动时仍保留上次有效列表。
+- 合并后的完整测试共 `2161` 项通过，GitHub Java 21 构建和 Windows 脚本验证均已通过；各平台成品还会在公开前再次审计。
+
+### 交流
+
+- QQ 群：`299419120`
+
+---
+
+## 繁體中文
+
+這是 `next-2026-08-09.1` 之後的體驗與穩定性預覽更新，重點改善 AI 講棋入口、產生進度與知識庫重新載入，並讓智子雲模型目錄與服務端保持一致。
+
+### 本版主要更新
+
+- AI 講棋入口固定顯示於頂部引擎區域，在一般布局、Windows 與 macOS 都能直接找到。感謝 `Fly143` 持續提交與完善此功能。
+- AI 講棋新增區間與整局進度，產生期間可看到實際完成比例；輸出支援 Markdown 標題、清單與重點內容。
+- 本機定式與知識庫可在執行期間重新載入，修改知識檔後不必重新啟動；證據標籤同步補齊六種語言。
+- 智子雲模型選單以服務端目前目錄為準，更新失敗時保留上次成功結果，不再混入已下線的舊模型。
+- 修正智子帳戶卡在 Windows 高 DPI 下的裁切與錯位，不同縮放比例下仍能完整顯示。
+
+### 下載前先看這幾句
+
+- 既有 Windows portable 可使用 `windows64.core-update.zip` 更新主程式；需要同步更新 engine、weight 或 runtime 時請下載對應完整套件。
+- 一般 Windows 使用者優先選擇 OpenCL portable；NVIDIA 使用者依顯示卡世代選擇 NVIDIA 或 RTX 50 CUDA 版。
+- AI 講棋不會內建或上傳你的 AI 服務金鑰，需要時請在功能設定中自行配置。
+- 這是預覽版，建議先更新副本並備份既有 `user-data`、自訂權重與棋譜。
+
+### 下載建議
+
+| 你的電腦 | 直接下載這個 |
+| --- | --- |
+| Windows 64 位，OpenCL 推薦版，免安裝 | [`2026-08-09-windows64.opencl.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-09.2/2026-08-09-windows64.opencl.portable.zip) |
+| 既有 Windows portable，只更新主程式 | [`2026-08-09-windows64.core-update.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-09.2/2026-08-09-windows64.core-update.zip) |
+| Windows 64 位，OpenCL 安裝版 | [`2026-08-09-windows64.opencl.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-09.2/2026-08-09-windows64.opencl.installer.exe) |
+| Windows 64 位，CPU 相容版，免安裝 | [`2026-08-09-windows64.with-katago.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-09.2/2026-08-09-windows64.with-katago.portable.zip) |
+| Windows 64 位，CPU 相容安裝版 | [`2026-08-09-windows64.with-katago.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-09.2/2026-08-09-windows64.with-katago.installer.exe) |
+| Windows 64 位，NVIDIA CUDA，免安裝 | [`2026-08-09-windows64.nvidia.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-09.2/2026-08-09-windows64.nvidia.portable.zip) |
+| Windows 64 位，NVIDIA CUDA 安裝版 | [`2026-08-09-windows64.nvidia.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-09.2/2026-08-09-windows64.nvidia.installer.exe) |
+| Windows 64 位，RTX 5070/5080/5090，免安裝 | [`2026-08-09-windows64.nvidia50.cuda.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-09.2/2026-08-09-windows64.nvidia50.cuda.portable.zip) |
+| 進階可選：TensorRT 預裝分卷，需下載全部檔案 | [`2026-08-09-windows64.nvidia.tensorrt.portable.7z.001`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-09.2/2026-08-09-windows64.nvidia.tensorrt.portable.7z.001)<br>[`2026-08-09-windows64.nvidia.tensorrt.portable.7z.002`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-09.2/2026-08-09-windows64.nvidia.tensorrt.portable.7z.002) |
+| Windows 64 位，RTX 50 CUDA 安裝版 | [`2026-08-09-windows64.nvidia50.cuda.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-09.2/2026-08-09-windows64.nvidia50.cuda.installer.exe) |
+| Windows 64 位，自行設定引擎，免安裝 | [`2026-08-09-windows64.without.engine.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-09.2/2026-08-09-windows64.without.engine.portable.zip) |
+| Windows 64 位，自行設定引擎，安裝版 | [`2026-08-09-windows64.without.engine.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-09.2/2026-08-09-windows64.without.engine.installer.exe) |
+| macOS Apple Silicon | [`2026-08-09-mac-apple-silicon.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-09.2/2026-08-09-mac-apple-silicon.with-katago.dmg) |
+| macOS Intel | [`2026-08-09-mac-intel.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-09.2/2026-08-09-mac-intel.with-katago.dmg) |
+| Linux 64 位，CPU 相容版 | [`2026-08-09-linux64.with-katago.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-09.2/2026-08-09-linux64.with-katago.zip) |
+| Linux 64 位，OpenCL 版 | [`2026-08-09-linux64.opencl.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-09.2/2026-08-09-linux64.opencl.zip) |
+| Linux 64 位，NVIDIA CUDA 版 | [`2026-08-09-linux64.nvidia.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-09.2/2026-08-09-linux64.nvidia.zip) |
+
+### 這一版為什麼值得測試
+
+- AI 講棋從入口、等待進度到最終排版都更清楚，知識檔也能直接重新載入生效。
+- 智子模型只顯示服務端目前可用項目，網路波動時仍保留上次有效清單。
+- 合併後完整測試共 `2161` 項通過，GitHub Java 21 build 與 Windows script validation 皆已通過；各平台成品會在公開前再次稽核。
+
+### 交流
+
+- QQ 群：`299419120`
+
+---
+
+## English
+
+This experience and stability pre-release follows `next-2026-08-09.1`. It improves the visibility, progress feedback, rendering, and knowledge reload flow of AI commentary, while keeping the Zhizi model catalog aligned with the service.
+
+### Release Highlights
+
+- The AI commentary entry is now always visible beside the engine area in standard layouts on Windows and macOS. Thanks to `Fly143` for continuing to contribute and refine this feature.
+- Range and whole-game generation now show real progress. Markdown headings, lists, and emphasis make longer commentary easier to read.
+- Local joseki and knowledge files can be reloaded without restarting the application, and evidence labels are complete across all six languages.
+- The Zhizi model selector follows the current server catalog, keeps the last successful result during network failures, and no longer mixes in retired models.
+- The Zhizi account card no longer clips or misaligns controls under Windows high-DPI scaling.
+
+### Read Before Downloading
+
+- Existing Windows portable users may install `windows64.core-update.zip`; download a complete package when engines, weights, or runtimes also need updating.
+- Most Windows users should choose the OpenCL portable package. NVIDIA users should select the NVIDIA or RTX 50 CUDA package that matches their GPU generation.
+- AI commentary does not bundle or upload your AI-service secret; configure the service only when you choose to use it.
+- This is a pre-release. Upgrade a copy first and back up existing `user-data`, custom weights, and kifu.
+
+### Download Guide
+
+| Your computer | Download this file |
+| --- | --- |
+| Windows 64-bit, OpenCL, recommended, portable | [`2026-08-09-windows64.opencl.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-09.2/2026-08-09-windows64.opencl.portable.zip) |
+| Existing Windows portable install, application-only update | [`2026-08-09-windows64.core-update.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-09.2/2026-08-09-windows64.core-update.zip) |
+| Windows 64-bit, OpenCL installer | [`2026-08-09-windows64.opencl.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-09.2/2026-08-09-windows64.opencl.installer.exe) |
+| Windows 64-bit, CPU fallback, portable | [`2026-08-09-windows64.with-katago.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-09.2/2026-08-09-windows64.with-katago.portable.zip) |
+| Windows 64-bit, CPU fallback installer | [`2026-08-09-windows64.with-katago.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-09.2/2026-08-09-windows64.with-katago.installer.exe) |
+| Windows 64-bit, NVIDIA CUDA, portable | [`2026-08-09-windows64.nvidia.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-09.2/2026-08-09-windows64.nvidia.portable.zip) |
+| Windows 64-bit, NVIDIA CUDA installer | [`2026-08-09-windows64.nvidia.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-09.2/2026-08-09-windows64.nvidia.installer.exe) |
+| Windows 64-bit, RTX 5070/5080/5090, portable | [`2026-08-09-windows64.nvidia50.cuda.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-09.2/2026-08-09-windows64.nvidia50.cuda.portable.zip) |
+| Advanced optional TensorRT split package; download every part | [`2026-08-09-windows64.nvidia.tensorrt.portable.7z.001`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-09.2/2026-08-09-windows64.nvidia.tensorrt.portable.7z.001)<br>[`2026-08-09-windows64.nvidia.tensorrt.portable.7z.002`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-09.2/2026-08-09-windows64.nvidia.tensorrt.portable.7z.002) |
+| Windows 64-bit, RTX 50 CUDA installer | [`2026-08-09-windows64.nvidia50.cuda.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-09.2/2026-08-09-windows64.nvidia50.cuda.installer.exe) |
+| Windows 64-bit, configure your own engine, portable | [`2026-08-09-windows64.without.engine.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-09.2/2026-08-09-windows64.without.engine.portable.zip) |
+| Windows 64-bit, configure your own engine, installer | [`2026-08-09-windows64.without.engine.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-09.2/2026-08-09-windows64.without.engine.installer.exe) |
+| macOS Apple Silicon | [`2026-08-09-mac-apple-silicon.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-09.2/2026-08-09-mac-apple-silicon.with-katago.dmg) |
+| macOS Intel | [`2026-08-09-mac-intel.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-09.2/2026-08-09-mac-intel.with-katago.dmg) |
+| Linux 64-bit, CPU fallback | [`2026-08-09-linux64.with-katago.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-09.2/2026-08-09-linux64.with-katago.zip) |
+| Linux 64-bit, OpenCL | [`2026-08-09-linux64.opencl.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-09.2/2026-08-09-linux64.opencl.zip) |
+| Linux 64-bit, NVIDIA CUDA | [`2026-08-09-linux64.nvidia.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-09.2/2026-08-09-linux64.nvidia.zip) |
+
+### Why Test This Release
+
+- AI commentary is clearer from discovery and progress feedback through final rendering, and knowledge changes can be reloaded immediately.
+- Zhizi now presents only current server-supported models while retaining the last valid list through transient network failures.
+- The merged suite passed all `2161` tests; GitHub Java 21 build and Windows script validation passed, and every platform artifact is audited again before publication.
+
+### Contact
+
+- QQ group: `299419120`
+
+---
+
+## 日本語
+
+`next-2026-08-09.1` に続く体験・安定性プレリリースです。AI 講解の入口、進捗表示、描画、knowledge reload を改善し、Zhizi model catalog を server と一致させました。
+
+### 主な更新
+
+- AI 講解の入口を top engine area に常時表示し、通常 layout、Windows、macOS から直接開けます。継続して改善した `Fly143` さんに感謝します。
+- 区間と整局の生成に実際の進捗を表示し、Markdown の見出し、list、強調で長い講解を読みやすくしました。
+- ローカル joseki と knowledge file を再起動せずに reload でき、evidence label を 6 言語で揃えました。
+- Zhizi model selector は現在の server catalog のみを表示し、通信失敗時は前回成功した一覧を保持します。
+- Windows high DPI で Zhizi account card が切れたりずれたりする問題を修正しました。
+
+### ダウンロード前に
+
+- 既存 Windows portable は `windows64.core-update.zip` でアプリのみ更新できます。engine、weight、runtime も更新する場合は完全版を選んでください。
+- 多くの Windows 利用者には OpenCL portable を推奨します。NVIDIA は GPU 世代に合う NVIDIA または RTX 50 CUDA package を選んでください。
+- AI 講解は AI service の secret を同梱または送信しません。使う場合のみ設定してください。
+- これは pre-release です。まずコピーを更新し、`user-data`、custom weight、棋譜をバックアップしてください。
+
+### ダウンロード案内
+
+| お使いの環境 | ダウンロードするファイル |
+| --- | --- |
+| Windows 64-bit、OpenCL 推奨 portable | [`2026-08-09-windows64.opencl.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-09.2/2026-08-09-windows64.opencl.portable.zip) |
+| 既存 Windows portable、アプリ本体のみ更新 | [`2026-08-09-windows64.core-update.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-09.2/2026-08-09-windows64.core-update.zip) |
+| Windows 64-bit、OpenCL installer | [`2026-08-09-windows64.opencl.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-09.2/2026-08-09-windows64.opencl.installer.exe) |
+| Windows 64-bit、CPU fallback portable | [`2026-08-09-windows64.with-katago.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-09.2/2026-08-09-windows64.with-katago.portable.zip) |
+| Windows 64-bit、CPU fallback installer | [`2026-08-09-windows64.with-katago.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-09.2/2026-08-09-windows64.with-katago.installer.exe) |
+| Windows 64-bit、NVIDIA CUDA portable | [`2026-08-09-windows64.nvidia.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-09.2/2026-08-09-windows64.nvidia.portable.zip) |
+| Windows 64-bit、NVIDIA CUDA installer | [`2026-08-09-windows64.nvidia.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-09.2/2026-08-09-windows64.nvidia.installer.exe) |
+| Windows 64-bit、RTX 5070/5080/5090 portable | [`2026-08-09-windows64.nvidia50.cuda.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-09.2/2026-08-09-windows64.nvidia50.cuda.portable.zip) |
+| 上級者向け TensorRT 分割 package、全 part が必要 | [`2026-08-09-windows64.nvidia.tensorrt.portable.7z.001`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-09.2/2026-08-09-windows64.nvidia.tensorrt.portable.7z.001)<br>[`2026-08-09-windows64.nvidia.tensorrt.portable.7z.002`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-09.2/2026-08-09-windows64.nvidia.tensorrt.portable.7z.002) |
+| Windows 64-bit、RTX 50 CUDA installer | [`2026-08-09-windows64.nvidia50.cuda.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-09.2/2026-08-09-windows64.nvidia50.cuda.installer.exe) |
+| Windows 64-bit、engine を自分で設定、portable | [`2026-08-09-windows64.without.engine.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-09.2/2026-08-09-windows64.without.engine.portable.zip) |
+| Windows 64-bit、engine を自分で設定、installer | [`2026-08-09-windows64.without.engine.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-09.2/2026-08-09-windows64.without.engine.installer.exe) |
+| macOS Apple Silicon | [`2026-08-09-mac-apple-silicon.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-09.2/2026-08-09-mac-apple-silicon.with-katago.dmg) |
+| macOS Intel | [`2026-08-09-mac-intel.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-09.2/2026-08-09-mac-intel.with-katago.dmg) |
+| Linux 64-bit、CPU fallback | [`2026-08-09-linux64.with-katago.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-09.2/2026-08-09-linux64.with-katago.zip) |
+| Linux 64-bit、OpenCL | [`2026-08-09-linux64.opencl.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-09.2/2026-08-09-linux64.opencl.zip) |
+| Linux 64-bit、NVIDIA CUDA | [`2026-08-09-linux64.nvidia.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-09.2/2026-08-09-linux64.nvidia.zip) |
+
+### このリリースを試す理由
+
+- AI 講解は入口、進捗、最終表示まで分かりやすくなり、knowledge file の変更もすぐ反映できます。
+- Zhizi は server が現在対応する model のみを表示し、一時的な通信障害では前回の有効一覧を保持します。
+- 統合後の `2161` tests、GitHub Java 21 build、Windows script validation が成功し、各 platform artifact は公開前に再監査されます。
+
+### 連絡先
+
+- QQ group: `299419120`
+
+---
+
+## 한국어
+
+`next-2026-08-09.1` 이후의 경험 및 안정성 pre-release입니다. AI 해설의 진입점, 진행률, 렌더링, knowledge reload를 개선하고 Zhizi model catalog를 server와 일치시켰습니다.
+
+### 주요 업데이트
+
+- AI 해설 진입점을 상단 engine 영역에 항상 표시해 일반 layout, Windows, macOS에서 바로 찾을 수 있습니다. 기능을 계속 개선한 `Fly143` 님께 감사드립니다.
+- 구간 및 전체 기보 생성에 실제 진행률을 표시하고 Markdown 제목, 목록, 강조로 긴 해설을 읽기 쉽게 만들었습니다.
+- 로컬 joseki와 knowledge file을 앱 재시작 없이 reload할 수 있고 evidence label을 6개 언어로 완성했습니다.
+- Zhizi model selector는 현재 server catalog만 표시하며 통신 실패 시 마지막 성공 목록을 유지합니다.
+- Windows high DPI에서 Zhizi account card가 잘리거나 어긋나는 문제를 수정했습니다.
+
+### 다운로드 전 확인
+
+- 기존 Windows portable은 `windows64.core-update.zip`으로 앱만 업데이트할 수 있습니다. engine, weight, runtime도 함께 업데이트하려면 전체 package를 받으세요.
+- 대부분의 Windows 사용자는 OpenCL portable을 권장합니다. NVIDIA 사용자는 GPU 세대에 맞는 NVIDIA 또는 RTX 50 CUDA package를 선택하세요.
+- AI 해설은 AI service secret을 내장하거나 업로드하지 않습니다. 사용할 때만 직접 설정하세요.
+- 이것은 pre-release입니다. 먼저 복사본을 업데이트하고 `user-data`, custom weight, 기보를 백업하세요.
+
+### 다운로드 안내
+
+| 환경 | 다운로드할 파일 |
+| --- | --- |
+| Windows 64-bit, OpenCL 권장 portable | [`2026-08-09-windows64.opencl.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-09.2/2026-08-09-windows64.opencl.portable.zip) |
+| 기존 Windows portable, 앱만 업데이트 | [`2026-08-09-windows64.core-update.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-09.2/2026-08-09-windows64.core-update.zip) |
+| Windows 64-bit, OpenCL installer | [`2026-08-09-windows64.opencl.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-09.2/2026-08-09-windows64.opencl.installer.exe) |
+| Windows 64-bit, CPU portable | [`2026-08-09-windows64.with-katago.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-09.2/2026-08-09-windows64.with-katago.portable.zip) |
+| Windows 64-bit, CPU installer | [`2026-08-09-windows64.with-katago.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-09.2/2026-08-09-windows64.with-katago.installer.exe) |
+| Windows 64-bit, NVIDIA CUDA portable | [`2026-08-09-windows64.nvidia.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-09.2/2026-08-09-windows64.nvidia.portable.zip) |
+| Windows 64-bit, NVIDIA CUDA installer | [`2026-08-09-windows64.nvidia.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-09.2/2026-08-09-windows64.nvidia.installer.exe) |
+| Windows 64-bit, RTX 5070/5080/5090 portable | [`2026-08-09-windows64.nvidia50.cuda.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-09.2/2026-08-09-windows64.nvidia50.cuda.portable.zip) |
+| 고급 선택: TensorRT 분할 package, 모든 part 필요 | [`2026-08-09-windows64.nvidia.tensorrt.portable.7z.001`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-09.2/2026-08-09-windows64.nvidia.tensorrt.portable.7z.001)<br>[`2026-08-09-windows64.nvidia.tensorrt.portable.7z.002`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-09.2/2026-08-09-windows64.nvidia.tensorrt.portable.7z.002) |
+| Windows 64-bit, RTX 50 CUDA installer | [`2026-08-09-windows64.nvidia50.cuda.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-09.2/2026-08-09-windows64.nvidia50.cuda.installer.exe) |
+| Windows 64-bit, 직접 engine 설정, portable | [`2026-08-09-windows64.without.engine.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-09.2/2026-08-09-windows64.without.engine.portable.zip) |
+| Windows 64-bit, 직접 engine 설정, installer | [`2026-08-09-windows64.without.engine.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-09.2/2026-08-09-windows64.without.engine.installer.exe) |
+| macOS Apple Silicon | [`2026-08-09-mac-apple-silicon.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-09.2/2026-08-09-mac-apple-silicon.with-katago.dmg) |
+| macOS Intel | [`2026-08-09-mac-intel.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-09.2/2026-08-09-mac-intel.with-katago.dmg) |
+| Linux 64-bit, CPU | [`2026-08-09-linux64.with-katago.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-09.2/2026-08-09-linux64.with-katago.zip) |
+| Linux 64-bit, OpenCL | [`2026-08-09-linux64.opencl.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-09.2/2026-08-09-linux64.opencl.zip) |
+| Linux 64-bit, NVIDIA CUDA | [`2026-08-09-linux64.nvidia.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-09.2/2026-08-09-linux64.nvidia.zip) |
+
+### 이 릴리스를 테스트할 이유
+
+- AI 해설은 진입점, 진행률, 최종 표시까지 더 명확해졌고 knowledge file 변경도 즉시 다시 읽을 수 있습니다.
+- Zhizi는 현재 server가 지원하는 model만 표시하고 일시적인 네트워크 오류에서는 마지막 유효 목록을 유지합니다.
+- 통합 후 `2161` tests, GitHub Java 21 build, Windows script validation이 통과했으며 각 platform artifact는 공개 전에 다시 검증됩니다.
+
+### 연락처
+
+- QQ 그룹: `299419120`
+
+---
+
+## ภาษาไทย
+
+นี่คือ experience และ stability pre-release หลัง `next-2026-08-09.1` โดยปรับปรุงทางเข้า progress rendering และ knowledge reload ของ AI commentary พร้อมทำให้ Zhizi model catalog ตรงกับ server
+
+### ไฮไลต์ของเวอร์ชันนี้
+
+- แสดงทางเข้า AI commentary ในพื้นที่ engine ด้านบนเสมอ จึงหาได้ง่ายใน layout ปกติ ทั้ง Windows และ macOS ขอบคุณ `Fly143` ที่พัฒนาอย่างต่อเนื่อง
+- การสร้างแบบช่วงและทั้งเกมแสดง progress จริง พร้อมรองรับหัวข้อ รายการ และข้อความเน้นแบบ Markdown
+- reload joseki และ knowledge file ในเครื่องได้โดยไม่ต้อง restart แอป และเพิ่ม evidence label ครบทั้ง 6 ภาษา
+- Zhizi model selector แสดงเฉพาะ catalog ปัจจุบันจาก server และเก็บรายการล่าสุดที่สำเร็จเมื่อ network ขัดข้อง
+- แก้ account card ของ Zhizi ที่ถูกตัดหรือวางผิดตำแหน่งบน Windows high DPI
+
+### ก่อนดาวน์โหลด
+
+- ผู้ใช้ Windows portable เดิมอัปเดตเฉพาะแอปด้วย `windows64.core-update.zip` ได้ หากต้องการอัปเดต engine, weight หรือ runtime ด้วย ให้เลือก package แบบเต็ม
+- ผู้ใช้ Windows ส่วนใหญ่แนะนำ OpenCL portable ส่วน NVIDIA ให้เลือก NVIDIA หรือ RTX 50 CUDA ตามรุ่น GPU
+- AI commentary ไม่ได้ฝังหรือ upload secret ของ AI service ตั้งค่าเฉพาะเมื่อคุณต้องการใช้
+- นี่คือ pre-release ควรอัปเดตสำเนาก่อน และ backup `user-data`, custom weight และ kifu
+
+### คู่มือดาวน์โหลด
+
+| คอมพิวเตอร์ของคุณ | ดาวน์โหลดไฟล์นี้ |
+| --- | --- |
+| Windows 64-bit, OpenCL แนะนำ, portable | [`2026-08-09-windows64.opencl.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-09.2/2026-08-09-windows64.opencl.portable.zip) |
+| มี Windows portable แล้ว อัปเดตเฉพาะโปรแกรม | [`2026-08-09-windows64.core-update.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-09.2/2026-08-09-windows64.core-update.zip) |
+| Windows 64-bit, OpenCL installer | [`2026-08-09-windows64.opencl.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-09.2/2026-08-09-windows64.opencl.installer.exe) |
+| Windows 64-bit, CPU portable | [`2026-08-09-windows64.with-katago.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-09.2/2026-08-09-windows64.with-katago.portable.zip) |
+| Windows 64-bit, CPU installer | [`2026-08-09-windows64.with-katago.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-09.2/2026-08-09-windows64.with-katago.installer.exe) |
+| Windows 64-bit, NVIDIA CUDA portable | [`2026-08-09-windows64.nvidia.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-09.2/2026-08-09-windows64.nvidia.portable.zip) |
+| Windows 64-bit, NVIDIA CUDA installer | [`2026-08-09-windows64.nvidia.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-09.2/2026-08-09-windows64.nvidia.installer.exe) |
+| Windows 64-bit, RTX 5070/5080/5090 portable | [`2026-08-09-windows64.nvidia50.cuda.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-09.2/2026-08-09-windows64.nvidia50.cuda.portable.zip) |
+| ตัวเลือกขั้นสูง TensorRT แบบแบ่งส่วน ต้องดาวน์โหลดทุกส่วน | [`2026-08-09-windows64.nvidia.tensorrt.portable.7z.001`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-09.2/2026-08-09-windows64.nvidia.tensorrt.portable.7z.001)<br>[`2026-08-09-windows64.nvidia.tensorrt.portable.7z.002`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-09.2/2026-08-09-windows64.nvidia.tensorrt.portable.7z.002) |
+| Windows 64-bit, RTX 50 CUDA installer | [`2026-08-09-windows64.nvidia50.cuda.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-09.2/2026-08-09-windows64.nvidia50.cuda.installer.exe) |
+| Windows 64-bit, ตั้งค่า engine เอง, portable | [`2026-08-09-windows64.without.engine.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-09.2/2026-08-09-windows64.without.engine.portable.zip) |
+| Windows 64-bit, ตั้งค่า engine เอง, installer | [`2026-08-09-windows64.without.engine.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-09.2/2026-08-09-windows64.without.engine.installer.exe) |
+| macOS Apple Silicon | [`2026-08-09-mac-apple-silicon.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-09.2/2026-08-09-mac-apple-silicon.with-katago.dmg) |
+| macOS Intel | [`2026-08-09-mac-intel.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-09.2/2026-08-09-mac-intel.with-katago.dmg) |
+| Linux 64-bit, CPU | [`2026-08-09-linux64.with-katago.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-09.2/2026-08-09-linux64.with-katago.zip) |
+| Linux 64-bit, OpenCL | [`2026-08-09-linux64.opencl.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-09.2/2026-08-09-linux64.opencl.zip) |
+| Linux 64-bit, NVIDIA CUDA | [`2026-08-09-linux64.nvidia.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-09.2/2026-08-09-linux64.nvidia.zip) |
+
+### ทำไมควรทดสอบเวอร์ชันนี้
+
+- AI commentary ชัดเจนขึ้นตั้งแต่ทางเข้า progress จนถึงผลลัพธ์ และโหลดการแก้ไข knowledge file ได้ทันที
+- Zhizi แสดงเฉพาะ model ที่ server รองรับในปัจจุบัน และเก็บรายการที่ใช้ได้ล่าสุดเมื่อ network มีปัญหาชั่วคราว
+- หลัง merge มี `2161` tests ผ่านทั้งหมด พร้อม GitHub Java 21 build และ Windows script validation; platform artifact ทุกชุดจะถูกตรวจอีกครั้งก่อนเผยแพร่
+
+### ติดต่อ
+
+- กลุ่ม QQ: `299419120`

--- a/.github/release-requests/next-2026-08-09.2.json
+++ b/.github/release-requests/next-2026-08-09.2.json
@@ -1,0 +1,7 @@
+{
+  "date_tag": "2026-08-09",
+  "release_tag": "next-2026-08-09.2",
+  "title": "LizzieYzy Next next-2026-08-09.2",
+  "prerelease": true,
+  "notes_file": ".github/release-notes/next-2026-08-09.2.md"
+}


### PR DESCRIPTION
## Summary

- prepares the audited six-language notes for next-2026-08-09.2
- publishes only the changes since next-2026-08-09.1
- uses the fail-closed multi-platform pre-release workflow

## Validation

- git diff --check
- release-request and six-language direct-download validation
- packaging helper and script test suite
- mvn -B -Dfmt.skip=true test: 2161 passed
- mvn -B -Dfmt.skip=true -DskipTests package
- macOS and Windows real UI smoke on the exact release source