### PR TITLE
Keep first-start window above the Windows taskbar

### DIFF
--- a/src/main/java/featurecat/lizzie/gui/LizzieFrame.java
+++ b/src/main/java/featurecat/lizzie/gui/LizzieFrame.java
@@ -1050,6 +1050,7 @@ public class LizzieFrame extends JFrame {
     if (!hasSetBounds) {
       setSize(1065, 700);
       setLocationRelativeTo(null); // Start centered, needs to be called *after* setSize...
+      constrainWindowToAvailableWorkArea(this);
     }
 
     listTable.addMouseWheelListener(

--- a/src/test/java/featurecat/lizzie/gui/LizzieFrameWindowBoundsTest.java
+++ b/src/test/java/featurecat/lizzie/gui/LizzieFrameWindowBoundsTest.java
@@ -29,6 +29,16 @@ class LizzieFrameWindowBoundsTest {
   }
 
   @Test
+  void keepsDefaultWindowAboveTaskbarAtHighDisplayScale() {
+    Rectangle fitted =
+        LizzieFrame.fitWindowBounds(
+            new Rectangle(107, 10, 1065, 700),
+            Collections.singletonList(new Rectangle(0, 0, 1280, 672)));
+
+    assertEquals(new Rectangle(107, 0, 1065, 672), fitted);
+  }
+
+  @Test
   void preservesBoundsThatAlreadyFit() {
     Rectangle requested = new Rectangle(40, 30, 1000, 700);
 


### PR DESCRIPTION
## Summary

- clamps the default first-start window to the active screen work area
- prevents the bottom toolbar from extending under the Windows taskbar at high display scaling
- adds a regression test for a 1280x672 logical work area

## Validation

- 
- [INFO] Scanning for projects...
[INFO] 
[INFO] -------------------------< featurecat:lizzie >--------------------------
[INFO] Building lizzie yzy2.5.3
[INFO]   from pom.xml
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- resources:3.4.0:resources (default-resources) @ lizzie ---
[INFO] Copying 219 resources from src/main/resources to target/classes
[INFO] 
[INFO] --- compiler:3.13.0:compile (default-compile) @ lizzie ---
[INFO] Nothing to compile - all classes are up to date.
[INFO] 
[INFO] --- resources:3.4.0:testResources (default-testResources) @ lizzie ---
[INFO] skip non existing resourceDirectory /Users/haoc/Developer/lizzyzy-youhua/lizzie-lifecycle-fix/src/test/resources
[INFO] 
[INFO] --- compiler:3.13.0:testCompile (default-testCompile) @ lizzie ---
[INFO] Nothing to compile - all classes are up to date.
[INFO] 
[INFO] --- surefire:3.5.2:test (default-test) @ lizzie ---
[INFO] Using auto detected provider org.apache.maven.surefire.junitplatform.JUnitPlatformProvider
[INFO] 
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running featurecat.lizzie.gui.LizzieFrameWindowBoundsTest
[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.044 s -- in featurecat.lizzie.gui.LizzieFrameWindowBoundsTest
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  0.602 s
[INFO] Finished at: 2026-08-10T21:07:53+08:00
[INFO] ------------------------------------------------------------------------ (5 passed)
- real Windows UI retest will run through Mac-to-Windows Testing Skill before merge

## Evidence

The automated Windows regression captured the remote-compute control at Y=1000 with its center below the taskbar work area. The control was visually clipped and the physical click activated the Windows shell instead of LizzieYzy Next.