### PR TITLE
fix(build): stop Maven lifecycle from formatting sources

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,13 +69,6 @@
 				<groupId>com.spotify.fmt</groupId>
 				<artifactId>fmt-maven-plugin</artifactId>
 				<version>2.29</version>
-				<executions>
-					<execution>
-						<goals>
-							<goal>format</goal>
-						</goals>
-					</execution>
-				</executions>
 			</plugin>
 
 		</plugins>


### PR DESCRIPTION
## Summary

- Remove the implicit `fmt:format` execution from the Maven lifecycle.
- Keep `com.spotify.fmt:fmt-maven-plugin:2.29` declared so explicit `mvn fmt:format` still works.
- Prevent normal `test` / `package` runs from modifying tracked Java sources.

## Type Of Change

- [x] Bug fix
- [ ] Feature
- [ ] Packaging / release update
- [ ] Docs / translation
- [ ] Refactor

## Testing

- [x] Tested locally
- [ ] Verified package contents if packaging changed
- [ ] Verified Fox sync flow if related
- [ ] Added screenshots if UI changed
- [ ] Updated README / docs if user-facing behavior changed
- [ ] Noted affected platforms if the change is platform-specific

Commands run:
- `unset DISPLAY && mvn -B -DskipTests package`
- `unset DISPLAY && mvn -B -Djava.awt.headless=true test`
- `mvn help:describe -Dplugin=com.spotify.fmt:fmt-maven-plugin:2.29 -Dgoal=format -Ddetail`

## Notes

Closes #238
