### PR TITLE
Add ReadBoard snapshot lifecycle regression coverage

### DIFF
--- a/src/test/java/featurecat/lizzie/analysis/ReadBoardEngineResumeTest.java
+++ b/src/test/java/featurecat/lizzie/analysis/ReadBoardEngineResumeTest.java
@@ -28,6 +28,8 @@ import java.io.OutputStream;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -1664,6 +1666,61 @@ class ReadBoardEngineResumeTest {
   }
 
   @Test
+  void closingReadBoardDuringDelayedSnapshotLoadKeepsFileAliveForEngineRestart()
+      throws Exception {
+    Stone[] authoritativeStones = stones(placement(0, 0, Stone.BLACK));
+    try (EngineResumeHarness harness =
+        EngineResumeHarness.create(rootHistory(authoritativeStones, false))) {
+      harness.frame.bothSync = true;
+      harness.leelaz.enableReadBoardGmaSupport();
+      Lizzie.config.suppressReadBoardWebSocketPonderingNotice = true;
+
+      harness.readBoard.parseLine("play>white>5 12 0 gma");
+      harness.sync(snapshot(authoritativeStones, Optional.empty(), Stone.EMPTY));
+      assertEquals(1, harness.leelaz.readBoardGmaCount);
+
+      assertTrue(harness.readBoard.handleReadBoardGmaEnginePlay("pass"));
+      harness.leelaz.isThinking = false;
+      harness.leelaz.blockNextLoadSgf();
+      harness.readBoard.afterReadBoardGmaTerminalResponseConsumed("close-readboard");
+      assertTrue(
+          harness.leelaz.awaitBlockedLoadSgf(),
+          "the exact snapshot load must reach the engine before closing ReadBoard");
+
+      Path pendingSnapshot = harness.leelaz.pendingLoadSgf();
+      assertNotNull(pendingSnapshot);
+      assertTrue(
+          Files.exists(pendingSnapshot),
+          "the temporary SGF must exist while the engine has not consumed loadsgf");
+
+      harness.readBoard.shutdown();
+
+      assertNull(harness.frame.readBoard, "closing ReadBoard should detach the helper window");
+      assertTrue(
+          Files.exists(pendingSnapshot),
+          "closing ReadBoard must not delete an SGF still being consumed by KataGo");
+
+      harness.leelaz.releaseBlockedLoadSgf();
+      assertTrue(
+          waitForFileDeletion(pendingSnapshot),
+          "the temporary SGF should be cleaned only after KataGo consumes it");
+
+      SnapshotTrackingLeelaz restartedEngine = SnapshotTrackingLeelaz.create();
+      Lizzie.leelaz = restartedEngine;
+      harness.board.resendMoveToEngine(restartedEngine, false);
+
+      assertNotNull(
+          restartedEngine.lastLoadedSgfContent(),
+          "a restarted engine should load the authoritative snapshot without a missing-file error");
+      assertTrue(restartedEngine.lastLoadedSgfContent().contains("AB[aa]"));
+      assertTrue(restartedEngine.lastLoadedSgfContent().contains("PL[W]"));
+      assertTrue(
+          waitForFileDeletion(restartedEngine.lastLoadedSgf()),
+          "the restarted engine snapshot should also be cleaned after consumption");
+    }
+  }
+
+  @Test
   void suppressedWebsocketPonderingNoticeContinuesWithoutChangingReadBoardPreference()
       throws Exception {
     try (EngineResumeHarness harness =
@@ -2097,6 +2154,17 @@ class ReadBoardEngineResumeTest {
   private static boolean waitForSentCommand(SnapshotTrackingLeelaz leelaz, String command)
       throws InterruptedException {
     return waitForSentCommandPrefix(leelaz, command, true);
+  }
+
+  private static boolean waitForFileDeletion(Path path) throws InterruptedException {
+    if (path == null) {
+      return false;
+    }
+    long deadline = System.nanoTime() + java.util.concurrent.TimeUnit.SECONDS.toNanos(2);
+    while (Files.exists(path) && System.nanoTime() < deadline) {
+      Thread.sleep(10L);
+    }
+    return Files.notExists(path);
   }
 
   private static boolean waitForSentCommandPrefix(SnapshotTrackingLeelaz leelaz, String prefix)

--- a/src/test/java/featurecat/lizzie/analysis/SnapshotTrackingLeelaz.java
+++ b/src/test/java/featurecat/lizzie/analysis/SnapshotTrackingLeelaz.java
@@ -39,6 +39,7 @@ class SnapshotTrackingLeelaz extends Leelaz {
   private boolean blackToPlay = true;
   private Path lastLoadedSgf;
   private String lastLoadedSgfContent;
+  private volatile Path pendingLoadSgf;
   private volatile CountDownLatch blockedLoadSgfStarted;
   private volatile CountDownLatch blockedLoadSgfRelease;
   private Runnable beforeNextClearBoard;
@@ -262,8 +263,13 @@ class SnapshotTrackingLeelaz extends Leelaz {
   @Override
   public void loadSgf(Path sgfFile) {
     recordedCommands().add("loadsgf " + sgfFile.toAbsolutePath());
-    waitForBlockedLoadSgfRelease();
-    restoreSnapshotSgf(sgfFile);
+    pendingLoadSgf = sgfFile;
+    try {
+      waitForBlockedLoadSgfRelease();
+      restoreSnapshotSgf(sgfFile);
+    } finally {
+      pendingLoadSgf = null;
+    }
   }
 
   void blockNextLoadSgf() {
@@ -301,6 +307,10 @@ class SnapshotTrackingLeelaz extends Leelaz {
 
   Path lastLoadedSgf() {
     return lastLoadedSgf;
+  }
+
+  Path pendingLoadSgf() {
+    return pendingLoadSgf;
   }
 
   String lastLoadedSgfContent() {


### PR DESCRIPTION
## Summary

- adds a deterministic regression for the ReadBoard lifecycle reported in #204
- verifies a temporary snapshot SGF remains available when ReadBoard closes while KataGo is still consuming `loadsgf`
- verifies cleanup happens only after consumption and a restarted engine can load a fresh authoritative snapshot
- keeps production behavior unchanged because the current snapshot lifecycle already passes this exact race test

感谢 @semanym 报告临时 SGF 生命周期问题并提供清晰的 Windows 复现路径。

## Validation

- `ReadBoardEngineResumeTest`: 67 tests passed on macOS and Windows
- ReadBoard sync/restore suite: 267 tests passed on macOS and Windows
- JDK 21 full suite: 2172 tests passed, 6 skipped on macOS
- Windows baseline full suite: 2171 tests passed, 3 skipped
- `mvn -B -Dfmt.skip=true -DskipTests package`: passed on macOS and Windows
- line-ending policy and `git diff --check`: passed

## Windows acceptance

- checked out and built commit `e4215f0e` on a real Windows 11 machine
- launched the current shaded jar with the complete portable package's bundled JDK 21, KataGo, configs, weights, and native `readboard.exe`
- triggered the actual `Alt+O` application shortcut; ReadBoard launched from `app/readboard/readboard.exe`, reported `ready`, and remained responsive
- closed native ReadBoard normally; it emitted `stopsync`, `endsync`, and exited with code 0 while LizzieYzy Next stayed responsive
- opened native ReadBoard a second time; it again reported `ready`
- closed ReadBoard and restarted the current KataGo engine; the new KataGo process remained active and the main UI stayed responsive
- scanned captured stdout/stderr after both cycles: no `Could not load sgf`, `does not exist`, `invalid permissions`, or stale `lizzie-snapshot` errors

This PR intentionally uses `Refs #204`, not `Fixes #204`. The deterministic race and real Windows open/close/restart path now pass, but the issue should remain open until the reporter validates a build with real board-sync input.

Refs #204
