### PR TITLE
Fix Windows quick analysis and UI lifecycle issues

### DIFF
--- a/src/main/java/featurecat/lizzie/analysis/AnalysisEngine.java
+++ b/src/main/java/featurecat/lizzie/analysis/AnalysisEngine.java
@@ -156,8 +156,8 @@ public class AnalysisEngine {
   private long remoteGtpStopAckGeneration;
   private long remoteGtpLastCompletionActivityMillis;
   private Leelaz sharedForegroundEngine;
-  private boolean automaticTensorRtForegroundReuse;
-  private String automaticTensorRtForegroundCommand;
+  private boolean automaticPrimaryForegroundReuse;
+  private String automaticPrimaryForegroundCommand;
   private boolean sharedForegroundLeaseStarting;
   private boolean sharedForegroundLeaseActive;
   private Leelaz.ForegroundAnalysisLease sharedForegroundLease;
@@ -217,23 +217,27 @@ public class AnalysisEngine {
     this.purpose =
         purpose == null ? AnalysisResourceCoordinator.Purpose.OTHER : purpose;
     this.persistentPreload = persistentPreload;
-    automaticTensorRtForegroundReuse =
-        shouldAutomaticallyReuseTensorRtForeground(
+    String foregroundCommand = Lizzie.leelaz == null ? null : Lizzie.leelaz.engineCommand();
+    boolean lightweightQuickModelRequested =
+        commandOverride != null && !commandOverride.trim().isEmpty();
+    automaticPrimaryForegroundReuse =
+        shouldAutomaticallyReusePrimaryForeground(
             this.purpose,
-            KataGoRuntimeHelper.isBundledTensorRtCommand(
-                Lizzie.leelaz == null ? null : Lizzie.leelaz.engineCommand()));
+            RemoteComputeConfig.isRemoteComputeEngineCommand(foregroundCommand),
+            KataGoRuntimeHelper.isBundledNvidiaCommand(foregroundCommand),
+            KataGoRuntimeHelper.isBundledTensorRtCommand(foregroundCommand),
+            lightweightQuickModelRequested);
     this.dedicatedLightweightQuickModel =
         this.purpose == AnalysisResourceCoordinator.Purpose.AUTO_QUICK_ANALYSIS
-            && !automaticTensorRtForegroundReuse
-            && commandOverride != null
-            && !commandOverride.trim().isEmpty();
+            && !automaticPrimaryForegroundReuse
+            && lightweightQuickModelRequested;
     this.dedicatedLightweightQuickModelCommand =
         this.dedicatedLightweightQuickModel ? commandOverride.trim() : "";
-    if (Lizzie.config.analysisReuseCurrentEngine || automaticTensorRtForegroundReuse) {
+    if (Lizzie.config.analysisReuseCurrentEngine || automaticPrimaryForegroundReuse) {
       useRemoteCompute = true;
       sharedForegroundEngine = Lizzie.leelaz;
-      automaticTensorRtForegroundCommand =
-          automaticTensorRtForegroundReuse && sharedForegroundEngine != null
+      automaticPrimaryForegroundCommand =
+          automaticPrimaryForegroundReuse && sharedForegroundEngine != null
               ? sharedForegroundEngine.engineCommand()
               : null;
       foregroundLeaseAvailability =
@@ -279,10 +283,16 @@ public class AnalysisEngine {
         : commandOverride;
   }
 
-  static boolean shouldAutomaticallyReuseTensorRtForeground(
-      AnalysisResourceCoordinator.Purpose purpose, boolean bundledTensorRtPrimary) {
+  static boolean shouldAutomaticallyReusePrimaryForeground(
+      AnalysisResourceCoordinator.Purpose purpose,
+      boolean remotePrimary,
+      boolean bundledNvidiaPrimary,
+      boolean bundledTensorRtPrimary,
+      boolean lightweightQuickModelRequested) {
     return purpose == AnalysisResourceCoordinator.Purpose.AUTO_QUICK_ANALYSIS
-        && bundledTensorRtPrimary;
+        && ((remotePrimary && !lightweightQuickModelRequested)
+            || (bundledNvidiaPrimary
+                && (bundledTensorRtPrimary || !lightweightQuickModelRequested)));
   }
 
   static boolean shouldShowGeneratedConfigNotice(boolean isPreLoad, boolean generatedConfig) {
@@ -2466,10 +2476,10 @@ public class AnalysisEngine {
     }
     if (sharedForegroundEngine != null) {
       boolean automaticReuseStillMatches =
-          automaticTensorRtForegroundReuse
+          automaticPrimaryForegroundReuse
               && Lizzie.leelaz != null
-              && automaticTensorRtForegroundCommand != null
-              && automaticTensorRtForegroundCommand.equals(Lizzie.leelaz.engineCommand());
+              && automaticPrimaryForegroundCommand != null
+              && automaticPrimaryForegroundCommand.equals(Lizzie.leelaz.engineCommand());
       return (Lizzie.config.analysisReuseCurrentEngine || automaticReuseStillMatches)
           && sharedForegroundEngine == Lizzie.leelaz;
     }
@@ -2485,8 +2495,8 @@ public class AnalysisEngine {
     return sharedForegroundEngine != null;
   }
 
-  public boolean usesAutomaticTensorRtForegroundReuse() {
-    return automaticTensorRtForegroundReuse;
+  public boolean usesAutomaticPrimaryForegroundReuse() {
+    return automaticPrimaryForegroundReuse;
   }
 
   public AnalysisResourceCoordinator.Purpose purpose() {

--- a/src/main/java/featurecat/lizzie/analysis/Leelaz.java
+++ b/src/main/java/featurecat/lizzie/analysis/Leelaz.java
@@ -314,9 +314,11 @@ public class Leelaz {
   public boolean isThinking = false;
   public boolean isInputCommand = false;
 
-  public boolean getRcentLine = false;
+  public volatile boolean getRcentLine = false;
+  private final Object parameterReadTimeoutLock = new Object();
+  private long parameterReadTimeoutGeneration;
   private int recentLineNumber = 0;
-  public String recentRulesLine = "";
+  public volatile String recentRulesLine = "";
   public int usingSpecificRules = -1; // 1=中国规则2=中古规则3=日本规则4=TT规则5=其他规则
   public boolean preload = false;
   public volatile boolean started = false;
@@ -12324,27 +12326,46 @@ public class Leelaz {
   }
 
   public void getParameterScadule(boolean sendCommand) {
-    getRcentLine = true;
-    if (sendCommand) {
-      recentLineNumber = 0;
-      sendCommand("kata-get-param playoutDoublingAdvantage");
-      sendCommand("kata-get-param analysisWideRootNoise");
-      sendCommand("kata-get-rules");
+    getParameterScadule(sendCommand, TimeUnit.SECONDS.toMillis(30));
+  }
+
+  void getParameterScadule(boolean sendCommand, long timeoutMillis) {
+    final long timeoutGeneration;
+    synchronized (parameterReadTimeoutLock) {
+      timeoutGeneration = ++parameterReadTimeoutGeneration;
+      getRcentLine = true;
+      if (sendCommand) {
+        recentLineNumber = 0;
+        sendCommand("kata-get-param playoutDoublingAdvantage");
+        sendCommand("kata-get-param analysisWideRootNoise");
+        sendCommand("kata-get-rules");
+      }
     }
-    Runnable runnable =
-        new Runnable() {
-          public void run() {
-            try {
-              Thread.sleep(30000);
-            } catch (InterruptedException e) {
-              // TODO Auto-generated catch block
-              e.printStackTrace();
-            }
-            Lizzie.leelaz.getRcentLine = false;
-          }
-        };
-    Thread thread = new Thread(runnable);
-    thread.start();
+    Thread timeoutThread =
+        new Thread(
+            () -> {
+              try {
+                Thread.sleep(Math.max(0L, timeoutMillis));
+              } catch (InterruptedException interrupted) {
+                Thread.currentThread().interrupt();
+                return;
+              }
+              synchronized (parameterReadTimeoutLock) {
+                if (parameterReadTimeoutGeneration == timeoutGeneration) {
+                  getRcentLine = false;
+                }
+              }
+            },
+            "lizzie-katago-parameter-timeout");
+    timeoutThread.setDaemon(true);
+    timeoutThread.start();
+  }
+
+  public void cancelParameterRead() {
+    synchronized (parameterReadTimeoutLock) {
+      parameterReadTimeoutGeneration++;
+      getRcentLine = false;
+    }
   }
 
   public void getSuicidalAndRules() {

--- a/src/main/java/featurecat/lizzie/gui/KataGoAutoSetupDialog.java
+++ b/src/main/java/featurecat/lizzie/gui/KataGoAutoSetupDialog.java
@@ -119,6 +119,9 @@ public class KataGoAutoSetupDialog extends JDialog {
   private static final int GPU_INFO_TEXT_LENGTH = 132;
   private static final int DIALOG_WIDTH = 1200;
   private static final int DIALOG_HEIGHT = 900;
+  private static final int SIDEBAR_MIN_WIDTH = 218;
+  private static final int SIDEBAR_MAX_WIDTH = 330;
+  private static final int SIDEBAR_TEXT_CHROME_WIDTH = 100;
   private static final int VALUE_COLUMN_WIDTH = 390;
   private static final int WEIGHT_CATALOG_ROW_HEIGHT = 34;
   private static final int WEIGHT_CATALOG_VISIBLE_ROWS = 6;
@@ -636,16 +639,15 @@ public class KataGoAutoSetupDialog extends JDialog {
 
   private JPanel createSidebarPanel() {
     JPanel sidebar = new SidebarBackdropPanel();
-    sidebar.setPreferredSize(new Dimension(218, 10));
     sidebar.setBorder(BorderFactory.createEmptyBorder(20, 12, 16, 12));
 
-    sectionNav.setListData(
-        new String[] {
-          text("AutoSetup.navOverview"),
-          text("AutoSetup.navWeights"),
-          text("AutoSetup.navBenchmark"),
-          text("AutoSetup.navAcceleration")
-        });
+    String[] sectionLabels = {
+      text("AutoSetup.navOverview"),
+      text("AutoSetup.navWeights"),
+      text("AutoSetup.navBenchmark"),
+      text("AutoSetup.navAcceleration")
+    };
+    sectionNav.setListData(sectionLabels);
     sectionNav.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
     sectionNav.setSelectedIndex(0);
     sectionNav.setFixedCellHeight(58);
@@ -684,6 +686,15 @@ public class KataGoAutoSetupDialog extends JDialog {
     btnRemoteCompute.setText(text("Menu.remoteCompute"));
     btnRemoteCompute.setIcon(new NavIcon(4, false));
     btnRemoteCompute.addActionListener(event -> openRemoteComputeCenter());
+
+    Font sidebarFont = deriveSidebarNavFont(sectionNav.getFont(), null, true);
+    FontMetrics sidebarMetrics = sectionNav.getFontMetrics(sidebarFont);
+    String[] measuredLabels = new String[sectionLabels.length + 1];
+    System.arraycopy(sectionLabels, 0, measuredLabels, 0, sectionLabels.length);
+    measuredLabels[sectionLabels.length] = btnRemoteCompute.getText();
+    int sidebarWidth = localizedSidebarWidth(sidebarMetrics, measuredLabels);
+    sidebar.setPreferredSize(new Dimension(sidebarWidth, 10));
+    btnRemoteCompute.setPreferredSize(new Dimension(sidebarWidth - 24, 54));
 
     JPanel navigation = new JPanel(new GridBagLayout());
     navigation.setOpaque(false);
@@ -5293,6 +5304,20 @@ public class KataGoAutoSetupDialog extends JDialog {
       base = new Font(Font.DIALOG, Font.PLAIN, 12);
     }
     return base.deriveFont(selected ? Font.BOLD : Font.PLAIN, base.getSize2D() + 1.5f);
+  }
+
+  static int localizedSidebarWidth(FontMetrics metrics, String... labels) {
+    int widestText = 0;
+    if (metrics != null && labels != null) {
+      for (String label : labels) {
+        if (label != null) {
+          widestText = Math.max(widestText, metrics.stringWidth(label));
+        }
+      }
+    }
+    return Math.max(
+        SIDEBAR_MIN_WIDTH,
+        Math.min(SIDEBAR_MAX_WIDTH, widestText + SIDEBAR_TEXT_CHROME_WIDTH));
   }
 
   private static final class SidebarNavRenderer extends JPanel implements ListCellRenderer<String> {

--- a/src/main/java/featurecat/lizzie/gui/LizzieFrame.java
+++ b/src/main/java/featurecat/lizzie/gui/LizzieFrame.java
@@ -10996,7 +10996,17 @@ public class LizzieFrame extends JFrame {
       Utils.showMsg(Lizzie.resourceBundle.getString("WholeGameAnalysis.conflict.analysis"));
       return;
     }
-    setkatarules = new SetKataRules();
+    Leelaz rulesEngine = Lizzie.leelaz;
+    if (!isRulesEngineReady(rulesEngine)) {
+      Utils.showMsg(Lizzie.resourceBundle.getString("LizzieFrame.setParamNoEngineHint"));
+      return;
+    }
+    if (!rulesEngine.isKatago) {
+      Utils.showMsg(Lizzie.resourceBundle.getString("SetKataRules.notKataGoHint"));
+      return;
+    }
+    SetKataRules rulesDialog = new SetKataRules(rulesEngine);
+    setkatarules = rulesDialog;
     setkatarules.setVisible(true);
     Runnable runnable =
         new Runnable() {
@@ -11005,26 +11015,39 @@ public class LizzieFrame extends JFrame {
             for (int i = 0; i < 10; i++) {
               try {
                 Thread.sleep(200);
-                if (setkatarules.getRules()) {
+                if (rulesDialog.hasRulesResponse()) {
                   success = true;
                   break;
                 }
 
               } catch (InterruptedException e) {
-                // TODO Auto-generated catch block
-                e.printStackTrace();
+                Thread.currentThread().interrupt();
+                return;
               }
             }
-            Lizzie.leelaz.getRcentLine = false;
-            if (!success) {
-              if (setkatarules.isVisible())
-                JOptionPane.showMessageDialog(
-                    setkatarules, Lizzie.resourceBundle.getString("LizzieFrame.ruleWarning"));
-            }
+            rulesEngine.cancelParameterRead();
+            boolean responseReceived = success;
+            SwingUtilities.invokeLater(
+                () -> {
+                  if (!rulesDialog.isVisible() || rulesEngine != Lizzie.leelaz) {
+                    return;
+                  }
+                  if (responseReceived) {
+                    rulesDialog.getRules();
+                  } else {
+                    JOptionPane.showMessageDialog(
+                        rulesDialog, Lizzie.resourceBundle.getString("LizzieFrame.ruleWarning"));
+                  }
+                });
           }
         };
-    Thread thread = new Thread(runnable);
+    Thread thread = new Thread(runnable, "lizzie-katago-rules-loader");
+    thread.setDaemon(true);
     thread.start();
+  }
+
+  static boolean isRulesEngineReady(Leelaz engine) {
+    return engine != null && engine.isLoaded() && engine.isStarted();
   }
 
   public void endHumanSlGameIfActive() {
@@ -14658,15 +14681,20 @@ public class LizzieFrame extends JFrame {
     if (analysisEngine == null) {
       return false;
     }
+    boolean lightweightQuickModelRequested =
+        KataGoAutoSetupHelper.resolveQuickAnalysisEngineCommand().isPresent();
+    boolean bundledTensorRtPrimary = isCurrentPrimaryEngineBundledTensorRt();
+    boolean needsAutomaticPrimaryForegroundReuse =
+        (isCurrentPrimaryEngineRemote() && !lightweightQuickModelRequested)
+            || (isCurrentPrimaryEngineBundledNvidia()
+                && (bundledTensorRtPrimary || !lightweightQuickModelRequested));
     boolean needsDedicatedLightweightModel =
-        !isCurrentPrimaryEngineBundledTensorRt()
-            && KataGoAutoSetupHelper.resolveQuickAnalysisEngineCommand().isPresent();
-    boolean needsAutomaticTensorRtForegroundReuse = isCurrentPrimaryEngineBundledTensorRt();
+        lightweightQuickModelRequested && !needsAutomaticPrimaryForegroundReuse;
     if (shouldReplaceAutomaticQuickAnalysisEngine(
         needsDedicatedLightweightModel,
         analysisEngine.usesDedicatedLightweightQuickModel(),
-        needsAutomaticTensorRtForegroundReuse,
-        analysisEngine.usesAutomaticTensorRtForegroundReuse(),
+        needsAutomaticPrimaryForegroundReuse,
+        analysisEngine.usesAutomaticPrimaryForegroundReuse(),
         analysisEngine.matchesCurrentAnalysisBackend(),
         analysisEngine.isAnalysisInProgress())) {
       AnalysisEngine staleEngine = analysisEngine;
@@ -14685,14 +14713,14 @@ public class LizzieFrame extends JFrame {
   static boolean shouldReplaceAutomaticQuickAnalysisEngine(
       boolean wantsDedicatedLightweightModel,
       boolean currentUsesDedicatedLightweightModel,
-      boolean wantsAutomaticTensorRtForegroundReuse,
-      boolean currentUsesAutomaticTensorRtForegroundReuse,
+      boolean wantsAutomaticPrimaryForegroundReuse,
+      boolean currentUsesAutomaticPrimaryForegroundReuse,
       boolean currentMatchesBackend,
       boolean currentAnalysisInProgress) {
     return currentAnalysisInProgress
         || !currentMatchesBackend
         || wantsDedicatedLightweightModel != currentUsesDedicatedLightweightModel
-        || wantsAutomaticTensorRtForegroundReuse != currentUsesAutomaticTensorRtForegroundReuse;
+        || wantsAutomaticPrimaryForegroundReuse != currentUsesAutomaticPrimaryForegroundReuse;
   }
 
   private void releaseDedicatedLightweightQuickAnalysisEngine() {
@@ -19077,12 +19105,17 @@ public class LizzieFrame extends JFrame {
         && KataGoRuntimeHelper.isBundledTensorRtCommand(Lizzie.leelaz.engineCommand());
   }
 
+  private boolean isCurrentPrimaryEngineBundledNvidia() {
+    return Lizzie.leelaz != null
+        && KataGoRuntimeHelper.isBundledNvidiaCommand(Lizzie.leelaz.engineCommand());
+  }
+
   private QuickAnalysisWarmupAction currentQuickAnalysisWarmupAction(boolean requiresAutoAnalyze) {
     boolean dependsOnPrimary =
         quickAnalysisDependsOnPrimary(
             isCurrentPrimaryEngineRemote(),
             isCurrentPrimaryEngineBundledOpenCl(),
-            isCurrentPrimaryEngineBundledTensorRt(),
+            isCurrentPrimaryEngineBundledNvidia(),
             Lizzie.config != null && Lizzie.config.analysisReuseCurrentEngine);
     boolean primaryLoaded =
         !dependsOnPrimary || (Lizzie.leelaz != null && Lizzie.leelaz.isLoaded());
@@ -19101,9 +19134,9 @@ public class LizzieFrame extends JFrame {
   static boolean quickAnalysisDependsOnPrimary(
       boolean remotePrimary,
       boolean bundledOpenClPrimary,
-      boolean bundledTensorRtPrimary,
+      boolean bundledNvidiaPrimary,
       boolean reusePrimary) {
-    return remotePrimary || bundledOpenClPrimary || bundledTensorRtPrimary || reusePrimary;
+    return remotePrimary || bundledOpenClPrimary || bundledNvidiaPrimary || reusePrimary;
   }
 
   static QuickAnalysisWarmupAction decideQuickAnalysisWarmup(

--- a/src/main/java/featurecat/lizzie/gui/Message.java
+++ b/src/main/java/featurecat/lizzie/gui/Message.java
@@ -25,6 +25,7 @@ public class Message extends JDialog {
     setTitle(resourceBundle.getString("Message.title")); // "消息提醒");
     setAlwaysOnTop(true);
     setDefaultCloseOperation(DISPOSE_ON_CLOSE);
+    AccessibilitySupport.installEscapeAction(getRootPane(), this, this::closeAndDispose);
     //  setLocationByPlatform(true);
     lblmessage = new JLabel("", JLabel.CENTER);
     getContentPane().setBackground(MessageTheme.background());

--- a/src/main/java/featurecat/lizzie/gui/SetKataRules.java
+++ b/src/main/java/featurecat/lizzie/gui/SetKataRules.java
@@ -1,6 +1,7 @@
 package featurecat.lizzie.gui;
 
 import featurecat.lizzie.Lizzie;
+import featurecat.lizzie.analysis.Leelaz;
 import featurecat.lizzie.util.Utils;
 import java.awt.Dimension;
 import java.awt.Insets;
@@ -37,8 +38,14 @@ public class SetKataRules extends JDialog {
   // private JFontLabel lblNewLabel_3;
   private JFontRadioButton rdoButtonGo;
   private JFontRadioButton rdoNoButtonGo;
+  private final Leelaz engine;
 
   public SetKataRules() {
+    this(Lizzie.leelaz);
+  }
+
+  SetKataRules(Leelaz engine) {
+    this.engine = engine;
     // this.setModal(true);
     // setType(Type.POPUP);
     setResizable(false);
@@ -50,10 +57,10 @@ public class SetKataRules extends JDialog {
     this.addWindowListener(
         new WindowAdapter() {
           public void windowClosing(WindowEvent e) {
-            if (Lizzie.leelaz.isPondering()) Lizzie.leelaz.ponder();
-            setVisible(false);
+            closeDialog();
           }
         });
+    AccessibilitySupport.installEscapeAction(getRootPane(), this, this::closeDialog);
 
     JFontLabel lblScoringRule =
         new JFontLabel(resourceBundle.getString("SetKataRules.lblScoringRule")); // ("胜负判断:");
@@ -291,8 +298,7 @@ public class SetKataRules extends JDialog {
     btnCancel.addActionListener(
         new ActionListener() {
           public void actionPerformed(ActionEvent e) {
-            if (Lizzie.leelaz.isPondering()) Lizzie.leelaz.ponder();
-            setVisible(false);
+            closeDialog();
           }
         });
     btnCancel.setBounds(292, 293, 93, 23);
@@ -303,7 +309,12 @@ public class SetKataRules extends JDialog {
     btnApply.addActionListener(
         new ActionListener() {
           public void actionPerformed(ActionEvent e) {
-            if (Lizzie.leelaz.hasExclusiveGtpWorkInProgress()) {
+            if (!isCurrentEngine() || !engine.isLoaded() || !engine.isStarted()) {
+              Utils.showMsg(resourceBundle.getString("LizzieFrame.setParamNoEngineHint"));
+              setVisible(false);
+              return;
+            }
+            if (engine.hasExclusiveGtpWorkInProgress()) {
               Utils.showMsg(
                   resourceBundle.getString("AnalysisSettings.reuseStatus.existing_lease"));
               return;
@@ -333,31 +344,31 @@ public class SetKataRules extends JDialog {
             if (rdoButtonGo.isSelected()) jo.put("hasButton", true);
             if (rdoNoButtonGo.isSelected()) jo.put("hasButton", false);
 
-            int oriRules = Lizzie.leelaz.usingSpecificRules;
+            int oriRules = engine.usingSpecificRules;
             if (jo.optString("scoring", "").contentEquals("AREA")
                 && jo.optString("ko", "").contentEquals("POSITIONAL")
                 && jo.optBoolean("suicide", false)
                 && jo.optString("tax", "").contentEquals("NONE")
                 && jo.optString("whiteHandicapBonus", "").contentEquals("N")
                 && !jo.optBoolean("hasButton", true)) {
-              Lizzie.leelaz.usingSpecificRules = 4; // tt规则
+              engine.usingSpecificRules = 4; // tt规则
             } else if (jo.optString("scoring", "").contentEquals("AREA")
                 && jo.optString("tax", "").contentEquals("NONE")
                 && !jo.optBoolean("hasButton", true)) {
-              Lizzie.leelaz.usingSpecificRules = 1; // 中国规则
+              engine.usingSpecificRules = 1; // 中国规则
             } else if (jo.optString("scoring", "").contentEquals("AREA")
                 && jo.optString("tax", "").contentEquals("ALL")
                 && !jo.optBoolean("hasButton", true)) {
-              Lizzie.leelaz.usingSpecificRules = 2; // 中古规则
+              engine.usingSpecificRules = 2; // 中古规则
             } else if (jo.optString("scoring", "").contentEquals("TERRITORY")
                 && jo.optString("tax", "").contentEquals("SEKI")) {
-              Lizzie.leelaz.usingSpecificRules = 3; // 日本规则
+              engine.usingSpecificRules = 3; // 日本规则
             } else if (jo.optString("scoring", "").contentEquals("AREA")
                 || jo.optString("scoring", "").contentEquals("TERRITORY")) {
-              Lizzie.leelaz.usingSpecificRules = 5; // 其他规则
+              engine.usingSpecificRules = 5; // 其他规则
             }
-            if (Lizzie.leelaz.usingSpecificRules != oriRules) Lizzie.frame.refresh();
-            Lizzie.leelaz.sendCommand("kata-set-rules " + jo.toString());
+            if (engine.usingSpecificRules != oriRules) Lizzie.frame.refresh();
+            engine.sendCommand("kata-set-rules " + jo.toString());
 
             if (chkbxAutoLoadRules.isSelected()) {
               Lizzie.config.autoLoadKataRules = true;
@@ -368,9 +379,9 @@ public class SetKataRules extends JDialog {
               Lizzie.config.autoLoadKataRules = false;
               Lizzie.config.uiConfig.put("auto-load-kata-rules", false);
             }
-            Lizzie.leelaz.getParameterScadule(false);
-            Lizzie.leelaz.sendCommand("kata-get-rules");
-            if (Lizzie.leelaz.isPondering()) Lizzie.leelaz.ponder();
+            engine.getParameterScadule(false);
+            engine.sendCommand("kata-get-rules");
+            if (engine.isPondering()) engine.ponder();
             setVisible(false);
           }
         });
@@ -444,22 +455,34 @@ public class SetKataRules extends JDialog {
       // TODO Auto-generated catch block
       e1.printStackTrace();
     }
-    if (!Lizzie.leelaz.isKatago) {
+    if (!engine.isKatago) {
       //      Message msg = new Message();
       //      msg.setMessage("当前引擎不是KataGo引擎(或未加载完成),可能无法修改规则");
       //      msg.setVisible(true);
       Utils.showMsg(resourceBundle.getString("SetKataRules.notKataGoHint"));
     }
-    Lizzie.leelaz.getRcentLine = true;
-    Lizzie.leelaz.nameCmd();
-    Lizzie.leelaz.sendCommand("kata-get-rules");
+    engine.recentRulesLine = "";
+    engine.getParameterScadule(false);
+    engine.nameCmd();
+    engine.sendCommand("kata-get-rules");
+  }
+
+  private void closeDialog() {
+    if (isCurrentEngine() && engine.isPondering()) {
+      engine.ponder();
+    }
+    setVisible(false);
+  }
+
+  public boolean hasRulesResponse() {
+    return !engine.recentRulesLine.isEmpty();
   }
 
   public boolean getRules() {
-    if (Lizzie.leelaz.recentRulesLine.equals("")) {
+    if (engine.recentRulesLine.equals("")) {
       return false;
     } else {
-      String line = Lizzie.leelaz.recentRulesLine;
+      String line = engine.recentRulesLine;
       jo = new JSONObject(new String(line.substring(2)));
       // Lizzie.leelaz.usingSpecificRules=
       if (jo.optBoolean("hasButton", false)) rdoButtonGo.setSelected(true);
@@ -494,5 +517,9 @@ public class SetKataRules extends JDialog {
 
       return true;
     }
+  }
+
+  private boolean isCurrentEngine() {
+    return engine != null && engine == Lizzie.leelaz;
   }
 }

--- a/src/main/java/featurecat/lizzie/rules/Board.java
+++ b/src/main/java/featurecat/lizzie/rules/Board.java
@@ -3474,6 +3474,7 @@ public class Board {
   }
 
   public void setHistory(BoardHistoryList newList) {
+    movelistRefreshGeneration++;
     history = newList;
     syncBoardDimensionsWithHistory(newList);
     syncBoardKataFlagsWithHistory(newList);
@@ -3895,7 +3896,7 @@ public class Board {
   //  }
 
   public double lastWinrateDiff(BoardHistoryNode node) {
-    if (Lizzie.board.isPkBoard) {
+    if (isPkBoard) {
       if (node.previous().isPresent()
           && node.previous().get().previous().isPresent()
           && hasPrimaryAnalysisPayload(node.previous().get().previous().get().getData())) {
@@ -3923,7 +3924,7 @@ public class Board {
   }
 
   public double lastWinrateDiff2(BoardHistoryNode node) {
-    if (Lizzie.board.isPkBoard) {
+    if (isPkBoard) {
       if (node.previous().isPresent()
           && node.previous().get().previous().isPresent()
           && hasSecondaryAnalysisPayload(node.previous().get().previous().get().getData())) {
@@ -3972,7 +3973,7 @@ public class Board {
   }
 
   public double lastScoreMeanDiff(BoardHistoryNode node) {
-    if (Lizzie.board.isPkBoard) {
+    if (isPkBoard) {
       if (node.previous().isPresent()
           && node.previous().get().previous().isPresent()
           && node.previous().get().previous().get().getData().getPlayouts() > 0) {
@@ -4004,7 +4005,7 @@ public class Board {
   }
 
   public double lastScoreMeanDiff2(BoardHistoryNode node) {
-    if (Lizzie.board.isPkBoard) {
+    if (isPkBoard) {
       if (node.previous().isPresent()
           && node.previous().get().previous().isPresent()
           && node.previous().get().previous().get().getData().getPlayouts2() > 0) {
@@ -4037,19 +4038,26 @@ public class Board {
 
   public void setMovelistAll() {
     final int generation = ++movelistRefreshGeneration;
+    final BoardHistoryList refreshHistory = history;
+    if (refreshHistory == null) {
+      return;
+    }
     Thread thread =
         new Thread(
             new Runnable() {
               public void run() {
-                BoardHistoryNode node = Lizzie.board.getHistory().getStart();
+                BoardHistoryNode node = refreshHistory.getStart();
                 Stack<BoardHistoryNode> stack = new Stack<>();
                 stack.push(node);
                 int processed = 0;
                 while (!stack.isEmpty()) {
-                  if (generation != movelistRefreshGeneration) {
+                  if (generation != movelistRefreshGeneration || history != refreshHistory) {
                     return;
                   }
                   if (!pauseMovelistRefreshForRecentNavigation()) {
+                    return;
+                  }
+                  if (generation != movelistRefreshGeneration || history != refreshHistory) {
                     return;
                   }
                   BoardHistoryNode cur = stack.pop();
@@ -4110,7 +4118,7 @@ public class Board {
   }
 
   public void setMovelistAll2() {
-    BoardHistoryNode node = Lizzie.board.getHistory().getStart();
+    BoardHistoryNode node = history.getStart();
     Stack<BoardHistoryNode> stack = new Stack<>();
     stack.push(node);
     while (!stack.isEmpty()) {
@@ -4139,7 +4147,7 @@ public class Board {
             && previousNode.getData().winrate >= 0)
         || previousNode.getData().playoutsChanged) {
       double winrateDiff = lastWinrateDiff(node);
-      if (Lizzie.board.isPkBoard && playouts > 0) {
+      if (isPkBoard && playouts > 0) {
         if (node.isMainTrunk() && node.previous().get().isMainTrunk()) {
           if (node.getData().isMoveNode()
               && previousNode.previous().isPresent()
@@ -4232,7 +4240,7 @@ public class Board {
                 != previousNode.nodeInfo2.previousPlayouts)
         && previousNode.getData().winrate2 >= 0) {
       double winrateDiff = lastWinrateDiff2(node);
-      if (Lizzie.board.isPkBoard) {
+      if (isPkBoard) {
         if (node.getData().isMoveNode()
             && previousNode.previous().isPresent()
             && previousNode.getData().isMoveNode()) {

--- a/src/main/java/featurecat/lizzie/util/KataGoAutoSetupHelper.java
+++ b/src/main/java/featurecat/lizzie/util/KataGoAutoSetupHelper.java
@@ -3115,7 +3115,13 @@ public final class KataGoAutoSetupHelper {
   }
 
   private static PackageFlavor packageFlavorFromText(String value) {
-    String normalized = value == null ? "" : value.toLowerCase(Locale.ROOT).replace('\\', '/');
+    String normalized =
+        value == null
+            ? ""
+            : value
+                .toLowerCase(Locale.ROOT)
+                .replace('\\', '/')
+                .replaceAll("[\\s._]+", "-");
     if (normalized.contains("without.engine") || normalized.contains("without-engine")) {
       return PackageFlavor.WITHOUT_ENGINE;
     }

--- a/src/main/java/featurecat/lizzie/util/KataGoRuntimeHelper.java
+++ b/src/main/java/featurecat/lizzie/util/KataGoRuntimeHelper.java
@@ -598,6 +598,18 @@ public final class KataGoRuntimeHelper {
     return resolveNvidiaBackend(enginePath) != null;
   }
 
+  public static boolean isBundledNvidiaCommand(String engineCommand) {
+    if (engineCommand == null || engineCommand.trim().isEmpty()) {
+      return false;
+    }
+    try {
+      Path executable = resolveCommandExecutable(Utils.splitCommand(engineCommand));
+      return Config.isBundledKataGoExecutable(executable) && isNvidiaBundledPath(executable);
+    } catch (RuntimeException e) {
+      return false;
+    }
+  }
+
   public static boolean isBundledTensorRtPath(Path enginePath) {
     return isWindowsPlatform()
         && enginePath != null

--- a/src/test/java/featurecat/lizzie/analysis/AnalysisEngineRequestTest.java
+++ b/src/test/java/featurecat/lizzie/analysis/AnalysisEngineRequestTest.java
@@ -9,6 +9,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import featurecat.lizzie.Config;
 import featurecat.lizzie.Lizzie;
+import featurecat.lizzie.analysis.remote.RemoteComputeConfig;
 import featurecat.lizzie.gui.HumanSlGameController;
 import featurecat.lizzie.gui.GtpConsolePane;
 import featurecat.lizzie.gui.LizzieFrame;
@@ -126,23 +127,57 @@ class AnalysisEngineRequestTest {
   }
 
   @Test
-  void onlyAutomaticQuickAnalysisOptsIntoTensorRtForegroundReuse() {
+  void automaticQuickAnalysisReusesRemoteAndBundledNvidiaForegroundWhenAppropriate() {
     assertTrue(
-        AnalysisEngine.shouldAutomaticallyReuseTensorRtForeground(
-            AnalysisResourceCoordinator.Purpose.AUTO_QUICK_ANALYSIS, true));
+        AnalysisEngine.shouldAutomaticallyReusePrimaryForeground(
+            AnalysisResourceCoordinator.Purpose.AUTO_QUICK_ANALYSIS, true, false, false, false));
     assertFalse(
-        AnalysisEngine.shouldAutomaticallyReuseTensorRtForeground(
-            AnalysisResourceCoordinator.Purpose.USER_QUICK_ANALYSIS, true));
+        AnalysisEngine.shouldAutomaticallyReusePrimaryForeground(
+            AnalysisResourceCoordinator.Purpose.AUTO_QUICK_ANALYSIS, true, false, false, true));
+    assertTrue(
+        AnalysisEngine.shouldAutomaticallyReusePrimaryForeground(
+            AnalysisResourceCoordinator.Purpose.AUTO_QUICK_ANALYSIS, false, true, true, true));
+    assertTrue(
+        AnalysisEngine.shouldAutomaticallyReusePrimaryForeground(
+            AnalysisResourceCoordinator.Purpose.AUTO_QUICK_ANALYSIS, false, true, false, false));
     assertFalse(
-        AnalysisEngine.shouldAutomaticallyReuseTensorRtForeground(
-            AnalysisResourceCoordinator.Purpose.WHOLE_GAME_ANALYSIS, true));
+        AnalysisEngine.shouldAutomaticallyReusePrimaryForeground(
+            AnalysisResourceCoordinator.Purpose.AUTO_QUICK_ANALYSIS, false, true, false, true));
     assertFalse(
-        AnalysisEngine.shouldAutomaticallyReuseTensorRtForeground(
-            AnalysisResourceCoordinator.Purpose.AUTO_QUICK_ANALYSIS, false));
+        AnalysisEngine.shouldAutomaticallyReusePrimaryForeground(
+            AnalysisResourceCoordinator.Purpose.USER_QUICK_ANALYSIS, true, true, true, false));
+    assertFalse(
+        AnalysisEngine.shouldAutomaticallyReusePrimaryForeground(
+            AnalysisResourceCoordinator.Purpose.WHOLE_GAME_ANALYSIS, true, true, true, false));
+    assertFalse(
+        AnalysisEngine.shouldAutomaticallyReusePrimaryForeground(
+            AnalysisResourceCoordinator.Purpose.AUTO_QUICK_ANALYSIS, false, false, false, false));
   }
 
   @Test
-  void automaticTensorRtForegroundReuseInvalidatesWhenThePrimaryEngineChanges() throws Exception {
+  void automaticQuickAnalysisBindsTheActiveRemoteEngineWithoutChangingUserSettings()
+      throws Exception {
+    try (TestEnvironment env = TestEnvironment.open()) {
+      Leelaz foreground = reusableForegroundEngine(true);
+      foreground.setEngineCommand(RemoteComputeConfig.COMMAND_ZHIZI);
+      Lizzie.leelaz = foreground;
+      Lizzie.config.analysisReuseCurrentEngine = false;
+      Lizzie.config.quickAnalysisLightweightModelEnabled = false;
+
+      AnalysisEngine engine = AnalysisEngine.createAutomaticQuickAnalysis();
+
+      assertTrue(engine.isLoaded());
+      assertTrue(engine.usesSharedForegroundEngine());
+      assertTrue(engine.usesAutomaticPrimaryForegroundReuse());
+      assertTrue(engine.matchesCurrentAnalysisBackend());
+      assertNull(engine.process);
+      assertFalse(Lizzie.config.analysisReuseCurrentEngine);
+    }
+  }
+
+  @Test
+  void automaticPrimaryForegroundReuseInvalidatesWhenThePrimaryEngineChanges()
+      throws Exception {
     try (TestEnvironment env = TestEnvironment.open()) {
       Leelaz firstForeground = reusableForegroundEngine(true);
       Leelaz secondForeground = reusableForegroundEngine(true);
@@ -155,11 +190,11 @@ class AnalysisEngineRequestTest {
           "purpose",
           AnalysisResourceCoordinator.Purpose.AUTO_QUICK_ANALYSIS);
       setField(AnalysisEngine.class, engine, "sharedForegroundEngine", firstForeground);
-      setField(AnalysisEngine.class, engine, "automaticTensorRtForegroundReuse", true);
+      setField(AnalysisEngine.class, engine, "automaticPrimaryForegroundReuse", true);
       setField(
           AnalysisEngine.class,
           engine,
-          "automaticTensorRtForegroundCommand",
+          "automaticPrimaryForegroundCommand",
           firstForeground.engineCommand());
 
       assertTrue(engine.matchesCurrentAnalysisBackend());
@@ -172,7 +207,7 @@ class AnalysisEngineRequestTest {
   }
 
   @Test
-  void automaticTensorRtForegroundReuseInvalidatesWhenTheSameEngineObjectChangesCommand()
+  void automaticPrimaryForegroundReuseInvalidatesWhenTheSameEngineObjectChangesCommand()
       throws Exception {
     try (TestEnvironment env = TestEnvironment.open()) {
       Leelaz foreground = reusableForegroundEngine(true);
@@ -186,11 +221,11 @@ class AnalysisEngineRequestTest {
           "purpose",
           AnalysisResourceCoordinator.Purpose.AUTO_QUICK_ANALYSIS);
       setField(AnalysisEngine.class, engine, "sharedForegroundEngine", foreground);
-      setField(AnalysisEngine.class, engine, "automaticTensorRtForegroundReuse", true);
+      setField(AnalysisEngine.class, engine, "automaticPrimaryForegroundReuse", true);
       setField(
           AnalysisEngine.class,
           engine,
-          "automaticTensorRtForegroundCommand",
+          "automaticPrimaryForegroundCommand",
           foreground.engineCommand());
 
       assertTrue(engine.matchesCurrentAnalysisBackend());

--- a/src/test/java/featurecat/lizzie/analysis/LeelazReaderIncarnationTest.java
+++ b/src/test/java/featurecat/lizzie/analysis/LeelazReaderIncarnationTest.java
@@ -33,6 +33,50 @@ import org.junit.jupiter.api.Test;
 
 class LeelazReaderIncarnationTest {
   @Test
+  void parameterReadTimeoutBelongsToTheEngineThatScheduledIt() throws Exception {
+    try (GlobalState ignored = GlobalState.install()) {
+      Leelaz scheduledEngine = new Leelaz("");
+      Leelaz replacementEngine = new Leelaz("");
+      replacementEngine.getRcentLine = true;
+      Lizzie.leelaz = replacementEngine;
+
+      scheduledEngine.getParameterScadule(false, 20L);
+
+      assertTrue(awaitParameterReadState(scheduledEngine, false, 1, TimeUnit.SECONDS));
+      assertTrue(replacementEngine.getRcentLine);
+    }
+  }
+
+  @Test
+  void staleParameterReadTimeoutCannotCancelANewerRequest() throws Exception {
+    try (GlobalState ignored = GlobalState.install()) {
+      Leelaz engine = new Leelaz("");
+
+      engine.getParameterScadule(false, 30L);
+      Thread.sleep(10L);
+      engine.getParameterScadule(false, 250L);
+
+      Thread.sleep(80L);
+      assertTrue(engine.getRcentLine);
+      assertTrue(awaitParameterReadState(engine, false, 1, TimeUnit.SECONDS));
+    }
+  }
+
+  @Test
+  void cancelledParameterReadCannotBeReactivatedByItsTimeout() throws Exception {
+    try (GlobalState ignored = GlobalState.install()) {
+      Leelaz engine = new Leelaz("");
+
+      engine.getParameterScadule(false, 30L);
+      engine.cancelParameterRead();
+
+      assertFalse(engine.getRcentLine);
+      Thread.sleep(80L);
+      assertFalse(engine.getRcentLine);
+    }
+  }
+
+  @Test
   void staleReadersDoNotConsumeOrTerminateReboundStreams() throws Exception {
     try (GlobalState ignored = GlobalState.install()) {
       Leelaz engine = new Leelaz("");
@@ -408,6 +452,18 @@ class LeelazReaderIncarnationTest {
     Field field = Leelaz.class.getDeclaredField(name);
     field.setAccessible(true);
     return field.get(engine);
+  }
+
+  private static boolean awaitParameterReadState(
+      Leelaz engine, boolean expected, long timeout, TimeUnit unit) throws InterruptedException {
+    long deadline = System.nanoTime() + unit.toNanos(timeout);
+    do {
+      if (engine.getRcentLine == expected) {
+        return true;
+      }
+      Thread.sleep(5L);
+    } while (System.nanoTime() < deadline);
+    return engine.getRcentLine == expected;
   }
 
   private static void setField(Leelaz engine, String name, Object value) throws Exception {

--- a/src/test/java/featurecat/lizzie/gui/KataGoAutoSetupDialogLayoutTest.java
+++ b/src/test/java/featurecat/lizzie/gui/KataGoAutoSetupDialogLayoutTest.java
@@ -8,6 +8,7 @@ import java.awt.CardLayout;
 import java.awt.Dimension;
 import java.awt.FlowLayout;
 import java.awt.Font;
+import java.awt.FontMetrics;
 import java.awt.Rectangle;
 import java.nio.file.Path;
 import java.util.List;
@@ -41,6 +42,28 @@ class KataGoAutoSetupDialogLayoutTest {
     assertEquals(14.5f, first.getSize2D());
     assertEquals(first.getSize2D(), second.getSize2D());
     assertEquals(Font.BOLD, second.getStyle());
+  }
+
+  @Test
+  void sidebarExpandsForThaiNavigationWithoutConsumingUnboundedSpace() {
+    JLabel measurementLabel = new JLabel();
+    Font selectedFont =
+        KataGoAutoSetupDialog.deriveSidebarNavFont(
+            new Font(Font.DIALOG, Font.PLAIN, 13), null, true);
+    FontMetrics metrics = measurementLabel.getFontMetrics(selectedFont);
+    String thaiAcceleration = "เร่งความเร็ว NVIDIA GPU";
+
+    int thaiWidth = KataGoAutoSetupDialog.localizedSidebarWidth(metrics, thaiAcceleration);
+
+    assertTrue(thaiWidth > 218, "the Thai acceleration label must expand the fixed-width sidebar");
+    assertTrue(
+        thaiWidth >= metrics.stringWidth(thaiAcceleration) + 100,
+        "the expanded width must include icon, gap, renderer, and sidebar insets");
+    assertEquals(218, KataGoAutoSetupDialog.localizedSidebarWidth(metrics, "概览"));
+    assertEquals(
+        330,
+        KataGoAutoSetupDialog.localizedSidebarWidth(
+            metrics, "A deliberately extreme navigation label that must remain bounded"));
   }
 
   @Test

--- a/src/test/java/featurecat/lizzie/gui/LizzieFrameRegressionTest.java
+++ b/src/test/java/featurecat/lizzie/gui/LizzieFrameRegressionTest.java
@@ -342,6 +342,17 @@ class LizzieFrameRegressionTest {
   }
 
   @Test
+  void rulesDialogRequiresAFullyStartedEngine() throws Exception {
+    assertFalse(LizzieFrame.isRulesEngineReady(null));
+    Leelaz engine = new Leelaz("");
+    assertFalse(LizzieFrame.isRulesEngineReady(engine));
+    engine.isLoaded = true;
+    assertFalse(LizzieFrame.isRulesEngineReady(engine));
+    engine.started = true;
+    assertTrue(LizzieFrame.isRulesEngineReady(engine));
+  }
+
+  @Test
   void automaticQuickAnalysisDoesNotReuseTheWrongModelBackend() {
     assertTrue(
         LizzieFrame.shouldReplaceAutomaticQuickAnalysisEngine(

--- a/src/test/java/featurecat/lizzie/gui/MessageThemeTest.java
+++ b/src/test/java/featurecat/lizzie/gui/MessageThemeTest.java
@@ -1,13 +1,29 @@
 package featurecat.lizzie.gui;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.awt.Color;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import javax.swing.JLabel;
 import javax.swing.UIManager;
 import org.junit.jupiter.api.Test;
 
 public class MessageThemeTest {
+  @Test
+  void messageDialogInstallsTheSharedEscapeCloseAction() throws Exception {
+    String source =
+        Files.readString(
+            Path.of("src/main/java/featurecat/lizzie/gui/Message.java"), StandardCharsets.UTF_8);
+
+    assertTrue(
+        source.contains(
+            "AccessibilitySupport.installEscapeAction(getRootPane(), this, this::closeAndDispose)"),
+        "blocking message dialogs must remain dismissible from the keyboard.");
+  }
+
   @Test
   void darkLookAndFeelBackgroundFallsBackToReadableMessageColors() {
     Color previousPanel = UIManager.getColor("Panel.background");

--- a/src/test/java/featurecat/lizzie/rules/BoardMovelistRefreshLifecycleTest.java
+++ b/src/test/java/featurecat/lizzie/rules/BoardMovelistRefreshLifecycleTest.java
@@ -1,0 +1,130 @@
+package featurecat.lizzie.rules;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import featurecat.lizzie.Lizzie;
+import java.lang.reflect.Field;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.Test;
+
+class BoardMovelistRefreshLifecycleTest {
+  private static final int BOARD_SIZE = 3;
+
+  @Test
+  void refreshUsesItsBoardInstanceWhenTheGlobalBoardIsUnavailable() throws Exception {
+    Board previousBoard = Lizzie.board;
+    Thread.UncaughtExceptionHandler previousHandler = Thread.getDefaultUncaughtExceptionHandler();
+    AtomicReference<Throwable> uncaught = new AtomicReference<>();
+    TrackingBoard board = trackingBoard(singleNodeHistory());
+    try {
+      Thread.setDefaultUncaughtExceptionHandler((thread, error) -> uncaught.compareAndSet(null, error));
+      Lizzie.board = null;
+
+      board.setMovelistAll();
+
+      assertTrue(board.firstUpdate.await(2, TimeUnit.SECONDS), "instance refresh should run.");
+      assertNull(uncaught.get(), "refresh must not dereference the global board.");
+    } finally {
+      board.releaseFirstUpdate.countDown();
+      Thread.setDefaultUncaughtExceptionHandler(previousHandler);
+      Lizzie.board = previousBoard;
+    }
+  }
+
+  @Test
+  void replacingHistoryCancelsAnInFlightRefreshBeforeItVisitsMoreNodes() throws Exception {
+    Board previousBoard = Lizzie.board;
+    TrackingBoard board = trackingBoard(twoNodeHistory());
+    try {
+      Lizzie.board = board;
+      board.blockFirstUpdate = true;
+      board.setMovelistAll();
+      assertTrue(board.firstUpdate.await(2, TimeUnit.SECONDS), "refresh should reach its first node.");
+
+      board.setHistory(singleNodeHistory());
+      board.releaseFirstUpdate.countDown();
+
+      assertFalse(
+          board.secondUpdate.await(500, TimeUnit.MILLISECONDS),
+          "the stale refresh must stop after its history is replaced.");
+      assertEquals(1, board.updates.get(), "only the already-running update may finish.");
+    } finally {
+      board.releaseFirstUpdate.countDown();
+      Lizzie.board = previousBoard;
+    }
+  }
+
+  private static TrackingBoard trackingBoard(BoardHistoryList history) throws Exception {
+    TrackingBoard board = allocate(TrackingBoard.class);
+    board.updates = new AtomicInteger();
+    board.firstUpdate = new CountDownLatch(1);
+    board.secondUpdate = new CountDownLatch(1);
+    board.releaseFirstUpdate = new CountDownLatch(1);
+    board.setHistory(history);
+    return board;
+  }
+
+  private static BoardHistoryList singleNodeHistory() {
+    return new BoardHistoryList(BoardData.empty(BOARD_SIZE, BOARD_SIZE));
+  }
+
+  private static BoardHistoryList twoNodeHistory() {
+    BoardHistoryList history = singleNodeHistory();
+    history.add(BoardData.empty(BOARD_SIZE, BOARD_SIZE));
+    return history;
+  }
+
+  @SuppressWarnings("unchecked")
+  private static <T> T allocate(Class<T> type) throws Exception {
+    return (T) UnsafeHolder.UNSAFE.allocateInstance(type);
+  }
+
+  private static final class TrackingBoard extends Board {
+    private AtomicInteger updates;
+    private CountDownLatch firstUpdate;
+    private CountDownLatch secondUpdate;
+    private CountDownLatch releaseFirstUpdate;
+    private volatile boolean blockFirstUpdate;
+
+    private TrackingBoard() {
+      super();
+    }
+
+    @Override
+    public void updateMovelist(BoardHistoryNode node) {
+      int update = updates.incrementAndGet();
+      if (update == 1) {
+        firstUpdate.countDown();
+        if (blockFirstUpdate) {
+          try {
+            releaseFirstUpdate.await(2, TimeUnit.SECONDS);
+          } catch (InterruptedException ex) {
+            Thread.currentThread().interrupt();
+          }
+        }
+      } else {
+        secondUpdate.countDown();
+      }
+    }
+  }
+
+  private static final class UnsafeHolder {
+    private static final sun.misc.Unsafe UNSAFE = loadUnsafe();
+
+    private static sun.misc.Unsafe loadUnsafe() {
+      try {
+        Field field = sun.misc.Unsafe.class.getDeclaredField("theUnsafe");
+        field.setAccessible(true);
+        return (sun.misc.Unsafe) field.get(null);
+      } catch (ReflectiveOperationException ex) {
+        throw new IllegalStateException("Failed to access Unsafe", ex);
+      }
+    }
+  }
+}

--- a/src/test/java/featurecat/lizzie/rules/BoardMovelistRefreshLifecycleTest.java
+++ b/src/test/java/featurecat/lizzie/rules/BoardMovelistRefreshLifecycleTest.java
@@ -14,8 +14,6 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.Test;
 
 class BoardMovelistRefreshLifecycleTest {
-  private static final int BOARD_SIZE = 3;
-
   @Test
   void refreshUsesItsBoardInstanceWhenTheGlobalBoardIsUnavailable() throws Exception {
     Board previousBoard = Lizzie.board;
@@ -71,12 +69,12 @@ class BoardMovelistRefreshLifecycleTest {
   }
 
   private static BoardHistoryList singleNodeHistory() {
-    return new BoardHistoryList(BoardData.empty(BOARD_SIZE, BOARD_SIZE));
+    return new BoardHistoryList(BoardData.empty(Board.boardWidth, Board.boardHeight));
   }
 
   private static BoardHistoryList twoNodeHistory() {
     BoardHistoryList history = singleNodeHistory();
-    history.add(BoardData.empty(BOARD_SIZE, BOARD_SIZE));
+    history.add(BoardData.empty(Board.boardWidth, Board.boardHeight));
     return history;
   }
 

--- a/src/test/java/featurecat/lizzie/util/KataGoAutoSetupHelperTest.java
+++ b/src/test/java/featurecat/lizzie/util/KataGoAutoSetupHelperTest.java
@@ -338,7 +338,9 @@ public class KataGoAutoSetupHelperTest {
       {"opencl", KataGoAutoSetupHelper.PackageFlavor.OPENCL},
       {"nvidia", KataGoAutoSetupHelper.PackageFlavor.NVIDIA},
       {"nvidia50.cuda", KataGoAutoSetupHelper.PackageFlavor.NVIDIA50_CUDA},
+      {"nvidia.tensorrt", KataGoAutoSetupHelper.PackageFlavor.TENSORRT},
       {"nvidia-tensorrt", KataGoAutoSetupHelper.PackageFlavor.TENSORRT},
+      {"NVIDIA TensorRT", KataGoAutoSetupHelper.PackageFlavor.TENSORRT},
       {"cpu", KataGoAutoSetupHelper.PackageFlavor.CPU},
       {"with-katago", KataGoAutoSetupHelper.PackageFlavor.WITH_KATAGO}
     };

--- a/src/test/java/featurecat/lizzie/util/KataGoRuntimeHelperTest.java
+++ b/src/test/java/featurecat/lizzie/util/KataGoRuntimeHelperTest.java
@@ -223,6 +223,13 @@ public class KataGoRuntimeHelperTest {
           assertTrue(KataGoRuntimeHelper.isBundledTensorRtPath(namedEngine));
           assertTrue(KataGoRuntimeHelper.isBundledTensorRtPath(markedEngine));
           assertTrue(
+              KataGoRuntimeHelper.isBundledNvidiaCommand(
+                  "\""
+                      + markedEngine
+                      + "\" gtp -model \""
+                      + tempRoot.resolve("weight.bin.gz")
+                      + "\""));
+          assertTrue(
               KataGoRuntimeHelper.isBundledTensorRtCommand(
                   "\""
                       + markedEngine
@@ -233,6 +240,7 @@ public class KataGoRuntimeHelperTest {
           Files.writeString(
               markedDir.resolve("lizzieyzy-next-engine-backend.txt"), "nvidia50-cuda\n");
           assertFalse(KataGoRuntimeHelper.isBundledTensorRtPath(markedEngine));
+          assertTrue(KataGoRuntimeHelper.isBundledNvidiaCommand(markedEngine.toString()));
         });
   }
 


### PR DESCRIPTION
## Summary

This PR contains fixes found during a full Windows user-acceptance pass against current `main`.

- Make automatic quick winrate curves safely reuse the active remote or bundled NVIDIA foreground engine, avoiding a second TensorRT cold start and preserving the user's global reuse setting.
- Bind parameter timeouts, KataGo rules prompts, and background movelist refreshes to the exact engine/board generation that created them, so stale work cannot alter a replacement engine or newly opened SGF.
- Improve failed/not-ready engine handling, TensorRT package-flavor detection, and Escape handling for message/rules dialogs.
- Size the one-click setup navigation from localized text metrics, fixing Thai text clipping at Windows high DPI.
- Add regression coverage for engine replacement, quick-analysis routing, stale board refreshes, dialog behavior, TensorRT detection, and localized layout.

## Automated verification

- `mvn -B -Djava.awt.headless=true -Dfmt.skip=true test`
  - 2,224 tests, 0 failures, 0 errors, 8 skipped
- `mvn -B -Djava.awt.headless=true -Dfmt.skip=true -DskipTests package`
  - BUILD SUCCESS
- `python -m unittest discover -s scripts -p 'test_*.py' -v`
  - 73 tests, 0 failures/errors, 2 platform-only skips
- `python scripts/test_windows_launcher_packaging.py`
  - passed
- `git diff --check`
  - passed
- Real packaged-EXE launcher smoke, both normal and `-OpenAutoSetup`
  - passed; bundled JVM used and no “Failed to launch JVM”

## Real Windows acceptance

Tested with a copied Windows NVIDIA TensorRT portable package on Windows 11 Pro 23H2 (build 22631), RTX 3070 Laptop GPU, 2560x1600 display.

- Fresh first launch loaded the bundled TensorRT engine without a restart; the initial config persisted `default-engine=0`, `autoload-default=true`, and `first-time-load=false`.
- CUDA and TensorRT quick curves started in under one second and completed in about eight seconds with one KataGo process.
- OpenCL completed its first-device tune and then analyzed normally on the RTX 3070.
- Zhizi remote analysis produced the quick curve without launching a second local KataGo; pause/resume and return to local analysis remained responsive.
- Alt+O launched packaged readboard v3.0.6; native Yike game switching worked; bundled JCEF web views opened without component download.
- Missing-engine startup remained non-blocking and exposed the clickable/keyboard-operable repair state.
- Simplified Chinese, Traditional Chinese, English, Japanese, Korean, and Thai were restarted and checked.
- 100%, 150%, and 200% UI scaling were checked with the real EXE. Main dialogs remained on screen, and the Thai NVIDIA acceleration label no longer clipped.
- Java Access Bridge/JAccessInspector connected to the packaged Swing JVM. F6/Shift+F6, Tab/Shift+Tab, Enter/Space, and Escape paths were exercised.

## Residual platform coverage

- Hardware coverage is RTX 3070; RTX 50-series hardware was not available locally.
- Two script tests are intentionally skipped outside macOS/native Bash.
- Accessibility was inspected with Java Access Bridge/JAccessInspector, not NVDA or Narrator.