### PR TITLE
Release engine lifecycle before reporting sync failure

### DIFF
--- a/src/main/java/featurecat/lizzie/analysis/EngineManager.java
+++ b/src/main/java/featurecat/lizzie/analysis/EngineManager.java
@@ -2701,11 +2701,11 @@ public class EngineManager {
     if (explicitRestart && !isMain && target != null) {
       return () -> {
         if (Lizzie.leelaz2 != target || !target.isStarted() || !target.isLoaded()) {
-          target.isLoaded = false;
-          target.markLifecycleBoardSynchronizationFailed(
-              "restart engine was unavailable before board synchronization", targetWasUnrestored);
-          showEngineSynchronizationFailure(target);
-          reservations.close();
+          settleBoardSynchronizationFailure(
+              target,
+              "restart engine was unavailable before board synchronization",
+              targetWasUnrestored,
+              reservations);
           return;
         }
         target.confirmBoardSynchronization(
@@ -2726,10 +2726,8 @@ public class EngineManager {
               }
             },
             detail -> {
-              target.isLoaded = false;
-              target.markLifecycleBoardSynchronizationFailed(detail, targetWasUnrestored);
-              showEngineSynchronizationFailure(target);
-              reservations.close();
+              settleBoardSynchronizationFailure(
+                  target, detail, targetWasUnrestored, reservations);
             });
       };
     }
@@ -2750,10 +2748,12 @@ public class EngineManager {
     return () -> {
       if (Lizzie.leelaz != target || !target.isStarted() || !target.isLoaded()) {
         if (explicitRestart) {
-          target.isLoaded = false;
-          target.markLifecycleBoardSynchronizationFailed(
-              "restart engine was unavailable before board synchronization", targetWasUnrestored);
-          showEngineSynchronizationFailure(target);
+          settleBoardSynchronizationFailure(
+              target,
+              "restart engine was unavailable before board synchronization",
+              targetWasUnrestored,
+              reservations);
+          return;
         }
         reservations.close();
         return;
@@ -2778,12 +2778,26 @@ public class EngineManager {
             }
           },
           detail -> {
-            target.isLoaded = false;
-            target.markLifecycleBoardSynchronizationFailed(detail, targetWasUnrestored);
-            showEngineSynchronizationFailure(target);
-            reservations.close();
+            settleBoardSynchronizationFailure(
+                target, detail, targetWasUnrestored, reservations);
           });
     };
+  }
+
+  private void settleBoardSynchronizationFailure(
+      Leelaz target,
+      String detail,
+      boolean targetWasUnrestored,
+      EngineLifecycleReservations reservations) {
+    target.isLoaded = false;
+    try {
+      target.markLifecycleBoardSynchronizationFailed(detail, targetWasUnrestored);
+    } finally {
+      // Publish the failure only after the engine can accept work again. Callers and UI
+      // observers must never see a terminal failure while its lifecycle lease is still held.
+      reservations.close();
+    }
+    showEngineSynchronizationFailure(target);
   }
 
   protected void switchEngineInternal(int index, boolean isMain, Runnable afterSync) {


### PR DESCRIPTION
## Summary

- releases the engine lifecycle reservation before publishing a terminal board-synchronization failure
- prevents UI and callers from observing a failed engine that still reports exclusive lifecycle work
- applies the same settlement order to unavailable, send-failure, and timeout paths

## Root cause

The Windows lifecycle test reliably woke from the failure notification before `reservations.close()` ran. That ordering exposed a real race: the failure was visible while the engine was still reserved.

## Validation

- lifecycle failure tests repeated 5 times: passed
- full test suite: 2161 tests, 0 failures, 0 errors, 5 environment skips
- shaded jar package: passed
- `git diff --check`: passed

Windows real-machine verification will repeat the previously failing test before merge.