### PR TITLE
Release next-2026-08-14.1 pre-release

### DIFF
--- a/.github/release-notes/next-2026-08-14.1.md
+++ b/.github/release-notes/next-2026-08-14.1.md
@@ -1,0 +1,323 @@
+# LizzieYzy Next next-2026-08-14.1
+
+## 中文
+
+这是 `next-2026-08-13.1` 之后的 Windows 稳定性预览更新，重点解决 TensorRT 首次启动、自动快速胜率曲线、远程算力恢复、引擎与棋谱切换，以及六语高缩放界面问题。
+
+### 本版主要更新
+
+- 修复全新或迁移后的 Windows TensorRT 免安装版首次打开不加载引擎、必须重启一次才工作的情况；仅在用户从未明确选择启动方式时写入有效默认引擎，明确的“无引擎”、手动选择和最后使用模式保持不变。
+- 自动快速胜率曲线现在会安全复用已启动的 TensorRT、NVIDIA CUDA 或智子远程前台引擎，不再冷启动第二个 TensorRT 进程或建立第二套 timing cache，也不会改写用户的全局引擎复用设置。
+- 参数读取超时、规则弹窗和棋谱后台刷新现在绑定到创建它们的引擎或棋盘历史代次；切换引擎、打开新棋谱或退出旧任务后，过期线程不会再清空新引擎、改动新棋谱或造成分析停住。
+- 完善 TensorRT 包类型与 KataGo 版本元数据识别，支持带点号的 `nvidia.tensorrt` 包名，并在发布阶段核对真实二进制版本，阻止错误版本说明进入安装包。
+- 修复泰语“一键设置”侧栏在 Windows 100%、150%、200% 缩放下文字裁切；侧栏会按本地化文字与字体动态计算宽度，主要弹窗同时补齐 Esc 关闭和键盘操作路径。
+
+### 下载前先看这几句
+
+- 已有 Windows 免安装版可以下载 `windows64.core-update.zip` 更新主程序；完整包继续使用现有官方引擎、权重和运行库，发布审计更严格。
+- 普通 Windows 用户优先选择 OpenCL 免安装版；NVIDIA 用户按显卡代际选择 NVIDIA 或 RTX 50 CUDA 版。
+- 自动快速曲线会选择当前可用的本地或远程引擎；手动整盘分析、远程算力设置及用户自定义权重保持原行为。
+- 这是预发布版。建议先覆盖到副本，并备份现有 `user-data`、自定义权重和棋谱。
+
+### 下载建议
+
+| 你的电脑 | 直接下载这个 |
+| --- | --- |
+| Windows 64 位，OpenCL 版，推荐，免安装 | [`2026-08-14-windows64.opencl.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-14.1/2026-08-14-windows64.opencl.portable.zip) |
+| 已有 Windows 免安装版，只更新主程序 | [`2026-08-14-windows64.core-update.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-14.1/2026-08-14-windows64.core-update.zip) |
+| Windows 64 位，OpenCL 安装版 | [`2026-08-14-windows64.opencl.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-14.1/2026-08-14-windows64.opencl.installer.exe) |
+| Windows 64 位，CPU 兼容版，免安装 | [`2026-08-14-windows64.with-katago.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-14.1/2026-08-14-windows64.with-katago.portable.zip) |
+| Windows 64 位，CPU 兼容安装版 | [`2026-08-14-windows64.with-katago.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-14.1/2026-08-14-windows64.with-katago.installer.exe) |
+| Windows 64 位，NVIDIA CUDA 版，免安装 | [`2026-08-14-windows64.nvidia.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-14.1/2026-08-14-windows64.nvidia.portable.zip) |
+| Windows 64 位，NVIDIA CUDA 安装版 | [`2026-08-14-windows64.nvidia.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-14.1/2026-08-14-windows64.nvidia.installer.exe) |
+| Windows 64 位，RTX 5070/5080/5090，免安装 | [`2026-08-14-windows64.nvidia50.cuda.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-14.1/2026-08-14-windows64.nvidia50.cuda.portable.zip) |
+| 高级可选：TensorRT 预装分卷包，需下载全部分卷 | [`2026-08-14-windows64.nvidia.tensorrt.portable.7z.001`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-14.1/2026-08-14-windows64.nvidia.tensorrt.portable.7z.001)<br>[`2026-08-14-windows64.nvidia.tensorrt.portable.7z.002`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-14.1/2026-08-14-windows64.nvidia.tensorrt.portable.7z.002) |
+| Windows 64 位，RTX 50 CUDA 安装版 | [`2026-08-14-windows64.nvidia50.cuda.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-14.1/2026-08-14-windows64.nvidia50.cuda.installer.exe) |
+| Windows 64 位，自行配置引擎，免安装 | [`2026-08-14-windows64.without.engine.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-14.1/2026-08-14-windows64.without.engine.portable.zip) |
+| Windows 64 位，自行配置引擎，安装版 | [`2026-08-14-windows64.without.engine.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-14.1/2026-08-14-windows64.without.engine.installer.exe) |
+| macOS Apple Silicon | [`2026-08-14-mac-apple-silicon.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-14.1/2026-08-14-mac-apple-silicon.with-katago.dmg) |
+| macOS Intel | [`2026-08-14-mac-intel.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-14.1/2026-08-14-mac-intel.with-katago.dmg) |
+| Linux 64 位，CPU 兼容版 | [`2026-08-14-linux64.with-katago.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-14.1/2026-08-14-linux64.with-katago.zip) |
+| Linux 64 位，OpenCL 版 | [`2026-08-14-linux64.opencl.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-14.1/2026-08-14-linux64.opencl.zip) |
+| Linux 64 位，NVIDIA CUDA 版 | [`2026-08-14-linux64.nvidia.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-14.1/2026-08-14-linux64.nvidia.zip) |
+
+### 这一版为什么值得测试
+
+- JDK 21 完整测试共 `2224` 项，`0` 失败、`0` 错误，Windows 专项脚本、shaded jar 与发布打包守卫全部通过。
+- Windows 11、RTX 3070 Laptop 真机验证：首次启动 5 秒内出现内置引擎进程，无需第二次打开；TensorRT/CUDA 曲线约 1 秒出现首段、约 8 秒完成，智子远程曲线也能持续完成并正常暂停、继续和切回本地。
+- 使用真实 Windows EXE 复测 OpenCL、Alt+O 棋盘同步、弈客列表与网页、缺引擎修复、六种语言及 100%/150%/200% 缩放，主界面和主要设置窗口没有发现阻塞、裁切或异常下载。
+- 发布流程会对 Windows、macOS 和 Linux 成品逐项检查文件名、版本、签名或运行时结构及 SHA-256，全部通过后才公开。
+
+### 交流
+
+- QQ 群：`299419120`
+
+---
+
+## 繁體中文
+
+這是 `next-2026-08-13.1` 之後的 Windows 穩定性預覽更新，重點修正 TensorRT 首次啟動、自動快速勝率曲線、遠端算力恢復、engine 與棋譜切換，以及六語高縮放介面問題。
+
+### 本版主要更新
+
+- 修正全新或遷移後的 Windows TensorRT portable 首次開啟不載入 engine、必須重新啟動才可使用的問題；只有從未明確選擇啟動模式時才設定有效預設 engine，明確的「無 engine」、手動選擇與最後使用模式維持不變。
+- 自動快速勝率曲線現在會安全共用已啟動的 TensorRT、NVIDIA CUDA 或智子遠端前景 engine，不再冷啟動第二個 TensorRT process 或建立第二套 timing cache，也不會改寫使用者的全域共用設定。
+- 參數讀取 timeout、規則 dialog 與棋譜背景更新會綁定到建立它們的 engine 或棋盤歷史 generation；切換 engine、開啟新棋譜或結束舊 task 後，過期 thread 不會再清空新 engine、修改新棋譜或讓分析停止。
+- 完善 TensorRT package 類型與 KataGo 版本 metadata 識別，支援含點號的 `nvidia.tensorrt` 名稱，並在發布階段核對實際 binary version，阻止錯誤版本說明進入安裝包。
+- 修正泰文「一鍵設定」側欄在 Windows 100%、150%、200% 縮放下被裁切；側欄依本地化文字與 font 動態計算寬度，主要 dialog 也補齊 Esc 關閉與 keyboard 操作。
+
+### 下載前先看這幾句
+
+- 既有 Windows portable 可下載 `windows64.core-update.zip` 更新主程式；完整 package 延續現有官方 engine、weight 與 runtime，發布 audit 更嚴格。
+- 一般 Windows 使用者優先選擇 OpenCL portable；NVIDIA 使用者依顯示卡世代選擇 NVIDIA 或 RTX 50 CUDA 版。
+- 自動快速曲線會選擇目前可用的本機或遠端 engine；手動整盤分析、遠端算力設定與自訂 weight 維持原本行為。
+- 這是預覽版，建議先更新副本並備份既有 `user-data`、自訂權重與棋譜。
+
+### 下載建議
+
+| 你的電腦 | 直接下載這個 |
+| --- | --- |
+| Windows 64 位，OpenCL 推薦版，免安裝 | [`2026-08-14-windows64.opencl.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-14.1/2026-08-14-windows64.opencl.portable.zip) |
+| 既有 Windows portable，只更新主程式 | [`2026-08-14-windows64.core-update.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-14.1/2026-08-14-windows64.core-update.zip) |
+| Windows 64 位，OpenCL 安裝版 | [`2026-08-14-windows64.opencl.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-14.1/2026-08-14-windows64.opencl.installer.exe) |
+| Windows 64 位，CPU 相容版，免安裝 | [`2026-08-14-windows64.with-katago.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-14.1/2026-08-14-windows64.with-katago.portable.zip) |
+| Windows 64 位，CPU 相容安裝版 | [`2026-08-14-windows64.with-katago.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-14.1/2026-08-14-windows64.with-katago.installer.exe) |
+| Windows 64 位，NVIDIA CUDA，免安裝 | [`2026-08-14-windows64.nvidia.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-14.1/2026-08-14-windows64.nvidia.portable.zip) |
+| Windows 64 位，NVIDIA CUDA 安裝版 | [`2026-08-14-windows64.nvidia.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-14.1/2026-08-14-windows64.nvidia.installer.exe) |
+| Windows 64 位，RTX 5070/5080/5090，免安裝 | [`2026-08-14-windows64.nvidia50.cuda.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-14.1/2026-08-14-windows64.nvidia50.cuda.portable.zip) |
+| 進階可選：TensorRT 預裝分卷，需下載全部檔案 | [`2026-08-14-windows64.nvidia.tensorrt.portable.7z.001`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-14.1/2026-08-14-windows64.nvidia.tensorrt.portable.7z.001)<br>[`2026-08-14-windows64.nvidia.tensorrt.portable.7z.002`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-14.1/2026-08-14-windows64.nvidia.tensorrt.portable.7z.002) |
+| Windows 64 位，RTX 50 CUDA 安裝版 | [`2026-08-14-windows64.nvidia50.cuda.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-14.1/2026-08-14-windows64.nvidia50.cuda.installer.exe) |
+| Windows 64 位，自行設定 engine，免安裝 | [`2026-08-14-windows64.without.engine.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-14.1/2026-08-14-windows64.without.engine.portable.zip) |
+| Windows 64 位，自行設定 engine，安裝版 | [`2026-08-14-windows64.without.engine.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-14.1/2026-08-14-windows64.without.engine.installer.exe) |
+| macOS Apple Silicon | [`2026-08-14-mac-apple-silicon.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-14.1/2026-08-14-mac-apple-silicon.with-katago.dmg) |
+| macOS Intel | [`2026-08-14-mac-intel.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-14.1/2026-08-14-mac-intel.with-katago.dmg) |
+| Linux 64 位，CPU 相容版 | [`2026-08-14-linux64.with-katago.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-14.1/2026-08-14-linux64.with-katago.zip) |
+| Linux 64 位，OpenCL 版 | [`2026-08-14-linux64.opencl.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-14.1/2026-08-14-linux64.opencl.zip) |
+| Linux 64 位，NVIDIA CUDA 版 | [`2026-08-14-linux64.nvidia.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-14.1/2026-08-14-linux64.nvidia.zip) |
+
+### 這一版為什麼值得測試
+
+- JDK 21 完整測試共 `2224` 項，`0` failure、`0` error；Windows 專項 script、shaded jar 與 release packaging guard 全部通過。
+- Windows 11、RTX 3070 Laptop 實機驗證：首次啟動 5 秒內出現內建 engine process，不需第二次開啟；TensorRT/CUDA 曲線約 1 秒出現第一段、約 8 秒完成，智子遠端曲線也能完成並正常暫停、繼續與切回本機。
+- 使用真實 Windows EXE 重測 OpenCL、Alt+O 棋盤同步、弈客列表與網頁、缺 engine 修復、六種語言及 100%/150%/200% 縮放，主要畫面與設定視窗未發現阻塞、裁切或異常下載。
+- 發布流程會逐項檢查 Windows、macOS 與 Linux 成品的檔名、版本、簽章或 runtime 結構及 SHA-256，全部通過後才公開。
+
+### 交流
+
+- QQ 群：`299419120`
+
+---
+
+## English
+
+This Windows stability pre-release follows `next-2026-08-13.1`. It focuses on first-session TensorRT startup, automatic quick win-rate curves, remote-compute recovery, engine and SGF switching, and six-language high-DPI layout.
+
+### Release Highlights
+
+- Fixed fresh or migrated Windows TensorRT portable installs failing to load an engine until the second launch. A valid default is selected only when no startup mode was ever chosen; explicit no-engine, manual, and last-used modes remain untouched.
+- Automatic quick curves now safely reuse an active TensorRT, NVIDIA CUDA, or Zhizi remote foreground engine. They no longer cold-start a second TensorRT process or timing cache, and they do not change the user's global engine-reuse preference.
+- Parameter-read timeouts, the rules dialog, and background movelist refreshes are now bound to the exact engine or board-history generation that created them. Stale work cannot clear a replacement engine, modify a newly opened SGF, or stall analysis after switching.
+- Improved TensorRT package-flavor and KataGo version-metadata detection, including dotted `nvidia.tensorrt` package names. Release packaging now checks the real binary version before accepting displayed metadata.
+- Fixed Thai one-click-setup navigation clipping at 100%, 150%, and 200% Windows scaling. Its width now follows localized font metrics, and primary dialogs have complete Escape and keyboard paths.
+
+### Read Before Downloading
+
+- Existing Windows portable users may install `windows64.core-update.zip` for the application fixes. Full packages retain the current official engines, weights, and runtimes with stricter release auditing.
+- Most Windows users should choose the OpenCL portable package. NVIDIA users should select the NVIDIA or RTX 50 CUDA package matching their GPU generation.
+- Automatic quick curves select the currently available local or remote engine. Manual whole-game analysis, remote settings, and custom weights retain their existing behavior.
+- This is a pre-release. Upgrade a copy first and back up existing `user-data`, custom weights, and kifu.
+
+### Download Guide
+
+| Your computer | Download this file |
+| --- | --- |
+| Windows 64-bit, OpenCL, recommended, portable | [`2026-08-14-windows64.opencl.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-14.1/2026-08-14-windows64.opencl.portable.zip) |
+| Existing Windows portable install, application-only update | [`2026-08-14-windows64.core-update.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-14.1/2026-08-14-windows64.core-update.zip) |
+| Windows 64-bit, OpenCL installer | [`2026-08-14-windows64.opencl.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-14.1/2026-08-14-windows64.opencl.installer.exe) |
+| Windows 64-bit, CPU fallback, portable | [`2026-08-14-windows64.with-katago.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-14.1/2026-08-14-windows64.with-katago.portable.zip) |
+| Windows 64-bit, CPU fallback installer | [`2026-08-14-windows64.with-katago.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-14.1/2026-08-14-windows64.with-katago.installer.exe) |
+| Windows 64-bit, NVIDIA CUDA, portable | [`2026-08-14-windows64.nvidia.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-14.1/2026-08-14-windows64.nvidia.portable.zip) |
+| Windows 64-bit, NVIDIA CUDA installer | [`2026-08-14-windows64.nvidia.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-14.1/2026-08-14-windows64.nvidia.installer.exe) |
+| Windows 64-bit, RTX 5070/5080/5090, portable | [`2026-08-14-windows64.nvidia50.cuda.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-14.1/2026-08-14-windows64.nvidia50.cuda.portable.zip) |
+| Advanced optional TensorRT split package; download every part | [`2026-08-14-windows64.nvidia.tensorrt.portable.7z.001`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-14.1/2026-08-14-windows64.nvidia.tensorrt.portable.7z.001)<br>[`2026-08-14-windows64.nvidia.tensorrt.portable.7z.002`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-14.1/2026-08-14-windows64.nvidia.tensorrt.portable.7z.002) |
+| Windows 64-bit, RTX 50 CUDA installer | [`2026-08-14-windows64.nvidia50.cuda.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-14.1/2026-08-14-windows64.nvidia50.cuda.installer.exe) |
+| Windows 64-bit, configure your own engine, portable | [`2026-08-14-windows64.without.engine.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-14.1/2026-08-14-windows64.without.engine.portable.zip) |
+| Windows 64-bit, configure your own engine, installer | [`2026-08-14-windows64.without.engine.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-14.1/2026-08-14-windows64.without.engine.installer.exe) |
+| macOS Apple Silicon | [`2026-08-14-mac-apple-silicon.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-14.1/2026-08-14-mac-apple-silicon.with-katago.dmg) |
+| macOS Intel | [`2026-08-14-mac-intel.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-14.1/2026-08-14-mac-intel.with-katago.dmg) |
+| Linux 64-bit, CPU fallback | [`2026-08-14-linux64.with-katago.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-14.1/2026-08-14-linux64.with-katago.zip) |
+| Linux 64-bit, OpenCL | [`2026-08-14-linux64.opencl.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-14.1/2026-08-14-linux64.opencl.zip) |
+| Linux 64-bit, NVIDIA CUDA | [`2026-08-14-linux64.nvidia.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-14.1/2026-08-14-linux64.nvidia.zip) |
+
+### Why Test This Release
+
+- The complete JDK 21 suite passed `2,224` tests with `0` failures and `0` errors. Windows-specific scripts, shaded packaging, and release-packaging guards also passed.
+- A Windows 11 RTX 3070 Laptop system showed the bundled engine process within five seconds on the first launch, with no restart required. TensorRT/CUDA curves produced their first segment in about one second and completed in about eight seconds; Zhizi remote curves also completed and survived pause, resume, and switching back to local analysis.
+- The real Windows EXE was retested with OpenCL, Alt+O board sync, native and web Yike flows, missing-engine repair, all six languages, and 100%/150%/200% scaling without blocking dialogs, clipped primary controls, or unexpected component downloads.
+- The release pipeline audits filenames, versions, signatures or runtime structure, and SHA-256 for every Windows, macOS, and Linux artifact before publication.
+
+### Contact
+
+- QQ group: `299419120`
+
+---
+
+## 日本語
+
+`next-2026-08-13.1` に続く Windows 安定性プレリリースです。TensorRT の初回起動、自動クイック勝率曲線、リモート計算の復帰、engine・SGF 切り替え、6 言語の高 DPI レイアウトを改善しました。
+
+### 主な更新
+
+- 新規または移行済みの Windows TensorRT portable で、初回起動時に engine が読み込まれず再起動が必要になる問題を修正しました。起動方式が一度も明示されていない場合だけ有効な既定 engine を選び、「engine なし」、手動、前回使用の設定は保持します。
+- 自動クイック曲線は、起動済みの TensorRT、NVIDIA CUDA、または智子 remote foreground engine を安全に再利用します。2 個目の TensorRT process や timing cache を cold start せず、global の engine 再利用設定も変更しません。
+- parameter 読み取り timeout、rules dialog、背景 movelist refresh を、それぞれを作成した engine または board-history generation に結び付けました。古い task が新しい engine を消去したり、新しい SGF を変更したり、切り替え後の解析を止めたりしません。
+- 点を含む `nvidia.tensorrt` 名を含め、TensorRT package 種別と KataGo version metadata の検出を改善しました。release packaging は表示 metadata を採用する前に実 binary version を確認します。
+- Windows 100%、150%、200% scaling でタイ語の一括設定 sidebar が切れる問題を修正しました。幅は localized font metrics から計算され、主要 dialog の Esc と keyboard 操作も補完しました。
+
+### ダウンロード前に
+
+- 既存 Windows portable は `windows64.core-update.zip` でアプリを更新できます。full package は現在の公式 engine、weight、runtime を維持し、release audit を強化しています。
+- 多くの Windows 利用者には OpenCL portable を推奨します。NVIDIA は GPU 世代に合う NVIDIA または RTX 50 CUDA package を選んでください。
+- 自動クイック曲線は現在利用可能な local または remote engine を選びます。手動の全局解析、remote 設定、custom weight の動作は変わりません。
+- これは pre-release です。まずコピーを更新し、`user-data`、custom weight、棋譜を backup してください。
+
+### ダウンロード案内
+
+| お使いの環境 | ダウンロードするファイル |
+| --- | --- |
+| Windows 64-bit、OpenCL 推奨 portable | [`2026-08-14-windows64.opencl.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-14.1/2026-08-14-windows64.opencl.portable.zip) |
+| 既存 Windows portable、アプリ本体のみ更新 | [`2026-08-14-windows64.core-update.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-14.1/2026-08-14-windows64.core-update.zip) |
+| Windows 64-bit、OpenCL installer | [`2026-08-14-windows64.opencl.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-14.1/2026-08-14-windows64.opencl.installer.exe) |
+| Windows 64-bit、CPU fallback portable | [`2026-08-14-windows64.with-katago.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-14.1/2026-08-14-windows64.with-katago.portable.zip) |
+| Windows 64-bit、CPU fallback installer | [`2026-08-14-windows64.with-katago.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-14.1/2026-08-14-windows64.with-katago.installer.exe) |
+| Windows 64-bit、NVIDIA CUDA portable | [`2026-08-14-windows64.nvidia.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-14.1/2026-08-14-windows64.nvidia.portable.zip) |
+| Windows 64-bit、NVIDIA CUDA installer | [`2026-08-14-windows64.nvidia.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-14.1/2026-08-14-windows64.nvidia.installer.exe) |
+| Windows 64-bit、RTX 5070/5080/5090 portable | [`2026-08-14-windows64.nvidia50.cuda.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-14.1/2026-08-14-windows64.nvidia50.cuda.portable.zip) |
+| 上級者向け TensorRT 分割 package、全 part が必要 | [`2026-08-14-windows64.nvidia.tensorrt.portable.7z.001`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-14.1/2026-08-14-windows64.nvidia.tensorrt.portable.7z.001)<br>[`2026-08-14-windows64.nvidia.tensorrt.portable.7z.002`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-14.1/2026-08-14-windows64.nvidia.tensorrt.portable.7z.002) |
+| Windows 64-bit、RTX 50 CUDA installer | [`2026-08-14-windows64.nvidia50.cuda.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-14.1/2026-08-14-windows64.nvidia50.cuda.installer.exe) |
+| Windows 64-bit、engine を自分で設定、portable | [`2026-08-14-windows64.without.engine.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-14.1/2026-08-14-windows64.without.engine.portable.zip) |
+| Windows 64-bit、engine を自分で設定、installer | [`2026-08-14-windows64.without.engine.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-14.1/2026-08-14-windows64.without.engine.installer.exe) |
+| macOS Apple Silicon | [`2026-08-14-mac-apple-silicon.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-14.1/2026-08-14-mac-apple-silicon.with-katago.dmg) |
+| macOS Intel | [`2026-08-14-mac-intel.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-14.1/2026-08-14-mac-intel.with-katago.dmg) |
+| Linux 64-bit、CPU fallback | [`2026-08-14-linux64.with-katago.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-14.1/2026-08-14-linux64.with-katago.zip) |
+| Linux 64-bit、OpenCL | [`2026-08-14-linux64.opencl.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-14.1/2026-08-14-linux64.opencl.zip) |
+| Linux 64-bit、NVIDIA CUDA | [`2026-08-14-linux64.nvidia.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-14.1/2026-08-14-linux64.nvidia.zip) |
+
+### このリリースを試す理由
+
+- JDK 21 full suite は `2224` tests、`0` failure、`0` error で、Windows 専用 script、shaded jar、release packaging guard も成功しました。
+- Windows 11、RTX 3070 Laptop 実機で、初回起動 5 秒以内に内蔵 engine process が現れ、再起動不要であることを確認しました。TensorRT/CUDA 曲線は約 1 秒で最初の区間、約 8 秒で全体が完成し、智子 remote 曲線も pause、resume、local への復帰を含め完了しました。
+- 実際の Windows EXE で OpenCL、Alt+O board sync、弈客 native/web、engine 欠落修復、6 言語、100%/150%/200% scaling を再確認し、blocking dialog、主要 control の切れ、不要な component download はありませんでした。
+- 公開前に release pipeline が Windows、macOS、Linux の全成果物についてファイル名、version、署名または runtime 構造、SHA-256 を検査します。
+
+### 連絡先
+
+- QQ group: `299419120`
+
+---
+
+## 한국어
+
+`next-2026-08-13.1` 이후의 Windows 안정성 pre-release입니다. TensorRT 최초 실행, 자동 빠른 승률 곡선, 원격 연산 복구, engine 및 SGF 전환, 6개 언어 고해상도 UI를 개선했습니다.
+
+### 주요 업데이트
+
+- 새로 설치했거나 이전 설정을 옮긴 Windows TensorRT portable에서 첫 실행 때 engine이 로드되지 않아 다시 실행해야 하던 문제를 수정했습니다. 시작 방식을 한 번도 명시하지 않은 경우에만 유효한 기본 engine을 선택하며, 명시적 engine 없음, 수동 선택, 마지막 사용 모드는 유지합니다.
+- 자동 빠른 곡선은 이미 실행 중인 TensorRT, NVIDIA CUDA 또는 智子 remote foreground engine을 안전하게 재사용합니다. 두 번째 TensorRT process나 timing cache를 cold start하지 않고 사용자의 global engine 재사용 설정도 바꾸지 않습니다.
+- parameter 읽기 timeout, rules dialog, background movelist refresh를 생성 당시의 engine 또는 board-history generation에 연결했습니다. 오래된 task가 교체된 engine을 지우거나 새 SGF를 수정하거나 전환 후 분석을 멈추게 하지 않습니다.
+- 점이 포함된 `nvidia.tensorrt` 이름을 포함해 TensorRT package 유형과 KataGo version metadata 감지를 개선했습니다. release packaging은 표시 metadata를 채택하기 전에 실제 binary version을 확인합니다.
+- Windows 100%, 150%, 200% scaling에서 태국어 one-click setup sidebar가 잘리던 문제를 수정했습니다. localized font metrics에 따라 폭을 계산하며 주요 dialog의 Esc 및 keyboard 경로도 보완했습니다.
+
+### 다운로드 전 확인
+
+- 기존 Windows portable은 `windows64.core-update.zip`으로 앱을 업데이트할 수 있습니다. full package는 현재 공식 engine, weight, runtime을 유지하면서 release audit을 강화했습니다.
+- 대부분의 Windows 사용자는 OpenCL portable을 권장합니다. NVIDIA 사용자는 GPU 세대에 맞는 NVIDIA 또는 RTX 50 CUDA package를 선택하세요.
+- 자동 빠른 곡선은 현재 사용 가능한 local 또는 remote engine을 선택합니다. 수동 전체 분석, remote 설정, custom weight 동작은 그대로 유지됩니다.
+- 이것은 pre-release입니다. 먼저 복사본을 업데이트하고 `user-data`, custom weight, 기보를 backup하세요.
+
+### 다운로드 안내
+
+| 환경 | 다운로드할 파일 |
+| --- | --- |
+| Windows 64-bit, OpenCL 권장 portable | [`2026-08-14-windows64.opencl.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-14.1/2026-08-14-windows64.opencl.portable.zip) |
+| 기존 Windows portable, 앱만 업데이트 | [`2026-08-14-windows64.core-update.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-14.1/2026-08-14-windows64.core-update.zip) |
+| Windows 64-bit, OpenCL installer | [`2026-08-14-windows64.opencl.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-14.1/2026-08-14-windows64.opencl.installer.exe) |
+| Windows 64-bit, CPU portable | [`2026-08-14-windows64.with-katago.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-14.1/2026-08-14-windows64.with-katago.portable.zip) |
+| Windows 64-bit, CPU installer | [`2026-08-14-windows64.with-katago.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-14.1/2026-08-14-windows64.with-katago.installer.exe) |
+| Windows 64-bit, NVIDIA CUDA portable | [`2026-08-14-windows64.nvidia.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-14.1/2026-08-14-windows64.nvidia.portable.zip) |
+| Windows 64-bit, NVIDIA CUDA installer | [`2026-08-14-windows64.nvidia.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-14.1/2026-08-14-windows64.nvidia.installer.exe) |
+| Windows 64-bit, RTX 5070/5080/5090 portable | [`2026-08-14-windows64.nvidia50.cuda.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-14.1/2026-08-14-windows64.nvidia50.cuda.portable.zip) |
+| 고급 선택: TensorRT 분할 package, 모든 part 필요 | [`2026-08-14-windows64.nvidia.tensorrt.portable.7z.001`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-14.1/2026-08-14-windows64.nvidia.tensorrt.portable.7z.001)<br>[`2026-08-14-windows64.nvidia.tensorrt.portable.7z.002`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-14.1/2026-08-14-windows64.nvidia.tensorrt.portable.7z.002) |
+| Windows 64-bit, RTX 50 CUDA installer | [`2026-08-14-windows64.nvidia50.cuda.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-14.1/2026-08-14-windows64.nvidia50.cuda.installer.exe) |
+| Windows 64-bit, 직접 engine 설정, portable | [`2026-08-14-windows64.without.engine.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-14.1/2026-08-14-windows64.without.engine.portable.zip) |
+| Windows 64-bit, 직접 engine 설정, installer | [`2026-08-14-windows64.without.engine.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-14.1/2026-08-14-windows64.without.engine.installer.exe) |
+| macOS Apple Silicon | [`2026-08-14-mac-apple-silicon.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-14.1/2026-08-14-mac-apple-silicon.with-katago.dmg) |
+| macOS Intel | [`2026-08-14-mac-intel.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-14.1/2026-08-14-mac-intel.with-katago.dmg) |
+| Linux 64-bit, CPU | [`2026-08-14-linux64.with-katago.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-14.1/2026-08-14-linux64.with-katago.zip) |
+| Linux 64-bit, OpenCL | [`2026-08-14-linux64.opencl.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-14.1/2026-08-14-linux64.opencl.zip) |
+| Linux 64-bit, NVIDIA CUDA | [`2026-08-14-linux64.nvidia.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-14.1/2026-08-14-linux64.nvidia.zip) |
+
+### 이 릴리스를 테스트할 이유
+
+- JDK 21 full suite는 `2224` tests, `0` failure, `0` error이며 Windows 전용 script, shaded jar, release packaging guard도 통과했습니다.
+- Windows 11 RTX 3070 Laptop 실기에서 최초 실행 5초 이내에 내장 engine process가 나타나 재실행이 필요 없었습니다. TensorRT/CUDA 곡선은 약 1초에 첫 구간, 약 8초에 전체가 완성되었고, 智子 remote 곡선도 pause, resume, local 전환까지 정상 완료했습니다.
+- 실제 Windows EXE로 OpenCL, Alt+O board sync, 弈客 native/web, engine 누락 복구, 6개 언어, 100%/150%/200% scaling을 재검증했으며 blocking dialog, 주요 control 잘림, 예기치 않은 component download가 없었습니다.
+- 공개 전 release pipeline이 모든 Windows, macOS, Linux 산출물의 파일명, version, 서명 또는 runtime 구조와 SHA-256을 검사합니다.
+
+### 연락처
+
+- QQ 그룹：`299419120`
+
+---
+
+## ภาษาไทย
+
+นี่คือ Windows stability pre-release หลัง `next-2026-08-13.1` โดยเน้นการเริ่ม TensorRT ครั้งแรก กราฟ win-rate แบบเร็วอัตโนมัติ การกลับมาทำงานของ remote compute การสลับ engine/SGF และ UI หกภาษาบน high-DPI
+
+### ไฮไลต์ของเวอร์ชันนี้
+
+- แก้ Windows TensorRT portable ที่ติดตั้งใหม่หรือย้ายค่ามาแล้วไม่โหลด engine ในการเปิดครั้งแรกจนต้องเปิดซ้ำ ระบบจะเลือก default engine เฉพาะเมื่อผู้ใช้ไม่เคยระบุ startup mode และจะคงโหมด no engine, manual และ last-used ที่เลือกไว้
+- กราฟเร็วอัตโนมัติใช้ TensorRT, NVIDIA CUDA หรือ 智子 remote foreground engine ที่ทำงานอยู่ได้อย่างปลอดภัย จึงไม่ cold-start TensorRT process หรือ timing cache ชุดที่สอง และไม่แก้ global engine-reuse preference ของผู้ใช้
+- parameter-read timeout, rules dialog และ background movelist refresh ถูกผูกกับ engine หรือ board-history generation ที่สร้างงานนั้น งานเก่าจึงไม่ล้าง engine ใหม่ แก้ SGF ที่เพิ่งเปิด หรือทำให้ analysis หยุดหลังสลับ
+- ปรับการตรวจชนิด TensorRT package และ KataGo version metadata รวมถึงชื่อแบบมีจุด `nvidia.tensorrt` และให้ release packaging ตรวจ binary version จริงก่อนยอมรับข้อความ version
+- แก้ sidebar ของ one-click setup ภาษาไทยถูกตัดที่ Windows scaling 100%, 150% และ 200% โดยคำนวณความกว้างจาก localized font metrics พร้อมเติมเส้นทาง Esc และ keyboard ให้ dialog หลัก
+
+### ก่อนดาวน์โหลด
+
+- ผู้ใช้ Windows portable เดิมอัปเดตแอปด้วย `windows64.core-update.zip` ได้ ส่วน full package ยังคง official engine, weight และ runtime ปัจจุบัน พร้อม release audit ที่เข้มงวดขึ้น
+- ผู้ใช้ Windows ส่วนใหญ่แนะนำ OpenCL portable ส่วน NVIDIA ให้เลือก NVIDIA หรือ RTX 50 CUDA ตามรุ่น GPU
+- กราฟเร็วอัตโนมัติจะเลือก local หรือ remote engine ที่พร้อมใช้งาน ส่วน manual whole-game analysis, remote settings และ custom weight ทำงานเหมือนเดิม
+- นี่คือ pre-release ควรอัปเดตสำเนาก่อน และ backup `user-data`, custom weight และ kifu
+
+### คู่มือดาวน์โหลด
+
+| คอมพิวเตอร์ของคุณ | ดาวน์โหลดไฟล์นี้ |
+| --- | --- |
+| Windows 64-bit, OpenCL แนะนำ, portable | [`2026-08-14-windows64.opencl.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-14.1/2026-08-14-windows64.opencl.portable.zip) |
+| มี Windows portable แล้ว อัปเดตเฉพาะโปรแกรม | [`2026-08-14-windows64.core-update.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-14.1/2026-08-14-windows64.core-update.zip) |
+| Windows 64-bit, OpenCL installer | [`2026-08-14-windows64.opencl.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-14.1/2026-08-14-windows64.opencl.installer.exe) |
+| Windows 64-bit, CPU portable | [`2026-08-14-windows64.with-katago.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-14.1/2026-08-14-windows64.with-katago.portable.zip) |
+| Windows 64-bit, CPU installer | [`2026-08-14-windows64.with-katago.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-14.1/2026-08-14-windows64.with-katago.installer.exe) |
+| Windows 64-bit, NVIDIA CUDA portable | [`2026-08-14-windows64.nvidia.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-14.1/2026-08-14-windows64.nvidia.portable.zip) |
+| Windows 64-bit, NVIDIA CUDA installer | [`2026-08-14-windows64.nvidia.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-14.1/2026-08-14-windows64.nvidia.installer.exe) |
+| Windows 64-bit, RTX 5070/5080/5090 portable | [`2026-08-14-windows64.nvidia50.cuda.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-14.1/2026-08-14-windows64.nvidia50.cuda.portable.zip) |
+| ตัวเลือกขั้นสูง TensorRT แบบแบ่งส่วน ต้องดาวน์โหลดทุกส่วน | [`2026-08-14-windows64.nvidia.tensorrt.portable.7z.001`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-14.1/2026-08-14-windows64.nvidia.tensorrt.portable.7z.001)<br>[`2026-08-14-windows64.nvidia.tensorrt.portable.7z.002`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-14.1/2026-08-14-windows64.nvidia.tensorrt.portable.7z.002) |
+| Windows 64-bit, RTX 50 CUDA installer | [`2026-08-14-windows64.nvidia50.cuda.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-14.1/2026-08-14-windows64.nvidia50.cuda.installer.exe) |
+| Windows 64-bit, ตั้งค่า engine เอง, portable | [`2026-08-14-windows64.without.engine.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-14.1/2026-08-14-windows64.without.engine.portable.zip) |
+| Windows 64-bit, ตั้งค่า engine เอง, installer | [`2026-08-14-windows64.without.engine.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-14.1/2026-08-14-windows64.without.engine.installer.exe) |
+| macOS Apple Silicon | [`2026-08-14-mac-apple-silicon.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-14.1/2026-08-14-mac-apple-silicon.with-katago.dmg) |
+| macOS Intel | [`2026-08-14-mac-intel.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-14.1/2026-08-14-mac-intel.with-katago.dmg) |
+| Linux 64-bit, CPU | [`2026-08-14-linux64.with-katago.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-14.1/2026-08-14-linux64.with-katago.zip) |
+| Linux 64-bit, OpenCL | [`2026-08-14-linux64.opencl.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-14.1/2026-08-14-linux64.opencl.zip) |
+| Linux 64-bit, NVIDIA CUDA | [`2026-08-14-linux64.nvidia.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-14.1/2026-08-14-linux64.nvidia.zip) |
+
+### ทำไมควรทดสอบเวอร์ชันนี้
+
+- full JDK 21 suite ผ่าน `2224` tests โดยมี `0` failure และ `0` error พร้อม Windows-specific scripts, shaded jar และ release packaging guards
+- เครื่องจริง Windows 11 RTX 3070 Laptop พบ bundled engine process ภายใน 5 วินาทีในการเปิดครั้งแรกโดยไม่ต้อง restart กราฟ TensorRT/CUDA แสดงช่วงแรกประมาณ 1 วินาทีและเสร็จประมาณ 8 วินาที ส่วนกราฟ 智子 remote ก็ทำงานจบและรองรับ pause, resume และกลับสู่ local
+- ทดสอบ Windows EXE จริงกับ OpenCL, Alt+O board sync, 弈客 native/web, การซ่อม engine ที่หาย, หกภาษา และ scaling 100%/150%/200% โดยไม่พบ blocking dialog, control หลักถูกตัด หรือการดาวน์โหลด component ที่ไม่คาดคิด
+- ก่อนเผยแพร่ release pipeline จะตรวจชื่อไฟล์ version ลายเซ็นหรือโครงสร้าง runtime และ SHA-256 ของไฟล์ Windows, macOS และ Linux ทุกไฟล์
+
+### ติดต่อ
+
+- กลุ่ม QQ: `299419120`

