### PR TITLE
Publish next-2026-08-12.1 pre-release

### DIFF
--- a/.github/release-notes/next-2026-08-12.1.md
+++ b/.github/release-notes/next-2026-08-12.1.md
@@ -1,0 +1,317 @@
+# LizzieYzy Next next-2026-08-12.1
+
+## 中文
+
+这是 `next-2026-08-09.2` 之后的稳定性预览更新，重点修复智子登录状态、Windows 高 DPI 界面与首次启动窗口，并让构建和跨平台协作更加可靠。
+
+### 本版主要更新
+
+- 修复智子云算力在勾选记住登录后，重启应用仍丢失登录状态的问题；Windows 保存的敏感凭据改用系统 DPAPI 保护。
+- 修复远程算力界面在 Windows 高 DPI 下的裁切、错位和空间不足；首次启动窗口会保持在任务栏上方的可用屏幕区域。
+- 调整引擎任务失败时的资源释放顺序，避免独占任务结束后仍短暂占用引擎。
+- 修复 GitHub Bug 报告表单的下拉选项校验，用户提交问题时不再被无效表单阻断。
+- 统一仓库文本换行规则并增加自动检查；Maven 构建不再擅自格式化源码。感谢 `qiyi71w` 提交并推动构建生命周期修复。
+
+### 下载前先看这几句
+
+- 已有 Windows 免安装版可使用 `windows64.core-update.zip` 更新主程序；需要同步更新引擎、权重或运行库时请下载对应完整包。
+- 普通 Windows 用户优先选择 OpenCL 免安装版；NVIDIA 用户按显卡代际选择 NVIDIA 或 RTX 50 CUDA 版。
+- 智子账号只有在用户主动选择记住登录或密码时才会保存；Windows 使用系统凭据保护，不再保存可还原的明文密码。
+- 这是预发布版。建议先覆盖到副本并备份现有 `user-data`、自定义权重和棋谱。
+
+### 下载建议
+
+| 你的电脑 | 直接下载这个 |
+| --- | --- |
+| Windows 64 位，OpenCL 版，推荐，免安装 | [`2026-08-12-windows64.opencl.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.1/2026-08-12-windows64.opencl.portable.zip) |
+| 已有 Windows 免安装版，只更新主程序 | [`2026-08-12-windows64.core-update.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.1/2026-08-12-windows64.core-update.zip) |
+| Windows 64 位，OpenCL 安装版 | [`2026-08-12-windows64.opencl.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.1/2026-08-12-windows64.opencl.installer.exe) |
+| Windows 64 位，CPU 兼容版，免安装 | [`2026-08-12-windows64.with-katago.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.1/2026-08-12-windows64.with-katago.portable.zip) |
+| Windows 64 位，CPU 兼容安装版 | [`2026-08-12-windows64.with-katago.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.1/2026-08-12-windows64.with-katago.installer.exe) |
+| Windows 64 位，NVIDIA CUDA 版，免安装 | [`2026-08-12-windows64.nvidia.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.1/2026-08-12-windows64.nvidia.portable.zip) |
+| Windows 64 位，NVIDIA CUDA 安装版 | [`2026-08-12-windows64.nvidia.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.1/2026-08-12-windows64.nvidia.installer.exe) |
+| Windows 64 位，RTX 5070/5080/5090，免安装 | [`2026-08-12-windows64.nvidia50.cuda.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.1/2026-08-12-windows64.nvidia50.cuda.portable.zip) |
+| 高级可选：TensorRT 预装分卷包，需下载全部分卷 | [`2026-08-12-windows64.nvidia.tensorrt.portable.7z.001`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.1/2026-08-12-windows64.nvidia.tensorrt.portable.7z.001)<br>[`2026-08-12-windows64.nvidia.tensorrt.portable.7z.002`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.1/2026-08-12-windows64.nvidia.tensorrt.portable.7z.002) |
+| Windows 64 位，RTX 50 CUDA 安装版 | [`2026-08-12-windows64.nvidia50.cuda.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.1/2026-08-12-windows64.nvidia50.cuda.installer.exe) |
+| Windows 64 位，自行配置引擎，免安装 | [`2026-08-12-windows64.without.engine.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.1/2026-08-12-windows64.without.engine.portable.zip) |
+| Windows 64 位，自行配置引擎，安装版 | [`2026-08-12-windows64.without.engine.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.1/2026-08-12-windows64.without.engine.installer.exe) |
+| macOS Apple Silicon | [`2026-08-12-mac-apple-silicon.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.1/2026-08-12-mac-apple-silicon.with-katago.dmg) |
+| macOS Intel | [`2026-08-12-mac-intel.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.1/2026-08-12-mac-intel.with-katago.dmg) |
+| Linux 64 位，CPU 兼容版 | [`2026-08-12-linux64.with-katago.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.1/2026-08-12-linux64.with-katago.zip) |
+| Linux 64 位，OpenCL 版 | [`2026-08-12-linux64.opencl.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.1/2026-08-12-linux64.opencl.zip) |
+| Linux 64 位，NVIDIA CUDA 版 | [`2026-08-12-linux64.nvidia.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.1/2026-08-12-linux64.nvidia.zip) |
+
+### 这一版为什么值得测试
+
+- Windows 11 真机在 125% 缩放下完成了主界面、远程算力和 KataGo 一键设置检查，未发现裁切或错位。
+- Windows 与 macOS 均完成完整 Maven 测试：`2165` 项、`0` 失败、`0` 错误、`3` 跳过；两端打包均成功。
+- Windows 全新检出已验证换行策略，macOS 也完成真实 Swing 启动冒烟；所有平台成品仍会在公开前再次审计。
+
+### 交流
+
+- QQ 群：`299419120`
+
+---
+
+## 繁體中文
+
+這是 `next-2026-08-09.2` 之後的穩定性預覽更新，重點修正智子登入狀態、Windows 高 DPI 介面與首次啟動視窗，並提高建置與跨平台協作的可靠性。
+
+### 本版主要更新
+
+- 修正勾選記住登入後，重新啟動仍遺失智子雲登入狀態的問題；Windows 敏感憑證改由系統 DPAPI 保護。
+- 修正遠端算力介面在 Windows 高 DPI 下的裁切、錯位與空間不足；首次啟動視窗會維持在工作列上方的可用螢幕區域。
+- 調整 engine 任務失敗時的資源釋放順序，避免獨佔任務結束後仍短暫占用 engine。
+- 修正 GitHub Bug 回報表單的選單驗證，避免無效表單阻擋使用者提交問題。
+- 統一 repository 文字換行並加入自動檢查；Maven build 不再自動格式化 source。感謝 `qiyi71w` 提交並推動建置生命週期修正。
+
+### 下載前先看這幾句
+
+- 既有 Windows portable 可使用 `windows64.core-update.zip` 更新主程式；需要同步更新 engine、weight 或 runtime 時請下載完整套件。
+- 一般 Windows 使用者優先選擇 OpenCL portable；NVIDIA 使用者依顯示卡世代選擇 NVIDIA 或 RTX 50 CUDA 版。
+- 只有使用者主動選擇記住登入或密碼時才會保存智子帳號狀態；Windows 使用系統憑證保護。
+- 這是預覽版，建議先更新副本並備份既有 `user-data`、自訂權重與棋譜。
+
+### 下載建議
+
+| 你的電腦 | 直接下載這個 |
+| --- | --- |
+| Windows 64 位，OpenCL 推薦版，免安裝 | [`2026-08-12-windows64.opencl.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.1/2026-08-12-windows64.opencl.portable.zip) |
+| 既有 Windows portable，只更新主程式 | [`2026-08-12-windows64.core-update.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.1/2026-08-12-windows64.core-update.zip) |
+| Windows 64 位，OpenCL 安裝版 | [`2026-08-12-windows64.opencl.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.1/2026-08-12-windows64.opencl.installer.exe) |
+| Windows 64 位，CPU 相容版，免安裝 | [`2026-08-12-windows64.with-katago.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.1/2026-08-12-windows64.with-katago.portable.zip) |
+| Windows 64 位，CPU 相容安裝版 | [`2026-08-12-windows64.with-katago.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.1/2026-08-12-windows64.with-katago.installer.exe) |
+| Windows 64 位，NVIDIA CUDA，免安裝 | [`2026-08-12-windows64.nvidia.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.1/2026-08-12-windows64.nvidia.portable.zip) |
+| Windows 64 位，NVIDIA CUDA 安裝版 | [`2026-08-12-windows64.nvidia.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.1/2026-08-12-windows64.nvidia.installer.exe) |
+| Windows 64 位，RTX 5070/5080/5090，免安裝 | [`2026-08-12-windows64.nvidia50.cuda.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.1/2026-08-12-windows64.nvidia50.cuda.portable.zip) |
+| 進階可選：TensorRT 預裝分卷，需下載全部檔案 | [`2026-08-12-windows64.nvidia.tensorrt.portable.7z.001`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.1/2026-08-12-windows64.nvidia.tensorrt.portable.7z.001)<br>[`2026-08-12-windows64.nvidia.tensorrt.portable.7z.002`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.1/2026-08-12-windows64.nvidia.tensorrt.portable.7z.002) |
+| Windows 64 位，RTX 50 CUDA 安裝版 | [`2026-08-12-windows64.nvidia50.cuda.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.1/2026-08-12-windows64.nvidia50.cuda.installer.exe) |
+| Windows 64 位，自行設定引擎，免安裝 | [`2026-08-12-windows64.without.engine.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.1/2026-08-12-windows64.without.engine.portable.zip) |
+| Windows 64 位，自行設定引擎，安裝版 | [`2026-08-12-windows64.without.engine.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.1/2026-08-12-windows64.without.engine.installer.exe) |
+| macOS Apple Silicon | [`2026-08-12-mac-apple-silicon.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.1/2026-08-12-mac-apple-silicon.with-katago.dmg) |
+| macOS Intel | [`2026-08-12-mac-intel.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.1/2026-08-12-mac-intel.with-katago.dmg) |
+| Linux 64 位，CPU 相容版 | [`2026-08-12-linux64.with-katago.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.1/2026-08-12-linux64.with-katago.zip) |
+| Linux 64 位，OpenCL 版 | [`2026-08-12-linux64.opencl.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.1/2026-08-12-linux64.opencl.zip) |
+| Linux 64 位，NVIDIA CUDA 版 | [`2026-08-12-linux64.nvidia.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.1/2026-08-12-linux64.nvidia.zip) |
+
+### 這一版為什麼值得測試
+
+- Windows 11 真機在 125% 縮放下完成主畫面、遠端算力與 KataGo 一鍵設定檢查，未發現裁切或錯位。
+- Windows 與 macOS 均完成完整 Maven 測試：`2165` 項、`0` failure、`0` error、`3` skipped；兩端 package 皆成功。
+- Windows 全新 checkout 已驗證換行規則，macOS 也完成真實 Swing 啟動冒煙；各平台成品公開前仍會再次稽核。
+
+### 交流
+
+- QQ 群：`299419120`
+
+---
+
+## English
+
+This stability pre-release follows `next-2026-08-09.2`. It focuses on Zhizi session persistence, Windows high-DPI layouts and first-start placement, while making builds and cross-platform collaboration more reliable.
+
+### Release Highlights
+
+- Fixed Zhizi sessions being lost after restart when remember-login was enabled. Sensitive Windows credentials are now protected with native DPAPI.
+- Fixed clipping, alignment, and space issues in Remote Compute at Windows high DPI. The first-start window now stays within the usable screen area above the taskbar.
+- Corrected engine-resource release ordering after task failures so an ended exclusive task does not briefly keep the engine occupied.
+- Fixed dropdown validation in the GitHub bug-report form so valid reports are no longer blocked.
+- Standardized repository line endings and added enforcement. Maven no longer reformats source during normal builds. Thanks to `qiyi71w` for contributing and driving the Maven lifecycle fix.
+
+### Read Before Downloading
+
+- Existing Windows portable users may install `windows64.core-update.zip`; download a complete package when engines, weights, or runtimes also need updating.
+- Most Windows users should choose the OpenCL portable package. NVIDIA users should select the NVIDIA or RTX 50 CUDA package matching their GPU generation.
+- Zhizi account state is saved only when the user explicitly enables remember-login or remember-password. Windows stores it with operating-system credential protection.
+- This is a pre-release. Upgrade a copy first and back up existing `user-data`, custom weights, and kifu.
+
+### Download Guide
+
+| Your computer | Download this file |
+| --- | --- |
+| Windows 64-bit, OpenCL, recommended, portable | [`2026-08-12-windows64.opencl.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.1/2026-08-12-windows64.opencl.portable.zip) |
+| Existing Windows portable install, application-only update | [`2026-08-12-windows64.core-update.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.1/2026-08-12-windows64.core-update.zip) |
+| Windows 64-bit, OpenCL installer | [`2026-08-12-windows64.opencl.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.1/2026-08-12-windows64.opencl.installer.exe) |
+| Windows 64-bit, CPU fallback, portable | [`2026-08-12-windows64.with-katago.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.1/2026-08-12-windows64.with-katago.portable.zip) |
+| Windows 64-bit, CPU fallback installer | [`2026-08-12-windows64.with-katago.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.1/2026-08-12-windows64.with-katago.installer.exe) |
+| Windows 64-bit, NVIDIA CUDA, portable | [`2026-08-12-windows64.nvidia.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.1/2026-08-12-windows64.nvidia.portable.zip) |
+| Windows 64-bit, NVIDIA CUDA installer | [`2026-08-12-windows64.nvidia.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.1/2026-08-12-windows64.nvidia.installer.exe) |
+| Windows 64-bit, RTX 5070/5080/5090, portable | [`2026-08-12-windows64.nvidia50.cuda.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.1/2026-08-12-windows64.nvidia50.cuda.portable.zip) |
+| Advanced optional TensorRT split package; download every part | [`2026-08-12-windows64.nvidia.tensorrt.portable.7z.001`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.1/2026-08-12-windows64.nvidia.tensorrt.portable.7z.001)<br>[`2026-08-12-windows64.nvidia.tensorrt.portable.7z.002`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.1/2026-08-12-windows64.nvidia.tensorrt.portable.7z.002) |
+| Windows 64-bit, RTX 50 CUDA installer | [`2026-08-12-windows64.nvidia50.cuda.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.1/2026-08-12-windows64.nvidia50.cuda.installer.exe) |
+| Windows 64-bit, configure your own engine, portable | [`2026-08-12-windows64.without.engine.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.1/2026-08-12-windows64.without.engine.portable.zip) |
+| Windows 64-bit, configure your own engine, installer | [`2026-08-12-windows64.without.engine.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.1/2026-08-12-windows64.without.engine.installer.exe) |
+| macOS Apple Silicon | [`2026-08-12-mac-apple-silicon.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.1/2026-08-12-mac-apple-silicon.with-katago.dmg) |
+| macOS Intel | [`2026-08-12-mac-intel.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.1/2026-08-12-mac-intel.with-katago.dmg) |
+| Linux 64-bit, CPU fallback | [`2026-08-12-linux64.with-katago.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.1/2026-08-12-linux64.with-katago.zip) |
+| Linux 64-bit, OpenCL | [`2026-08-12-linux64.opencl.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.1/2026-08-12-linux64.opencl.zip) |
+| Linux 64-bit, NVIDIA CUDA | [`2026-08-12-linux64.nvidia.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.1/2026-08-12-linux64.nvidia.zip) |
+
+### Why Test This Release
+
+- The real Windows 11 application was checked at 125% scaling across the main window, Remote Compute, and KataGo Auto Setup without clipping or misalignment.
+- Full Maven suites completed on Windows and macOS: `2165` tests, `0` failures, `0` errors, and `3` skipped; packaging succeeded on both systems.
+- A fresh Windows checkout verified the line-ending policy, and the real Swing application passed a macOS launch smoke test. Every platform artifact is audited again before publication.
+
+### Contact
+
+- QQ group: `299419120`
+
+---
+
+## 日本語
+
+`next-2026-08-09.2` に続く安定性プレリリースです。Zhizi のログイン状態、Windows high DPI の表示、初回ウィンドウ位置を修正し、build と cross-platform collaboration の信頼性を高めました。
+
+### 主な更新
+
+- remember-login を有効にしても再起動後に Zhizi session が失われる問題を修正し、Windows の機密 credential を native DPAPI で保護しました。
+- Windows high DPI で Remote Compute が切れる、ずれる、狭くなる問題を修正しました。初回ウィンドウは taskbar より上の利用可能領域に表示されます。
+- task failure 後の engine resource 解放順序を修正し、終了した exclusive task が engine を占有し続けないようにしました。
+- GitHub bug report form の dropdown validation を修正し、正しい report が送信できない問題を解消しました。
+- repository の line ending を統一して自動検査を追加し、通常の Maven build が source を再整形しないようにしました。Maven lifecycle 修正を貢献した `qiyi71w` さんに感謝します。
+
+### ダウンロード前に
+
+- 既存 Windows portable は `windows64.core-update.zip` でアプリのみ更新できます。engine、weight、runtime も更新する場合は完全版を選んでください。
+- 多くの Windows 利用者には OpenCL portable を推奨します。NVIDIA は GPU 世代に合う NVIDIA または RTX 50 CUDA package を選んでください。
+- Zhizi account state は remember-login または remember-password を明示的に選んだ場合だけ保存され、Windows では OS credential protection を使用します。
+- これは pre-release です。まずコピーを更新し、`user-data`、custom weight、棋譜を backup してください。
+
+### ダウンロード案内
+
+| お使いの環境 | ダウンロードするファイル |
+| --- | --- |
+| Windows 64-bit、OpenCL 推奨 portable | [`2026-08-12-windows64.opencl.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.1/2026-08-12-windows64.opencl.portable.zip) |
+| 既存 Windows portable、アプリ本体のみ更新 | [`2026-08-12-windows64.core-update.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.1/2026-08-12-windows64.core-update.zip) |
+| Windows 64-bit、OpenCL installer | [`2026-08-12-windows64.opencl.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.1/2026-08-12-windows64.opencl.installer.exe) |
+| Windows 64-bit、CPU fallback portable | [`2026-08-12-windows64.with-katago.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.1/2026-08-12-windows64.with-katago.portable.zip) |
+| Windows 64-bit、CPU fallback installer | [`2026-08-12-windows64.with-katago.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.1/2026-08-12-windows64.with-katago.installer.exe) |
+| Windows 64-bit、NVIDIA CUDA portable | [`2026-08-12-windows64.nvidia.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.1/2026-08-12-windows64.nvidia.portable.zip) |
+| Windows 64-bit、NVIDIA CUDA installer | [`2026-08-12-windows64.nvidia.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.1/2026-08-12-windows64.nvidia.installer.exe) |
+| Windows 64-bit、RTX 5070/5080/5090 portable | [`2026-08-12-windows64.nvidia50.cuda.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.1/2026-08-12-windows64.nvidia50.cuda.portable.zip) |
+| 上級者向け TensorRT 分割 package、全 part が必要 | [`2026-08-12-windows64.nvidia.tensorrt.portable.7z.001`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.1/2026-08-12-windows64.nvidia.tensorrt.portable.7z.001)<br>[`2026-08-12-windows64.nvidia.tensorrt.portable.7z.002`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.1/2026-08-12-windows64.nvidia.tensorrt.portable.7z.002) |
+| Windows 64-bit、RTX 50 CUDA installer | [`2026-08-12-windows64.nvidia50.cuda.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.1/2026-08-12-windows64.nvidia50.cuda.installer.exe) |
+| Windows 64-bit、engine を自分で設定、portable | [`2026-08-12-windows64.without.engine.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.1/2026-08-12-windows64.without.engine.portable.zip) |
+| Windows 64-bit、engine を自分で設定、installer | [`2026-08-12-windows64.without.engine.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.1/2026-08-12-windows64.without.engine.installer.exe) |
+| macOS Apple Silicon | [`2026-08-12-mac-apple-silicon.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.1/2026-08-12-mac-apple-silicon.with-katago.dmg) |
+| macOS Intel | [`2026-08-12-mac-intel.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.1/2026-08-12-mac-intel.with-katago.dmg) |
+| Linux 64-bit、CPU fallback | [`2026-08-12-linux64.with-katago.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.1/2026-08-12-linux64.with-katago.zip) |
+| Linux 64-bit、OpenCL | [`2026-08-12-linux64.opencl.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.1/2026-08-12-linux64.opencl.zip) |
+| Linux 64-bit、NVIDIA CUDA | [`2026-08-12-linux64.nvidia.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.1/2026-08-12-linux64.nvidia.zip) |
+
+### このリリースを試す理由
+
+- Windows 11 実機の 125% scale で main window、Remote Compute、KataGo Auto Setup を確認し、切れやずれは見つかりませんでした。
+- Windows と macOS の full Maven suite は `2165` tests、`0` failure、`0` error、`3` skipped で、両方の package が成功しました。
+- Windows の fresh checkout で line-ending policy を検証し、macOS でも実際の Swing app を起動確認しました。各 platform artifact は公開前に再監査されます。
+
+### 連絡先
+
+- QQ group: `299419120`
+
+---
+
+## 한국어
+
+`next-2026-08-09.2` 이후의 안정성 pre-release입니다. Zhizi 로그인 상태, Windows high DPI UI, 최초 창 위치를 수정하고 build 및 cross-platform 협업의 신뢰성을 높였습니다.
+
+### 주요 업데이트
+
+- remember-login을 켰는데도 재시작 후 Zhizi session이 사라지던 문제를 수정했습니다. Windows 민감 credential은 native DPAPI로 보호됩니다.
+- Windows high DPI에서 Remote Compute가 잘리거나 어긋나고 공간이 부족한 문제를 수정했습니다. 최초 창은 taskbar 위의 사용 가능한 화면 영역에 표시됩니다.
+- task 실패 후 engine resource 해제 순서를 바로잡아 종료된 exclusive task가 engine을 잠시 계속 점유하지 않게 했습니다.
+- GitHub bug report form의 dropdown validation을 수정해 올바른 report가 차단되지 않게 했습니다.
+- repository line ending을 통일하고 자동 검사를 추가했으며, 일반 Maven build가 source를 다시 format하지 않게 했습니다. Maven lifecycle 수정을 기여한 `qiyi71w` 님께 감사드립니다.
+
+### 다운로드 전 확인
+
+- 기존 Windows portable은 `windows64.core-update.zip`으로 앱만 업데이트할 수 있습니다. engine, weight, runtime도 함께 업데이트하려면 전체 package를 받으세요.
+- 대부분의 Windows 사용자는 OpenCL portable을 권장합니다. NVIDIA 사용자는 GPU 세대에 맞는 NVIDIA 또는 RTX 50 CUDA package를 선택하세요.
+- Zhizi account state는 remember-login 또는 remember-password를 명시적으로 선택한 경우에만 저장되며 Windows에서는 OS credential protection을 사용합니다.
+- 이것은 pre-release입니다. 먼저 복사본을 업데이트하고 `user-data`, custom weight, 기보를 backup하세요.
+
+### 다운로드 안내
+
+| 환경 | 다운로드할 파일 |
+| --- | --- |
+| Windows 64-bit, OpenCL 권장 portable | [`2026-08-12-windows64.opencl.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.1/2026-08-12-windows64.opencl.portable.zip) |
+| 기존 Windows portable, 앱만 업데이트 | [`2026-08-12-windows64.core-update.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.1/2026-08-12-windows64.core-update.zip) |
+| Windows 64-bit, OpenCL installer | [`2026-08-12-windows64.opencl.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.1/2026-08-12-windows64.opencl.installer.exe) |
+| Windows 64-bit, CPU portable | [`2026-08-12-windows64.with-katago.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.1/2026-08-12-windows64.with-katago.portable.zip) |
+| Windows 64-bit, CPU installer | [`2026-08-12-windows64.with-katago.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.1/2026-08-12-windows64.with-katago.installer.exe) |
+| Windows 64-bit, NVIDIA CUDA portable | [`2026-08-12-windows64.nvidia.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.1/2026-08-12-windows64.nvidia.portable.zip) |
+| Windows 64-bit, NVIDIA CUDA installer | [`2026-08-12-windows64.nvidia.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.1/2026-08-12-windows64.nvidia.installer.exe) |
+| Windows 64-bit, RTX 5070/5080/5090 portable | [`2026-08-12-windows64.nvidia50.cuda.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.1/2026-08-12-windows64.nvidia50.cuda.portable.zip) |
+| 고급 선택: TensorRT 분할 package, 모든 part 필요 | [`2026-08-12-windows64.nvidia.tensorrt.portable.7z.001`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.1/2026-08-12-windows64.nvidia.tensorrt.portable.7z.001)<br>[`2026-08-12-windows64.nvidia.tensorrt.portable.7z.002`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.1/2026-08-12-windows64.nvidia.tensorrt.portable.7z.002) |
+| Windows 64-bit, RTX 50 CUDA installer | [`2026-08-12-windows64.nvidia50.cuda.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.1/2026-08-12-windows64.nvidia50.cuda.installer.exe) |
+| Windows 64-bit, 직접 engine 설정, portable | [`2026-08-12-windows64.without.engine.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.1/2026-08-12-windows64.without.engine.portable.zip) |
+| Windows 64-bit, 직접 engine 설정, installer | [`2026-08-12-windows64.without.engine.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.1/2026-08-12-windows64.without.engine.installer.exe) |
+| macOS Apple Silicon | [`2026-08-12-mac-apple-silicon.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.1/2026-08-12-mac-apple-silicon.with-katago.dmg) |
+| macOS Intel | [`2026-08-12-mac-intel.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.1/2026-08-12-mac-intel.with-katago.dmg) |
+| Linux 64-bit, CPU | [`2026-08-12-linux64.with-katago.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.1/2026-08-12-linux64.with-katago.zip) |
+| Linux 64-bit, OpenCL | [`2026-08-12-linux64.opencl.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.1/2026-08-12-linux64.opencl.zip) |
+| Linux 64-bit, NVIDIA CUDA | [`2026-08-12-linux64.nvidia.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.1/2026-08-12-linux64.nvidia.zip) |
+
+### 이 릴리스를 테스트할 이유
+
+- Windows 11 실기의 125% scaling에서 main window, Remote Compute, KataGo Auto Setup을 검사했고 잘림이나 어긋남이 없었습니다.
+- Windows와 macOS full Maven suite는 `2165` tests, `0` failure, `0` error, `3` skipped였고 양쪽 package가 성공했습니다.
+- Windows fresh checkout에서 line-ending policy를 검증했고 macOS에서도 실제 Swing app launch smoke를 마쳤습니다. 모든 platform artifact는 공개 전에 다시 검증됩니다.
+
+### 연락처
+
+- QQ 그룹: `299419120`
+
+---
+
+## ภาษาไทย
+
+นี่คือ stability pre-release หลัง `next-2026-08-09.2` โดยเน้นแก้สถานะการเข้าสู่ระบบ Zhizi, UI บน Windows high DPI และตำแหน่งหน้าต่างครั้งแรก พร้อมเพิ่มความน่าเชื่อถือของ build ข้าม platform
+
+### ไฮไลต์ของเวอร์ชันนี้
+
+- แก้ปัญหา Zhizi session หายหลัง restart แม้เปิด remember-login และปกป้อง credential สำคัญบน Windows ด้วย native DPAPI
+- แก้ Remote Compute ถูกตัด วางผิดตำแหน่ง หรือมีพื้นที่ไม่พอบน Windows high DPI หน้าต่างครั้งแรกจะแสดงในพื้นที่ใช้งานเหนือ taskbar
+- แก้ลำดับการคืน engine resource หลัง task ล้มเหลว เพื่อไม่ให้ exclusive task ที่จบแล้วค้างการครอบครอง engine
+- แก้ dropdown validation ของ GitHub bug report form เพื่อไม่ให้ report ที่ถูกต้องถูกบล็อก
+- ทำ line ending ของ repository ให้เป็นมาตรฐานและเพิ่มการตรวจอัตโนมัติ Maven build ปกติจะไม่ format source เอง ขอบคุณ `qiyi71w` สำหรับการช่วยแก้ Maven lifecycle
+
+### ก่อนดาวน์โหลด
+
+- ผู้ใช้ Windows portable เดิมอัปเดตเฉพาะแอปด้วย `windows64.core-update.zip` ได้ หากต้องการอัปเดต engine, weight หรือ runtime ด้วย ให้เลือก package แบบเต็ม
+- ผู้ใช้ Windows ส่วนใหญ่แนะนำ OpenCL portable ส่วน NVIDIA ให้เลือก NVIDIA หรือ RTX 50 CUDA ตามรุ่น GPU
+- Zhizi account state จะถูกบันทึกเมื่อผู้ใช้เลือก remember-login หรือ remember-password เท่านั้น และ Windows ใช้การปกป้อง credential ของระบบ
+- นี่คือ pre-release ควรอัปเดตสำเนาก่อน และ backup `user-data`, custom weight และ kifu
+
+### คู่มือดาวน์โหลด
+
+| คอมพิวเตอร์ของคุณ | ดาวน์โหลดไฟล์นี้ |
+| --- | --- |
+| Windows 64-bit, OpenCL แนะนำ, portable | [`2026-08-12-windows64.opencl.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.1/2026-08-12-windows64.opencl.portable.zip) |
+| มี Windows portable แล้ว อัปเดตเฉพาะโปรแกรม | [`2026-08-12-windows64.core-update.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.1/2026-08-12-windows64.core-update.zip) |
+| Windows 64-bit, OpenCL installer | [`2026-08-12-windows64.opencl.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.1/2026-08-12-windows64.opencl.installer.exe) |
+| Windows 64-bit, CPU portable | [`2026-08-12-windows64.with-katago.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.1/2026-08-12-windows64.with-katago.portable.zip) |
+| Windows 64-bit, CPU installer | [`2026-08-12-windows64.with-katago.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.1/2026-08-12-windows64.with-katago.installer.exe) |
+| Windows 64-bit, NVIDIA CUDA portable | [`2026-08-12-windows64.nvidia.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.1/2026-08-12-windows64.nvidia.portable.zip) |
+| Windows 64-bit, NVIDIA CUDA installer | [`2026-08-12-windows64.nvidia.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.1/2026-08-12-windows64.nvidia.installer.exe) |
+| Windows 64-bit, RTX 5070/5080/5090 portable | [`2026-08-12-windows64.nvidia50.cuda.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.1/2026-08-12-windows64.nvidia50.cuda.portable.zip) |
+| ตัวเลือกขั้นสูง TensorRT แบบแบ่งส่วน ต้องดาวน์โหลดทุกส่วน | [`2026-08-12-windows64.nvidia.tensorrt.portable.7z.001`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.1/2026-08-12-windows64.nvidia.tensorrt.portable.7z.001)<br>[`2026-08-12-windows64.nvidia.tensorrt.portable.7z.002`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.1/2026-08-12-windows64.nvidia.tensorrt.portable.7z.002) |
+| Windows 64-bit, RTX 50 CUDA installer | [`2026-08-12-windows64.nvidia50.cuda.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.1/2026-08-12-windows64.nvidia50.cuda.installer.exe) |
+| Windows 64-bit, ตั้งค่า engine เอง, portable | [`2026-08-12-windows64.without.engine.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.1/2026-08-12-windows64.without.engine.portable.zip) |
+| Windows 64-bit, ตั้งค่า engine เอง, installer | [`2026-08-12-windows64.without.engine.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.1/2026-08-12-windows64.without.engine.installer.exe) |
+| macOS Apple Silicon | [`2026-08-12-mac-apple-silicon.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.1/2026-08-12-mac-apple-silicon.with-katago.dmg) |
+| macOS Intel | [`2026-08-12-mac-intel.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.1/2026-08-12-mac-intel.with-katago.dmg) |
+| Linux 64-bit, CPU | [`2026-08-12-linux64.with-katago.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.1/2026-08-12-linux64.with-katago.zip) |
+| Linux 64-bit, OpenCL | [`2026-08-12-linux64.opencl.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.1/2026-08-12-linux64.opencl.zip) |
+| Linux 64-bit, NVIDIA CUDA | [`2026-08-12-linux64.nvidia.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.1/2026-08-12-linux64.nvidia.zip) |
+
+### ทำไมควรทดสอบเวอร์ชันนี้
+
+- ตรวจแอปจริงบน Windows 11 ที่ scaling 125% ทั้ง main window, Remote Compute และ KataGo Auto Setup โดยไม่พบข้อความถูกตัดหรือวางผิดตำแหน่ง
+- Maven suite เต็มบน Windows และ macOS มี `2165` tests, `0` failure, `0` error, `3` skipped และ package สำเร็จทั้งสองระบบ
+- fresh checkout บน Windows ผ่าน line-ending policy และ macOS ผ่านการเปิดแอป Swing จริง ทุก platform artifact จะถูกตรวจอีกครั้งก่อนเผยแพร่
+
+### ติดต่อ
+
+- กลุ่ม QQ: `299419120`

