### PR TITLE
Fix legacy theme blunder rule fallback

### DIFF
--- a/src/main/java/featurecat/lizzie/theme/Theme.java
+++ b/src/main/java/featurecat/lizzie/theme/Theme.java
@@ -15,12 +15,12 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStreamWriter;
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.Collections;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.stream.IntStream;
 import javax.imageio.ImageIO;
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -31,6 +31,18 @@ import org.json.JSONTokener;
 public class Theme {
   public static final String CUSTOM_BOARD_IMAGE_KEY = "custom-board-image";
   public static final String CUSTOM_BACKGROUND_IMAGE_KEY = "custom-window-background-image";
+  private static final String BLUNDER_THRESHOLDS_KEY = "blunder-winrate-thresholds";
+  private static final String BLUNDER_COLORS_KEY = "blunder-node-colors";
+  private static final double[] DEFAULT_BLUNDER_THRESHOLDS = {-24, -12, -6, -3, -1, 3, 100};
+  private static final int[][] DEFAULT_BLUNDER_COLORS = {
+    {155, 25, 150},
+    {208, 16, 19},
+    {200, 140, 50},
+    {180, 180, 0},
+    {140, 202, 34},
+    {0, 220, 0},
+    {0, 210, 210}
+  };
 
   BufferedImage blackStoneCached = null;
   BufferedImage whiteStoneCached = null;
@@ -43,12 +55,13 @@ public class Theme {
   public String path = null;
   public JSONObject config = new JSONObject();
   private JSONObject uiConfig = null;
-  private Optional<List<Double>> blunderWinrateThresholds = Optional.empty();
+  private BlunderNodeRuleSet blunderNodeRuleSet;
 
   public Theme() {}
 
   public boolean getTheme(JSONObject uiConfig) {
     this.uiConfig = uiConfig;
+    this.blunderNodeRuleSet = null;
     String themeName = uiConfig.optString("theme");
     this.path = Theme.pathPrefix + (themeName.isEmpty() ? "" : themeName + separator);
     File file = new File(this.path + this.configFile);
@@ -349,37 +362,112 @@ public class Theme {
 
   /** The threshold list of the blunder winrate */
   public Optional<List<Double>> blunderWinrateThresholds() {
-    String key = "blunder-winrate-thresholds";
-    Optional<JSONArray> array = Optional.ofNullable(config.optJSONArray(key));
-    if (!array.isPresent()) {
-      array = Optional.ofNullable(uiConfig.optJSONArray(key));
-    }
-    array.ifPresent(
-        m -> {
-          blunderWinrateThresholds = Optional.of(new ArrayList<Double>());
-          m.forEach(a -> blunderWinrateThresholds.get().add(Double.valueOf(a.toString())));
-        });
-    return blunderWinrateThresholds;
+    return Optional.of(blunderNodeRuleSet().thresholds);
   }
 
   /** The color list of the blunder node */
   public Optional<Map<Double, Color>> blunderNodeColors() {
-    Optional<Map<Double, Color>> map = Optional.of(new HashMap<Double, Color>());
-    String key = "blunder-node-colors";
-    Optional<JSONArray> array = Optional.ofNullable(config.optJSONArray(key));
-    if (!array.isPresent()) {
-      array = Optional.ofNullable(uiConfig.optJSONArray(key));
+    return Optional.of(blunderNodeRuleSet().colorsByThreshold);
+  }
+
+  private synchronized BlunderNodeRuleSet blunderNodeRuleSet() {
+    if (blunderNodeRuleSet == null) {
+      blunderNodeRuleSet =
+          parseBlunderNodeRuleSet(config)
+              .orElseGet(
+                  () ->
+                      parseBlunderNodeRuleSet(uiConfig)
+                          .orElseGet(Theme::defaultBlunderNodeRuleSet));
     }
-    array.ifPresent(
-        a -> {
-          IntStream.range(0, a.length())
-              .forEach(
-                  i -> {
-                    Color color = array2Color((JSONArray) a.get(i), null);
-                    blunderWinrateThresholds.map(l -> l.get(i)).map(t -> map.get().put(t, color));
-                  });
-        });
-    return map;
+    return blunderNodeRuleSet;
+  }
+
+  private static Optional<BlunderNodeRuleSet> parseBlunderNodeRuleSet(JSONObject source) {
+    if (source == null) {
+      return Optional.empty();
+    }
+
+    JSONArray thresholds = source.optJSONArray(BLUNDER_THRESHOLDS_KEY);
+    JSONArray colors = source.optJSONArray(BLUNDER_COLORS_KEY);
+    if (thresholds == null
+        || colors == null
+        || thresholds.length() == 0
+        || thresholds.length() != colors.length()) {
+      return Optional.empty();
+    }
+
+    List<Double> parsedThresholds = new ArrayList<>(thresholds.length());
+    Map<Double, Color> parsedColors = new LinkedHashMap<>();
+    double previousThreshold = Double.NEGATIVE_INFINITY;
+    for (int i = 0; i < thresholds.length(); i++) {
+      Object thresholdValue = thresholds.opt(i);
+      if (!(thresholdValue instanceof Number)) {
+        return Optional.empty();
+      }
+      double threshold = ((Number) thresholdValue).doubleValue();
+      if (!Double.isFinite(threshold)
+          || (i > 0 && Double.compare(threshold, previousThreshold) <= 0)) {
+        return Optional.empty();
+      }
+
+      Color color = parseBlunderNodeColor(colors.optJSONArray(i));
+      if (color == null) {
+        return Optional.empty();
+      }
+      parsedThresholds.add(threshold);
+      parsedColors.put(threshold, color);
+      previousThreshold = threshold;
+    }
+
+    return Optional.of(new BlunderNodeRuleSet(parsedThresholds, parsedColors));
+  }
+
+  private static Color parseBlunderNodeColor(JSONArray channels) {
+    if (channels == null || (channels.length() != 3 && channels.length() != 4)) {
+      return null;
+    }
+
+    int[] values = new int[channels.length()];
+    for (int i = 0; i < channels.length(); i++) {
+      Object channelValue = channels.opt(i);
+      if (!(channelValue instanceof Number)) {
+        return null;
+      }
+      double channel = ((Number) channelValue).doubleValue();
+      if (!Double.isFinite(channel)
+          || channel != Math.rint(channel)
+          || channel < 0
+          || channel > 255) {
+        return null;
+      }
+      values[i] = (int) channel;
+    }
+    return values.length == 3
+        ? new Color(values[0], values[1], values[2])
+        : new Color(values[0], values[1], values[2], values[3]);
+  }
+
+  private static BlunderNodeRuleSet defaultBlunderNodeRuleSet() {
+    List<Double> thresholds = new ArrayList<>(DEFAULT_BLUNDER_THRESHOLDS.length);
+    Map<Double, Color> colors = new LinkedHashMap<>();
+    for (int i = 0; i < DEFAULT_BLUNDER_THRESHOLDS.length; i++) {
+      double threshold = DEFAULT_BLUNDER_THRESHOLDS[i];
+      int[] color = DEFAULT_BLUNDER_COLORS[i];
+      thresholds.add(threshold);
+      colors.put(threshold, new Color(color[0], color[1], color[2]));
+    }
+    return new BlunderNodeRuleSet(thresholds, colors);
+  }
+
+  private static final class BlunderNodeRuleSet {
+    private final List<Double> thresholds;
+    private final Map<Double, Color> colorsByThreshold;
+
+    private BlunderNodeRuleSet(List<Double> thresholds, Map<Double, Color> colorsByThreshold) {
+      this.thresholds = Collections.unmodifiableList(new ArrayList<>(thresholds));
+      this.colorsByThreshold =
+          Collections.unmodifiableMap(new LinkedHashMap<>(colorsByThreshold));
+    }
   }
 
   private Color getColorByKey(String key, Color defaultColor) {

--- a/src/test/java/featurecat/lizzie/theme/ThemeBlunderNodeRulesTest.java
+++ b/src/test/java/featurecat/lizzie/theme/ThemeBlunderNodeRulesTest.java
@@ -1,0 +1,135 @@
+package featurecat.lizzie.theme;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.awt.Color;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class ThemeBlunderNodeRulesTest {
+  private static final List<Double> DEFAULT_THRESHOLDS =
+      List.of(-24.0, -12.0, -6.0, -3.0, -1.0, 3.0, 100.0);
+
+  @Test
+  void validThemeRulesWinAsAnAtomicPair() {
+    Theme theme = themeWith(rules("[-8,-2,100]", "[[1,2,3],[4,5,6],[7,8,9]]"), globalRules());
+
+    assertEquals(List.of(-8.0, -2.0, 100.0), theme.blunderWinrateThresholds().orElseThrow());
+    assertEquals(new Color(4, 5, 6), theme.blunderNodeColors().orElseThrow().get(-2.0));
+  }
+
+  @Test
+  void missingThemeColorsFallsBackToTheCompleteGlobalPair() {
+    JSONObject incompleteTheme = new JSONObject();
+    incompleteTheme.put("blunder-winrate-thresholds", new JSONArray("[-8,-2,100]"));
+
+    assertUsesGlobalRules(themeWith(incompleteTheme, globalRules()));
+  }
+
+  @Test
+  void emptyThemeRulesFallBackToTheCompleteGlobalPair() {
+    assertUsesGlobalRules(themeWith(rules("[]", "[]"), globalRules()));
+  }
+
+  @Test
+  void malformedThresholdFallsBackToTheCompleteGlobalPair() {
+    assertUsesGlobalRules(
+        themeWith(rules("[-8,\"bad\",100]", "[[1,2,3],[4,5,6],[7,8,9]]"), globalRules()));
+  }
+
+  @Test
+  void mismatchedLengthsFallBackToTheCompleteGlobalPair() {
+    assertUsesGlobalRules(themeWith(rules("[-8,100]", "[[1,2,3]]"), globalRules()));
+  }
+
+  @Test
+  void invalidColorChannelFallsBackToTheCompleteGlobalPair() {
+    assertUsesGlobalRules(
+        themeWith(rules("[-8,100]", "[[1,2,3],[4,5,256]]"), globalRules()));
+  }
+
+  @Test
+  void duplicateOrUnsortedThresholdsFallBackToTheCompleteGlobalPair() {
+    assertUsesGlobalRules(
+        themeWith(rules("[-8,-8,100]", "[[1,2,3],[4,5,6],[7,8,9]]"), globalRules()));
+    assertUsesGlobalRules(
+        themeWith(rules("[-2,-8,100]", "[[1,2,3],[4,5,6],[7,8,9]]"), globalRules()));
+  }
+
+  @Test
+  void invalidThemeAndGlobalRulesUseBuiltInDefaults() {
+    Theme theme = themeWith(rules("[-8,100]", "[[1,2,3]]"), new JSONObject());
+
+    assertEquals(DEFAULT_THRESHOLDS, theme.blunderWinrateThresholds().orElseThrow());
+    assertEquals(
+        new Color(0, 210, 210), theme.blunderNodeColors().orElseThrow().get(100.0));
+  }
+
+  @Test
+  void colorGetterWorksBeforeThresholdGetter() {
+    Theme theme = themeWith(rules("[-8,100]", "[[1,2,3],[4,5,6,7]]"), globalRules());
+
+    Map<Double, Color> colors = theme.blunderNodeColors().orElseThrow();
+
+    assertEquals(new Color(1, 2, 3), colors.get(-8.0));
+    assertEquals(new Color(4, 5, 6, 7), colors.get(100.0));
+    assertEquals(List.of(-8.0, 100.0), theme.blunderWinrateThresholds().orElseThrow());
+  }
+
+  @Test
+  void invalidLegacyThemeFallsBackWithoutRewritingIt(@TempDir Path tempDir) throws Exception {
+    String previousPathPrefix = Theme.pathPrefix;
+    Path themeDirectory = tempDir.resolve("legacy");
+    Files.createDirectories(themeDirectory);
+    Path themeFile = themeDirectory.resolve("theme.txt");
+    String original =
+        rules("[-8,100]", "[[1,2,3]]").toString(2) + System.lineSeparator();
+    Files.writeString(themeFile, original, StandardCharsets.UTF_8);
+    try {
+      Theme.pathPrefix = tempDir.toString() + java.io.File.separator;
+      JSONObject ui = globalRules();
+      ui.put("theme", "legacy");
+      Theme theme = new Theme();
+
+      theme.getTheme(ui);
+
+      assertUsesGlobalRules(theme);
+      assertEquals(original, Files.readString(themeFile, StandardCharsets.UTF_8));
+    } finally {
+      Theme.pathPrefix = previousPathPrefix;
+    }
+  }
+
+  private static Theme themeWith(JSONObject themeRules, JSONObject globalRules) {
+    globalRules.put("theme", "missing-test-theme-" + UUID.randomUUID());
+    Theme theme = new Theme();
+    theme.getTheme(globalRules);
+    theme.config = themeRules;
+    return theme;
+  }
+
+  private static JSONObject rules(String thresholds, String colors) {
+    JSONObject rules = new JSONObject();
+    rules.put("blunder-winrate-thresholds", new JSONArray(thresholds));
+    rules.put("blunder-node-colors", new JSONArray(colors));
+    return rules;
+  }
+
+  private static JSONObject globalRules() {
+    return rules("[-12,0,100]", "[[11,12,13],[21,22,23],[31,32,33]]");
+  }
+
+  private static void assertUsesGlobalRules(Theme theme) {
+    assertEquals(List.of(-12.0, 0.0, 100.0), theme.blunderWinrateThresholds().orElseThrow());
+    assertEquals(new Color(11, 12, 13), theme.blunderNodeColors().orElseThrow().get(-12.0));
+    assertEquals(new Color(31, 32, 33), theme.blunderNodeColors().orElseThrow().get(100.0));
+  }
+}


### PR DESCRIPTION
## Summary

- treats blunder thresholds and node colors as one atomic theme rule set
- falls back from an invalid legacy theme to the complete global pair, then to built-in defaults
- validates array sizes, ordering, duplicate thresholds, finite values, and RGBA channels
- removes getter call-order dependence without rewriting existing theme files

感谢 @qiyi71w 对旧主题兼容问题的完整整理和清晰复现说明，这让问题边界能够被准确覆盖。

## Validation

- `git diff --check`
- `python3 scripts/check_line_endings.py`
- `python3 scripts/check_markdown_links.py`
- `mvn -B -Dfmt.skip=true -Dtest=ThemeBlunderNodeRulesTest test` (10 passed)
- `mvn -B -Dfmt.skip=true -Djava.awt.headless=true test` (2181 passed, 6 skipped)
- `mvn -B -Dfmt.skip=true -DskipTests package`
- launched the shaded Swing app with an isolated profile and a malformed legacy theme; startup and main UI remained healthy, the complete global rules were selected, and the legacy file remained unchanged

Fixes #240