--- a/.github/release-requests/next-2026-08-14.1.json
+++ b/.github/release-requests/next-2026-08-14.1.json
@@ -1,0 +1,7 @@
+{
+  "date_tag": "2026-08-14",
+  "release_tag": "next-2026-08-14.1",
+  "title": "LizzieYzy Next next-2026-08-14.1",
+  "prerelease": true,
+  "notes_file": ".github/release-notes/next-2026-08-14.1.md"
+}


### PR DESCRIPTION
## Release request

Prepare the audited multi-platform pre-release `next-2026-08-14.1` from current `main`.

This release includes the changes merged through PR #260, including:

- first-session TensorRT engine autoload and package metadata auditing
- automatic quick curves using the active TensorRT/CUDA or Zhizi remote foreground engine
- safer engine timeout, rules-dialog, and SGF/background-refresh lifecycles
- TensorRT dotted package-flavor detection
- Thai one-click-setup layout at Windows 100%, 150%, and 200% scaling
- keyboard and Escape behavior for primary dialogs

## Release notes

- Six reviewed language sections: Simplified Chinese, Traditional Chinese, English, Japanese, Korean, and Thai
- Direct links for every expected Windows, macOS, and Linux artifact
- User-facing download guidance and exact Windows acceptance results
- Exact test count updated to 2,224

## Validation

- Release request parser and six-language direct-download-table validation: passed
- `python scripts/test_publish_release_request.py`: 22 tests, 0 failures, 1 platform skip
- `python -m unittest discover -s scripts -p 'test_*.py' -v`: 73 tests, 0 failures/errors, 2 platform skips
- `python scripts/check_line_endings.py`: passed
- `python scripts/check_markdown_links.py`: passed
- `git diff --check`: passed

After this PR passes CI and is merged, `publish-requested-pre-release.yml` will create a draft, build all four platform jobs, audit the complete asset set, install the six-language notes, and only then publish the GitHub pre-release.