### PR TITLE
Fix Windows Zhizi login persistence

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,11 +16,18 @@ concurrency:
 jobs:
   windows-script-validation:
     runs-on: windows-latest
-    timeout-minutes: 5
+    timeout-minutes: 15
 
     steps:
       - name: Checkout
         uses: actions/checkout@v5
+
+      - name: Set up Java 21
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: '21'
+          cache: maven
 
       - name: Parse RTX 50 benchmark script
         shell: pwsh
@@ -36,6 +43,13 @@ jobs:
             $errors | Format-List | Out-String | Write-Error
             exit 1
           }
+
+      - name: Verify Windows credential persistence
+        shell: pwsh
+        run: >-
+          mvn -B -Dfmt.skip=true
+          "-Dtest=PlatformCredentialStoreTest,RemoteComputeConfigTest,MigratingCredentialStoreTest"
+          test
 
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Verify Windows credential persistence
         shell: pwsh
         run: >-
-          mvn -B -Dfmt.skip=true
+          mvn -B "-Dfmt.skip=true"
           "-Dtest=PlatformCredentialStoreTest,RemoteComputeConfigTest,MigratingCredentialStoreTest"
           test
 

--- a/pom.xml
+++ b/pom.xml
@@ -111,6 +111,12 @@
 	<dependencies>
 
 		<dependency>
+			<groupId>net.java.dev.jna</groupId>
+			<artifactId>jna-platform</artifactId>
+			<version>5.19.1</version>
+		</dependency>
+
+		<dependency>
 			<groupId>org.json</groupId>
 			<artifactId>json</artifactId>
 			<version>20231013</version>

--- a/src/main/java/featurecat/lizzie/analysis/remote/PlatformCredentialStore.java
+++ b/src/main/java/featurecat/lizzie/analysis/remote/PlatformCredentialStore.java
@@ -1,5 +1,7 @@
 package featurecat.lizzie.analysis.remote;
 
+import com.sun.jna.platform.win32.Crypt32Util;
+import com.sun.jna.platform.win32.WinCrypt;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
@@ -11,6 +13,8 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Base64;
 import java.util.HexFormat;
 import java.util.List;
 import java.util.Locale;
