### PR TITLE
Fix Windows portable upgrade engine recovery

### DIFF
--- a/.github/workflows/build-windows-release.yml
+++ b/.github/workflows/build-windows-release.yml
@@ -398,7 +398,6 @@ jobs:
 
       - name: Smoke test Windows upgrade install path
         timeout-minutes: 25
-        continue-on-error: true
         shell: powershell
         run: |
           $inputDir = Join-Path $PWD "dist\windows\input-with-katago"

--- a/src/main/java/featurecat/lizzie/Config.java
+++ b/src/main/java/featurecat/lizzie/Config.java
@@ -13,6 +13,7 @@ import java.awt.Color;
 import java.awt.Frame;
 import java.awt.Toolkit;
 import java.io.*;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.AtomicMoveNotSupportedException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -716,7 +717,7 @@ public class Config {
       }
       int tier;
       try {
-        tier = configUserStateTier(new JSONObject(Files.readString(configFile)));
+        tier = configUserStateTier(readJsonObject(configFile));
       } catch (Exception e) {
         continue;
       }
@@ -765,7 +766,7 @@ public class Config {
       return false;
     }
     try {
-      JSONObject parsed = new JSONObject(Files.readString(configFile));
+      JSONObject parsed = readJsonObject(configFile);
       return parsed.optJSONObject("ui") != null || parsed.optJSONObject("leelaz") != null;
     } catch (Exception e) {
       return false;
@@ -777,8 +778,8 @@ public class Config {
     Path targetConfigFile = target.resolve("config.txt");
     Path sourceConfigFile = source.resolve("config.txt");
     try {
-      JSONObject targetConfig = new JSONObject(Files.readString(targetConfigFile));
-      JSONObject sourceConfig = new JSONObject(Files.readString(sourceConfigFile));
+      JSONObject targetConfig = readJsonObject(targetConfigFile);
+      JSONObject sourceConfig = readJsonObject(sourceConfigFile);
       JSONObject targetUi = targetConfig.optJSONObject("ui");
       if (targetUi != null && targetUi.optBoolean(WINDOWS_PORTABLE_STATE_MIGRATION_KEY, false)) {
         return false;
@@ -1155,6 +1156,43 @@ public class Config {
     return "";
   }
 
+  private static boolean isClearlyBrokenJavaJarCommand(String command) {
+    List<String> commandParts = Utils.splitCommand(command == null ? "" : command.trim());
+    if (commandParts.isEmpty() || !Utils.isJavaCommand(commandParts.get(0))) {
+      return false;
+    }
+    for (int i = 0; i < commandParts.size(); i++) {
+      if (!"-jar".equalsIgnoreCase(commandParts.get(i))) {
+        continue;
+      }
+      if (i + 1 >= commandParts.size()) {
+        return true;
+      }
+      String jarToken = commandParts.get(i + 1);
+      if (jarToken == null || jarToken.trim().isEmpty()) {
+        return true;
+      }
+      try {
+        Path jarPath = Path.of(jarToken.trim());
+        if (jarPath.isAbsolute()) {
+          return !Files.isRegularFile(jarPath);
+        }
+        LinkedHashSet<Path> roots = new LinkedHashSet<>();
+        roots.add(Path.of(System.getProperty("user.dir", ".")).toAbsolutePath().normalize());
+        findBundledAppRoot().ifPresent(roots::add);
+        for (Path root : roots) {
+          if (Files.isRegularFile(root.resolve(jarPath).normalize())) {
+            return false;
+          }
+        }
+        return true;
+      } catch (RuntimeException e) {
+        return true;
+      }
+    }
+    return false;
+  }
+
   public static boolean isBundledKataGoExecutable(Path executable) {
     if (executable == null) {
       return false;
@@ -1270,11 +1308,12 @@ public class Config {
     return false;
   }
 
-  private void applyBundledKataGoDefaults() {
+  private boolean applyBundledKataGoDefaults() {
     BundledKataGoConfig bundledConfig = detectBundledKataGoConfig();
     if (bundledConfig == null) {
-      return;
+      return false;
     }
+    String configBeforeRepair = config.toString();
 
     JSONObject ui = config.getJSONObject("ui");
     JSONObject leelaz = config.getJSONObject("leelaz");
@@ -1349,12 +1388,15 @@ public class Config {
                 ui.has("analysis-engine-command-customized"),
                 ui.optBoolean("analysis-engine-command-customized", false),
                 ui.optString("analysis-engine-command", ""));
-        if (!analysisCustomized
-            && isManagedBundledDefaultCommand(ui.optString("analysis-engine-command", ""))) {
+        String analysisCommand = ui.optString("analysis-engine-command", "");
+        if ((!analysisCustomized && isManagedBundledDefaultCommand(analysisCommand))
+            || isClearlyBrokenJavaJarCommand(analysisCommand)) {
           ui.put("analysis-engine-command", bundledConfig.analysisCommand);
           ui.put("analysis-engine-command-customized", false);
         }
-        if (isManagedBundledDefaultCommand(ui.optString("estimate-command", ""))) {
+        String estimateCommand = ui.optString("estimate-command", "");
+        if (isManagedBundledDefaultCommand(estimateCommand)
+            || isClearlyBrokenJavaJarCommand(estimateCommand)) {
           ui.put("estimate-command", bundledConfig.estimateCommand);
         }
         ui.put(DEFAULT_TRANSFORMER_MIGRATION_KEY, true);
@@ -1388,9 +1430,23 @@ public class Config {
       putIfMissing(bundledEngine, "initialCommand", "");
     }
 
-    // Existing profiles may deliberately use manual or no-engine startup. Discovering a bundled
-    // engine must never rewrite that choice; only a genuinely new profile receives defaults.
-    boolean shouldPreferBundled = newProfile;
+    // Existing profiles may deliberately use manual or no-engine startup. Preserve that choice;
+    // only a new profile or an automatically loaded Java launcher whose JAR is gone may switch to
+    // the complete package's bundled engine.
+    int configuredDefaultIndex = ui.optInt("default-engine", -1);
+    JSONObject configuredDefaultEngine =
+        configuredDefaultIndex >= 0 && configuredDefaultIndex < engineSettings.length()
+            ? engineSettings.optJSONObject(configuredDefaultIndex)
+            : null;
+    String configuredDefaultCommand =
+        configuredDefaultEngine == null ? "" : configuredDefaultEngine.optString("command", "");
+    boolean brokenAutomaticDefault =
+        !newProfile
+            && ui.optBoolean("autoload-default", false)
+            && (configuredDefaultEngine == null
+                || configuredDefaultCommand.trim().isEmpty()
+                || isClearlyBrokenJavaJarCommand(configuredDefaultCommand));
+    boolean shouldPreferBundled = newProfile || brokenAutomaticDefault;
     if (shouldPreferBundled) {
       for (int i = 0; i < engineSettings.length(); i++) {
         JSONObject engineInfo = engineSettings.optJSONObject(i);
@@ -1398,14 +1454,27 @@ public class Config {
           engineInfo.put("isDefault", i == bundledIndex);
         }
       }
-      ui.put("autoload-default", true);
-      ui.put("autoload-last", false);
-      ui.put("autoload-empty", false);
+      if (newProfile) {
+        ui.put("autoload-default", true);
+        ui.put("autoload-last", false);
+        ui.put("autoload-empty", false);
+      }
       ui.put("default-engine", bundledIndex);
-      ui.put("analysis-engine-command", bundledConfig.analysisCommand);
-      ui.put("analysis-engine-command-customized", false);
-      ui.put("estimate-command", bundledConfig.estimateCommand);
+      if (newProfile) {
+        ui.put("analysis-engine-command", bundledConfig.analysisCommand);
+        ui.put("analysis-engine-command-customized", false);
+        ui.put("estimate-command", bundledConfig.estimateCommand);
+      }
     }
+    return !configBeforeRepair.equals(config.toString());
+  }
+
+  private boolean applyBundledKataGoDefaultsAndPersist() throws IOException {
+    boolean changed = applyBundledKataGoDefaults();
+    if (changed) {
+      writeConfig(this.config, new File(configFilename));
+    }
+    return changed;
   }
 
   public boolean moveListTopCurNode = false;
@@ -1900,8 +1969,7 @@ public class Config {
         System.exit(1);
       }
     }
-    try (FileInputStream fp = new FileInputStream(file);
-        InputStreamReader reader = new InputStreamReader(fp, "utf-8")) {
+    try (Reader reader = openUtf8JsonReader(file)) {
       JSONObject mergedcfg = new JSONObject(new JSONTokener(reader));
       boolean modified = mergeDefaults(mergedcfg, defaultCfg);
 
@@ -1924,6 +1992,32 @@ public class Config {
     }
   }
 
+  private static Reader openUtf8JsonReader(File file) throws IOException {
+    PushbackReader reader =
+        new PushbackReader(
+            new InputStreamReader(new FileInputStream(file), StandardCharsets.UTF_8), 1);
+    try {
+      int first = reader.read();
+      if (first != -1 && first != '\uFEFF') {
+        reader.unread(first);
+      }
+      return reader;
+    } catch (IOException | RuntimeException e) {
+      reader.close();
+      throw e;
+    }
+  }
+
+  private static JSONObject readJsonObject(Path file) throws IOException {
+    try (Reader reader = openUtf8JsonReader(file.toFile())) {
+      return new JSONObject(new JSONTokener(reader));
+    }
+  }
+
+  static JSONObject readJsonObjectForTests(Path file) throws IOException {
+    return readJsonObject(file);
+  }
+
   private JSONObject loadAndMergeConfig(
       JSONObject defaultCfg, String fileName, boolean needValidation) throws IOException {
     File file = new File(fileName);
@@ -1937,8 +2031,7 @@ public class Config {
       }
     }
 
-    try (FileInputStream fp = new FileInputStream(file);
-        InputStreamReader reader = new InputStreamReader(fp, "utf-8")) {
+    try (Reader reader = openUtf8JsonReader(file)) {
       JSONObject mergedcfg = new JSONObject(new JSONTokener(reader));
       boolean modified = mergeDefaults(mergedcfg, defaultCfg);
 
@@ -1961,8 +2054,7 @@ public class Config {
       System.exit(1);
     }
 
-    try (FileInputStream fp = new FileInputStream(file);
-        InputStreamReader reader = new InputStreamReader(fp, "utf-8")) {
+    try (Reader reader = openUtf8JsonReader(file)) {
       JSONObject mergedcfg = new JSONObject(new JSONTokener(reader));
       boolean modified = mergeDefaults(mergedcfg, defaultCfg);
 
@@ -2121,7 +2213,7 @@ public class Config {
       backupUnreadableConfig(new File(configFilename));
       this.config = loadAndMergeConfigdef(defaultConfig, configFilename, true);
     }
-    applyBundledKataGoDefaults();
+    applyBundledKataGoDefaultsAndPersist();
     // Persisted properties
 
     this.saveBoard = loadAndMergeSaveBoardConfig(saveBoardConf, saveBoardFilename, false);

--- a/src/main/java/featurecat/lizzie/Config.java
+++ b/src/main/java/featurecat/lizzie/Config.java
@@ -1382,7 +1382,7 @@ public class Config {
       if (!reusedAutoSetupEntry) {
         bundledEngine.put("name", BUNDLED_ENGINE_NAME);
       }
-      if (!newProfile && bundledConfig.transformerDefault) {
+      if (!newProfile) {
         boolean analysisCustomized =
             AnalysisEngineCommandHelper.isAnalysisCommandCustomized(
                 ui.has("analysis-engine-command-customized"),
@@ -1399,7 +1399,9 @@ public class Config {
             || isClearlyBrokenJavaJarCommand(estimateCommand)) {
           ui.put("estimate-command", bundledConfig.estimateCommand);
         }
-        ui.put(DEFAULT_TRANSFORMER_MIGRATION_KEY, true);
+        if (bundledConfig.transformerDefault) {
+          ui.put(DEFAULT_TRANSFORMER_MIGRATION_KEY, true);
+        }
       }
     }
     if (createdBundledEngine) {

--- a/src/main/java/featurecat/lizzie/Config.java
+++ b/src/main/java/featurecat/lizzie/Config.java
@@ -1969,8 +1969,8 @@ public class Config {
         System.exit(1);
       }
     }
-    try (Reader reader = openUtf8JsonReader(file)) {
-      JSONObject mergedcfg = new JSONObject(new JSONTokener(reader));
+    try {
+      JSONObject mergedcfg = readJsonObject(file.toPath());
       boolean modified = mergeDefaults(mergedcfg, defaultCfg);
 
       if (needValidation) checkEmptyBlunderThresholds(mergedcfg);
@@ -2031,16 +2031,14 @@ public class Config {
       }
     }
 
-    try (Reader reader = openUtf8JsonReader(file)) {
-      JSONObject mergedcfg = new JSONObject(new JSONTokener(reader));
-      boolean modified = mergeDefaults(mergedcfg, defaultCfg);
+    JSONObject mergedcfg = readJsonObject(file.toPath());
+    boolean modified = mergeDefaults(mergedcfg, defaultCfg);
 
-      if (needValidation) checkEmptyBlunderThresholds(mergedcfg);
-      if (modified) {
-        writeConfig(mergedcfg, file);
-      }
-      return mergedcfg;
+    if (needValidation) checkEmptyBlunderThresholds(mergedcfg);
+    if (modified) {
+      writeConfig(mergedcfg, file);
     }
+    return mergedcfg;
   }
 
   private JSONObject loadAndMergeConfigdef(
@@ -2054,16 +2052,14 @@ public class Config {
       System.exit(1);
     }
 
-    try (Reader reader = openUtf8JsonReader(file)) {
-      JSONObject mergedcfg = new JSONObject(new JSONTokener(reader));
-      boolean modified = mergeDefaults(mergedcfg, defaultCfg);
+    JSONObject mergedcfg = readJsonObject(file.toPath());
+    boolean modified = mergeDefaults(mergedcfg, defaultCfg);
 
-      if (needValidation) checkEmptyBlunderThresholds(mergedcfg);
-      if (modified) {
-        writeConfig(mergedcfg, file);
-      }
-      return mergedcfg;
+    if (needValidation) checkEmptyBlunderThresholds(mergedcfg);
+    if (modified) {
+      writeConfig(mergedcfg, file);
     }
+    return mergedcfg;
   }
 
   /**
@@ -2208,7 +2204,7 @@ public class Config {
     // Main properties
     try {
       this.config = loadAndMergeConfig(defaultConfig, configFilename, true);
-    } catch (Exception e) {
+    } catch (JSONException e) {
       e.printStackTrace();
       backupUnreadableConfig(new File(configFilename));
       this.config = loadAndMergeConfigdef(defaultConfig, configFilename, true);

--- a/src/test/java/featurecat/lizzie/ConfigBundledKataGoDefaultsTest.java
+++ b/src/test/java/featurecat/lizzie/ConfigBundledKataGoDefaultsTest.java
@@ -194,6 +194,41 @@ public class ConfigBundledKataGoDefaultsTest {
   }
 
   @Test
+  void utf8BomConfigCanMergeAndAtomicallyPersistOnWindows() throws Exception {
+    Path tempRoot = Files.createTempDirectory("lizzie-config-bom-merge");
+    Path configFile = tempRoot.resolve("config.txt");
+    byte[] json =
+        "{\"ui\":{\"first-time-load\":false},\"leelaz\":{\"custom\":\"preserved\"}}"
+            .getBytes(StandardCharsets.UTF_8);
+    byte[] withBom = new byte[json.length + 3];
+    withBom[0] = (byte) 0xEF;
+    withBom[1] = (byte) 0xBB;
+    withBom[2] = (byte) 0xBF;
+    System.arraycopy(json, 0, withBom, 3, json.length);
+    Files.write(configFile, withBom);
+
+    Config config = ConfigTestHelper.createForTests(tempRoot);
+    Method method =
+        Config.class.getDeclaredMethod(
+            "loadAndMergeConfig", JSONObject.class, String.class, boolean.class);
+    method.setAccessible(true);
+    JSONObject defaults =
+        new JSONObject()
+            .put("ui", new JSONObject().put("show-status", true))
+            .put("leelaz", new JSONObject().put("default-added", true));
+
+    JSONObject merged =
+        (JSONObject) method.invoke(config, defaults, configFile.toString(), false);
+
+    assertFalse(merged.getJSONObject("ui").getBoolean("first-time-load"));
+    assertTrue(merged.getJSONObject("ui").getBoolean("show-status"));
+    assertEquals("preserved", merged.getJSONObject("leelaz").getString("custom"));
+    JSONObject persisted = Config.readJsonObjectForTests(configFile);
+    assertTrue(persisted.getJSONObject("leelaz").getBoolean("default-added"));
+    assertFalse(Files.exists(tempRoot.resolve("config.txt.unreadable-backup")));
+  }
+
+  @Test
   void utf8BomPortableConfigIsNotBackedUpAsUnreadable() throws Exception {
     Path parent = Files.createTempDirectory("lizzie-portable-bom");
     Path currentRoot = Files.createDirectories(parent.resolve("current"));

--- a/src/test/java/featurecat/lizzie/ConfigBundledKataGoDefaultsTest.java
+++ b/src/test/java/featurecat/lizzie/ConfigBundledKataGoDefaultsTest.java
@@ -526,6 +526,41 @@ public class ConfigBundledKataGoDefaultsTest {
   }
 
   @Test
+  void brokenLegacyAuxiliaryEnginesAreRepairedWithoutVersionMetadata() throws Exception {
+    Path tempRoot = Files.createTempDirectory("lizzie-bundled-katago-legacy-package");
+    Files.writeString(tempRoot.resolve("config.txt"), "{}");
+    createBundledKataGoAssets(tempRoot);
+
+    Config config = ConfigTestHelper.createForTests(tempRoot);
+    JSONObject ui =
+        new JSONObject()
+            .put("first-time-load", false)
+            .put("autoload-default", true)
+            .put("default-engine", 0)
+            .put("analysis-engine-command", "java -jar legacy/missing-analysis.jar")
+            .put("analysis-engine-command-customized", true)
+            .put("estimate-command", "java -jar legacy/missing-estimate.jar");
+    JSONObject leelaz =
+        new JSONObject()
+            .put(
+                "engine-settings-list",
+                new JSONArray()
+                    .put(
+                        new JSONObject()
+                            .put("name", "Legacy KataGo")
+                            .put("command", "java -jar legacy/missing-engine.jar")
+                            .put("isDefault", true)));
+    config.config = new JSONObject().put("ui", ui).put("leelaz", leelaz);
+
+    withUserDir(tempRoot, () -> applyBundledKataGoDefaults(config));
+
+    assertFalse(ui.getString("analysis-engine-command").contains("java -jar"));
+    assertFalse(ui.getBoolean("analysis-engine-command-customized"));
+    assertFalse(ui.getString("estimate-command").contains("java -jar"));
+    assertFalse(ui.optBoolean("migrated-default-transformer-v1", false));
+  }
+
+  @Test
   void existingJavaJarDefaultIsPreservedWhenLauncherStillExists() throws Exception {
     Path tempRoot = Files.createTempDirectory("lizzie-bundled-katago-valid-java");
     Files.writeString(tempRoot.resolve("config.txt"), "{}");

--- a/src/test/java/featurecat/lizzie/ConfigBundledKataGoDefaultsTest.java
+++ b/src/test/java/featurecat/lizzie/ConfigBundledKataGoDefaultsTest.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import featurecat.lizzie.analysis.remote.RemoteComputeConfig;
 import featurecat.lizzie.util.KataGoAutoSetupHelper;
 import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.attribute.FileTime;
@@ -173,6 +174,49 @@ public class ConfigBundledKataGoDefaultsTest {
     JSONObject recovered = new JSONObject(Files.readString(currentData.resolve("config.txt")));
     assertEquals(
         2, recovered.getJSONObject("leelaz").getJSONArray("engine-settings-list").length());
+  }
+
+  @Test
+  void utf8BomConfigRemainsReadable() throws Exception {
+    Path tempRoot = Files.createTempDirectory("lizzie-config-bom");
+    Path configFile = tempRoot.resolve("config.txt");
+    byte[] json = "{\"ui\":{\"first-time-load\":false}}".getBytes(StandardCharsets.UTF_8);
+    byte[] withBom = new byte[json.length + 3];
+    withBom[0] = (byte) 0xEF;
+    withBom[1] = (byte) 0xBB;
+    withBom[2] = (byte) 0xBF;
+    System.arraycopy(json, 0, withBom, 3, json.length);
+    Files.write(configFile, withBom);
+
+    JSONObject parsed = Config.readJsonObjectForTests(configFile);
+
+    assertFalse(parsed.getJSONObject("ui").getBoolean("first-time-load"));
+  }
+
+  @Test
+  void utf8BomPortableConfigIsNotBackedUpAsUnreadable() throws Exception {
+    Path parent = Files.createTempDirectory("lizzie-portable-bom");
+    Path currentRoot = Files.createDirectories(parent.resolve("current"));
+    Files.writeString(currentRoot.resolve(".lizzie-portable"), "portable");
+    Path currentData = Files.createDirectories(currentRoot.resolve("user-data"));
+    byte[] json = richPortableConfig().toString(2).getBytes(StandardCharsets.UTF_8);
+    byte[] withBom = new byte[json.length + 3];
+    withBom[0] = (byte) 0xEF;
+    withBom[1] = (byte) 0xBB;
+    withBom[2] = (byte) 0xBF;
+    System.arraycopy(json, 0, withBom, 3, json.length);
+    Files.write(currentData.resolve("config.txt"), withBom);
+
+    Config.prepareWindowsPortableWorkDirWithSourcesForTests(currentRoot);
+
+    assertFalse(Files.exists(currentData.resolve("config.txt.unreadable-backup")));
+    JSONObject parsed = Config.readJsonObjectForTests(currentData.resolve("config.txt"));
+    assertEquals(
+        "saved-user",
+        parsed
+            .getJSONObject("leelaz")
+            .getJSONObject(RemoteComputeConfig.CONFIG_KEY)
+            .getString("zhizi-identifier"));
   }
 
   @Test
@@ -390,6 +434,96 @@ public class ConfigBundledKataGoDefaultsTest {
         customCommand,
         storedEngine.getString("command"),
         "a custom command in the default slot must not be overwritten by the bundled default.");
+  }
+
+  @Test
+  void brokenLegacyJavaDefaultFallsBackToBundledEngine() throws Exception {
+    Path tempRoot = Files.createTempDirectory("lizzie-bundled-katago-broken-legacy");
+    Files.writeString(tempRoot.resolve("config.txt"), "{}");
+    createBundledKataGoAssets(tempRoot, KataGoAutoSetupHelper.DEFAULT_TRANSFORMER_FILE_NAME);
+
+    Config config = ConfigTestHelper.createForTests(tempRoot);
+    JSONObject ui =
+        new JSONObject()
+            .put("first-time-load", false)
+            .put("autoload-default", true)
+            .put("autoload-last", false)
+            .put("autoload-empty", false)
+            .put("default-engine", 0)
+            .put("analysis-engine-command", "java -jar legacy/missing-analysis.jar")
+            .put("estimate-command", "java -jar legacy/missing-estimate.jar");
+    JSONObject legacyEngine =
+        new JSONObject()
+            .put("name", "Legacy KataGo")
+            .put("command", "java -jar legacy/missing-engine.jar")
+            .put("isDefault", true);
+    JSONObject leelaz =
+        new JSONObject().put("engine-settings-list", new JSONArray().put(legacyEngine));
+    config.config = new JSONObject().put("ui", ui).put("leelaz", leelaz);
+
+    boolean changed =
+        withUserDirResult(tempRoot, () -> applyBundledKataGoDefaultsAndPersist(config));
+
+    JSONArray engines = leelaz.getJSONArray("engine-settings-list");
+    int defaultIndex = ui.getInt("default-engine");
+    assertTrue(changed);
+    assertEquals(2, engines.length());
+    assertEquals(1, defaultIndex);
+    assertFalse(engines.getJSONObject(0).getBoolean("isDefault"));
+    assertTrue(engines.getJSONObject(defaultIndex).getBoolean("isDefault"));
+    assertFalse(engines.getJSONObject(defaultIndex).getString("command").contains("java -jar"));
+    assertFalse(ui.getString("analysis-engine-command").contains("java -jar"));
+    assertFalse(ui.getString("estimate-command").contains("java -jar"));
+    assertTrue(ui.getBoolean("autoload-default"));
+    assertFalse(ui.getBoolean("autoload-last"));
+    assertFalse(ui.getBoolean("autoload-empty"));
+
+    JSONObject persisted = Config.readJsonObjectForTests(tempRoot.resolve("config.txt"));
+    int persistedDefault = persisted.getJSONObject("ui").getInt("default-engine");
+    assertEquals(1, persistedDefault);
+    assertFalse(
+        persisted
+            .getJSONObject("leelaz")
+            .getJSONArray("engine-settings-list")
+            .getJSONObject(persistedDefault)
+            .getString("command")
+            .contains("java -jar"));
+  }
+
+  @Test
+  void existingJavaJarDefaultIsPreservedWhenLauncherStillExists() throws Exception {
+    Path tempRoot = Files.createTempDirectory("lizzie-bundled-katago-valid-java");
+    Files.writeString(tempRoot.resolve("config.txt"), "{}");
+    createBundledKataGoAssets(tempRoot, KataGoAutoSetupHelper.DEFAULT_TRANSFORMER_FILE_NAME);
+    Path launcher = Files.createDirectories(tempRoot.resolve("legacy")).resolve("engine.jar");
+    Files.write(launcher, new byte[] {1});
+    String command = "java -jar " + quote(launcher);
+
+    Config config = ConfigTestHelper.createForTests(tempRoot);
+    JSONObject ui =
+        new JSONObject()
+            .put("first-time-load", false)
+            .put("autoload-default", true)
+            .put("default-engine", 0)
+            .put("analysis-engine-command", command)
+            .put("estimate-command", command);
+    JSONObject customEngine =
+        new JSONObject()
+            .put("name", "Custom Java Engine")
+            .put("command", command)
+            .put("isDefault", true);
+    JSONObject leelaz =
+        new JSONObject().put("engine-settings-list", new JSONArray().put(customEngine));
+    config.config = new JSONObject().put("ui", ui).put("leelaz", leelaz);
+
+    withUserDir(tempRoot, () -> applyBundledKataGoDefaults(config));
+
+    assertEquals(0, ui.getInt("default-engine"));
+    assertEquals(
+        command,
+        leelaz.getJSONArray("engine-settings-list").getJSONObject(0).getString("command"));
+    assertEquals(command, ui.getString("analysis-engine-command"));
+    assertEquals(command, ui.getString("estimate-command"));
   }
 
   @Test
@@ -758,10 +892,16 @@ public class ConfigBundledKataGoDefaultsTest {
     assertTrue(Files.exists(tempRoot.resolve("save").resolve("save")));
   }
 
-  private static void applyBundledKataGoDefaults(Config config) throws Exception {
+  private static boolean applyBundledKataGoDefaults(Config config) throws Exception {
     Method method = Config.class.getDeclaredMethod("applyBundledKataGoDefaults");
     method.setAccessible(true);
-    method.invoke(config);
+    return (Boolean) method.invoke(config);
+  }
+
+  private static boolean applyBundledKataGoDefaultsAndPersist(Config config) throws Exception {
+    Method method = Config.class.getDeclaredMethod("applyBundledKataGoDefaultsAndPersist");
+    method.setAccessible(true);
+    return (Boolean) method.invoke(config);
   }
 
   private static JSONObject createDefaultConfig(Config config) throws Exception {
@@ -841,6 +981,21 @@ public class ConfigBundledKataGoDefaultsTest {
     }
   }
 
+  private static <T> T withUserDirResult(Path userDir, ThrowingSupplier<T> action)
+      throws Exception {
+    String previousUserDir = System.getProperty("user.dir");
+    try {
+      System.setProperty("user.dir", userDir.toString());
+      return action.get();
+    } finally {
+      if (previousUserDir == null) {
+        System.clearProperty("user.dir");
+      } else {
+        System.setProperty("user.dir", previousUserDir);
+      }
+    }
+  }
+
   private static void createBundledKataGoAssets(Path root) throws Exception {
     createBundledKataGoAssets(root, "");
   }
@@ -892,5 +1047,9 @@ public class ConfigBundledKataGoDefaultsTest {
 
   private interface ThrowingRunnable {
     void run() throws Exception;
+  }
+
+  private interface ThrowingSupplier<T> {
+    T get() throws Exception;
   }
 }


### PR DESCRIPTION
## Summary

- Preserve UTF-8 BOM Windows portable configurations during upgrade.
- Repair a broken auto-loaded legacy Java launcher to the bundled KataGo engine without overwriting valid custom or remote engines.
- Persist the repaired default, analysis, and estimate commands before startup continues.
- Close JSON readers before atomic replacement on Windows, and only rebuild configuration for genuine JSON syntax failures.
- Repair removed legacy quick-analysis and estimate launchers even when an older complete package lacks current model metadata.
- Make the Windows old-to-new installer smoke test a mandatory release gate.

## Root cause

The previous release build could create a valid bundled KataGo entry while keeping `default-engine=0` on a removed legacy launcher. PowerShell also wrote the smoke-test config with a UTF-8 BOM, which startup migration treated as unreadable.

## Validation

- Full JDK 21 suite: 2171 tests, 0 failures, 0 errors, 1 platform-only skip.
- JDK 21 shaded package: passed.
- Targeted bundled-KataGo and portable-config suite: 31 tests passed.
- Line endings, Markdown links, release helpers, R2, macOS bundle, JCEF, KataGo assets, Windows launcher, Python, and shell checks: passed.

## Windows acceptance

- Windows 11 targeted suite: 31 tests, 0 failures, 0 errors.
- Windows 11 full suite: 2171 tests, 0 failures, 0 errors, 3 platform-only skips.
- Windows shaded package: passed.
- Real Windows portable upgrade and launcher startup: passed. The UTF-8 BOM configuration was preserved without a backup/reset, the default engine selected bundled KataGo, and the quick-analysis and estimate commands no longer referenced removed Java launchers.