--- a/.github/release-requests/next-2026-08-12.1.json
+++ b/.github/release-requests/next-2026-08-12.1.json
@@ -1,0 +1,7 @@
+{
+  "date_tag": "2026-08-12",
+  "release_tag": "next-2026-08-12.1",
+  "title": "LizzieYzy Next next-2026-08-12.1",
+  "prerelease": true,
+  "notes_file": ".github/release-notes/next-2026-08-12.1.md"
+}


### PR DESCRIPTION
## Summary

- requests the audited next-2026-08-12.1 pre-release
- adds fixed-structure release notes in Simplified Chinese, Traditional Chinese, English, Japanese, Korean, and Thai
- documents Zhizi session persistence, Windows high-DPI fixes, engine lifecycle cleanup, and build consistency changes since next-2026-08-09.2

## Validation

- real Windows 11 UI smoke at 125% scaling: main window, Remote Compute, and KataGo Auto Setup
- Windows full Maven suite: 2165 tests, 0 failures, 0 errors, 3 skipped
- Windows package build: passed
- macOS full Maven suite and package build: passed
- real macOS Swing launch smoke: passed
- release request and all six direct-download tables: passed
- release publisher/generator tests: 24 passed
- line-ending policy, Markdown links, and git diff check: passed

The release remains unpublished until all Windows, Linux, macOS Intel, and macOS Apple Silicon workflows and asset audits succeed.