### PR TITLE
Fix Windows TensorRT first launch and quick curves

### DIFF
--- a/.github/workflows/build-windows-release.yml
+++ b/.github/workflows/build-windows-release.yml
@@ -226,6 +226,10 @@ jobs:
             "engines/katago/windows-x64-nvidia-tensorrt/lizzieyzy-next-katago-engine-manifest.txt"
           grep -qx "Asset SHA-256: be09c4ecc02028e2bdf98ff489683840bc9be480ba94f1cfe6f7e15018e36be6" \
             "engines/katago/windows-x64-nvidia-tensorrt/lizzieyzy-next-katago-engine-manifest.txt"
+          grep -qx "KataGo release: v1.17.2" \
+            "dist/windows/input-nvidia.tensorrt/engines/katago/VERSION.txt"
+          grep -qx "Windows TensorRT bundle: katago-v1.17.2-trt10.9.0-cuda12.8-windows-x64.zip" \
+            "dist/windows/input-nvidia.tensorrt/engines/katago/VERSION.txt"
           grep -q "Advanced optional TensorRT split package" "dist/release/${{ inputs.date_tag }}-windows64.nvidia.tensorrt.portable.README.txt"
           grep -q '"engineBackend": "nvidia-tensorrt"' "dist/release/${{ inputs.date_tag }}-windows64.nvidia.tensorrt.portable.manifest.json"
           test -f "dist/windows/input-without.engine/PROJECT_INFO.txt"
@@ -341,6 +345,11 @@ jobs:
             --reject-version 1.17.0 \
             --reject-version 1.17.1 \
             "$tensorrt_engine"
+          python3 scripts/audit_katago_package_metadata.py \
+            --version-file "dist/windows/app-image-nvidia.tensorrt/LizzieYzy Next NVIDIA TensorRT/app/engines/katago/VERSION.txt" \
+            --engine-manifest "dist/windows/app-image-nvidia.tensorrt/LizzieYzy Next NVIDIA TensorRT/app/engines/katago/windows-x64/lizzieyzy-next-katago-engine-manifest.txt" \
+            --expected-version 1.17.2 \
+            --expected-asset katago-v1.17.2-trt10.9.0-cuda12.8-windows-x64.zip
 
       - name: Smoke test bundled Windows app images
         shell: powershell

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,6 +91,7 @@ jobs:
         run: |
           python3 -m py_compile \
             scripts/audit_katago_binary_version.py \
+            scripts/audit_katago_package_metadata.py \
             scripts/generate_release_notes.py \
             scripts/macos_bundle_version.py \
             scripts/macos_katago_bundle.py \
@@ -101,6 +102,7 @@ jobs:
             scripts/summarize_jfr.py \
             scripts/test_generate_release_notes.py \
             scripts/test_audit_katago_binary_version.py \
+            scripts/test_audit_katago_package_metadata.py \
             scripts/test_macos_drag_dmg_script.py \
             scripts/test_macos_bundle_version.py \
             scripts/test_macos_katago_bundle.py \
@@ -109,6 +111,7 @@ jobs:
             scripts/test_windows_launcher_packaging.py
           python3 scripts/test_generate_release_notes.py
           python3 scripts/test_audit_katago_binary_version.py
+          python3 scripts/test_audit_katago_package_metadata.py
           python3 scripts/test_macos_drag_dmg_script.py
           python3 scripts/test_macos_bundle_version.py
           python3 scripts/test_macos_katago_bundle.py