@@ -30,11 +34,22 @@ public final class PlatformCredentialStore {
 
   public static CredentialStore create(Path credentialDirectory) {
     return create(
-        System.getProperty("os.name", ""), credentialDirectory, new ProcessCommandRunner());
+        System.getProperty("os.name", ""),
+        credentialDirectory,
+        new ProcessCommandRunner(),
+        new JnaWindowsDataProtector());
   }
 
   static CredentialStore create(
       String osName, Path credentialDirectory, CredentialCommandRunner runner) {
+    return create(osName, credentialDirectory, runner, new JnaWindowsDataProtector());
+  }
+
+  static CredentialStore create(
+      String osName,
+      Path credentialDirectory,
+      CredentialCommandRunner runner,
+      WindowsDataProtector windowsDataProtector) {
     String os = normalize(osName);
     if (os.contains("mac")) {
       return new MacKeychainStore(runner);
@@ -43,7 +58,7 @@ public final class PlatformCredentialStore {
       if (credentialDirectory == null) {
         return new UnavailableStore("session-only");
       }
-      return new WindowsDpapiStore(credentialDirectory, runner);
+      return new WindowsDpapiStore(credentialDirectory, windowsDataProtector);
     }
     if (os.contains("linux")) {
       return new LinuxSecretServiceStore(runner);
@@ -262,43 +277,14 @@ public final class PlatformCredentialStore {
     }
   }
 
-  private static final class WindowsDpapiStore extends CommandCredentialStore {
-    private static final String POWERSHELL = "powershell.exe";
-    private static final String LOAD_DPAPI_ASSEMBLY =
-        "$ErrorActionPreference='Stop';"
-            + "[void][Reflection.Assembly]::LoadWithPartialName('System.Security');"
-            + "[Console]::InputEncoding=[Text.Encoding]::UTF8;"
-            + "[Console]::OutputEncoding=[Text.Encoding]::UTF8;";
-    private static final String PROTECT_SCRIPT =
-        LOAD_DPAPI_ASSEMBLY
-            + "$v=[Console]::In.ReadToEnd();"
-            + "$b=[Text.Encoding]::UTF8.GetBytes($v);"
-            + "$p=[Security.Cryptography.ProtectedData]::Protect($b,$null,"
-            + "[Security.Cryptography.DataProtectionScope]::CurrentUser);"
-            + "[Console]::Out.Write([Convert]::ToBase64String($p))";
-    private static final String UNPROTECT_SCRIPT =
-        LOAD_DPAPI_ASSEMBLY
-            + "$v=[Console]::In.ReadToEnd().Trim();"
-            + "$b=[Convert]::FromBase64String($v);"
-            + "$p=[Security.Cryptography.ProtectedData]::Unprotect($b,$null,"
-            + "[Security.Cryptography.DataProtectionScope]::CurrentUser);"
-            + "[Console]::Out.Write([Text.Encoding]::UTF8.GetString($p))";
-    private static final String PROBE_SCRIPT =
-        LOAD_DPAPI_ASSEMBLY
-            + "$s='lizzieyzy-next-dpapi-probe';"
-            + "$b=[Text.Encoding]::UTF8.GetBytes($s);"
-            + "$p=[Security.Cryptography.ProtectedData]::Protect($b,$null,"
-            + "[Security.Cryptography.DataProtectionScope]::CurrentUser);"
-            + "$u=[Security.Cryptography.ProtectedData]::Unprotect($p,$null,"
-            + "[Security.Cryptography.DataProtectionScope]::CurrentUser);"
-            + "if([Text.Encoding]::UTF8.GetString($u) -cne $s){exit 1};exit 0";
-
+  private static final class WindowsDpapiStore implements CredentialStore {
     private final Path directory;
+    private final WindowsDataProtector protector;
     private volatile Boolean available;
 
-    WindowsDpapiStore(Path directory, CredentialCommandRunner runner) {
-      super(runner);
+    WindowsDpapiStore(Path directory, WindowsDataProtector protector) {
       this.directory = directory;
+      this.protector = protector;
     }
 
     @Override
@@ -312,21 +298,20 @@ public final class PlatformCredentialStore {
       if (cached != null) {
         return cached;
       }
+      byte[] probe = "lizzieyzy-next-dpapi-probe".getBytes(StandardCharsets.UTF_8);
+      byte[] encrypted = null;
+      byte[] decrypted = null;
       boolean detected;
       try {
-        detected =
-            run(
-                        List.of(
-                            POWERSHELL,
-                            "-NoProfile",
-                            "-NonInteractive",
-                            "-Command",
-                            PROBE_SCRIPT),
-                        "")
-                    .exitCode
-                == 0;
-      } catch (IOException e) {
+        encrypted = protector.protect(probe);
+        decrypted = protector.unprotect(encrypted);
+        detected = MessageDigest.isEqual(probe, decrypted);
+      } catch (IOException | LinkageError | RuntimeException e) {
         detected = false;
+      } finally {
+        clear(probe);
+        clear(encrypted);
+        clear(decrypted);
       }
       available = detected;
       return detected;
@@ -338,36 +323,52 @@ public final class PlatformCredentialStore {
       if (!isAvailable() || !Files.isRegularFile(path)) {
         return Optional.empty();
       }
-      String encrypted = Files.readString(path, StandardCharsets.US_ASCII).trim();
-      if (encrypted.isEmpty()) {
+      String encoded = Files.readString(path, StandardCharsets.US_ASCII).trim();
+      if (encoded.isEmpty()) {
         return Optional.empty();
       }
-      CommandResult result = run(powershell(UNPROTECT_SCRIPT), encrypted);
-      if (result.exitCode != 0) {
-        throw failure("read");
+      byte[] encrypted = null;
+      byte[] plaintext = null;
+      try {
+        encrypted = Base64.getDecoder().decode(encoded);
+        plaintext = protector.unprotect(encrypted);
+        return nonEmptySecret(new String(plaintext, StandardCharsets.UTF_8));
+      } catch (RuntimeException e) {
+        throw CommandCredentialStore.failure("read");
+      } finally {
+        clear(encrypted);
+        clear(plaintext);
       }
-      return nonEmptySecret(result.output);
     }
 
     @Override
     public void write(Kind kind, String account, String secret) throws IOException {
       if (!isAvailable() || secret == null || secret.isEmpty()) {
-        throw failure("write");
+        throw CommandCredentialStore.failure("write");
       }
-      CommandResult result = run(powershell(PROTECT_SCRIPT), secret);
-      if (result.exitCode != 0 || nonEmptySecret(result.output).isEmpty()) {
-        throw failure("write");
-      }
-      String encrypted = result.output.trim();
-      CommandResult verification = run(powershell(UNPROTECT_SCRIPT), encrypted);
-      if (verification.exitCode != 0 || !secret.equals(verification.output)) {
-        throw failure("verify");
+      byte[] plaintext = secret.getBytes(StandardCharsets.UTF_8);
+      byte[] encrypted = null;
+      byte[] verification = null;
+      String encoded;
+      try {
+        encrypted = protector.protect(plaintext);
+        verification = protector.unprotect(encrypted);
+        if (!MessageDigest.isEqual(plaintext, verification)) {
+          throw CommandCredentialStore.failure("verify");
+        }
+        encoded = Base64.getEncoder().encodeToString(encrypted);
+      } catch (RuntimeException e) {
+        throw CommandCredentialStore.failure("write");
+      } finally {
+        clear(plaintext);
+        clear(encrypted);
+        clear(verification);
       }
       Files.createDirectories(directory);
       Path target = credentialPath(kind, account);
       Path temporary = Files.createTempFile(directory, target.getFileName().toString(), ".tmp");
       try {
-        Files.writeString(temporary, encrypted, StandardCharsets.US_ASCII);
+        Files.writeString(temporary, encoded, StandardCharsets.US_ASCII);
         moveAtomically(temporary, target);
       } finally {
         Files.deleteIfExists(temporary);
@@ -380,12 +381,52 @@ public final class PlatformCredentialStore {
     }
 
     private Path credentialPath(Kind kind, String account) {
-      return directory.resolve(kind.id() + "-" + accountDigest(account(account)) + ".dpapi");
+      return directory.resolve(
+          kind.id() + "-" + accountDigest(CommandCredentialStore.account(account)) + ".dpapi");
     }
 
-    private static List<String> powershell(String script) {
-      return List.of(POWERSHELL, "-NoProfile", "-NonInteractive", "-Command", script);
+    private static void clear(byte[] bytes) {
+      if (bytes != null) {
+        Arrays.fill(bytes, (byte) 0);
+      }
     }
+  }
+
+  interface WindowsDataProtector {
+    byte[] protect(byte[] plaintext) throws IOException;
+
+    byte[] unprotect(byte[] encrypted) throws IOException;
+  }
+
+  private static final class JnaWindowsDataProtector implements WindowsDataProtector {
+    @Override
+    public byte[] protect(byte[] plaintext) throws IOException {
+      return callDpapi(
+          () -> Crypt32Util.cryptProtectData(plaintext, WinCrypt.CRYPTPROTECT_UI_FORBIDDEN));
+    }
+
+    @Override
+    public byte[] unprotect(byte[] encrypted) throws IOException {
+      return callDpapi(
+          () -> Crypt32Util.cryptUnprotectData(encrypted, WinCrypt.CRYPTPROTECT_UI_FORBIDDEN));
+    }
+
+    private static byte[] callDpapi(DpapiCall call) throws IOException {
+      try {
+        byte[] result = call.run();
+        if (result == null || result.length == 0) {
+          throw new IOException("Windows DPAPI returned no data.");
+        }
+        return result;
+      } catch (LinkageError | RuntimeException e) {
+        throw new IOException("Windows DPAPI is unavailable.", e);
+      }
+    }
+  }
+
+  @FunctionalInterface
+  private interface DpapiCall {
+    byte[] run();
   }
 
   private static final class UnavailableStore implements CredentialStore {

--- a/src/main/java/featurecat/lizzie/analysis/remote/PlatformCredentialStore.java
+++ b/src/main/java/featurecat/lizzie/analysis/remote/PlatformCredentialStore.java
@@ -264,18 +264,34 @@ public final class PlatformCredentialStore {
 
   private static final class WindowsDpapiStore extends CommandCredentialStore {
     private static final String POWERSHELL = "powershell.exe";
+    private static final String LOAD_DPAPI_ASSEMBLY =
+        "$ErrorActionPreference='Stop';"
+            + "[void][Reflection.Assembly]::LoadWithPartialName('System.Security');"
+            + "[Console]::InputEncoding=[Text.Encoding]::UTF8;"
+            + "[Console]::OutputEncoding=[Text.Encoding]::UTF8;";
     private static final String PROTECT_SCRIPT =
-        "$v=[Console]::In.ReadToEnd();"
+        LOAD_DPAPI_ASSEMBLY
+            + "$v=[Console]::In.ReadToEnd();"
             + "$b=[Text.Encoding]::UTF8.GetBytes($v);"
             + "$p=[Security.Cryptography.ProtectedData]::Protect($b,$null,"
             + "[Security.Cryptography.DataProtectionScope]::CurrentUser);"
             + "[Console]::Out.Write([Convert]::ToBase64String($p))";
     private static final String UNPROTECT_SCRIPT =
-        "$v=[Console]::In.ReadToEnd().Trim();"
+        LOAD_DPAPI_ASSEMBLY
+            + "$v=[Console]::In.ReadToEnd().Trim();"
             + "$b=[Convert]::FromBase64String($v);"
             + "$p=[Security.Cryptography.ProtectedData]::Unprotect($b,$null,"
             + "[Security.Cryptography.DataProtectionScope]::CurrentUser);"
             + "[Console]::Out.Write([Text.Encoding]::UTF8.GetString($p))";
+    private static final String PROBE_SCRIPT =
+        LOAD_DPAPI_ASSEMBLY
+            + "$s='lizzieyzy-next-dpapi-probe';"
+            + "$b=[Text.Encoding]::UTF8.GetBytes($s);"
+            + "$p=[Security.Cryptography.ProtectedData]::Protect($b,$null,"
+            + "[Security.Cryptography.DataProtectionScope]::CurrentUser);"
+            + "$u=[Security.Cryptography.ProtectedData]::Unprotect($p,$null,"
+            + "[Security.Cryptography.DataProtectionScope]::CurrentUser);"
+            + "if([Text.Encoding]::UTF8.GetString($u) -cne $s){exit 1};exit 0";
 
     private final Path directory;
     private volatile Boolean available;
@@ -305,7 +321,7 @@ public final class PlatformCredentialStore {
                             "-NoProfile",
                             "-NonInteractive",
                             "-Command",
-                            "$null=[Security.Cryptography.ProtectedData];exit 0"),
+                            PROBE_SCRIPT),
                         "")
                     .exitCode
                 == 0;
@@ -342,11 +358,16 @@ public final class PlatformCredentialStore {
       if (result.exitCode != 0 || nonEmptySecret(result.output).isEmpty()) {
         throw failure("write");
       }
+      String encrypted = result.output.trim();
+      CommandResult verification = run(powershell(UNPROTECT_SCRIPT), encrypted);
+      if (verification.exitCode != 0 || !secret.equals(verification.output)) {
+        throw failure("verify");
+      }
       Files.createDirectories(directory);
       Path target = credentialPath(kind, account);
       Path temporary = Files.createTempFile(directory, target.getFileName().toString(), ".tmp");
       try {
-        Files.writeString(temporary, result.output.trim(), StandardCharsets.US_ASCII);
+        Files.writeString(temporary, encrypted, StandardCharsets.US_ASCII);
         moveAtomically(temporary, target);
       } finally {
         Files.deleteIfExists(temporary);

--- a/src/test/java/featurecat/lizzie/analysis/remote/PlatformCredentialStoreTest.java
+++ b/src/test/java/featurecat/lizzie/analysis/remote/PlatformCredentialStoreTest.java
@@ -2,6 +2,7 @@ package featurecat.lizzie.analysis.remote;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
@@ -11,6 +12,8 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 
 class PlatformCredentialStoreTest {
   @Test
@@ -67,7 +70,7 @@ class PlatformCredentialStoreTest {
     Path directory = Files.createTempDirectory("dpapi-store");
     RecordingRunner runner = new RecordingRunner();
     runner.protectedOutput = "encrypted-dpapi-blob";
-    runner.unprotectedOutput = "windows-secret";
+    runner.unprotectedOutput = "never-in-file";
     CredentialStore store = PlatformCredentialStore.create("Windows 11", directory, runner);
 
     store.write(CredentialStore.Kind.ACCOUNT_TOKEN, "user@example.com", "never-in-file");
@@ -80,10 +83,48 @@ class PlatformCredentialStoreTest {
     assertEquals("encrypted-dpapi-blob", Files.readString(files.get(0)));
     assertFalse(files.get(0).getFileName().toString().contains("user@example.com"));
     assertEquals(
-        "windows-secret",
+        "never-in-file",
         store.read(CredentialStore.Kind.ACCOUNT_TOKEN, "user@example.com").orElseThrow());
     assertFalse(runner.flattenedCommands().contains("never-in-file"));
     assertTrue(runner.inputs.contains("never-in-file"));
+    assertTrue(runner.flattenedCommands().contains("LoadWithPartialName('System.Security')"));
+    assertTrue(runner.flattenedCommands().contains("$ErrorActionPreference='Stop'"));
+    assertTrue(runner.flattenedCommands().contains("lizzieyzy-next-dpapi-probe"));
+  }
+
+  @Test
+  void windowsDpapiRejectsCredentialThatCannotBeReadBack() throws Exception {
+    Path directory = Files.createTempDirectory("dpapi-store-verification");
+    RecordingRunner runner = new RecordingRunner();
+    runner.protectedOutput = "encrypted-dpapi-blob";
+    runner.unprotectedOutput = "different-secret";
+    CredentialStore store = PlatformCredentialStore.create("Windows 11", directory, runner);
+
+    assertThrows(
+        IOException.class,
+        () -> store.write(CredentialStore.Kind.ACCOUNT_TOKEN, "user@example.com", "token"));
+    try (var files = Files.list(directory)) {
+      assertEquals(0L, files.count());
+    }
+  }
+
+  @Test
+  @EnabledOnOs(OS.WINDOWS)
+  void windowsDpapiRoundTripsAcrossRealPowerShellProcesses() throws Exception {
+    Path directory = Files.createTempDirectory("dpapi-store-real");
+    String account = "dpapi-regression-test";
+    String secret = "round-trip-secret-\u4e2d\u6587";
+
+    CredentialStore writer = PlatformCredentialStore.create(directory);
+    assertTrue(writer.isAvailable());
+    writer.write(CredentialStore.Kind.ACCOUNT_TOKEN, account, secret);
+
+    CredentialStore reader = PlatformCredentialStore.create(directory);
+    assertTrue(reader.isAvailable());
+    assertEquals(secret, reader.read(CredentialStore.Kind.ACCOUNT_TOKEN, account).orElseThrow());
+
+    reader.delete(CredentialStore.Kind.ACCOUNT_TOKEN, account);
+    assertTrue(reader.read(CredentialStore.Kind.ACCOUNT_TOKEN, account).isEmpty());
   }
 
   @Test

--- a/src/test/java/featurecat/lizzie/analysis/remote/PlatformCredentialStoreTest.java
+++ b/src/test/java/featurecat/lizzie/analysis/remote/PlatformCredentialStoreTest.java
@@ -6,10 +6,13 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Base64;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledOnOs;
@@ -69,9 +72,10 @@ class PlatformCredentialStoreTest {
   void windowsDpapiPersistsOnlyEncryptedUserScopedBlob() throws Exception {
     Path directory = Files.createTempDirectory("dpapi-store");
     RecordingRunner runner = new RecordingRunner();
-    runner.protectedOutput = "encrypted-dpapi-blob";
-    runner.unprotectedOutput = "never-in-file";
-    CredentialStore store = PlatformCredentialStore.create("Windows 11", directory, runner);
+    FakeWindowsDataProtector protector = new FakeWindowsDataProtector();
+    protector.protectedOutput = "encrypted-dpapi-blob".getBytes(StandardCharsets.UTF_8);
+    CredentialStore store =
+        PlatformCredentialStore.create("Windows 11", directory, runner, protector);
 
     store.write(CredentialStore.Kind.ACCOUNT_TOKEN, "user@example.com", "never-in-file");
 
@@ -80,25 +84,26 @@ class PlatformCredentialStoreTest {
       files = paths.toList();
     }
     assertEquals(1, files.size());
-    assertEquals("encrypted-dpapi-blob", Files.readString(files.get(0)));
+    assertEquals(
+        Base64.getEncoder().encodeToString(protector.protectedOutput),
+        Files.readString(files.get(0)));
     assertFalse(files.get(0).getFileName().toString().contains("user@example.com"));
     assertEquals(
         "never-in-file",
         store.read(CredentialStore.Kind.ACCOUNT_TOKEN, "user@example.com").orElseThrow());
-    assertFalse(runner.flattenedCommands().contains("never-in-file"));
-    assertTrue(runner.inputs.contains("never-in-file"));
-    assertTrue(runner.flattenedCommands().contains("LoadWithPartialName('System.Security')"));
-    assertTrue(runner.flattenedCommands().contains("$ErrorActionPreference='Stop'"));
-    assertTrue(runner.flattenedCommands().contains("lizzieyzy-next-dpapi-probe"));
+    assertTrue(runner.commands.isEmpty());
+    assertTrue(protector.protectCalls >= 2);
+    assertTrue(protector.unprotectCalls >= 3);
   }
 
   @Test
   void windowsDpapiRejectsCredentialThatCannotBeReadBack() throws Exception {
     Path directory = Files.createTempDirectory("dpapi-store-verification");
     RecordingRunner runner = new RecordingRunner();
-    runner.protectedOutput = "encrypted-dpapi-blob";
-    runner.unprotectedOutput = "different-secret";
-    CredentialStore store = PlatformCredentialStore.create("Windows 11", directory, runner);
+    FakeWindowsDataProtector protector = new FakeWindowsDataProtector();
+    protector.corruptAfterProbe = true;
+    CredentialStore store =
+        PlatformCredentialStore.create("Windows 11", directory, runner, protector);
 
     assertThrows(
         IOException.class,
@@ -110,7 +115,7 @@ class PlatformCredentialStoreTest {
 
   @Test
   @EnabledOnOs(OS.WINDOWS)
-  void windowsDpapiRoundTripsAcrossRealPowerShellProcesses() throws Exception {
+  void windowsDpapiRoundTripsAcrossRealNativeCalls() throws Exception {
     Path directory = Files.createTempDirectory("dpapi-store-real");
     String account = "dpapi-regression-test";
     String secret = "round-trip-secret-\u4e2d\u6587";
@@ -141,8 +146,6 @@ class PlatformCredentialStoreTest {
     final List<List<String>> commands = new ArrayList<>();
     final List<String> inputs = new ArrayList<>();
     String readOutput = "";
-    String protectedOutput = "encrypted";
-    String unprotectedOutput = "decrypted";
 
     @Override
     public PlatformCredentialStore.CommandResult run(
@@ -150,12 +153,6 @@ class PlatformCredentialStoreTest {
       commands.add(List.copyOf(command));
       inputs.add(input == null ? "" : input);
       String flattened = String.join(" ", command);
-      if (flattened.contains("Unprotect(")) {
-        return new PlatformCredentialStore.CommandResult(0, unprotectedOutput);
-      }
-      if (flattened.contains("Protect(")) {
-        return new PlatformCredentialStore.CommandResult(0, protectedOutput);
-      }
       if (flattened.contains("find-generic-password") || flattened.contains("secret-tool lookup")) {
         return new PlatformCredentialStore.CommandResult(0, readOutput);
       }
@@ -171,6 +168,31 @@ class PlatformCredentialStoreTest {
         out.append(String.join(" ", command));
       }
       return out.toString();
+    }
+  }
+
+  private static final class FakeWindowsDataProtector
+      implements PlatformCredentialStore.WindowsDataProtector {
+    byte[] protectedOutput = "encrypted".getBytes(StandardCharsets.UTF_8);
+    byte[] lastPlaintext = new byte[0];
+    int protectCalls;
+    int unprotectCalls;
+    boolean corruptAfterProbe;
+
+    @Override
+    public byte[] protect(byte[] plaintext) {
+      protectCalls++;
+      lastPlaintext = Arrays.copyOf(plaintext, plaintext.length);
+      return Arrays.copyOf(protectedOutput, protectedOutput.length);
+    }
+
+    @Override
+    public byte[] unprotect(byte[] encrypted) {
+      unprotectCalls++;
+      if (corruptAfterProbe && unprotectCalls > 1) {
+        return "different-secret".getBytes(StandardCharsets.UTF_8);
+      }
+      return Arrays.copyOf(lastPlaintext, lastPlaintext.length);
     }
   }
 }

--- a/src/test/java/featurecat/lizzie/analysis/remote/RemoteComputeConfigTest.java
+++ b/src/test/java/featurecat/lizzie/analysis/remote/RemoteComputeConfigTest.java
@@ -750,8 +750,8 @@ class RemoteComputeConfigTest {
 
   @Test
   void startupKeepsZhiziSelectedWhenRememberedLoginIsAvailable() throws Exception {
-    withConfig(
-        () -> {
+    withConfigAndStore(
+        store -> {
           RemoteComputeConfig.clearZhiziToken();
           ArrayList<EngineData> engines = new ArrayList<>();
           EngineData local = new EngineData();
@@ -767,10 +767,24 @@ class RemoteComputeConfigTest {
           Utils.saveEngineSettings(engines);
 
           RemoteComputeConfig.saveZhiziToken(
-              "remembered-token", true, RemoteComputeConfig.DEFAULT_ZHIZI_ARGS, "user");
+              "remembered-token",
+              true,
+              RemoteComputeConfig.DEFAULT_ZHIZI_ARGS,
+              "user",
+              "remembered-password",
+              true);
+          RemoteComputeConfig.setCredentialStoreForTests(store);
+
+          RemoteComputeConfig.State restored = RemoteComputeConfig.load();
           RemoteComputeConfig.StartupSelection selection =
               RemoteComputeConfig.resolveStartupSelection(-1, true);
 
+          assertEquals("remembered-token", restored.zhiziAccountToken);
+          assertEquals("remembered-password", restored.zhiziPassword);
+          assertTrue(restored.rememberZhiziToken);
+          assertTrue(restored.rememberZhiziPassword);
+          assertTrue(restored.tokenStoredSecurely);
+          assertTrue(restored.passwordStoredSecurely);
           assertEquals(-1, selection.engineIndex);
           assertTrue(selection.loadDefault);
         });


### PR DESCRIPTION
## Summary

- Fix Windows secure credential persistence for Zhizi Cloud login.
- Restore the saved token and password after a real process restart so the selected Zhizi engine can remain active.
- Replace the PowerShell subprocess bridge with direct Windows DPAPI calls and cover the packaged artifact on a physical Windows 11 machine.

## Root cause

Some Windows security environments allow LizzieYzy Next to run but reject child PowerShell processes created by Java with `CreateProcess error=5`. The PowerShell-based DPAPI bridge therefore became unavailable and credential storage fell back to the current session, so the remembered Zhizi login disappeared after restart.

## Changes

- Call Windows `CryptProtectData` / `CryptUnprotectData` directly through JNA instead of launching PowerShell.
- Use the current Windows user scope with UI disabled, keeping credentials unreadable outside that user account.
- Verify every encrypted value can be decrypted before atomically writing it.
- Clear temporary plaintext and ciphertext byte arrays after each operation.
- Preserve the existing migration behavior and `%APPDATA%\LizzieYzy Next` secure-storage location.
- Keep the Windows-only native DPAPI round-trip in the credential persistence test suite and Windows CI.

## Validation

- Physical Windows 11 machine `LL321`, exact commit `24bca2fd`:
  - Reproduced `CreateProcess error=5` with the old PowerShell bridge, including from an interactive scheduled task.
  - Focused credential persistence suite: 38 tests, 0 failures, 0 errors, 0 skipped.
  - Full regression suite: 2165 tests, 0 failures, 0 errors, 3 platform skips.
  - Shaded jar package: passed.
  - Shaded-jar native probe: `backend=windows-dpapi available=true` and `SHADED_DPAPI_ROUNDTRIP=PASS`.
  - Built application launched successfully and rendered the main window.
  - Real Zhizi login with both remember options enabled created native DPAPI token/password records.
  - After a normal application close and same-directory restart, no credentials were entered again; the existing manual engine-start mode correctly restored the Zhizi engine in the chooser.
  - With the isolated profile set to load its default engine automatically, the next restart loaded the saved Zhizi VIP engine directly and resumed live analysis.
  - Persistence flags and both DPAPI records remained valid after restart. No account identifier, password, token, or encrypted contents were included in the report.
- macOS isolated regression suite: 2165 tests, 0 failures, 0 errors, 6 platform skips.
- macOS shaded jar package and JNA native-resource audit: passed.
- Targeted formatting check and `git diff --check`: passed.
- GitHub CI Windows validation and Ubuntu build: passed.

## Release acceptance

The real Windows restart acceptance is complete for the shaded application artifact: saved login, saved password, selected Zhizi provider, manual-start restoration, default-engine automatic startup, and live analysis restoration all passed. A release build may reuse the same native DPAPI path without the blocked PowerShell child process.
