### PR TITLE
Publish next-2026-08-13.1 pre-release

### DIFF
--- a/.github/release-notes/next-2026-08-13.1.md
+++ b/.github/release-notes/next-2026-08-13.1.md
@@ -1,0 +1,317 @@
+# LizzieYzy Next next-2026-08-13.1
+
+## 中文
+
+这是 `next-2026-08-12.2` 之后的稳定性预览更新，重点完善 AI 讲棋、评论显示、自动快速胜率曲线和旧主题兼容性。
+
+### 本版主要更新
+
+- AI 讲棋会根据用户选择的棋力、讲解风格、术语密度和变化详细度生成更合适的内容，并继续遵守 KataGo 证据边界。感谢 `Fly143` 推进完整的多语言讲棋方案。
+- 修复点击 AI 解说后，评论区在 macOS 和 Windows 显示白色长方框的问题；普通评论按安全纯文本显示，AI Markdown 使用受限格式渲染，原始 SGF 评论仍可编辑和保存。
+- 修复加载棋谱后自动快速胜率曲线偶发不生成、慢引擎启动后静默停止，以及浏览棋谱时中断的问题；任务会等待引擎真正可用，只补齐缺失局面，并在完成后立即恢复棋盘实时分析。
+- 修复旧主题中错误节点阈值与颜色配置不完整时的显示异常，失效主题会整体回退到有效的全局规则或内置默认值。感谢 `qiyi71w` 的详细整理。
+- 增加棋盘同步临时 SGF 生命周期回归保障，覆盖关闭同步工具和重启引擎的竞态路径。感谢 `semanym` 提供清晰的 Windows 复现流程。
+
+### 下载前先看这几句
+
+- 已有 Windows 免安装版可以下载 `windows64.core-update.zip` 更新主程序；本版没有更换内置引擎、权重或运行库。
+- 普通 Windows 用户优先选择 OpenCL 免安装版；NVIDIA 用户按显卡代际选择 NVIDIA 或 RTX 50 CUDA 版。
+- AI 解说仍需要用户自行配置兼容的 LLM 服务；快速胜率曲线继续使用当前可用的本地或远程分析引擎。
+- 这是预发布版。建议先覆盖到副本，并备份现有 `user-data`、自定义权重和棋谱。
+
+### 下载建议
+
+| 你的电脑 | 直接下载这个 |
+| --- | --- |
+| Windows 64 位，OpenCL 版，推荐，免安装 | [`2026-08-13-windows64.opencl.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-13.1/2026-08-13-windows64.opencl.portable.zip) |
+| 已有 Windows 免安装版，只更新主程序 | [`2026-08-13-windows64.core-update.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-13.1/2026-08-13-windows64.core-update.zip) |
+| Windows 64 位，OpenCL 安装版 | [`2026-08-13-windows64.opencl.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-13.1/2026-08-13-windows64.opencl.installer.exe) |
+| Windows 64 位，CPU 兼容版，免安装 | [`2026-08-13-windows64.with-katago.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-13.1/2026-08-13-windows64.with-katago.portable.zip) |
+| Windows 64 位，CPU 兼容安装版 | [`2026-08-13-windows64.with-katago.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-13.1/2026-08-13-windows64.with-katago.installer.exe) |
+| Windows 64 位，NVIDIA CUDA 版，免安装 | [`2026-08-13-windows64.nvidia.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-13.1/2026-08-13-windows64.nvidia.portable.zip) |
+| Windows 64 位，NVIDIA CUDA 安装版 | [`2026-08-13-windows64.nvidia.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-13.1/2026-08-13-windows64.nvidia.installer.exe) |
+| Windows 64 位，RTX 5070/5080/5090，免安装 | [`2026-08-13-windows64.nvidia50.cuda.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-13.1/2026-08-13-windows64.nvidia50.cuda.portable.zip) |
+| 高级可选：TensorRT 预装分卷包，需下载全部分卷 | [`2026-08-13-windows64.nvidia.tensorrt.portable.7z.001`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-13.1/2026-08-13-windows64.nvidia.tensorrt.portable.7z.001)<br>[`2026-08-13-windows64.nvidia.tensorrt.portable.7z.002`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-13.1/2026-08-13-windows64.nvidia.tensorrt.portable.7z.002) |
+| Windows 64 位，RTX 50 CUDA 安装版 | [`2026-08-13-windows64.nvidia50.cuda.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-13.1/2026-08-13-windows64.nvidia50.cuda.installer.exe) |
+| Windows 64 位，自行配置引擎，免安装 | [`2026-08-13-windows64.without.engine.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-13.1/2026-08-13-windows64.without.engine.portable.zip) |
+| Windows 64 位，自行配置引擎，安装版 | [`2026-08-13-windows64.without.engine.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-13.1/2026-08-13-windows64.without.engine.installer.exe) |
+| macOS Apple Silicon | [`2026-08-13-mac-apple-silicon.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-13.1/2026-08-13-mac-apple-silicon.with-katago.dmg) |
+| macOS Intel | [`2026-08-13-mac-intel.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-13.1/2026-08-13-mac-intel.with-katago.dmg) |
+| Linux 64 位，CPU 兼容版 | [`2026-08-13-linux64.with-katago.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-13.1/2026-08-13-linux64.with-katago.zip) |
+| Linux 64 位，OpenCL 版 | [`2026-08-13-linux64.opencl.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-13.1/2026-08-13-linux64.opencl.zip) |
+| Linux 64 位，NVIDIA CUDA 版 | [`2026-08-13-linux64.nvidia.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-13.1/2026-08-13-linux64.nvidia.zip) |
+
+### 这一版为什么值得测试
+
+- JDK 21 完整测试共 `2205` 项，`0` 失败、`0` 错误，shaded jar 打包通过。
+- macOS 和 Windows NVIDIA 真机均验证 AI 解说不再出现白框、40 手快速胜率/目差曲线完整生成，并能立即恢复棋盘实时分析。
+- 发布流程会对 Windows、macOS 和 Linux 成品逐项检查文件名、版本、签名或运行时结构及 SHA-256，全部通过后才公开。
+
+### 交流
+
+- QQ 群：`299419120`
+
+---
+
+## 繁體中文
+
+這是 `next-2026-08-12.2` 之後的穩定性預覽更新，重點完善 AI 講棋、評論顯示、自動快速勝率曲線與舊主題相容性。
+
+### 本版主要更新
+
+- AI 講棋會依使用者選擇的棋力、講解風格、術語密度與變化詳細度產生更合適的內容，並繼續遵守 KataGo 證據邊界。感謝 `Fly143` 推進完整的多語言講棋方案。
+- 修正點擊 AI 解說後，評論區在 macOS 與 Windows 顯示白色長方框的問題；一般評論以安全純文字顯示，AI Markdown 使用受限格式渲染，原始 SGF 評論仍可編輯與保存。
+- 修正載入棋譜後自動快速勝率曲線偶爾不產生、慢速 engine 啟動後靜默停止，以及瀏覽棋譜時中斷的問題；task 會等待 engine 真正可用，只補齊缺失局面，完成後立即恢復棋盤即時分析。
+- 修正舊主題中錯誤節點門檻與顏色設定不完整時的顯示異常，失效主題會整體回退到有效的全域規則或內建預設值。感謝 `qiyi71w` 的詳細整理。
+- 增加棋盤同步暫存 SGF 生命週期回歸保障，涵蓋關閉同步工具與重新啟動 engine 的競態路徑。感謝 `semanym` 提供清楚的 Windows 重現流程。
+
+### 下載前先看這幾句
+
+- 既有 Windows portable 可下載 `windows64.core-update.zip` 更新主程式；本版沒有更換內建 engine、weight 或 runtime。
+- 一般 Windows 使用者優先選擇 OpenCL portable；NVIDIA 使用者依顯示卡世代選擇 NVIDIA 或 RTX 50 CUDA 版。
+- AI 解說仍需由使用者自行設定相容的 LLM 服務；快速勝率曲線繼續使用目前可用的本機或遠端分析 engine。
+- 這是預覽版，建議先更新副本並備份既有 `user-data`、自訂權重與棋譜。
+
+### 下載建議
+
+| 你的電腦 | 直接下載這個 |
+| --- | --- |
+| Windows 64 位，OpenCL 推薦版，免安裝 | [`2026-08-13-windows64.opencl.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-13.1/2026-08-13-windows64.opencl.portable.zip) |
+| 既有 Windows portable，只更新主程式 | [`2026-08-13-windows64.core-update.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-13.1/2026-08-13-windows64.core-update.zip) |
+| Windows 64 位，OpenCL 安裝版 | [`2026-08-13-windows64.opencl.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-13.1/2026-08-13-windows64.opencl.installer.exe) |
+| Windows 64 位，CPU 相容版，免安裝 | [`2026-08-13-windows64.with-katago.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-13.1/2026-08-13-windows64.with-katago.portable.zip) |
+| Windows 64 位，CPU 相容安裝版 | [`2026-08-13-windows64.with-katago.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-13.1/2026-08-13-windows64.with-katago.installer.exe) |
+| Windows 64 位，NVIDIA CUDA，免安裝 | [`2026-08-13-windows64.nvidia.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-13.1/2026-08-13-windows64.nvidia.portable.zip) |
+| Windows 64 位，NVIDIA CUDA 安裝版 | [`2026-08-13-windows64.nvidia.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-13.1/2026-08-13-windows64.nvidia.installer.exe) |
+| Windows 64 位，RTX 5070/5080/5090，免安裝 | [`2026-08-13-windows64.nvidia50.cuda.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-13.1/2026-08-13-windows64.nvidia50.cuda.portable.zip) |
+| 進階可選：TensorRT 預裝分卷，需下載全部檔案 | [`2026-08-13-windows64.nvidia.tensorrt.portable.7z.001`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-13.1/2026-08-13-windows64.nvidia.tensorrt.portable.7z.001)<br>[`2026-08-13-windows64.nvidia.tensorrt.portable.7z.002`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-13.1/2026-08-13-windows64.nvidia.tensorrt.portable.7z.002) |
+| Windows 64 位，RTX 50 CUDA 安裝版 | [`2026-08-13-windows64.nvidia50.cuda.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-13.1/2026-08-13-windows64.nvidia50.cuda.installer.exe) |
+| Windows 64 位，自行設定 engine，免安裝 | [`2026-08-13-windows64.without.engine.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-13.1/2026-08-13-windows64.without.engine.portable.zip) |
+| Windows 64 位，自行設定 engine，安裝版 | [`2026-08-13-windows64.without.engine.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-13.1/2026-08-13-windows64.without.engine.installer.exe) |
+| macOS Apple Silicon | [`2026-08-13-mac-apple-silicon.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-13.1/2026-08-13-mac-apple-silicon.with-katago.dmg) |
+| macOS Intel | [`2026-08-13-mac-intel.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-13.1/2026-08-13-mac-intel.with-katago.dmg) |
+| Linux 64 位，CPU 相容版 | [`2026-08-13-linux64.with-katago.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-13.1/2026-08-13-linux64.with-katago.zip) |
+| Linux 64 位，OpenCL 版 | [`2026-08-13-linux64.opencl.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-13.1/2026-08-13-linux64.opencl.zip) |
+| Linux 64 位，NVIDIA CUDA 版 | [`2026-08-13-linux64.nvidia.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-13.1/2026-08-13-linux64.nvidia.zip) |
+
+### 這一版為什麼值得測試
+
+- JDK 21 完整測試共 `2205` 項，`0` failure、`0` error，shaded jar package 通過。
+- macOS 與 Windows NVIDIA 實機均驗證 AI 解說不再出現白框、40 手快速勝率/目差曲線完整產生，並能立即恢復棋盤即時分析。
+- 發布流程會逐項檢查 Windows、macOS 與 Linux 成品的檔名、版本、簽章或 runtime 結構及 SHA-256，全部通過後才公開。
+
+### 交流
+
+- QQ 群：`299419120`
+
+---
+
+## English
+
+This stability pre-release follows `next-2026-08-12.2`. It improves AI commentary, comment rendering, automatic quick win-rate curves, and legacy-theme compatibility.
+
+### Release Highlights
+
+- AI commentary now adapts to the selected playing level, explanation style, terminology density, and variation detail while preserving KataGo evidence boundaries. Thanks to `Fly143` for advancing the complete multilingual commentary design.
+- Fixed opaque white rectangles appearing in the comment panel after AI commentary on macOS and Windows. Ordinary comments render as safe text, AI Markdown uses a restricted renderer, and original SGF comments remain editable and saveable.
+- Fixed automatic quick curves sometimes not starting after a game was loaded, silently stopping while a slow engine started, or being cancelled by navigation. One task waits for a genuinely ready engine, fills only missing positions, and restores live board analysis immediately after completion.
+- Fixed incomplete blunder thresholds or node colors in legacy themes. Invalid theme rules now fall back atomically to valid global rules or built-in defaults. Thanks to `qiyi71w` for the detailed report.
+- Added deterministic coverage for temporary board-sync SGF lifetimes across sync-tool shutdown and engine restart races. Thanks to `semanym` for the clear Windows reproduction path.
+
+### Read Before Downloading
+
+- Existing Windows portable users may install `windows64.core-update.zip`; this release does not replace bundled engines, weights, or runtimes.
+- Most Windows users should choose the OpenCL portable package. NVIDIA users should select the NVIDIA or RTX 50 CUDA package matching their GPU generation.
+- AI commentary still requires a user-configured compatible LLM service. Quick curves continue to use the currently available local or remote analysis engine.
+- This is a pre-release. Upgrade a copy first and back up existing `user-data`, custom weights, and kifu.
+
+### Download Guide
+
+| Your computer | Download this file |
+| --- | --- |
+| Windows 64-bit, OpenCL, recommended, portable | [`2026-08-13-windows64.opencl.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-13.1/2026-08-13-windows64.opencl.portable.zip) |
+| Existing Windows portable install, application-only update | [`2026-08-13-windows64.core-update.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-13.1/2026-08-13-windows64.core-update.zip) |
+| Windows 64-bit, OpenCL installer | [`2026-08-13-windows64.opencl.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-13.1/2026-08-13-windows64.opencl.installer.exe) |
+| Windows 64-bit, CPU fallback, portable | [`2026-08-13-windows64.with-katago.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-13.1/2026-08-13-windows64.with-katago.portable.zip) |
+| Windows 64-bit, CPU fallback installer | [`2026-08-13-windows64.with-katago.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-13.1/2026-08-13-windows64.with-katago.installer.exe) |
+| Windows 64-bit, NVIDIA CUDA, portable | [`2026-08-13-windows64.nvidia.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-13.1/2026-08-13-windows64.nvidia.portable.zip) |
+| Windows 64-bit, NVIDIA CUDA installer | [`2026-08-13-windows64.nvidia.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-13.1/2026-08-13-windows64.nvidia.installer.exe) |
+| Windows 64-bit, RTX 5070/5080/5090, portable | [`2026-08-13-windows64.nvidia50.cuda.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-13.1/2026-08-13-windows64.nvidia50.cuda.portable.zip) |
+| Advanced optional TensorRT split package; download every part | [`2026-08-13-windows64.nvidia.tensorrt.portable.7z.001`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-13.1/2026-08-13-windows64.nvidia.tensorrt.portable.7z.001)<br>[`2026-08-13-windows64.nvidia.tensorrt.portable.7z.002`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-13.1/2026-08-13-windows64.nvidia.tensorrt.portable.7z.002) |
+| Windows 64-bit, RTX 50 CUDA installer | [`2026-08-13-windows64.nvidia50.cuda.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-13.1/2026-08-13-windows64.nvidia50.cuda.installer.exe) |
+| Windows 64-bit, configure your own engine, portable | [`2026-08-13-windows64.without.engine.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-13.1/2026-08-13-windows64.without.engine.portable.zip) |
+| Windows 64-bit, configure your own engine, installer | [`2026-08-13-windows64.without.engine.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-13.1/2026-08-13-windows64.without.engine.installer.exe) |
+| macOS Apple Silicon | [`2026-08-13-mac-apple-silicon.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-13.1/2026-08-13-mac-apple-silicon.with-katago.dmg) |
+| macOS Intel | [`2026-08-13-mac-intel.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-13.1/2026-08-13-mac-intel.with-katago.dmg) |
+| Linux 64-bit, CPU fallback | [`2026-08-13-linux64.with-katago.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-13.1/2026-08-13-linux64.with-katago.zip) |
+| Linux 64-bit, OpenCL | [`2026-08-13-linux64.opencl.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-13.1/2026-08-13-linux64.opencl.zip) |
+| Linux 64-bit, NVIDIA CUDA | [`2026-08-13-linux64.nvidia.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-13.1/2026-08-13-linux64.nvidia.zip) |
+
+### Why Test This Release
+
+- The complete JDK 21 suite passed `2205` tests with `0` failures and `0` errors, and shaded packaging passed.
+- Real macOS and Windows NVIDIA systems verified that AI commentary no longer creates a white block, a 40-move win-rate/score curve completes, and live board analysis resumes immediately.
+- The release pipeline audits filenames, versions, signatures or runtime structure, and SHA-256 for every Windows, macOS, and Linux artifact before publication.
+
+### Contact
+
+- QQ group: `299419120`
+
+---
+
+## 日本語
+
+`next-2026-08-12.2` に続く安定性プレリリースです。AI 解説、コメント表示、自動クイック勝率曲線、旧テーマ互換性を改善しました。
+
+### 主な更新
+
+- AI 解説は選択した棋力、解説スタイル、用語密度、変化の詳しさに合わせて内容を調整し、KataGo の根拠範囲を守ります。完全な多言語解説設計を進めた `Fly143` さんに感謝します。
+- AI 解説後に macOS と Windows のコメント欄へ白い長方形が表示される問題を修正しました。通常コメントは安全なテキスト、AI Markdown は制限付き renderer で表示し、元の SGF コメントは編集・保存できます。
+- 棋譜読み込み後に自動クイック曲線が始まらない、遅い engine 起動中に静かに停止する、棋譜移動で中断する問題を修正しました。単一 task が engine の実際の準備完了を待ち、未解析局面だけを補完し、完了後すぐ盤面のリアルタイム解析を再開します。
+- 旧テーマの悪手しきい値または node 色が不完全な場合の表示異常を修正しました。無効なテーマ規則は有効な global 規則または内蔵既定値へ一括 fallback します。詳細な報告をまとめた `qiyi71w` さんに感謝します。
+- 同期ツール終了と engine 再起動の競合を含む、一時 board-sync SGF の lifecycle 回帰テストを追加しました。明確な Windows 再現手順を提供した `semanym` さんに感謝します。
+
+### ダウンロード前に
+
+- 既存 Windows portable は `windows64.core-update.zip` でアプリだけ更新できます。このリリースでは内蔵 engine、weight、runtime を変更していません。
+- 多くの Windows 利用者には OpenCL portable を推奨します。NVIDIA は GPU 世代に合う NVIDIA または RTX 50 CUDA package を選んでください。
+- AI 解説には互換 LLM service の設定が必要です。クイック曲線は現在利用可能な local または remote analysis engine を使います。
+- これは pre-release です。まずコピーを更新し、`user-data`、custom weight、棋譜を backup してください。
+
+### ダウンロード案内
+
+| お使いの環境 | ダウンロードするファイル |
+| --- | --- |
+| Windows 64-bit、OpenCL 推奨 portable | [`2026-08-13-windows64.opencl.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-13.1/2026-08-13-windows64.opencl.portable.zip) |
+| 既存 Windows portable、アプリ本体のみ更新 | [`2026-08-13-windows64.core-update.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-13.1/2026-08-13-windows64.core-update.zip) |
+| Windows 64-bit、OpenCL installer | [`2026-08-13-windows64.opencl.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-13.1/2026-08-13-windows64.opencl.installer.exe) |
+| Windows 64-bit、CPU fallback portable | [`2026-08-13-windows64.with-katago.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-13.1/2026-08-13-windows64.with-katago.portable.zip) |
+| Windows 64-bit、CPU fallback installer | [`2026-08-13-windows64.with-katago.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-13.1/2026-08-13-windows64.with-katago.installer.exe) |
+| Windows 64-bit、NVIDIA CUDA portable | [`2026-08-13-windows64.nvidia.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-13.1/2026-08-13-windows64.nvidia.portable.zip) |
+| Windows 64-bit、NVIDIA CUDA installer | [`2026-08-13-windows64.nvidia.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-13.1/2026-08-13-windows64.nvidia.installer.exe) |
+| Windows 64-bit、RTX 5070/5080/5090 portable | [`2026-08-13-windows64.nvidia50.cuda.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-13.1/2026-08-13-windows64.nvidia50.cuda.portable.zip) |
+| 上級者向け TensorRT 分割 package、全 part が必要 | [`2026-08-13-windows64.nvidia.tensorrt.portable.7z.001`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-13.1/2026-08-13-windows64.nvidia.tensorrt.portable.7z.001)<br>[`2026-08-13-windows64.nvidia.tensorrt.portable.7z.002`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-13.1/2026-08-13-windows64.nvidia.tensorrt.portable.7z.002) |
+| Windows 64-bit、RTX 50 CUDA installer | [`2026-08-13-windows64.nvidia50.cuda.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-13.1/2026-08-13-windows64.nvidia50.cuda.installer.exe) |
+| Windows 64-bit、engine を自分で設定、portable | [`2026-08-13-windows64.without.engine.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-13.1/2026-08-13-windows64.without.engine.portable.zip) |
+| Windows 64-bit、engine を自分で設定、installer | [`2026-08-13-windows64.without.engine.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-13.1/2026-08-13-windows64.without.engine.installer.exe) |
+| macOS Apple Silicon | [`2026-08-13-mac-apple-silicon.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-13.1/2026-08-13-mac-apple-silicon.with-katago.dmg) |
+| macOS Intel | [`2026-08-13-mac-intel.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-13.1/2026-08-13-mac-intel.with-katago.dmg) |
+| Linux 64-bit、CPU fallback | [`2026-08-13-linux64.with-katago.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-13.1/2026-08-13-linux64.with-katago.zip) |
+| Linux 64-bit、OpenCL | [`2026-08-13-linux64.opencl.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-13.1/2026-08-13-linux64.opencl.zip) |
+| Linux 64-bit、NVIDIA CUDA | [`2026-08-13-linux64.nvidia.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-13.1/2026-08-13-linux64.nvidia.zip) |
+
+### このリリースを試す理由
+
+- JDK 21 full suite は `2205` tests、`0` failure、`0` error で、shaded jar package も成功しました。
+- macOS と Windows NVIDIA 実機で AI 解説の白枠が消え、40 手の勝率/目差曲線が完成し、盤面のリアルタイム解析がすぐ再開することを確認しました。
+- 公開前に release pipeline が Windows、macOS、Linux の全成果物についてファイル名、version、署名または runtime 構造、SHA-256 を検査します。
+
+### 連絡先
+
+- QQ group: `299419120`
+
+---
+
+## 한국어
+
+`next-2026-08-12.2` 이후의 안정성 pre-release입니다. AI 해설, comment 표시, 자동 빠른 승률 곡선, 기존 theme 호환성을 개선했습니다.
+
+### 주요 업데이트
+
+- AI 해설은 선택한 기력, 설명 스타일, 용어 밀도, 변화 상세도에 맞춰 내용을 조정하면서 KataGo 근거 범위를 지킵니다. 완전한 다국어 해설 설계를 추진한 `Fly143` 님께 감사드립니다.
+- AI 해설 후 macOS와 Windows comment 영역에 흰 사각형이 나타나던 문제를 수정했습니다. 일반 comment는 안전한 text, AI Markdown은 제한된 renderer로 표시하며 원본 SGF comment는 계속 편집하고 저장할 수 있습니다.
+- 기보를 불러온 뒤 자동 빠른 곡선이 시작되지 않거나, 느린 engine 시작 중 조용히 중단되거나, 기보 탐색으로 취소되는 문제를 수정했습니다. 하나의 task가 engine이 실제 준비될 때까지 기다리고 누락된 국면만 채운 뒤 실시간 보드 분석을 즉시 복구합니다.
+- 기존 theme의 blunder 임계값이나 node 색상이 불완전할 때 발생하는 표시 오류를 수정했습니다. 잘못된 theme 규칙은 유효한 global 규칙 또는 내장 기본값으로 한 번에 fallback합니다. 자세히 정리한 `qiyi71w` 님께 감사드립니다.
+- sync tool 종료와 engine 재시작 race를 포함한 임시 board-sync SGF lifecycle 회귀 테스트를 추가했습니다. 명확한 Windows 재현 절차를 제공한 `semanym` 님께 감사드립니다.
+
+### 다운로드 전 확인
+
+- 기존 Windows portable은 `windows64.core-update.zip`으로 앱만 업데이트할 수 있습니다. 이번 버전은 내장 engine, weight, runtime을 교체하지 않습니다.
+- 대부분의 Windows 사용자는 OpenCL portable을 권장합니다. NVIDIA 사용자는 GPU 세대에 맞는 NVIDIA 또는 RTX 50 CUDA package를 선택하세요.
+- AI 해설은 사용자가 설정한 호환 LLM service가 필요합니다. 빠른 곡선은 현재 사용 가능한 local 또는 remote analysis engine을 계속 사용합니다.
+- 이것은 pre-release입니다. 먼저 복사본을 업데이트하고 `user-data`, custom weight, 기보를 backup하세요.
+
+### 다운로드 안내
+
+| 환경 | 다운로드할 파일 |
+| --- | --- |
+| Windows 64-bit, OpenCL 권장 portable | [`2026-08-13-windows64.opencl.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-13.1/2026-08-13-windows64.opencl.portable.zip) |
+| 기존 Windows portable, 앱만 업데이트 | [`2026-08-13-windows64.core-update.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-13.1/2026-08-13-windows64.core-update.zip) |
+| Windows 64-bit, OpenCL installer | [`2026-08-13-windows64.opencl.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-13.1/2026-08-13-windows64.opencl.installer.exe) |
+| Windows 64-bit, CPU portable | [`2026-08-13-windows64.with-katago.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-13.1/2026-08-13-windows64.with-katago.portable.zip) |
+| Windows 64-bit, CPU installer | [`2026-08-13-windows64.with-katago.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-13.1/2026-08-13-windows64.with-katago.installer.exe) |
+| Windows 64-bit, NVIDIA CUDA portable | [`2026-08-13-windows64.nvidia.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-13.1/2026-08-13-windows64.nvidia.portable.zip) |
+| Windows 64-bit, NVIDIA CUDA installer | [`2026-08-13-windows64.nvidia.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-13.1/2026-08-13-windows64.nvidia.installer.exe) |
+| Windows 64-bit, RTX 5070/5080/5090 portable | [`2026-08-13-windows64.nvidia50.cuda.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-13.1/2026-08-13-windows64.nvidia50.cuda.portable.zip) |
+| 고급 선택: TensorRT 분할 package, 모든 part 필요 | [`2026-08-13-windows64.nvidia.tensorrt.portable.7z.001`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-13.1/2026-08-13-windows64.nvidia.tensorrt.portable.7z.001)<br>[`2026-08-13-windows64.nvidia.tensorrt.portable.7z.002`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-13.1/2026-08-13-windows64.nvidia.tensorrt.portable.7z.002) |
+| Windows 64-bit, RTX 50 CUDA installer | [`2026-08-13-windows64.nvidia50.cuda.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-13.1/2026-08-13-windows64.nvidia50.cuda.installer.exe) |
+| Windows 64-bit, 직접 engine 설정, portable | [`2026-08-13-windows64.without.engine.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-13.1/2026-08-13-windows64.without.engine.portable.zip) |
+| Windows 64-bit, 직접 engine 설정, installer | [`2026-08-13-windows64.without.engine.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-13.1/2026-08-13-windows64.without.engine.installer.exe) |
+| macOS Apple Silicon | [`2026-08-13-mac-apple-silicon.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-13.1/2026-08-13-mac-apple-silicon.with-katago.dmg) |
+| macOS Intel | [`2026-08-13-mac-intel.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-13.1/2026-08-13-mac-intel.with-katago.dmg) |
+| Linux 64-bit, CPU | [`2026-08-13-linux64.with-katago.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-13.1/2026-08-13-linux64.with-katago.zip) |
+| Linux 64-bit, OpenCL | [`2026-08-13-linux64.opencl.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-13.1/2026-08-13-linux64.opencl.zip) |
+| Linux 64-bit, NVIDIA CUDA | [`2026-08-13-linux64.nvidia.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-13.1/2026-08-13-linux64.nvidia.zip) |
+
+### 이 릴리스를 테스트할 이유
+
+- JDK 21 full suite는 `2205` tests, `0` failure, `0` error이며 shaded jar package도 성공했습니다.
+- macOS와 Windows NVIDIA 실기에서 AI 해설 흰 박스가 사라지고, 40수 승률/점수 곡선이 완성되며, 실시간 보드 분석이 즉시 재개되는 것을 확인했습니다.
+- 공개 전 release pipeline이 모든 Windows, macOS, Linux 산출물의 파일명, version, 서명 또는 runtime 구조와 SHA-256을 검사합니다.
+
+### 연락처
+
+- QQ 그룹：`299419120`
+
+---
+
+## ภาษาไทย
+
+นี่คือ stability pre-release หลัง `next-2026-08-12.2` โดยปรับปรุงคำอธิบาย AI, การแสดง comment, กราฟ win-rate แบบเร็วอัตโนมัติ และความเข้ากันได้กับ theme รุ่นเก่า
+
+### ไฮไลต์ของเวอร์ชันนี้
+
+- คำอธิบาย AI ปรับตามระดับฝีมือ รูปแบบการอธิบาย ความหนาแน่นของศัพท์ และรายละเอียด variation ที่เลือก โดยยังยึดขอบเขตหลักฐานจาก KataGo ขอบคุณ `Fly143` ที่พัฒนาการออกแบบคำอธิบายหลายภาษาแบบครบถ้วน
+- แก้กล่องสีขาวทึบในพื้นที่ comment หลังใช้ AI commentary บน macOS และ Windows โดย comment ทั่วไปแสดงเป็นข้อความปลอดภัย ส่วน AI Markdown ใช้ renderer แบบจำกัด และ comment ต้นฉบับใน SGF ยังแก้ไขและบันทึกได้
+- แก้กราฟเร็วอัตโนมัติไม่เริ่มหลังเปิดเกม หยุดเงียบระหว่างรอ engine ที่เริ่มช้า หรือถูกยกเลิกเมื่อเลื่อนดูเกม task เดียวจะรอจน engine พร้อมจริง วิเคราะห์เฉพาะตำแหน่งที่ขาด และกลับสู่การวิเคราะห์กระดานสดทันทีเมื่อเสร็จ
+- แก้การแสดงผลผิดปกติเมื่อ theme เก่ามีค่า blunder threshold หรือสี node ไม่ครบ โดยกฎ theme ที่ไม่ถูกต้องจะ fallback ทั้งชุดไปยังกฎ global ที่ใช้ได้หรือค่าเริ่มต้น ขอบคุณ `qiyi71w` สำหรับรายงานโดยละเอียด
+- เพิ่ม regression coverage สำหรับอายุไฟล์ SGF ชั่วคราวของ board sync ระหว่างปิด sync tool และ restart engine ขอบคุณ `semanym` สำหรับขั้นตอนทำซ้ำบน Windows ที่ชัดเจน
+
+### ก่อนดาวน์โหลด
+
+- ผู้ใช้ Windows portable เดิมอัปเดตเฉพาะแอปด้วย `windows64.core-update.zip` ได้ รุ่นนี้ไม่ได้เปลี่ยน engine, weight หรือ runtime ที่มากับ package
+- ผู้ใช้ Windows ส่วนใหญ่แนะนำ OpenCL portable ส่วน NVIDIA ให้เลือก NVIDIA หรือ RTX 50 CUDA ตามรุ่น GPU
+- AI commentary ยังต้องตั้งค่า LLM service ที่เข้ากันได้เอง ส่วนกราฟเร็วใช้ local หรือ remote analysis engine ที่พร้อมใช้งานในขณะนั้น
+- นี่คือ pre-release ควรอัปเดตสำเนาก่อน และ backup `user-data`, custom weight และ kifu
+
+### คู่มือดาวน์โหลด
+
+| คอมพิวเตอร์ของคุณ | ดาวน์โหลดไฟล์นี้ |
+| --- | --- |
+| Windows 64-bit, OpenCL แนะนำ, portable | [`2026-08-13-windows64.opencl.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-13.1/2026-08-13-windows64.opencl.portable.zip) |
+| มี Windows portable แล้ว อัปเดตเฉพาะโปรแกรม | [`2026-08-13-windows64.core-update.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-13.1/2026-08-13-windows64.core-update.zip) |
+| Windows 64-bit, OpenCL installer | [`2026-08-13-windows64.opencl.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-13.1/2026-08-13-windows64.opencl.installer.exe) |
+| Windows 64-bit, CPU portable | [`2026-08-13-windows64.with-katago.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-13.1/2026-08-13-windows64.with-katago.portable.zip) |
+| Windows 64-bit, CPU installer | [`2026-08-13-windows64.with-katago.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-13.1/2026-08-13-windows64.with-katago.installer.exe) |
+| Windows 64-bit, NVIDIA CUDA portable | [`2026-08-13-windows64.nvidia.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-13.1/2026-08-13-windows64.nvidia.portable.zip) |
+| Windows 64-bit, NVIDIA CUDA installer | [`2026-08-13-windows64.nvidia.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-13.1/2026-08-13-windows64.nvidia.installer.exe) |
+| Windows 64-bit, RTX 5070/5080/5090 portable | [`2026-08-13-windows64.nvidia50.cuda.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-13.1/2026-08-13-windows64.nvidia50.cuda.portable.zip) |
+| ตัวเลือกขั้นสูง TensorRT แบบแบ่งส่วน ต้องดาวน์โหลดทุกส่วน | [`2026-08-13-windows64.nvidia.tensorrt.portable.7z.001`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-13.1/2026-08-13-windows64.nvidia.tensorrt.portable.7z.001)<br>[`2026-08-13-windows64.nvidia.tensorrt.portable.7z.002`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-13.1/2026-08-13-windows64.nvidia.tensorrt.portable.7z.002) |
+| Windows 64-bit, RTX 50 CUDA installer | [`2026-08-13-windows64.nvidia50.cuda.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-13.1/2026-08-13-windows64.nvidia50.cuda.installer.exe) |
+| Windows 64-bit, ตั้งค่า engine เอง, portable | [`2026-08-13-windows64.without.engine.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-13.1/2026-08-13-windows64.without.engine.portable.zip) |
+| Windows 64-bit, ตั้งค่า engine เอง, installer | [`2026-08-13-windows64.without.engine.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-13.1/2026-08-13-windows64.without.engine.installer.exe) |
+| macOS Apple Silicon | [`2026-08-13-mac-apple-silicon.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-13.1/2026-08-13-mac-apple-silicon.with-katago.dmg) |
+| macOS Intel | [`2026-08-13-mac-intel.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-13.1/2026-08-13-mac-intel.with-katago.dmg) |
+| Linux 64-bit, CPU | [`2026-08-13-linux64.with-katago.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-13.1/2026-08-13-linux64.with-katago.zip) |
+| Linux 64-bit, OpenCL | [`2026-08-13-linux64.opencl.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-13.1/2026-08-13-linux64.opencl.zip) |
+| Linux 64-bit, NVIDIA CUDA | [`2026-08-13-linux64.nvidia.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-13.1/2026-08-13-linux64.nvidia.zip) |
+
+### ทำไมควรทดสอบเวอร์ชันนี้
+
+- full JDK 21 suite ผ่าน `2205` tests โดยมี `0` failure และ `0` error และ shaded jar package สำเร็จ
+- เครื่องจริง macOS และ Windows NVIDIA ยืนยันว่า AI commentary ไม่มี white block แล้ว กราฟ win-rate/score 40 ตาเสร็จครบ และการวิเคราะห์กระดานสดกลับมาทันที
+- ก่อนเผยแพร่ release pipeline จะตรวจชื่อไฟล์ version ลายเซ็นหรือโครงสร้าง runtime และ SHA-256 ของไฟล์ Windows, macOS และ Linux ทุกไฟล์
+
+### ติดต่อ
+
+- กลุ่ม QQ: `299419120`

