### PR TITLE
Fix bug report issue form dropdown validation

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -38,8 +38,8 @@ body:
     attributes:
       label: Is this related to Fox sync?
       options:
-        - Yes
-        - No
+        - "Yes"
+        - "No"
     validations:
       required: true
   - type: input


### PR DESCRIPTION
## What changed

Fixed the Bug Report issue form dropdown options by quoting the `Yes` and `No` values.

## Why

GitHub Issue Forms parse unquoted `Yes` and `No` values as YAML booleans, which can make the form validation fail and prevent the template from loading correctly.

## Impact

The Bug Report template should now render correctly in the New Issue flow.

## Validation

Reviewed the issue form YAML structure and updated only the invalid dropdown values.