--- a/scripts/audit_katago_package_metadata.py
+++ b/scripts/audit_katago_package_metadata.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""Verify that packaged KataGo display metadata matches its engine asset manifest."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import sys
+
+
+class PackageMetadataAuditError(RuntimeError):
+    pass
+
+
+def parse_metadata(path: Path) -> dict[str, str]:
+    if not path.is_file():
+        raise PackageMetadataAuditError(f"metadata file not found: {path}")
+    metadata: dict[str, str] = {}
+    for raw_line in path.read_text(encoding="utf-8").splitlines():
+        key, separator, value = raw_line.partition(":")
+        if separator and key.strip() and value.strip():
+            metadata[key.strip()] = value.strip()
+    return metadata
+
+
+def normalize_version(value: str) -> str:
+    return value.strip().removeprefix("v")
+
+
+def audit_package_metadata(
+    version_file: Path,
+    engine_manifest: Path,
+    expected_version: str,
+    expected_asset: str,
+) -> None:
+    display = parse_metadata(version_file)
+    engine = parse_metadata(engine_manifest)
+    display_version = normalize_version(display.get("KataGo release", ""))
+    engine_version = normalize_version(engine.get("KataGo release", ""))
+    expected = normalize_version(expected_version)
+    display_asset = display.get("Windows TensorRT bundle", "")
+    engine_asset = engine.get("Asset", "")
+
+    if display_version != expected or engine_version != expected:
+        raise PackageMetadataAuditError(
+            "KataGo version mismatch: "
+            f"display={display_version or '<missing>'}, "
+            f"engine={engine_version or '<missing>'}, expected={expected}"
+        )
+    if display_asset != expected_asset or engine_asset != expected_asset:
+        raise PackageMetadataAuditError(
+            "KataGo asset mismatch: "
+            f"display={display_asset or '<missing>'}, "
+            f"engine={engine_asset or '<missing>'}, expected={expected_asset}"
+        )
+    print(
+        f"{version_file}: KataGo v{expected} / {expected_asset} matches {engine_manifest}"
+    )
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--version-file", required=True, type=Path)
+    parser.add_argument("--engine-manifest", required=True, type=Path)
+    parser.add_argument("--expected-version", required=True)
+    parser.add_argument("--expected-asset", required=True)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    audit_package_metadata(
+        args.version_file,
+        args.engine_manifest,
+        args.expected_version,
+        args.expected_asset,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except (OSError, PackageMetadataAuditError) as exc:
+        print(f"KataGo package metadata audit failed: {exc}", file=sys.stderr)
+        raise SystemExit(1)

--- a/scripts/package_windows_exe.sh
+++ b/scripts/package_windows_exe.sh
@@ -477,7 +477,65 @@ copy_bundle_engine_assets() {
     printf '%s\n' "$engine_backend" \
       >"$input_dir/engines/katago/$engine_target_dir/$ENGINE_BACKEND_MARKER_NAME"
   fi
+  if [[ "$engine_backend" == *tensorrt* ]]; then
+    write_tensorrt_version_file "$input_dir" "$engine_target_dir"
+  fi
   cp "$ROOT_DIR/weights/default.bin.gz" "$input_dir/weights/default.bin.gz"
+}
+
+write_tensorrt_version_file() {
+  local input_dir="$1"
+  local engine_target_dir="$2"
+  local version_file="$input_dir/engines/katago/VERSION.txt"
+  local engine_manifest="$input_dir/engines/katago/$engine_target_dir/$TENSORRT_ENGINE_MANIFEST_NAME"
+
+  if [[ ! -f "$engine_manifest" ]]; then
+    echo "TensorRT KataGo engine manifest not found: $engine_manifest"
+    exit 1
+  fi
+  resolve_python_bin
+  "$PYTHON_BIN" - "$version_file" "$engine_manifest" <<'PY'
+from datetime import datetime, timezone
+from pathlib import Path
+import sys
+
+version_path = Path(sys.argv[1])
+engine_manifest_path = Path(sys.argv[2])
+
+def parse_metadata(path):
+    result = {}
+    if not path.is_file():
+        return result
+    for raw_line in path.read_text(encoding="utf-8").splitlines():
+        key, separator, value = raw_line.partition(":")
+        if separator and key.strip() and value.strip():
+            result[key.strip()] = value.strip()
+    return result
+
+base = parse_metadata(version_path)
+engine = parse_metadata(engine_manifest_path)
+release = engine.get("KataGo release", "").strip()
+asset = engine.get("Asset", "").strip()
+if not release or not asset:
+    raise SystemExit(f"Incomplete TensorRT engine manifest: {engine_manifest_path}")
+
+lines = [
+    f"KataGo release: {release}",
+    f"Windows TensorRT bundle: {asset}",
+]
+for key in (
+    "Model source",
+    "Model SHA-256",
+    "Model size",
+    "Model architecture",
+    "Minimum KataGo version",
+):
+    value = base.get(key, "").strip()
+    if value:
+        lines.append(f"{key}: {value}")
+lines.append(f"Prepared at: {datetime.now(timezone.utc).strftime('%Y-%m-%d %H:%M:%S +0000')}")
+version_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+PY
 }
 
 prepare_bundled_nvidia_runtime_assets() {

--- a/scripts/test_audit_katago_package_metadata.py
+++ b/scripts/test_audit_katago_package_metadata.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+
+from pathlib import Path
+import tempfile
+import unittest
+
+from audit_katago_package_metadata import (
+    PackageMetadataAuditError,
+    audit_package_metadata,
+)
+
+
+class AuditKataGoPackageMetadataTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp_dir.cleanup)
+        self.root = Path(self.temp_dir.name)
+        self.version_file = self.root / "VERSION.txt"
+        self.engine_manifest = self.root / "engine-manifest.txt"
+
+    def write_metadata(
+        self,
+        display_version: str = "v1.17.2",
+        engine_version: str = "v1.17.2",
+        display_asset: str = "katago-v1.17.2-trt.zip",
+        engine_asset: str = "katago-v1.17.2-trt.zip",
+    ) -> None:
+        self.version_file.write_text(
+            f"KataGo release: {display_version}\n"
+            f"Windows TensorRT bundle: {display_asset}\n",
+            encoding="utf-8",
+        )
+        self.engine_manifest.write_text(
+            f"KataGo release: {engine_version}\nAsset: {engine_asset}\n",
+            encoding="utf-8",
+        )
+
+    def test_accepts_matching_version_and_asset(self) -> None:
+        self.write_metadata()
+        audit_package_metadata(
+            self.version_file,
+            self.engine_manifest,
+            "1.17.2",
+            "katago-v1.17.2-trt.zip",
+        )
+
+    def test_rejects_stale_display_version(self) -> None:
+        self.write_metadata(display_version="v1.17.1")
+        with self.assertRaises(PackageMetadataAuditError):
+            audit_package_metadata(
+                self.version_file,
+                self.engine_manifest,
+                "1.17.2",
+                "katago-v1.17.2-trt.zip",
+            )
+
+    def test_rejects_asset_mismatch(self) -> None:
+        self.write_metadata(display_asset="katago-v1.17.1-trt.zip")
+        with self.assertRaises(PackageMetadataAuditError):
+            audit_package_metadata(
+                self.version_file,
+                self.engine_manifest,
+                "1.17.2",
+                "katago-v1.17.2-trt.zip",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_windows_launcher_packaging.py
+++ b/scripts/test_windows_launcher_packaging.py
@@ -91,11 +91,18 @@ def main() -> None:
         "scripts/audit_katago_binary_version.py",
         "build-windows-release.yml",
     )
+    require(
+        workflow,
+        "scripts/audit_katago_package_metadata.py",
+        "build-windows-release.yml",
+    )
     require(workflow, 'runnable_engines=(', "build-windows-release.yml")
     require(workflow, 'standard_packaged_engines=(', "build-windows-release.yml")
     require(workflow, 'tensorrt_engine=', "build-windows-release.yml")
     require(workflow, "--expected-version 1.17.1", "build-windows-release.yml")
     require(workflow, "--expected-version 1.17.2", "build-windows-release.yml")
+    require(package_script, "write_tensorrt_version_file", "package_windows_exe.sh")
+    require(package_script, "Windows TensorRT bundle", "package_windows_exe.sh")
     require(workflow, "GitHub-hosted Windows runners do not have an NVIDIA display driver", "build-windows-release.yml")
     require(
         workflow,

--- a/src/main/java/featurecat/lizzie/Lizzie.java
+++ b/src/main/java/featurecat/lizzie/Lizzie.java
@@ -101,8 +101,14 @@ public class Lizzie {
   private static Image applicationIcon;
   private static boolean firstLaunchSession;
   private static volatile boolean startupProfileSaveFailed;
-  public static Float sysScaleFactor =
-      OS.isWindows() ? (java.awt.Toolkit.getDefaultToolkit().getScreenResolution() / 96.0f) : 1.0f;
+  public static Float sysScaleFactor = initialSystemScaleFactor();
+
+  static float initialSystemScaleFactor() {
+    if (!OS.isWindows() || GraphicsEnvironment.isHeadless()) {
+      return 1.0f;
+    }
+    return java.awt.Toolkit.getDefaultToolkit().getScreenResolution() / 96.0f;
+  }
 
   /** Launches the game window, and runs the game. */
   public static void main(String[] args) throws IOException {

--- a/src/main/java/featurecat/lizzie/analysis/AnalysisEngine.java
+++ b/src/main/java/featurecat/lizzie/analysis/AnalysisEngine.java
@@ -156,6 +156,8 @@ public class AnalysisEngine {
   private long remoteGtpStopAckGeneration;
   private long remoteGtpLastCompletionActivityMillis;
   private Leelaz sharedForegroundEngine;
+  private boolean automaticTensorRtForegroundReuse;
+  private String automaticTensorRtForegroundCommand;
   private boolean sharedForegroundLeaseStarting;
   private boolean sharedForegroundLeaseActive;
   private Leelaz.ForegroundAnalysisLease sharedForegroundLease;
@@ -215,15 +217,25 @@ public class AnalysisEngine {
     this.purpose =
         purpose == null ? AnalysisResourceCoordinator.Purpose.OTHER : purpose;
     this.persistentPreload = persistentPreload;
+    automaticTensorRtForegroundReuse =
+        shouldAutomaticallyReuseTensorRtForeground(
+            this.purpose,
+            KataGoRuntimeHelper.isBundledTensorRtCommand(
+                Lizzie.leelaz == null ? null : Lizzie.leelaz.engineCommand()));
     this.dedicatedLightweightQuickModel =
         this.purpose == AnalysisResourceCoordinator.Purpose.AUTO_QUICK_ANALYSIS
+            && !automaticTensorRtForegroundReuse
             && commandOverride != null
             && !commandOverride.trim().isEmpty();
     this.dedicatedLightweightQuickModelCommand =
         this.dedicatedLightweightQuickModel ? commandOverride.trim() : "";
-    if (Lizzie.config.analysisReuseCurrentEngine) {
+    if (Lizzie.config.analysisReuseCurrentEngine || automaticTensorRtForegroundReuse) {
       useRemoteCompute = true;
       sharedForegroundEngine = Lizzie.leelaz;
+      automaticTensorRtForegroundCommand =
+          automaticTensorRtForegroundReuse && sharedForegroundEngine != null
+              ? sharedForegroundEngine.engineCommand()
+              : null;
       foregroundLeaseAvailability =
           sharedForegroundEngine == null
               ? Leelaz.ExclusiveGtpLeaseAvailability.NO_FOREGROUND_ENGINE
@@ -265,6 +277,12 @@ public class AnalysisEngine {
     return commandOverride == null || commandOverride.trim().isEmpty()
         ? Lizzie.config.analysisEngineCommand
         : commandOverride;
+  }
+
+  static boolean shouldAutomaticallyReuseTensorRtForeground(
+      AnalysisResourceCoordinator.Purpose purpose, boolean bundledTensorRtPrimary) {
+    return purpose == AnalysisResourceCoordinator.Purpose.AUTO_QUICK_ANALYSIS
+        && bundledTensorRtPrimary;
   }
 
   static boolean shouldShowGeneratedConfigNotice(boolean isPreLoad, boolean generatedConfig) {
@@ -1056,16 +1074,24 @@ public class AnalysisEngine {
   }
 
   public void normalQuit() {
-    // TODO Auto-generated method stub
+    normalQuit(null);
+  }
+
+  /** Stops this worker and runs {@code afterRestore} once any shared foreground lease is restored. */
+  public void normalQuit(Runnable afterRestore) {
     requestShutdown();
     isNormalEnd = true;
     AnalysisResourceCoordinator.processStopped(this, purpose, process);
     shutdownRemoteGtpSetupAckTimeoutExecutor();
     if (sharedForegroundEngine != null) {
       requestDispatchFailed = true;
-      finishFailedRequestDispatch(false);
+      finishFailedRequestDispatch(false, afterRestore);
     } else {
-      releaseSharedForegroundLease();
+      boolean restorePending =
+          releaseSharedForegroundLease(afterRestore, afterRestore);
+      if (!restorePending && afterRestore != null) {
+        afterRestore.run();
+      }
     }
     if (this.useJavaSSH) {
       if (this.javaSSH != null) this.javaSSH.close();
@@ -1568,6 +1594,11 @@ public class AnalysisEngine {
   }
 
   private void finishFailedRequestDispatch(boolean showProgressDialog) {
+    finishFailedRequestDispatch(showProgressDialog, null);
+  }
+
+  private void finishFailedRequestDispatch(
+      boolean showProgressDialog, Runnable afterForegroundRestore) {
     Runnable failedRequestCallback = failureCallback;
     analyzeMap.clear();
     remoteGtpQueue().clear();
@@ -1593,7 +1624,8 @@ public class AnalysisEngine {
         failedRequestCallback == null
             ? null
             : () -> javax.swing.SwingUtilities.invokeLater(failedRequestCallback);
-    boolean restorePending = releaseSharedForegroundLease(deliverFailure, deliverFailure);
+    Runnable finishRestore = chainCallbacks(deliverFailure, afterForegroundRestore);
+    boolean restorePending = releaseSharedForegroundLease(finishRestore, finishRestore);
     resumeForegroundAnalysisIfRequested();
     if (Lizzie.frame.isBatchAnalysisMode) Lizzie.frame.isBatchAnalysisMode = false;
     if (waitFrame != null || showProgressDialog) {
@@ -1615,9 +1647,25 @@ public class AnalysisEngine {
             }
           });
     }
-    if (!restorePending && deliverFailure != null) {
-      deliverFailure.run();
+    if (!restorePending && finishRestore != null) {
+      finishRestore.run();
     }
+  }
+
+  private static Runnable chainCallbacks(Runnable first, Runnable second) {
+    if (first == null) {
+      return second;
+    }
+    if (second == null) {
+      return first;
+    }
+    return () -> {
+      try {
+        first.run();
+      } finally {
+        second.run();
+      }
+    };
   }
 
   public boolean sendRequest(BoardHistoryNode analyzeNode) {
@@ -2417,7 +2465,13 @@ public class AnalysisEngine {
           .isPresent();
     }
     if (sharedForegroundEngine != null) {
-      return Lizzie.config.analysisReuseCurrentEngine && sharedForegroundEngine == Lizzie.leelaz;
+      boolean automaticReuseStillMatches =
+          automaticTensorRtForegroundReuse
+              && Lizzie.leelaz != null
+              && automaticTensorRtForegroundCommand != null
+              && automaticTensorRtForegroundCommand.equals(Lizzie.leelaz.engineCommand());
+      return (Lizzie.config.analysisReuseCurrentEngine || automaticReuseStillMatches)
+          && sharedForegroundEngine == Lizzie.leelaz;
     }
     if (Lizzie.config.analysisReuseCurrentEngine) {
       return false;
@@ -2429,6 +2483,10 @@ public class AnalysisEngine {
 
   public boolean usesSharedForegroundEngine() {
     return sharedForegroundEngine != null;
+  }
+
+  public boolean usesAutomaticTensorRtForegroundReuse() {
+    return automaticTensorRtForegroundReuse;
   }
 
   public AnalysisResourceCoordinator.Purpose purpose() {

--- a/src/main/java/featurecat/lizzie/gui/LizzieFrame.java
+++ b/src/main/java/featurecat/lizzie/gui/LizzieFrame.java
@@ -422,6 +422,7 @@ public class LizzieFrame extends JFrame {
   private volatile boolean loadedGameQuickAnalysisRunning;
   private volatile long loadedGameQuickAnalysisDispatchStartedAt;
   private int loadedGameQuickAnalysisFailureCount;
+  private boolean kifuOpenWaitingForQuickAnalysisRestore;
   private static final int LOADED_GAME_QUICK_ANALYSIS_RETRY_MS = 1800;
   private static final int LOADED_GAME_QUICK_ANALYSIS_MAX_RETRY_MS = 30_000;
   private static final int LOADED_GAME_QUICK_ANALYSIS_WATCHDOG_MS = 30_000;
@@ -4400,6 +4401,13 @@ public class LizzieFrame extends JFrame {
   }
 
   public void openFile() {
+    if (!SwingUtilities.isEventDispatchThread()) {
+      SwingUtilities.invokeLater(this::openFile);
+      return;
+    }
+    if (deferKifuOpenUntilAutomaticQuickAnalysisRestored(this::openFile)) {
+      return;
+    }
     boolean ponder = false;
     if (Lizzie.leelaz.isPondering() || !Lizzie.leelaz.isLoaded) {
       ponder = true;
@@ -4425,6 +4433,34 @@ public class LizzieFrame extends JFrame {
     if (Lizzie.leelaz.isheatmap) Lizzie.leelaz.setHeatmap();
     this.setAlwaysOnTop(Lizzie.config.mainsalwaysontop);
     refresh();
+  }
+
+  private boolean deferKifuOpenUntilAutomaticQuickAnalysisRestored(Runnable continuation) {
+    if (kifuOpenWaitingForQuickAnalysisRestore) {
+      return true;
+    }
+    AnalysisEngine currentEngine = analysisEngine;
+    if (currentEngine == null
+        || !currentEngine.isAutomaticBackgroundTask()
+        || !currentEngine.usesSharedForegroundEngine()
+        || !currentEngine.hasRequestLifecycleInProgress()) {
+      return false;
+    }
+    kifuOpenWaitingForQuickAnalysisRestore = true;
+    stopQuickAnalysisNavigationResumeTimer();
+    stopLoadedGameQuickAnalysisRetry();
+    analysisEngine = null;
+    currentEngine.clearRequestCallbacks();
+    currentEngine.normalQuit(
+        () ->
+            SwingUtilities.invokeLater(
+                () -> {
+                  kifuOpenWaitingForQuickAnalysisRestore = false;
+                  if (continuation != null) {
+                    continuation.run();
+                  }
+                }));
+    return true;
   }
 
   public void openSgfStart() {
@@ -14510,48 +14546,60 @@ public class LizzieFrame extends JFrame {
             ? loadedGameQuickAnalysisGeneration
             : beginLoadedGameQuickAnalysis();
     BoardHistoryNode root = loadedGameQuickAnalysisRoot;
-    stopBusyQuickAnalysisEngineBeforeLoadedKifuAnalysis();
-    Runnable startRequests =
+    Runnable startWhenPreviousEngineRestored =
         new Runnable() {
           public void run() {
             if (!isCurrentLoadedGameQuickAnalysis(generation, root)) {
               return;
             }
+            Runnable startRequests =
+                new Runnable() {
+                  public void run() {
+                    if (!isCurrentLoadedGameQuickAnalysis(generation, root)) {
+                      return;
+                    }
+                    if (!isAnalysisEngineReusable(analysisEngine)) {
+                      finishLoadedGameQuickAnalysisAttempt(generation, root, true);
+                      return;
+                    }
+                    AnalysisEngine targetEngine = analysisEngine;
+                    targetEngine.setCompletionCallback(
+                        () -> finishLoadedGameQuickAnalysisAttempt(generation, root, false));
+                    targetEngine.setFailureCallback(
+                        () -> finishLoadedGameQuickAnalysisAttempt(generation, root, true));
+                    Thread requestSender =
+                        new Thread(
+                            () -> {
+                              if (!isCurrentLoadedGameQuickAnalysis(generation, root)
+                                  || targetEngine != analysisEngine) {
+                                return;
+                              }
+                              int requestCount = targetEngine.startRequestMissingMainline(false);
+                              if (requestCount < 0) {
+                                targetEngine.clearRequestCallbacks();
+                                finishLoadedGameQuickAnalysisAttempt(generation, root, true);
+                              } else if (requestCount == 0) {
+                                targetEngine.clearRequestCallbacks();
+                                finishLoadedGameQuickAnalysisAttempt(generation, root, false);
+                              }
+                            },
+                            "loaded-game-quick-analysis-request");
+                    requestSender.setDaemon(true);
+                    requestSender.start();
+                  }
+                };
             if (!isAnalysisEngineReusable(analysisEngine)) {
-              finishLoadedGameQuickAnalysisAttempt(generation, root, true);
+              ensureQuickAnalysisEngineAsync(startRequests, false);
               return;
             }
-            AnalysisEngine targetEngine = analysisEngine;
-            targetEngine.setCompletionCallback(
-                () -> finishLoadedGameQuickAnalysisAttempt(generation, root, false));
-            targetEngine.setFailureCallback(
-                () -> finishLoadedGameQuickAnalysisAttempt(generation, root, true));
-            Thread requestSender =
-                new Thread(
-                    () -> {
-                      if (!isCurrentLoadedGameQuickAnalysis(generation, root)
-                          || targetEngine != analysisEngine) {
-                        return;
-                      }
-                      int requestCount = targetEngine.startRequestMissingMainline(false);
-                      if (requestCount < 0) {
-                        targetEngine.clearRequestCallbacks();
-                        finishLoadedGameQuickAnalysisAttempt(generation, root, true);
-                      } else if (requestCount == 0) {
-                        targetEngine.clearRequestCallbacks();
-                        finishLoadedGameQuickAnalysisAttempt(generation, root, false);
-                      }
-                    },
-                    "loaded-game-quick-analysis-request");
-            requestSender.setDaemon(true);
-            requestSender.start();
+            startRequests.run();
           }
         };
-    if (isAnalysisEngineReusable(analysisEngine)) {
-      startRequests.run();
+    if (stopBusyQuickAnalysisEngineBeforeLoadedKifuAnalysis(
+        () -> SwingUtilities.invokeLater(startWhenPreviousEngineRestored))) {
       return;
     }
-    ensureQuickAnalysisEngineAsync(startRequests, false);
+    startWhenPreviousEngineRestored.run();
   }
 
   private void finishLoadedGameQuickAnalysisAttempt(
@@ -14603,27 +14651,48 @@ public class LizzieFrame extends JFrame {
   }
 
   private void stopBusyQuickAnalysisEngineBeforeLoadedKifuAnalysis() {
+    stopBusyQuickAnalysisEngineBeforeLoadedKifuAnalysis(null);
+  }
+
+  private boolean stopBusyQuickAnalysisEngineBeforeLoadedKifuAnalysis(Runnable afterRestore) {
     if (analysisEngine == null) {
-      return;
+      return false;
     }
     boolean needsDedicatedLightweightModel =
-        KataGoAutoSetupHelper.resolveQuickAnalysisEngineCommand().isPresent();
+        !isCurrentPrimaryEngineBundledTensorRt()
+            && KataGoAutoSetupHelper.resolveQuickAnalysisEngineCommand().isPresent();
+    boolean needsAutomaticTensorRtForegroundReuse = isCurrentPrimaryEngineBundledTensorRt();
     if (shouldReplaceAutomaticQuickAnalysisEngine(
         needsDedicatedLightweightModel,
         analysisEngine.usesDedicatedLightweightQuickModel(),
+        needsAutomaticTensorRtForegroundReuse,
+        analysisEngine.usesAutomaticTensorRtForegroundReuse(),
+        analysisEngine.matchesCurrentAnalysisBackend(),
         analysisEngine.isAnalysisInProgress())) {
-      analysisEngine.clearRequestCallbacks();
-      analysisEngine.normalQuit();
+      AnalysisEngine staleEngine = analysisEngine;
       analysisEngine = null;
+      staleEngine.clearRequestCallbacks();
+      if (afterRestore == null) {
+        staleEngine.normalQuit();
+      } else {
+        staleEngine.normalQuit(afterRestore);
+      }
+      return true;
     }
+    return false;
   }
 
   static boolean shouldReplaceAutomaticQuickAnalysisEngine(
       boolean wantsDedicatedLightweightModel,
       boolean currentUsesDedicatedLightweightModel,
+      boolean wantsAutomaticTensorRtForegroundReuse,
+      boolean currentUsesAutomaticTensorRtForegroundReuse,
+      boolean currentMatchesBackend,
       boolean currentAnalysisInProgress) {
     return currentAnalysisInProgress
-        || wantsDedicatedLightweightModel != currentUsesDedicatedLightweightModel;
+        || !currentMatchesBackend
+        || wantsDedicatedLightweightModel != currentUsesDedicatedLightweightModel
+        || wantsAutomaticTensorRtForegroundReuse != currentUsesAutomaticTensorRtForegroundReuse;
   }
 
   private void releaseDedicatedLightweightQuickAnalysisEngine() {
@@ -19003,11 +19072,17 @@ public class LizzieFrame extends JFrame {
     }
   }
 
+  private boolean isCurrentPrimaryEngineBundledTensorRt() {
+    return Lizzie.leelaz != null
+        && KataGoRuntimeHelper.isBundledTensorRtCommand(Lizzie.leelaz.engineCommand());
+  }
+
   private QuickAnalysisWarmupAction currentQuickAnalysisWarmupAction(boolean requiresAutoAnalyze) {
     boolean dependsOnPrimary =
         quickAnalysisDependsOnPrimary(
             isCurrentPrimaryEngineRemote(),
             isCurrentPrimaryEngineBundledOpenCl(),
+            isCurrentPrimaryEngineBundledTensorRt(),
             Lizzie.config != null && Lizzie.config.analysisReuseCurrentEngine);
     boolean primaryLoaded =
         !dependsOnPrimary || (Lizzie.leelaz != null && Lizzie.leelaz.isLoaded());
@@ -19024,19 +19099,22 @@ public class LizzieFrame extends JFrame {
   }
 
   static boolean quickAnalysisDependsOnPrimary(
-      boolean remotePrimary, boolean bundledOpenClPrimary, boolean reusePrimary) {
-    return remotePrimary || bundledOpenClPrimary || reusePrimary;
+      boolean remotePrimary,
+      boolean bundledOpenClPrimary,
+      boolean bundledTensorRtPrimary,
+      boolean reusePrimary) {
+    return remotePrimary || bundledOpenClPrimary || bundledTensorRtPrimary || reusePrimary;
   }
 
   static QuickAnalysisWarmupAction decideQuickAnalysisWarmup(
       boolean contextEligible,
-      boolean remotePrimary,
+      boolean dependsOnPrimary,
       boolean primaryLoaded,
       boolean primaryFailed) {
-    if (!contextEligible || (remotePrimary && primaryFailed)) {
+    if (!contextEligible || (dependsOnPrimary && primaryFailed)) {
       return QuickAnalysisWarmupAction.STOP;
     }
-    if (remotePrimary && !primaryLoaded) {
+    if (dependsOnPrimary && !primaryLoaded) {
       return QuickAnalysisWarmupAction.WAIT_FOR_PRIMARY;
     }
     return QuickAnalysisWarmupAction.START;

--- a/src/main/java/featurecat/lizzie/util/KataGoAutoSetupHelper.java
+++ b/src/main/java/featurecat/lizzie/util/KataGoAutoSetupHelper.java
@@ -1787,6 +1787,13 @@ public final class KataGoAutoSetupHelper {
             + quoteCommandPath(snapshot.workingDir, estimateConfig);
 
     ArrayList<EngineData> engines = Utils.getEngineData();
+    // Treat an entirely unspecified startup mode as part of this setup transaction. The engine
+    // flags and default index must be valid before saveEngineSettings normalizes and persists them.
+    boolean firstRunSetup =
+        !Lizzie.config.uiConfig.has("autoload-default")
+            && !Lizzie.config.uiConfig.has("autoload-empty")
+            && !Lizzie.config.uiConfig.has("autoload-last");
+    boolean selectAsDefault = makeDefault || firstRunSetup;
     String resolvedEngineName =
         Utils.isBlank(engineName) ? AUTO_SETUP_ENGINE_NAME : engineName.trim();
     int engineIndex =
@@ -1806,7 +1813,7 @@ public final class KataGoAutoSetupHelper {
     for (int i = 0; i < engines.size(); i++) {
       EngineData existing = engines.get(i);
       existing.index = i;
-      if (makeDefault) {
+      if (selectAsDefault) {
         existing.isDefault = false;
       }
     }
@@ -1818,7 +1825,7 @@ public final class KataGoAutoSetupHelper {
     engineData.width = normalizeBoardSize(createdEngine ? 19 : engineData.width);
     engineData.height = normalizeBoardSize(createdEngine ? 19 : engineData.height);
     engineData.komi = normalizeKomi(createdEngine ? 7.5F : engineData.komi);
-    engineData.isDefault = makeDefault || engineData.isDefault;
+    engineData.isDefault = selectAsDefault || engineData.isDefault;
     engineData.useJavaSSH = false;
     engineData.ip = "";
     engineData.port = "";
@@ -1828,21 +1835,18 @@ public final class KataGoAutoSetupHelper {
     engineData.keyGenPath = "";
     engineData.initialCommand = createdEngine ? "" : safeString(engineData.initialCommand);
 
-    Utils.saveEngineSettings(engines);
-    rememberPreferredWeight(snapshot.activeWeightPath);
     // Only force autoload=default on a truly fresh install. Once the user has picked
     // "start with no engine" or "pick manually", respect that choice across setup runs.
-    boolean firstRunSetup =
-        !Lizzie.config.uiConfig.has("autoload-default")
-            && !Lizzie.config.uiConfig.has("autoload-empty")
-            && !Lizzie.config.uiConfig.has("autoload-last");
     if (firstRunSetup) {
       Lizzie.config.uiConfig.put("autoload-default", true);
       Lizzie.config.uiConfig.put("autoload-empty", false);
+      Lizzie.config.uiConfig.put("autoload-last", false);
     }
-    if (makeDefault) {
+    if (selectAsDefault) {
       Lizzie.config.uiConfig.put("default-engine", engineIndex);
     }
+    Utils.saveEngineSettings(engines);
+    rememberPreferredWeight(snapshot.activeWeightPath);
     if (!Lizzie.config.analysisEngineCommandCustomized) {
       Lizzie.config.analysisEngineCommand = analysisCommand;
       Lizzie.config.uiConfig.put("analysis-engine-command", analysisCommand);

--- a/src/main/java/featurecat/lizzie/util/KataGoRuntimeHelper.java
+++ b/src/main/java/featurecat/lizzie/util/KataGoRuntimeHelper.java
@@ -598,6 +598,25 @@ public final class KataGoRuntimeHelper {
     return resolveNvidiaBackend(enginePath) != null;
   }
 
+  public static boolean isBundledTensorRtPath(Path enginePath) {
+    return isWindowsPlatform()
+        && enginePath != null
+        && Config.isBundledKataGoExecutable(enginePath)
+        && isTensorRtBackend(resolveNvidiaBackend(enginePath));
+  }
+
+  public static boolean isBundledTensorRtCommand(String engineCommand) {
+    if (engineCommand == null || engineCommand.trim().isEmpty()) {
+      return false;
+    }
+    try {
+      return isBundledTensorRtPath(
+          resolveCommandExecutable(Utils.splitCommand(engineCommand)));
+    } catch (RuntimeException e) {
+      return false;
+    }
+  }
+
   public static boolean isBundledOpenClPath(Path enginePath) {
     if (!isWindowsPlatform()
         || enginePath == null

--- a/src/test/java/featurecat/lizzie/analysis/AnalysisEngineRequestTest.java
+++ b/src/test/java/featurecat/lizzie/analysis/AnalysisEngineRequestTest.java
@@ -126,6 +126,82 @@ class AnalysisEngineRequestTest {
   }
 
   @Test
+  void onlyAutomaticQuickAnalysisOptsIntoTensorRtForegroundReuse() {
+    assertTrue(
+        AnalysisEngine.shouldAutomaticallyReuseTensorRtForeground(
+            AnalysisResourceCoordinator.Purpose.AUTO_QUICK_ANALYSIS, true));
+    assertFalse(
+        AnalysisEngine.shouldAutomaticallyReuseTensorRtForeground(
+            AnalysisResourceCoordinator.Purpose.USER_QUICK_ANALYSIS, true));
+    assertFalse(
+        AnalysisEngine.shouldAutomaticallyReuseTensorRtForeground(
+            AnalysisResourceCoordinator.Purpose.WHOLE_GAME_ANALYSIS, true));
+    assertFalse(
+        AnalysisEngine.shouldAutomaticallyReuseTensorRtForeground(
+            AnalysisResourceCoordinator.Purpose.AUTO_QUICK_ANALYSIS, false));
+  }
+
+  @Test
+  void automaticTensorRtForegroundReuseInvalidatesWhenThePrimaryEngineChanges() throws Exception {
+    try (TestEnvironment env = TestEnvironment.open()) {
+      Leelaz firstForeground = reusableForegroundEngine(true);
+      Leelaz secondForeground = reusableForegroundEngine(true);
+      TrackingAnalysisEngine engine = TrackingAnalysisEngine.create();
+      Lizzie.config.analysisReuseCurrentEngine = false;
+      Lizzie.leelaz = firstForeground;
+      setField(
+          AnalysisEngine.class,
+          engine,
+          "purpose",
+          AnalysisResourceCoordinator.Purpose.AUTO_QUICK_ANALYSIS);
+      setField(AnalysisEngine.class, engine, "sharedForegroundEngine", firstForeground);
+      setField(AnalysisEngine.class, engine, "automaticTensorRtForegroundReuse", true);
+      setField(
+          AnalysisEngine.class,
+          engine,
+          "automaticTensorRtForegroundCommand",
+          firstForeground.engineCommand());
+
+      assertTrue(engine.matchesCurrentAnalysisBackend());
+      assertFalse(Lizzie.config.analysisReuseCurrentEngine);
+
+      Lizzie.leelaz = secondForeground;
+
+      assertFalse(engine.matchesCurrentAnalysisBackend());
+    }
+  }
+
+  @Test
+  void automaticTensorRtForegroundReuseInvalidatesWhenTheSameEngineObjectChangesCommand()
+      throws Exception {
+    try (TestEnvironment env = TestEnvironment.open()) {
+      Leelaz foreground = reusableForegroundEngine(true);
+      foreground.setEngineCommand("bundled-tensorrt-command");
+      TrackingAnalysisEngine engine = TrackingAnalysisEngine.create();
+      Lizzie.config.analysisReuseCurrentEngine = false;
+      Lizzie.leelaz = foreground;
+      setField(
+          AnalysisEngine.class,
+          engine,
+          "purpose",
+          AnalysisResourceCoordinator.Purpose.AUTO_QUICK_ANALYSIS);
+      setField(AnalysisEngine.class, engine, "sharedForegroundEngine", foreground);
+      setField(AnalysisEngine.class, engine, "automaticTensorRtForegroundReuse", true);
+      setField(
+          AnalysisEngine.class,
+          engine,
+          "automaticTensorRtForegroundCommand",
+          foreground.engineCommand());
+
+      assertTrue(engine.matchesCurrentAnalysisBackend());
+
+      foreground.setEngineCommand("different-engine-command");
+
+      assertFalse(engine.matchesCurrentAnalysisBackend());
+    }
+  }
+
+  @Test
   void reuseModeRejectsNonKatagoWithoutFallingBackToDedicatedProcess() throws Exception {
     try (TestEnvironment env = TestEnvironment.open()) {
       Leelaz foreground = reusableForegroundEngine(false);
@@ -1134,6 +1210,40 @@ class AnalysisEngineRequestTest {
       javax.swing.SwingUtilities.invokeAndWait(() -> {});
 
       assertEquals(1, failures.get());
+    }
+  }
+
+  @Test
+  void normalQuitContinuationWaitsForSharedForegroundRestore() throws Exception {
+    try (TestEnvironment env = TestEnvironment.open()) {
+      TrackingAnalysisEngine engine = TrackingAnalysisEngine.create();
+      DeferredRestoreLeelaz foreground = new DeferredRestoreLeelaz();
+      AtomicInteger continuations = new AtomicInteger();
+      setField(AnalysisEngine.class, engine, "sharedForegroundEngine", foreground);
+      setField(AnalysisEngine.class, engine, "sharedForegroundLease", foregroundLease(foreground));
+
+      engine.normalQuit(continuations::incrementAndGet);
+
+      assertEquals(0, continuations.get());
+      foreground.completeRestore();
+      assertEquals(1, continuations.get());
+    }
+  }
+
+  @Test
+  void normalQuitContinuationAlsoRunsOnceWhenSharedRestoreFails() throws Exception {
+    try (TestEnvironment env = TestEnvironment.open()) {
+      TrackingAnalysisEngine engine = TrackingAnalysisEngine.create();
+      DeferredRestoreLeelaz foreground = new DeferredRestoreLeelaz();
+      AtomicInteger continuations = new AtomicInteger();
+      setField(AnalysisEngine.class, engine, "sharedForegroundEngine", foreground);
+      setField(AnalysisEngine.class, engine, "sharedForegroundLease", foregroundLease(foreground));
+
+      engine.normalQuit(continuations::incrementAndGet);
+
+      assertEquals(0, continuations.get());
+      foreground.failRestore();
+      assertEquals(1, continuations.get());
     }
   }
 

--- a/src/test/java/featurecat/lizzie/gui/LizzieFrameRegressionTest.java
+++ b/src/test/java/featurecat/lizzie/gui/LizzieFrameRegressionTest.java
@@ -319,10 +319,11 @@ class LizzieFrameRegressionTest {
   void quickAnalysisWarmupWaitsForRemotePrimaryEngine() {
     assertFalse(LizzieFrame.shouldDiscardQuickAnalysisWarmup(7L, 7L));
     assertTrue(LizzieFrame.shouldDiscardQuickAnalysisWarmup(7L, 8L));
-    assertTrue(LizzieFrame.quickAnalysisDependsOnPrimary(true, false, false));
-    assertTrue(LizzieFrame.quickAnalysisDependsOnPrimary(false, true, false));
-    assertTrue(LizzieFrame.quickAnalysisDependsOnPrimary(false, false, true));
-    assertFalse(LizzieFrame.quickAnalysisDependsOnPrimary(false, false, false));
+    assertTrue(LizzieFrame.quickAnalysisDependsOnPrimary(true, false, false, false));
+    assertTrue(LizzieFrame.quickAnalysisDependsOnPrimary(false, true, false, false));
+    assertTrue(LizzieFrame.quickAnalysisDependsOnPrimary(false, false, true, false));
+    assertTrue(LizzieFrame.quickAnalysisDependsOnPrimary(false, false, false, true));
+    assertFalse(LizzieFrame.quickAnalysisDependsOnPrimary(false, false, false, false));
     assertEquals(
         LizzieFrame.QuickAnalysisWarmupAction.START,
         LizzieFrame.decideQuickAnalysisWarmup(true, false, false, false));
@@ -342,11 +343,88 @@ class LizzieFrameRegressionTest {
 
   @Test
   void automaticQuickAnalysisDoesNotReuseTheWrongModelBackend() {
-    assertTrue(LizzieFrame.shouldReplaceAutomaticQuickAnalysisEngine(true, false, false));
-    assertFalse(LizzieFrame.shouldReplaceAutomaticQuickAnalysisEngine(true, true, false));
-    assertFalse(LizzieFrame.shouldReplaceAutomaticQuickAnalysisEngine(false, false, false));
-    assertTrue(LizzieFrame.shouldReplaceAutomaticQuickAnalysisEngine(false, true, false));
-    assertTrue(LizzieFrame.shouldReplaceAutomaticQuickAnalysisEngine(false, true, true));
+    assertTrue(
+        LizzieFrame.shouldReplaceAutomaticQuickAnalysisEngine(
+            true, false, false, false, true, false));
+    assertFalse(
+        LizzieFrame.shouldReplaceAutomaticQuickAnalysisEngine(
+            true, true, false, false, true, false));
+    assertFalse(
+        LizzieFrame.shouldReplaceAutomaticQuickAnalysisEngine(
+            false, false, false, false, true, false));
+    assertTrue(
+        LizzieFrame.shouldReplaceAutomaticQuickAnalysisEngine(
+            false, true, false, false, true, false));
+    assertTrue(
+        LizzieFrame.shouldReplaceAutomaticQuickAnalysisEngine(
+            false, true, false, false, true, true));
+    assertTrue(
+        LizzieFrame.shouldReplaceAutomaticQuickAnalysisEngine(
+            false, false, true, false, true, false));
+    assertTrue(
+        LizzieFrame.shouldReplaceAutomaticQuickAnalysisEngine(
+            false, false, false, true, true, false));
+    assertTrue(
+        LizzieFrame.shouldReplaceAutomaticQuickAnalysisEngine(
+            false, false, true, true, false, false));
+  }
+
+  @Test
+  void replacingBusyQuickAnalysisWaitsForForegroundRestoreBeforeContinuing() throws Exception {
+    TestEnvironment env = TestEnvironment.open();
+    try {
+      Lizzie.config = configWithAutoQuickAnalyze();
+      LizzieFrame frame = allocate(LizzieFrame.class);
+      ResourceTrackingAnalysisEngine engine = allocate(ResourceTrackingAnalysisEngine.class);
+      engine.analysisInProgress = true;
+      frame.analysisEngine = engine;
+      AtomicInteger continuations = new AtomicInteger();
+
+      assertTrue(
+          invokeStopBusyQuickAnalysisEngineBeforeLoadedKifuAnalysis(
+              frame, continuations::incrementAndGet));
+
+      assertNull(frame.analysisEngine);
+      assertEquals(1, engine.normalQuitCount);
+      assertEquals(0, continuations.get());
+
+      engine.completeExit();
+      assertEquals(1, continuations.get());
+    } finally {
+      env.close();
+    }
+  }
+
+  @Test
+  void openingKifuWaitsForSharedAutomaticQuickAnalysisRestore() throws Exception {
+    TestEnvironment env = TestEnvironment.open();
+    try {
+      Lizzie.config = configWithAutoQuickAnalyze();
+      Lizzie.board = boardWith(historyWithUnanalyzedMove());
+      LizzieFrame frame = allocate(LizzieFrame.class);
+      ResourceTrackingAnalysisEngine engine = allocate(ResourceTrackingAnalysisEngine.class);
+      engine.shared = true;
+      engine.automatic = true;
+      engine.requestLifecycleInProgress = true;
+      frame.analysisEngine = engine;
+      setField(frame, "loadedGameQuickAnalysisActive", true);
+      AtomicInteger continuations = new AtomicInteger();
+
+      assertTrue(invokeDeferKifuOpen(frame, continuations::incrementAndGet));
+
+      assertNull(frame.analysisEngine);
+      assertFalse((boolean) getField(frame, "loadedGameQuickAnalysisActive"));
+      assertEquals(1, engine.normalQuitCount);
+      assertEquals(0, continuations.get());
+      assertTrue(invokeDeferKifuOpen(frame, continuations::incrementAndGet));
+
+      engine.completeExit();
+      drainEdt();
+      assertEquals(1, continuations.get());
+      assertFalse((boolean) getField(frame, "kifuOpenWaitingForQuickAnalysisRestore"));
+    } finally {
+      env.close();
+    }
   }
 
   @Test
@@ -2063,6 +2141,38 @@ class LizzieFrameRegressionTest {
     SwingUtilities.invokeAndWait(() -> invokeReflective(method, frame));
   }
 
+  private static boolean invokeStopBusyQuickAnalysisEngineBeforeLoadedKifuAnalysis(
+      LizzieFrame frame, Runnable continuation) throws Exception {
+    Method method =
+        LizzieFrame.class.getDeclaredMethod(
+            "stopBusyQuickAnalysisEngineBeforeLoadedKifuAnalysis", Runnable.class);
+    method.setAccessible(true);
+    AtomicBoolean stopped = new AtomicBoolean(false);
+    SwingUtilities.invokeAndWait(
+        () -> stopped.set((boolean) invokeReflectiveResult(method, frame, continuation)));
+    return stopped.get();
+  }
+
+  private static boolean invokeDeferKifuOpen(LizzieFrame frame, Runnable continuation)
+      throws Exception {
+    Method method =
+        LizzieFrame.class.getDeclaredMethod(
+            "deferKifuOpenUntilAutomaticQuickAnalysisRestored", Runnable.class);
+    method.setAccessible(true);
+    AtomicBoolean deferred = new AtomicBoolean(false);
+    SwingUtilities.invokeAndWait(
+        () -> deferred.set((boolean) invokeReflectiveResult(method, frame, continuation)));
+    return deferred.get();
+  }
+
+  private static Object invokeReflectiveResult(Method method, Object target, Object... arguments) {
+    try {
+      return method.invoke(target, arguments);
+    } catch (ReflectiveOperationException e) {
+      throw new AssertionError(e);
+    }
+  }
+
   private static void invokeReflective(Method method, Object target) {
     try {
       method.invoke(target);
@@ -2542,7 +2652,9 @@ class LizzieFrameRegressionTest {
     private boolean analysisInProgress;
     private boolean automatic;
     private boolean reusable;
+    private boolean requestLifecycleInProgress;
     private int normalQuitCount;
+    private Runnable exitContinuation;
 
     @SuppressWarnings("unused")
     private ResourceTrackingAnalysisEngine() throws java.io.IOException {
@@ -2580,6 +2692,11 @@ class LizzieFrameRegressionTest {
     }
 
     @Override
+    public synchronized boolean hasRequestLifecycleInProgress() {
+      return requestLifecycleInProgress || analysisInProgress;
+    }
+
+    @Override
     public boolean isAutomaticBackgroundTask() {
       return automatic;
     }
@@ -2590,6 +2707,20 @@ class LizzieFrameRegressionTest {
     @Override
     public void normalQuit() {
       normalQuitCount++;
+    }
+
+    @Override
+    public void normalQuit(Runnable afterRestore) {
+      normalQuitCount++;
+      exitContinuation = afterRestore;
+    }
+
+    private void completeExit() {
+      Runnable continuation = exitContinuation;
+      exitContinuation = null;
+      if (continuation != null) {
+        continuation.run();
+      }
     }
   }
 

--- a/src/test/java/featurecat/lizzie/util/KataGoAutoSetupHelperTest.java
+++ b/src/test/java/featurecat/lizzie/util/KataGoAutoSetupHelperTest.java
@@ -1556,6 +1556,9 @@ public class KataGoAutoSetupHelperTest {
           autoSetupEngine.initialCommand = "kata-set-rules chinese";
           engines.add(autoSetupEngine);
           Utils.saveEngineSettings(engines);
+          Lizzie.config.uiConfig.put("autoload-default", false);
+          Lizzie.config.uiConfig.put("autoload-empty", false);
+          Lizzie.config.uiConfig.put("autoload-last", false);
 
           KataGoAutoSetupHelper.applyAutoSetup(KataGoAutoSetupHelper.inspectLocalSetup(), false);
 
@@ -1568,6 +1571,113 @@ public class KataGoAutoSetupHelperTest {
           assertEquals("kata-set-rules chinese", refreshed.initialCommand);
           assertFalse(refreshed.isDefault);
         });
+  }
+
+  @Test
+  void implicitStartupModePersistsAUsableDefaultDuringTheFirstAutoSetup() throws Exception {
+    Path tempRoot = Files.createTempDirectory("katago-first-auto-setup-default");
+    Path engine =
+        touch(
+            tempRoot
+                .resolve("engines")
+                .resolve("katago")
+                .resolve(detectTestPlatformDir())
+                .resolve(testKataGoBinaryName()));
+    Path configDir =
+        Files.createDirectories(tempRoot.resolve("engines").resolve("katago").resolve("configs"));
+    Path gtpConfig = touch(configDir.resolve("gtp.cfg"));
+    touch(configDir.resolve("analysis.cfg"));
+    touch(configDir.resolve("estimate.cfg"));
+    Path weight = touch(tempRoot.resolve("weights").resolve("default.bin.gz"));
+
+    withUserDirAndConfig(
+        tempRoot,
+        () -> {
+          EngineData existing =
+              engineData(
+                  KataGoAutoSetupHelper.getAutoSetupEngineName(),
+                  engine,
+                  gtpConfig,
+                  weight,
+                  false);
+          Utils.saveEngineSettings(new ArrayList<>(List.of(existing)));
+          Lizzie.config.uiConfig.remove("autoload-default");
+          Lizzie.config.uiConfig.remove("autoload-empty");
+          Lizzie.config.uiConfig.remove("autoload-last");
+          Lizzie.config.uiConfig.put("default-engine", -1);
+          Lizzie.config.config
+              .put("ui", Lizzie.config.uiConfig)
+              .put("leelaz", Lizzie.config.leelazConfig);
+
+          KataGoAutoSetupHelper.SetupResult result =
+              KataGoAutoSetupHelper.applyAutoSetup(
+                  KataGoAutoSetupHelper.inspectLocalSetup(), false);
+
+          ArrayList<EngineData> saved = Utils.getEngineData();
+          assertEquals(0, result.engineIndex);
+          assertEquals(0, Lizzie.config.uiConfig.optInt("default-engine", -1));
+          assertTrue(Lizzie.config.uiConfig.optBoolean("autoload-default"));
+          assertFalse(Lizzie.config.uiConfig.optBoolean("autoload-empty"));
+          assertFalse(Lizzie.config.uiConfig.optBoolean("autoload-last"));
+          assertTrue(saved.get(0).isDefault);
+
+          org.json.JSONObject persisted =
+              new org.json.JSONObject(Files.readString(Path.of(Lizzie.config.getConfigFilePath())));
+          assertEquals(0, persisted.getJSONObject("ui").getInt("default-engine"));
+          assertTrue(persisted.getJSONObject("ui").getBoolean("autoload-default"));
+          assertTrue(
+              persisted
+                  .getJSONObject("leelaz")
+                  .getJSONArray("engine-settings-list")
+                  .getJSONObject(0)
+                  .getBoolean("isDefault"));
+        });
+  }
+
+  @Test
+  void explicitStartupModesRemainUntouchedByBackgroundAutoSetupRepair() throws Exception {
+    for (boolean[] mode :
+        List.of(
+            new boolean[] {true, false, false},
+            new boolean[] {false, true, false},
+            new boolean[] {false, false, false},
+            new boolean[] {false, false, true})) {
+      Path tempRoot = Files.createTempDirectory("katago-explicit-startup-mode");
+      Path engine =
+          touch(
+              tempRoot
+                  .resolve("engines")
+                  .resolve("katago")
+                  .resolve(detectTestPlatformDir())
+                  .resolve(testKataGoBinaryName()));
+      Path configDir =
+          Files.createDirectories(
+              tempRoot.resolve("engines").resolve("katago").resolve("configs"));
+      Path gtpConfig = touch(configDir.resolve("gtp.cfg"));
+      touch(configDir.resolve("analysis.cfg"));
+      touch(configDir.resolve("estimate.cfg"));
+      Path weight = touch(tempRoot.resolve("weights").resolve("default.bin.gz"));
+
+      withUserDirAndConfig(
+          tempRoot,
+          () -> {
+            EngineData existing =
+                engineData("Custom default", engine, gtpConfig, weight, true);
+            Lizzie.config.uiConfig.put("autoload-default", mode[0]);
+            Lizzie.config.uiConfig.put("autoload-empty", mode[1]);
+            Lizzie.config.uiConfig.put("autoload-last", mode[2]);
+            Lizzie.config.uiConfig.put("default-engine", 0);
+            Utils.saveEngineSettings(new ArrayList<>(List.of(existing)));
+
+            KataGoAutoSetupHelper.applyAutoSetup(
+                KataGoAutoSetupHelper.inspectLocalSetup(), false);
+
+            assertEquals(mode[0], Lizzie.config.uiConfig.optBoolean("autoload-default"));
+            assertEquals(mode[1], Lizzie.config.uiConfig.optBoolean("autoload-empty"));
+            assertEquals(mode[2], Lizzie.config.uiConfig.optBoolean("autoload-last"));
+            assertEquals(0, Lizzie.config.uiConfig.optInt("default-engine"));
+          });
+    }
   }
 
   @Test

--- a/src/test/java/featurecat/lizzie/util/KataGoRuntimeHelperTest.java
+++ b/src/test/java/featurecat/lizzie/util/KataGoRuntimeHelperTest.java
@@ -201,6 +201,42 @@ public class KataGoRuntimeHelperTest {
   }
 
   @Test
+  void bundledTensorRtDetectionAcceptsPackageDirectoryAndBackendMarker() throws Exception {
+    withOsName(
+        WINDOWS_OS_NAME,
+        () -> {
+          Path tempRoot = Files.createTempDirectory("katago-helper-tensorrt-detection");
+          Path namedEngine =
+              touch(
+                  tempRoot
+                      .resolve("engines")
+                      .resolve("katago")
+                      .resolve("windows-x64-nvidia-tensorrt")
+                      .resolve("katago.exe"));
+          Path markedDir =
+              Files.createDirectories(
+                  tempRoot.resolve("app").resolve("engines").resolve("katago").resolve("windows-x64"));
+          Path markedEngine = touch(markedDir.resolve("katago.exe"));
+          Files.writeString(
+              markedDir.resolve("lizzieyzy-next-engine-backend.txt"), "nvidia-tensorrt\n");
+
+          assertTrue(KataGoRuntimeHelper.isBundledTensorRtPath(namedEngine));
+          assertTrue(KataGoRuntimeHelper.isBundledTensorRtPath(markedEngine));
+          assertTrue(
+              KataGoRuntimeHelper.isBundledTensorRtCommand(
+                  "\""
+                      + markedEngine
+                      + "\" gtp -model \""
+                      + tempRoot.resolve("weight.bin.gz")
+                      + "\""));
+
+          Files.writeString(
+              markedDir.resolve("lizzieyzy-next-engine-backend.txt"), "nvidia50-cuda\n");
+          assertFalse(KataGoRuntimeHelper.isBundledTensorRtPath(markedEngine));
+        });
+  }
+
+  @Test
   void bundledNvidiaEnginePrependsRuntimePath() throws Exception {
     withOsName(
         WINDOWS_OS_NAME,


### PR DESCRIPTION
## Summary

- Fix Windows TensorRT portable first launch so a profile with no explicit startup mode persists a valid default engine before the engine list is saved, and starts KataGo during the first session.
- Reuse the bundled foreground TensorRT engine for automatic quick winrate curves instead of cold-starting a second `katago analysis` process with a separate `maxBatchSize=64` timing cache.
- Serialize SGF replacement behind foreground-lease restoration, including rapid file switching and cancellation, so stateful GTP commands cannot race an automatic curve request.
- Generate TensorRT `VERSION.txt` from the actual engine manifest and audit the packaged version/asset in CI and the Windows release workflow.

## Root cause

The first automatic setup wrote `autoload-default=true` after saving engine settings while leaving `default-engine=-1` and `isDefault=false`; startup normalization only repaired that state on the next launch.

Automatic quick curves always preferred a separate analysis command. In the TensorRT bundle this launched another KataGo instance whose `maxBatchSize=64` cache differed from the foreground `b8` cache. On the tested RTX 3070 Laptop GPU, first inference spent about 61 seconds building that cache and the curve stayed empty for roughly 71 seconds. Reusing the foreground engine also exposed an SGF-switch race, now fixed by waiting for exact foreground restoration before opening/replacing the next game.

## Compatibility

Explicit startup choices remain unchanged: default engine, no engine, manual selection, and last-used engine. The global “reuse current engine” preference is not modified. Manual whole-game analysis, remote compute, OpenCL, CUDA, and non-bundled backends keep their existing policy.

## Validation

Automated:

- `mvn -B -Djava.awt.headless=true -Dfmt.skip=true test`: 2,215 tests, 0 failures, 0 errors, 8 skipped across 218 suites.
- `mvn -B -Djava.awt.headless=true -Dfmt.skip=true -DskipTests package`: BUILD SUCCESS.
- `python scripts/test_windows_launcher_packaging.py`: passed.
- `python scripts/test_audit_katago_binary_version.py`: 4/4 passed.
- `python scripts/test_audit_katago_package_metadata.py`: 3/3 passed.
- `python scripts/test_check_line_endings.py`: 6/6 passed.
- `python scripts/check_line_endings.py`, `bash -n scripts/package_windows_exe.sh`, and `git diff --check`: passed.

Real Windows portable EXE on an RTX 3070 Laptop GPU:

- Fresh and migrated-empty profiles launched packaged KataGo in the first session in 3.3–3.9 seconds and persisted default engine index 0 immediately.
- Explicit no-engine, manual-select, last-engine, and default-engine profiles retained their startup behavior.
- A 50-move SGF showed the first curve segment at 0.25 seconds, reached 7/48 at 1 second, 26/48 at 3 seconds, and completed by 5 seconds.
- Rapidly switched to a 230-move SGF without an exclusive-engine popup or UI freeze; analysis began within 1 second and completed normally.
- Opening and then cancelling the file chooser restored foreground pondering.
- Every curve scenario stayed responsive with exactly one `katago gtp` process, zero `katago analysis` processes, and no second TensorRT timing cache.
- Final packaged-runtime launcher smoke passed without relying on system Java.

The supplied 2026-08-13 TensorRT package was also confirmed to contain a real v1.17.2 engine while displaying v1.17.1 metadata; the new package audit rejects this mismatch.