--- a/.github/release-requests/next-2026-08-13.1.json
+++ b/.github/release-requests/next-2026-08-13.1.json
@@ -1,0 +1,7 @@
+{
+  "date_tag": "2026-08-13",
+  "release_tag": "next-2026-08-13.1",
+  "title": "LizzieYzy Next next-2026-08-13.1",
+  "prerelease": true,
+  "notes_file": ".github/release-notes/next-2026-08-13.1.md"
+}


### PR DESCRIPTION
## Summary

- requests the audited multi-platform pre-release `next-2026-08-13.1`
- keeps the established six-language, five-section release-note structure with direct GitHub asset links
- documents all changes merged since `next-2026-08-12.2`: localized AI commentary personas, safe comment rendering, reliable automatic quick curves, legacy-theme fallback, and ReadBoard lifecycle coverage
- excludes open PRs #254 and #256 because they are not part of the release source

## Validation

- release request and every direct-download table validated by the fail-closed publisher
- `python3 -m unittest scripts.test_publish_release_request scripts.test_generate_release_notes` — 24 passed
- `python3 scripts/check_line_endings.py`
- `python3 scripts/check_markdown_links.py`
- six languages with five matching sections each; no stale asset links
- release source already passed 2,205 JDK 21 tests, shaded packaging, and real macOS/Windows NVIDIA UI and analysis verification

The release remains a draft until all four platform workflows and release-asset audits succeed.