### PR TITLE
Publish next-2026-08-12.2 pre-release

### DIFF
--- a/.github/release-notes/next-2026-08-12.2.md
+++ b/.github/release-notes/next-2026-08-12.2.md
@@ -1,0 +1,317 @@
+# LizzieYzy Next next-2026-08-12.2
+
+## 中文
+
+这是 `next-2026-08-09.2` 之后的稳定性预览更新，重点修复智子登录状态、Windows 高 DPI 显示、首次启动窗口和旧免安装版覆盖升级。
+
+### 本版主要更新
+
+- 修复智子云算力勾选记住登录后，重启应用仍丢失登录状态的问题；Windows 敏感凭据使用系统 DPAPI 保护。
+- 修复远程算力界面在 Windows 高 DPI 下的裁切、错位和空间不足；首次启动窗口保持在任务栏上方的可用屏幕区域。
+- 修复 Windows 旧免安装版覆盖升级后仍选择已删除 Java 引擎的问题，主引擎、快速分析和形势判断会恢复到完整包内置 KataGo。
+- 修复 Windows 无法在配置文件仍打开时执行原子替换的问题；UTF-8 BOM 配置会保留，写入失败也不会再被误判为配置损坏并重置。
+- 调整引擎任务失败时的资源释放顺序；修复 GitHub Bug 报告表单校验，并统一仓库换行规则。感谢 `qiyi71w` 推动 Maven 构建生命周期修复。
+
+### 下载前先看这几句
+
+- 已有 Windows 免安装版可用 `windows64.core-update.zip` 更新主程序；需要同步更新引擎、权重或运行库时请下载对应完整包。
+- 普通 Windows 用户优先选择 OpenCL 免安装版；NVIDIA 用户按显卡代际选择 NVIDIA 或 RTX 50 CUDA 版。
+- 智子账号只有在用户主动选择记住登录或密码时才会保存；Windows 使用系统凭据保护。
+- 这是预发布版。建议先覆盖到副本，并备份现有 `user-data`、自定义权重和棋谱。
+
+### 下载建议
+
+| 你的电脑 | 直接下载这个 |
+| --- | --- |
+| Windows 64 位，OpenCL 版，推荐，免安装 | [`2026-08-12-windows64.opencl.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.2/2026-08-12-windows64.opencl.portable.zip) |
+| 已有 Windows 免安装版，只更新主程序 | [`2026-08-12-windows64.core-update.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.2/2026-08-12-windows64.core-update.zip) |
+| Windows 64 位，OpenCL 安装版 | [`2026-08-12-windows64.opencl.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.2/2026-08-12-windows64.opencl.installer.exe) |
+| Windows 64 位，CPU 兼容版，免安装 | [`2026-08-12-windows64.with-katago.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.2/2026-08-12-windows64.with-katago.portable.zip) |
+| Windows 64 位，CPU 兼容安装版 | [`2026-08-12-windows64.with-katago.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.2/2026-08-12-windows64.with-katago.installer.exe) |
+| Windows 64 位，NVIDIA CUDA 版，免安装 | [`2026-08-12-windows64.nvidia.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.2/2026-08-12-windows64.nvidia.portable.zip) |
+| Windows 64 位，NVIDIA CUDA 安装版 | [`2026-08-12-windows64.nvidia.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.2/2026-08-12-windows64.nvidia.installer.exe) |
+| Windows 64 位，RTX 5070/5080/5090，免安装 | [`2026-08-12-windows64.nvidia50.cuda.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.2/2026-08-12-windows64.nvidia50.cuda.portable.zip) |
+| 高级可选：TensorRT 预装分卷包，需下载全部分卷 | [`2026-08-12-windows64.nvidia.tensorrt.portable.7z.001`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.2/2026-08-12-windows64.nvidia.tensorrt.portable.7z.001)<br>[`2026-08-12-windows64.nvidia.tensorrt.portable.7z.002`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.2/2026-08-12-windows64.nvidia.tensorrt.portable.7z.002) |
+| Windows 64 位，RTX 50 CUDA 安装版 | [`2026-08-12-windows64.nvidia50.cuda.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.2/2026-08-12-windows64.nvidia50.cuda.installer.exe) |
+| Windows 64 位，自行配置引擎，免安装 | [`2026-08-12-windows64.without.engine.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.2/2026-08-12-windows64.without.engine.portable.zip) |
+| Windows 64 位，自行配置引擎，安装版 | [`2026-08-12-windows64.without.engine.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.2/2026-08-12-windows64.without.engine.installer.exe) |
+| macOS Apple Silicon | [`2026-08-12-mac-apple-silicon.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.2/2026-08-12-mac-apple-silicon.with-katago.dmg) |
+| macOS Intel | [`2026-08-12-mac-intel.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.2/2026-08-12-mac-intel.with-katago.dmg) |
+| Linux 64 位，CPU 兼容版 | [`2026-08-12-linux64.with-katago.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.2/2026-08-12-linux64.with-katago.zip) |
+| Linux 64 位，OpenCL 版 | [`2026-08-12-linux64.opencl.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.2/2026-08-12-linux64.opencl.zip) |
+| Linux 64 位，NVIDIA CUDA 版 | [`2026-08-12-linux64.nvidia.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.2/2026-08-12-linux64.nvidia.zip) |
+
+### 这一版为什么值得测试
+
+- Windows 11 真机完成旧完整免安装包覆盖升级与 `LizzieYzy Next.exe` 启动，原配置未被备份或重置，三个引擎命令均正确恢复。
+- Windows 与 macOS JDK 21 完整测试均为 `2171` 项、`0` 失败、`0` 错误；两端 shaded jar 打包成功。
+- Windows 11 的主界面、远程算力和 KataGo 一键设置已在 125% 缩放下完成真实 UI 检查；所有发布资产公开前还会再次审计。
+
+### 交流
+
+- QQ 群：`299419120`
+
+---
+
+## 繁體中文
+
+這是 `next-2026-08-09.2` 之後的穩定性預覽更新，重點修正智子登入狀態、Windows 高 DPI、首次啟動視窗與舊 portable 覆蓋升級。
+
+### 本版主要更新
+
+- 修正啟用記住登入後，重新啟動仍遺失智子雲登入狀態的問題；Windows 敏感憑證改由系統 DPAPI 保護。
+- 修正遠端算力介面在 Windows 高 DPI 下的裁切、錯位與空間不足；首次啟動視窗會保持在工作列上方的可用區域。
+- 修正 Windows 舊 portable 覆蓋升級後仍選擇已刪除 Java engine 的問題，主 engine、快速分析與形勢判斷會恢復到完整套件內建 KataGo。
+- 修正 Windows 無法在 config 仍開啟時原子替換檔案的問題；UTF-8 BOM 會保留，寫入失敗也不會再被誤判為 config 損壞並重設。
+- 調整 engine task 失敗時的資源釋放順序；修正 GitHub Bug 表單驗證並統一 repository 換行。感謝 `qiyi71w` 推動 Maven build lifecycle 修正。
+
+### 下載前先看這幾句
+
+- 既有 Windows portable 可使用 `windows64.core-update.zip` 更新主程式；需要同步更新 engine、weight 或 runtime 時請下載完整套件。
+- 一般 Windows 使用者優先選擇 OpenCL portable；NVIDIA 使用者依顯示卡世代選擇 NVIDIA 或 RTX 50 CUDA 版。
+- 只有使用者主動選擇記住登入或密碼時才會保存智子帳號狀態；Windows 使用系統憑證保護。
+- 這是預覽版，建議先更新副本並備份既有 `user-data`、自訂權重與棋譜。
+
+### 下載建議
+
+| 你的電腦 | 直接下載這個 |
+| --- | --- |
+| Windows 64 位，OpenCL 推薦版，免安裝 | [`2026-08-12-windows64.opencl.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.2/2026-08-12-windows64.opencl.portable.zip) |
+| 既有 Windows portable，只更新主程式 | [`2026-08-12-windows64.core-update.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.2/2026-08-12-windows64.core-update.zip) |
+| Windows 64 位，OpenCL 安裝版 | [`2026-08-12-windows64.opencl.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.2/2026-08-12-windows64.opencl.installer.exe) |
+| Windows 64 位，CPU 相容版，免安裝 | [`2026-08-12-windows64.with-katago.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.2/2026-08-12-windows64.with-katago.portable.zip) |
+| Windows 64 位，CPU 相容安裝版 | [`2026-08-12-windows64.with-katago.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.2/2026-08-12-windows64.with-katago.installer.exe) |
+| Windows 64 位，NVIDIA CUDA，免安裝 | [`2026-08-12-windows64.nvidia.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.2/2026-08-12-windows64.nvidia.portable.zip) |
+| Windows 64 位，NVIDIA CUDA 安裝版 | [`2026-08-12-windows64.nvidia.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.2/2026-08-12-windows64.nvidia.installer.exe) |
+| Windows 64 位，RTX 5070/5080/5090，免安裝 | [`2026-08-12-windows64.nvidia50.cuda.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.2/2026-08-12-windows64.nvidia50.cuda.portable.zip) |
+| 進階可選：TensorRT 預裝分卷，需下載全部檔案 | [`2026-08-12-windows64.nvidia.tensorrt.portable.7z.001`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.2/2026-08-12-windows64.nvidia.tensorrt.portable.7z.001)<br>[`2026-08-12-windows64.nvidia.tensorrt.portable.7z.002`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.2/2026-08-12-windows64.nvidia.tensorrt.portable.7z.002) |
+| Windows 64 位，RTX 50 CUDA 安裝版 | [`2026-08-12-windows64.nvidia50.cuda.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.2/2026-08-12-windows64.nvidia50.cuda.installer.exe) |
+| Windows 64 位，自行設定 engine，免安裝 | [`2026-08-12-windows64.without.engine.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.2/2026-08-12-windows64.without.engine.portable.zip) |
+| Windows 64 位，自行設定 engine，安裝版 | [`2026-08-12-windows64.without.engine.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.2/2026-08-12-windows64.without.engine.installer.exe) |
+| macOS Apple Silicon | [`2026-08-12-mac-apple-silicon.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.2/2026-08-12-mac-apple-silicon.with-katago.dmg) |
+| macOS Intel | [`2026-08-12-mac-intel.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.2/2026-08-12-mac-intel.with-katago.dmg) |
+| Linux 64 位，CPU 相容版 | [`2026-08-12-linux64.with-katago.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.2/2026-08-12-linux64.with-katago.zip) |
+| Linux 64 位，OpenCL 版 | [`2026-08-12-linux64.opencl.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.2/2026-08-12-linux64.opencl.zip) |
+| Linux 64 位，NVIDIA CUDA 版 | [`2026-08-12-linux64.nvidia.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.2/2026-08-12-linux64.nvidia.zip) |
+
+### 這一版為什麼值得測試
+
+- Windows 11 實機完成舊完整 portable 覆蓋升級與 `LizzieYzy Next.exe` 啟動，原 config 未被備份或重設，三個 engine command 均正確恢復。
+- Windows 與 macOS JDK 21 完整測試均為 `2171` 項、`0` failure、`0` error；兩端 shaded jar package 成功。
+- Windows 11 主畫面、遠端算力與 KataGo 一鍵設定已在 125% scaling 下完成真實 UI 檢查；所有 release asset 公開前會再次稽核。
+
+### 交流
+
+- QQ 群：`299419120`
+
+---
+
+## English
+
+This stability pre-release follows `next-2026-08-09.2`. It focuses on Zhizi session persistence, Windows high-DPI layouts, first-start placement, and safe upgrades of existing portable installations.
+
+### Release Highlights
+
+- Fixed Zhizi sessions being lost after restart when remember-login was enabled. Sensitive Windows credentials are protected with native DPAPI.
+- Fixed clipping, alignment, and space issues in Remote Compute at Windows high DPI. First-start windows remain inside the usable area above the taskbar.
+- Fixed Windows portable upgrades retaining a removed Java engine. The main, quick-analysis, and position-estimate commands now recover to the bundled KataGo in complete packages.
+- Fixed atomic config replacement on Windows while the JSON reader was still open. UTF-8 BOM configs are preserved, and I/O failures no longer trigger a destructive malformed-config reset.
+- Corrected engine-resource release after task failures, fixed GitHub bug-form validation, and enforced consistent line endings. Thanks to `qiyi71w` for driving the Maven lifecycle fix.
+
+### Read Before Downloading
+
+- Existing Windows portable users may install `windows64.core-update.zip`; download a complete package when engines, weights, or runtimes also need updating.
+- Most Windows users should choose the OpenCL portable package. NVIDIA users should select the NVIDIA or RTX 50 CUDA package matching their GPU generation.
+- Zhizi account state is saved only when the user explicitly enables remember-login or remember-password. Windows uses operating-system credential protection.
+- This is a pre-release. Upgrade a copy first and back up existing `user-data`, custom weights, and kifu.
+
+### Download Guide
+
+| Your computer | Download this file |
+| --- | --- |
+| Windows 64-bit, OpenCL, recommended, portable | [`2026-08-12-windows64.opencl.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.2/2026-08-12-windows64.opencl.portable.zip) |
+| Existing Windows portable install, application-only update | [`2026-08-12-windows64.core-update.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.2/2026-08-12-windows64.core-update.zip) |
+| Windows 64-bit, OpenCL installer | [`2026-08-12-windows64.opencl.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.2/2026-08-12-windows64.opencl.installer.exe) |
+| Windows 64-bit, CPU fallback, portable | [`2026-08-12-windows64.with-katago.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.2/2026-08-12-windows64.with-katago.portable.zip) |
+| Windows 64-bit, CPU fallback installer | [`2026-08-12-windows64.with-katago.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.2/2026-08-12-windows64.with-katago.installer.exe) |
+| Windows 64-bit, NVIDIA CUDA, portable | [`2026-08-12-windows64.nvidia.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.2/2026-08-12-windows64.nvidia.portable.zip) |
+| Windows 64-bit, NVIDIA CUDA installer | [`2026-08-12-windows64.nvidia.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.2/2026-08-12-windows64.nvidia.installer.exe) |
+| Windows 64-bit, RTX 5070/5080/5090, portable | [`2026-08-12-windows64.nvidia50.cuda.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.2/2026-08-12-windows64.nvidia50.cuda.portable.zip) |
+| Advanced optional TensorRT split package; download every part | [`2026-08-12-windows64.nvidia.tensorrt.portable.7z.001`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.2/2026-08-12-windows64.nvidia.tensorrt.portable.7z.001)<br>[`2026-08-12-windows64.nvidia.tensorrt.portable.7z.002`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.2/2026-08-12-windows64.nvidia.tensorrt.portable.7z.002) |
+| Windows 64-bit, RTX 50 CUDA installer | [`2026-08-12-windows64.nvidia50.cuda.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.2/2026-08-12-windows64.nvidia50.cuda.installer.exe) |
+| Windows 64-bit, configure your own engine, portable | [`2026-08-12-windows64.without.engine.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.2/2026-08-12-windows64.without.engine.portable.zip) |
+| Windows 64-bit, configure your own engine, installer | [`2026-08-12-windows64.without.engine.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.2/2026-08-12-windows64.without.engine.installer.exe) |
+| macOS Apple Silicon | [`2026-08-12-mac-apple-silicon.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.2/2026-08-12-mac-apple-silicon.with-katago.dmg) |
+| macOS Intel | [`2026-08-12-mac-intel.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.2/2026-08-12-mac-intel.with-katago.dmg) |
+| Linux 64-bit, CPU fallback | [`2026-08-12-linux64.with-katago.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.2/2026-08-12-linux64.with-katago.zip) |
+| Linux 64-bit, OpenCL | [`2026-08-12-linux64.opencl.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.2/2026-08-12-linux64.opencl.zip) |
+| Linux 64-bit, NVIDIA CUDA | [`2026-08-12-linux64.nvidia.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.2/2026-08-12-linux64.nvidia.zip) |
+
+### Why Test This Release
+
+- A real Windows 11 machine passed an old-complete-portable overlay upgrade and `LizzieYzy Next.exe` startup. Its config was not backed up or reset, and all three engine commands recovered correctly.
+- Full JDK 21 suites on Windows and macOS each completed `2171` tests with `0` failures and `0` errors; shaded packaging passed on both.
+- The Windows 11 main window, Remote Compute, and KataGo Auto Setup passed real UI checks at 125% scaling. Every release asset is audited again before publication.
+
+### Contact
+
+- QQ group: `299419120`
+
+---
+
+## 日本語
+
+`next-2026-08-09.2` に続く安定性プレリリースです。Zhizi のログイン状態、Windows high DPI、初回ウィンドウ位置、既存 portable の安全な上書き更新を改善しました。
+
+### 主な更新
+
+- remember-login を有効にしても再起動後に Zhizi session が失われる問題を修正し、Windows の機密 credential を native DPAPI で保護しました。
+- Windows high DPI で Remote Compute が切れる、ずれる、狭くなる問題を修正し、初回ウィンドウを taskbar より上の利用可能領域に表示します。
+- Windows portable 更新後に削除済み Java engine が選ばれる問題を修正し、main、quick analysis、position estimate を完全版内蔵 KataGo に復旧します。
+- JSON reader が開いたまま config を原子置換して失敗する Windows 固有問題を修正しました。UTF-8 BOM を保持し、I/O failure で config を破損扱いして初期化しません。
+- task failure 後の engine resource 解放、GitHub bug form validation、repository line ending を修正しました。Maven lifecycle を改善した `qiyi71w` さんに感謝します。
+
+### ダウンロード前に
+
+- 既存 Windows portable は `windows64.core-update.zip` でアプリだけ更新できます。engine、weight、runtime も更新する場合は完全版を選んでください。
+- 多くの Windows 利用者には OpenCL portable を推奨します。NVIDIA は GPU 世代に合う NVIDIA または RTX 50 CUDA package を選んでください。
+- Zhizi account state は remember-login または remember-password を明示的に選んだ場合だけ保存され、Windows では OS credential protection を使用します。
+- これは pre-release です。まずコピーを更新し、`user-data`、custom weight、棋譜を backup してください。
+
+### ダウンロード案内
+
+| お使いの環境 | ダウンロードするファイル |
+| --- | --- |
+| Windows 64-bit、OpenCL 推奨 portable | [`2026-08-12-windows64.opencl.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.2/2026-08-12-windows64.opencl.portable.zip) |
+| 既存 Windows portable、アプリ本体のみ更新 | [`2026-08-12-windows64.core-update.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.2/2026-08-12-windows64.core-update.zip) |
+| Windows 64-bit、OpenCL installer | [`2026-08-12-windows64.opencl.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.2/2026-08-12-windows64.opencl.installer.exe) |
+| Windows 64-bit、CPU fallback portable | [`2026-08-12-windows64.with-katago.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.2/2026-08-12-windows64.with-katago.portable.zip) |
+| Windows 64-bit、CPU fallback installer | [`2026-08-12-windows64.with-katago.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.2/2026-08-12-windows64.with-katago.installer.exe) |
+| Windows 64-bit、NVIDIA CUDA portable | [`2026-08-12-windows64.nvidia.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.2/2026-08-12-windows64.nvidia.portable.zip) |
+| Windows 64-bit、NVIDIA CUDA installer | [`2026-08-12-windows64.nvidia.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.2/2026-08-12-windows64.nvidia.installer.exe) |
+| Windows 64-bit、RTX 5070/5080/5090 portable | [`2026-08-12-windows64.nvidia50.cuda.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.2/2026-08-12-windows64.nvidia50.cuda.portable.zip) |
+| 上級者向け TensorRT 分割 package、全 part が必要 | [`2026-08-12-windows64.nvidia.tensorrt.portable.7z.001`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.2/2026-08-12-windows64.nvidia.tensorrt.portable.7z.001)<br>[`2026-08-12-windows64.nvidia.tensorrt.portable.7z.002`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.2/2026-08-12-windows64.nvidia.tensorrt.portable.7z.002) |
+| Windows 64-bit、RTX 50 CUDA installer | [`2026-08-12-windows64.nvidia50.cuda.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.2/2026-08-12-windows64.nvidia50.cuda.installer.exe) |
+| Windows 64-bit、engine を自分で設定、portable | [`2026-08-12-windows64.without.engine.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.2/2026-08-12-windows64.without.engine.portable.zip) |
+| Windows 64-bit、engine を自分で設定、installer | [`2026-08-12-windows64.without.engine.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.2/2026-08-12-windows64.without.engine.installer.exe) |
+| macOS Apple Silicon | [`2026-08-12-mac-apple-silicon.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.2/2026-08-12-mac-apple-silicon.with-katago.dmg) |
+| macOS Intel | [`2026-08-12-mac-intel.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.2/2026-08-12-mac-intel.with-katago.dmg) |
+| Linux 64-bit、CPU fallback | [`2026-08-12-linux64.with-katago.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.2/2026-08-12-linux64.with-katago.zip) |
+| Linux 64-bit、OpenCL | [`2026-08-12-linux64.opencl.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.2/2026-08-12-linux64.opencl.zip) |
+| Linux 64-bit、NVIDIA CUDA | [`2026-08-12-linux64.nvidia.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.2/2026-08-12-linux64.nvidia.zip) |
+
+### このリリースを試す理由
+
+- Windows 11 実機で旧完全版 portable の上書き更新と `LizzieYzy Next.exe` 起動を確認し、config の backup/reset は発生せず三つの engine command が復旧しました。
+- Windows/macOS の JDK 21 full suite はそれぞれ `2171` tests、`0` failure、`0` error で、shaded package も成功しました。
+- Windows 11 の main window、Remote Compute、KataGo Auto Setup を 125% scaling で実機確認し、公開前に全 release asset を再監査します。
+
+### 連絡先
+
+- QQ group: `299419120`
+
+---
+
+## 한국어
+
+`next-2026-08-09.2` 이후의 안정성 pre-release입니다. Zhizi 로그인 상태, Windows high DPI, 최초 창 위치, 기존 portable의 안전한 덮어쓰기 업데이트를 개선했습니다.
+
+### 주요 업데이트
+
+- remember-login을 켰는데도 재시작 후 Zhizi session이 사라지던 문제를 수정했고 Windows 민감 credential은 native DPAPI로 보호합니다.
+- Windows high DPI에서 Remote Compute가 잘리거나 어긋나고 공간이 부족한 문제를 수정했으며 최초 창은 taskbar 위의 사용 가능 영역에 표시됩니다.
+- Windows portable 업데이트 뒤 제거된 Java engine이 계속 선택되던 문제를 수정해 main, quick analysis, position estimate를 전체 package 내장 KataGo로 복구합니다.
+- JSON reader가 열린 상태에서 config 원자 교체가 실패하던 Windows 문제를 수정했습니다. UTF-8 BOM은 보존되고 I/O failure를 config 손상으로 오인해 초기화하지 않습니다.
+- task failure 후 engine resource 반환, GitHub bug form validation, repository line ending을 수정했습니다. Maven lifecycle 개선을 추진한 `qiyi71w` 님께 감사드립니다.
+
+### 다운로드 전 확인
+
+- 기존 Windows portable은 `windows64.core-update.zip`으로 앱만 업데이트할 수 있습니다. engine, weight, runtime도 업데이트하려면 전체 package를 받으세요.
+- 대부분의 Windows 사용자는 OpenCL portable을 권장합니다. NVIDIA 사용자는 GPU 세대에 맞는 NVIDIA 또는 RTX 50 CUDA package를 선택하세요.
+- Zhizi account state는 remember-login 또는 remember-password를 명시적으로 선택한 경우에만 저장되며 Windows에서는 OS credential protection을 사용합니다.
+- 이것은 pre-release입니다. 먼저 복사본을 업데이트하고 `user-data`, custom weight, 기보를 backup하세요.
+
+### 다운로드 안내
+
+| 환경 | 다운로드할 파일 |
+| --- | --- |
+| Windows 64-bit, OpenCL 권장 portable | [`2026-08-12-windows64.opencl.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.2/2026-08-12-windows64.opencl.portable.zip) |
+| 기존 Windows portable, 앱만 업데이트 | [`2026-08-12-windows64.core-update.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.2/2026-08-12-windows64.core-update.zip) |
+| Windows 64-bit, OpenCL installer | [`2026-08-12-windows64.opencl.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.2/2026-08-12-windows64.opencl.installer.exe) |
+| Windows 64-bit, CPU portable | [`2026-08-12-windows64.with-katago.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.2/2026-08-12-windows64.with-katago.portable.zip) |
+| Windows 64-bit, CPU installer | [`2026-08-12-windows64.with-katago.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.2/2026-08-12-windows64.with-katago.installer.exe) |
+| Windows 64-bit, NVIDIA CUDA portable | [`2026-08-12-windows64.nvidia.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.2/2026-08-12-windows64.nvidia.portable.zip) |
+| Windows 64-bit, NVIDIA CUDA installer | [`2026-08-12-windows64.nvidia.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.2/2026-08-12-windows64.nvidia.installer.exe) |
+| Windows 64-bit, RTX 5070/5080/5090 portable | [`2026-08-12-windows64.nvidia50.cuda.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.2/2026-08-12-windows64.nvidia50.cuda.portable.zip) |
+| 고급 선택: TensorRT 분할 package, 모든 part 필요 | [`2026-08-12-windows64.nvidia.tensorrt.portable.7z.001`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.2/2026-08-12-windows64.nvidia.tensorrt.portable.7z.001)<br>[`2026-08-12-windows64.nvidia.tensorrt.portable.7z.002`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.2/2026-08-12-windows64.nvidia.tensorrt.portable.7z.002) |
+| Windows 64-bit, RTX 50 CUDA installer | [`2026-08-12-windows64.nvidia50.cuda.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.2/2026-08-12-windows64.nvidia50.cuda.installer.exe) |
+| Windows 64-bit, 직접 engine 설정, portable | [`2026-08-12-windows64.without.engine.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.2/2026-08-12-windows64.without.engine.portable.zip) |
+| Windows 64-bit, 직접 engine 설정, installer | [`2026-08-12-windows64.without.engine.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.2/2026-08-12-windows64.without.engine.installer.exe) |
+| macOS Apple Silicon | [`2026-08-12-mac-apple-silicon.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.2/2026-08-12-mac-apple-silicon.with-katago.dmg) |
+| macOS Intel | [`2026-08-12-mac-intel.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.2/2026-08-12-mac-intel.with-katago.dmg) |
+| Linux 64-bit, CPU | [`2026-08-12-linux64.with-katago.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.2/2026-08-12-linux64.with-katago.zip) |
+| Linux 64-bit, OpenCL | [`2026-08-12-linux64.opencl.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.2/2026-08-12-linux64.opencl.zip) |
+| Linux 64-bit, NVIDIA CUDA | [`2026-08-12-linux64.nvidia.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.2/2026-08-12-linux64.nvidia.zip) |
+
+### 이 릴리스를 테스트할 이유
+
+- Windows 11 실기에서 기존 전체 portable 덮어쓰기 업데이트와 `LizzieYzy Next.exe` 시작을 확인했고 config backup/reset 없이 세 engine command가 복구됐습니다.
+- Windows/macOS JDK 21 full suite는 각각 `2171` tests, `0` failure, `0` error이며 shaded package도 성공했습니다.
+- Windows 11 main window, Remote Compute, KataGo Auto Setup을 125% scaling에서 실제 확인했고 공개 전 모든 release asset을 다시 검증합니다.
+
+### 연락처
+
+- QQ 그룹：`299419120`
+
+---
+
+## ภาษาไทย
+
+นี่คือ stability pre-release หลัง `next-2026-08-09.2` โดยเน้นสถานะการเข้าสู่ระบบ Zhizi, UI บน Windows high DPI, ตำแหน่งหน้าต่างครั้งแรก และการอัปเดต portable เดิมอย่างปลอดภัย
+
+### ไฮไลต์ของเวอร์ชันนี้
+
+- แก้ Zhizi session หายหลัง restart แม้เปิด remember-login และปกป้อง credential สำคัญบน Windows ด้วย native DPAPI
+- แก้ Remote Compute ถูกตัด วางผิดตำแหน่ง หรือมีพื้นที่ไม่พอบน Windows high DPI และให้หน้าต่างครั้งแรกอยู่ในพื้นที่ใช้งานเหนือ taskbar
+- แก้ Windows portable ที่อัปเดตแล้วแต่ยังเลือก Java engine ที่ถูกลบ โดยกู้ main, quick analysis และ position estimate ไปยัง KataGo ที่มากับ package เต็ม
+- แก้การแทนที่ config แบบ atomic บน Windows ขณะ JSON reader ยังเปิดอยู่ รักษา UTF-8 BOM และไม่ reset config เมื่อเกิด I/O failure
+- แก้การคืน engine resource หลัง task ล้มเหลว, GitHub bug form validation และ line ending ของ repository ขอบคุณ `qiyi71w` ที่ช่วยผลักดัน Maven lifecycle
+
+### ก่อนดาวน์โหลด
+
+- ผู้ใช้ Windows portable เดิมอัปเดตเฉพาะแอปด้วย `windows64.core-update.zip` ได้ หากต้องการอัปเดต engine, weight หรือ runtime ด้วย ให้เลือก package แบบเต็ม
+- ผู้ใช้ Windows ส่วนใหญ่แนะนำ OpenCL portable ส่วน NVIDIA ให้เลือก NVIDIA หรือ RTX 50 CUDA ตามรุ่น GPU
+- Zhizi account state จะถูกบันทึกเมื่อผู้ใช้เลือก remember-login หรือ remember-password เท่านั้น และ Windows ใช้การปกป้อง credential ของระบบ
+- นี่คือ pre-release ควรอัปเดตสำเนาก่อน และ backup `user-data`, custom weight และ kifu
+
+### คู่มือดาวน์โหลด
+
+| คอมพิวเตอร์ของคุณ | ดาวน์โหลดไฟล์นี้ |
+| --- | --- |
+| Windows 64-bit, OpenCL แนะนำ, portable | [`2026-08-12-windows64.opencl.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.2/2026-08-12-windows64.opencl.portable.zip) |
+| มี Windows portable แล้ว อัปเดตเฉพาะโปรแกรม | [`2026-08-12-windows64.core-update.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.2/2026-08-12-windows64.core-update.zip) |
+| Windows 64-bit, OpenCL installer | [`2026-08-12-windows64.opencl.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.2/2026-08-12-windows64.opencl.installer.exe) |
+| Windows 64-bit, CPU portable | [`2026-08-12-windows64.with-katago.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.2/2026-08-12-windows64.with-katago.portable.zip) |
+| Windows 64-bit, CPU installer | [`2026-08-12-windows64.with-katago.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.2/2026-08-12-windows64.with-katago.installer.exe) |
+| Windows 64-bit, NVIDIA CUDA portable | [`2026-08-12-windows64.nvidia.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.2/2026-08-12-windows64.nvidia.portable.zip) |
+| Windows 64-bit, NVIDIA CUDA installer | [`2026-08-12-windows64.nvidia.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.2/2026-08-12-windows64.nvidia.installer.exe) |
+| Windows 64-bit, RTX 5070/5080/5090 portable | [`2026-08-12-windows64.nvidia50.cuda.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.2/2026-08-12-windows64.nvidia50.cuda.portable.zip) |
+| ตัวเลือกขั้นสูง TensorRT แบบแบ่งส่วน ต้องดาวน์โหลดทุกส่วน | [`2026-08-12-windows64.nvidia.tensorrt.portable.7z.001`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.2/2026-08-12-windows64.nvidia.tensorrt.portable.7z.001)<br>[`2026-08-12-windows64.nvidia.tensorrt.portable.7z.002`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.2/2026-08-12-windows64.nvidia.tensorrt.portable.7z.002) |
+| Windows 64-bit, RTX 50 CUDA installer | [`2026-08-12-windows64.nvidia50.cuda.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.2/2026-08-12-windows64.nvidia50.cuda.installer.exe) |
+| Windows 64-bit, ตั้งค่า engine เอง, portable | [`2026-08-12-windows64.without.engine.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.2/2026-08-12-windows64.without.engine.portable.zip) |
+| Windows 64-bit, ตั้งค่า engine เอง, installer | [`2026-08-12-windows64.without.engine.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.2/2026-08-12-windows64.without.engine.installer.exe) |
+| macOS Apple Silicon | [`2026-08-12-mac-apple-silicon.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.2/2026-08-12-mac-apple-silicon.with-katago.dmg) |
+| macOS Intel | [`2026-08-12-mac-intel.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.2/2026-08-12-mac-intel.with-katago.dmg) |
+| Linux 64-bit, CPU | [`2026-08-12-linux64.with-katago.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.2/2026-08-12-linux64.with-katago.zip) |
+| Linux 64-bit, OpenCL | [`2026-08-12-linux64.opencl.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.2/2026-08-12-linux64.opencl.zip) |
+| Linux 64-bit, NVIDIA CUDA | [`2026-08-12-linux64.nvidia.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-12.2/2026-08-12-linux64.nvidia.zip) |
+
+### ทำไมควรทดสอบเวอร์ชันนี้
+
+- Windows 11 จริงผ่านการอัปเดตทับ portable แบบเต็มเดิมและเปิด `LizzieYzy Next.exe` โดย config ไม่ถูก backup/reset และกู้ command ของ engine ทั้งสามได้ถูกต้อง
+- full JDK 21 suite บน Windows และ macOS มี `2171` tests, `0` failure, `0` error และ shaded package สำเร็จทั้งสองระบบ
+- ตรวจ main window, Remote Compute และ KataGo Auto Setup จริงบน Windows 11 ที่ scaling 125% แล้ว และจะตรวจ release asset ทุกไฟล์อีกครั้งก่อนเผยแพร่
+
+### ติดต่อ
+
+- กลุ่ม QQ: `299419120`

--- a/.github/release-requests/next-2026-08-12.2.json
+++ b/.github/release-requests/next-2026-08-12.2.json
@@ -1,0 +1,7 @@
+{
+  "date_tag": "2026-08-12",
+  "release_tag": "next-2026-08-12.2",
+  "title": "LizzieYzy Next next-2026-08-12.2",
+  "prerelease": true,
+  "notes_file": ".github/release-notes/next-2026-08-12.2.md"
+}


### PR DESCRIPTION
## Summary

- Requests the audited multi-platform pre-release next-2026-08-12.2.
- Keeps the established six-language release-note structure and direct GitHub asset links.
- Includes the Windows portable-upgrade recovery verified on a real Windows 11 machine.

## Validation

- Release request and direct-download tables validated.
- Six languages, each with the fixed five-section structure.
- Line-ending, Markdown-link, and fail-closed publisher tests passed.

The release remains a draft until all platform workflows and asset audits succeed.