### PR TITLE
Fix HumanSL startup after portable app upgrades

### DIFF
--- a/src/main/java/featurecat/lizzie/gui/NewHumanSlGameDialog.java
+++ b/src/main/java/featurecat/lizzie/gui/NewHumanSlGameDialog.java
@@ -2,6 +2,7 @@ package featurecat.lizzie.gui;
 
 import featurecat.lizzie.Lizzie;
 import featurecat.lizzie.analysis.HumanSlAnalysisRunner;
+import featurecat.lizzie.util.AnalysisEngineCommandHelper;
 import featurecat.lizzie.util.KataGoAutoSetupHelper;
 import featurecat.lizzie.util.KataGoAutoSetupHelper.DownloadCancelledException;
 import featurecat.lizzie.util.Utils;
@@ -222,11 +223,12 @@ public final class NewHumanSlGameDialog extends JDialog {
   }
 
   private boolean startConfiguredGame(Path modelPath) {
-    String command = resolveAnalysisCommand();
-    if (command.trim().isEmpty()) {
+    AnalysisEngineCommandHelper.Result commandResult = resolveAnalysisCommand();
+    if (!commandResult.isSuccess()) {
       Utils.showMsg(resourceBundle.getString("HumanSlGame.error.noEngine"));
       return false;
     }
+    String command = commandResult.getCommand();
     HumanSlAnalysisRunner runner = new HumanSlAnalysisRunner(command, modelPath);
     if (!runner.start()) {
       Utils.showMsg(
@@ -259,12 +261,9 @@ public final class NewHumanSlGameDialog extends JDialog {
     return true;
   }
 
-  private String resolveAnalysisCommand() {
-    if (Lizzie.config == null) {
-      return "";
-    }
-    String command = Lizzie.config.analysisEngineCommand;
-    return command == null ? "" : command;
+  private AnalysisEngineCommandHelper.Result resolveAnalysisCommand() {
+    String command = Lizzie.config == null ? "" : Lizzie.config.analysisEngineCommand;
+    return AnalysisEngineCommandHelper.resolveHumanSlCommand(command);
   }
 
   public boolean isCancelled() {

--- a/src/main/java/featurecat/lizzie/util/AnalysisEngineCommandHelper.java
+++ b/src/main/java/featurecat/lizzie/util/AnalysisEngineCommandHelper.java
@@ -1,5 +1,6 @@
 package featurecat.lizzie.util;
 
+import featurecat.lizzie.Config;
 import featurecat.lizzie.Lizzie;
 import featurecat.lizzie.gui.EngineData;
 import java.io.IOException;
@@ -90,6 +91,56 @@ public final class AnalysisEngineCommandHelper {
     return fromDefaultEngine(engines);
   }
 
+  /**
+   * Returns a usable local analysis command for HumanSL without changing the user's saved engine
+   * choice. Release upgrades can relocate the bundled KataGo executable while an older absolute
+   * command remains in the profile. In that case HumanSL should use the current bundle rather than
+   * fail with the stale path. Valid external commands are intentionally left untouched.
+   */
+  public static Result resolveHumanSlCommand(String configuredCommand) {
+    KataGoAutoSetupHelper.SetupSnapshot snapshot = KataGoAutoSetupHelper.inspectLocalSetup();
+    return resolveHumanSlCommand(
+        configuredCommand,
+        snapshot == null ? null : snapshot.enginePath,
+        snapshot == null ? null : snapshot.analysisConfigPath,
+        snapshot == null ? null : snapshot.activeWeightPath);
+  }
+
+  static Result resolveHumanSlCommand(
+      String configuredCommand, Path enginePath, Path analysisConfigPath, Path weightPath) {
+    String command = configuredCommand == null ? "" : configuredCommand.trim();
+    if (!needsBundledRecovery(command)) {
+      return command.isEmpty()
+          ? Result.failure(message("AnalysisEngineCommandHelper.noEngineSelected"))
+          : Result.success(command, "", false, null);
+    }
+    if (!isRegularFile(enginePath)
+        || !isRegularFile(analysisConfigPath)
+        || !isRegularFile(weightPath)) {
+      return Result.failure(message("AnalysisEngineCommandHelper.noEngineSelected"));
+    }
+
+    List<String> parts = Utils.splitCommand(command);
+    if (parts.isEmpty()) {
+      parts.add(enginePath.toAbsolutePath().normalize().toString());
+      parts.add("analysis");
+    } else {
+      parts.set(0, enginePath.toAbsolutePath().normalize().toString());
+      int modeIndex = findAnalysisModeIndex(parts);
+      if (modeIndex >= 0) {
+        parts.set(modeIndex, "analysis");
+      } else {
+        parts.add(1, "analysis");
+      }
+    }
+    setOrAppendOption(parts, "-model", "--model", weightPath);
+    setOrAppendOption(parts, "-config", "--config", analysisConfigPath);
+    if (!containsToken(parts, "-quit-without-waiting")) {
+      parts.add("-quit-without-waiting");
+    }
+    return Result.success(buildCommandLine(parts), "", false, analysisConfigPath);
+  }
+
   public static Path ensureAnalysisConfig(Path gtpConfigPath) throws IOException {
     if (gtpConfigPath == null || !Files.isRegularFile(gtpConfigPath)) {
       throw new IOException(message("AnalysisEngineCommandHelper.missingConfig"));
@@ -122,6 +173,74 @@ public final class AnalysisEngineCommandHelper {
       }
     }
     return -1;
+  }
+
+  private static int findAnalysisModeIndex(List<String> command) {
+    for (int i = 1; i < command.size(); i++) {
+      String token = command.get(i);
+      if ("analysis".equalsIgnoreCase(token) || "gtp".equalsIgnoreCase(token)) {
+        return i;
+      }
+    }
+    return -1;
+  }
+
+  private static boolean needsBundledRecovery(String command) {
+    if (command == null || command.trim().isEmpty()) {
+      return true;
+    }
+    if (normalizeCommand(command).equals(normalizeCommand(DEFAULT_ANALYSIS_COMMAND))) {
+      return true;
+    }
+    if (!Config.isBundledKataGoCommand(command)) {
+      return false;
+    }
+    List<String> parts = Utils.splitCommand(command);
+    if (parts.isEmpty()) {
+      return true;
+    }
+    Path executable = KataGoRuntimeHelper.resolveCommandExecutable(parts);
+    return !isRegularFile(executable)
+        || !isRegularFile(optionPath(parts, "-model", "--model"))
+        || !isRegularFile(optionPath(parts, "-config", "--config"));
+  }
+
+  private static Path optionPath(List<String> command, String shortOption, String longOption) {
+    for (int i = 0; i < command.size() - 1; i++) {
+      String token = command.get(i);
+      if (shortOption.equals(token) || longOption.equals(token)) {
+        try {
+          Path path = Path.of(command.get(i + 1));
+          return path.isAbsolute()
+              ? path.toAbsolutePath().normalize()
+              : Path.of(System.getProperty("user.dir", "."))
+                  .resolve(path)
+                  .toAbsolutePath()
+                  .normalize();
+        } catch (RuntimeException e) {
+          return null;
+        }
+      }
+    }
+    return null;
+  }
+
+  private static void setOrAppendOption(
+      List<String> command, String shortOption, String longOption, Path value) {
+    String normalizedValue = value.toAbsolutePath().normalize().toString();
+    for (int i = 0; i < command.size() - 1; i++) {
+      String token = command.get(i);
+      if (shortOption.equals(token) || longOption.equals(token)) {
+        command.set(i + 1, normalizedValue);
+        return;
+      }
+    }
+    command.add(shortOption);
+    command.add(normalizedValue);
+  }
+
+  private static boolean isRegularFile(Path path) {
+    return path != null && Files.isRegularFile(path);
   }
 
   private static String normalizeCommand(String command) {

--- a/src/test/java/featurecat/lizzie/util/AnalysisEngineCommandHelperTest.java
+++ b/src/test/java/featurecat/lizzie/util/AnalysisEngineCommandHelperTest.java
@@ -212,6 +212,121 @@ class AnalysisEngineCommandHelperTest {
   }
 
   @Test
+  void humanSlRebasesAStaleBundledCommandToTheCurrentInstallation() throws Exception {
+    Path currentRoot = tempDir.resolve("当前 LizzieYzy Next.app").resolve("Contents").resolve("app");
+    Path engine = writeFile(currentRoot.resolve("engines/katago/macos-arm64/katago"));
+    Path config = writeFile(currentRoot.resolve("engines/katago/configs/analysis.cfg"));
+    Path weight = writeFile(currentRoot.resolve("weights/default.bin.gz"));
+    Path staleRoot = tempDir.resolve("old build").resolve("LizzieYzy Next.app/Contents/app");
+    String staleCommand =
+        quote(staleRoot.resolve("engines/katago/macos-arm64/katago"))
+            + " analysis -model "
+            + quote(staleRoot.resolve("weights/default.bin.gz"))
+            + " -config "
+            + quote(staleRoot.resolve("engines/katago/configs/analysis.cfg"))
+            + " -analysis-threads 3";
+
+    AnalysisEngineCommandHelper.Result result =
+        AnalysisEngineCommandHelper.resolveHumanSlCommand(staleCommand, engine, config, weight);
+
+    assertTrue(result.isSuccess(), result.getMessage());
+    List<String> parts = Utils.splitCommand(result.getCommand());
+    assertEquals(engine.toString(), parts.get(0));
+    assertEquals("analysis", parts.get(1));
+    assertEquals(weight.toString(), parts.get(parts.indexOf("-model") + 1));
+    assertEquals(config.toString(), parts.get(parts.indexOf("-config") + 1));
+    assertTrue(parts.contains("-analysis-threads"));
+    assertTrue(parts.contains("-quit-without-waiting"));
+  }
+
+  @Test
+  void humanSlNeverMixesAStaleEngineAndConfigWithTheCurrentBundledWeight() throws Exception {
+    Path currentRoot = tempDir.resolve("installed app");
+    Path engine = writeFile(currentRoot.resolve("engines/katago/macos-arm64/katago"));
+    Path config = writeFile(currentRoot.resolve("engines/katago/configs/analysis.cfg"));
+    Path weight = writeFile(currentRoot.resolve("weights/default.bin.gz"));
+    Path staleRoot = tempDir.resolve("deleted developer app image");
+    String mixedCommand =
+        quote(staleRoot.resolve("engines/katago/macos-arm64/katago"))
+            + " analysis -model "
+            + quote(weight)
+            + " -config "
+            + quote(staleRoot.resolve("engines/katago/configs/analysis.cfg"))
+            + " -quit-without-waiting";
+
+    AnalysisEngineCommandHelper.Result result =
+        AnalysisEngineCommandHelper.resolveHumanSlCommand(mixedCommand, engine, config, weight);
+
+    assertTrue(result.isSuccess(), result.getMessage());
+    List<String> parts = Utils.splitCommand(result.getCommand());
+    assertEquals(engine.toString(), parts.get(0));
+    assertEquals(weight.toString(), parts.get(parts.indexOf("-model") + 1));
+    assertEquals(config.toString(), parts.get(parts.indexOf("-config") + 1));
+    assertFalse(result.getCommand().contains(staleRoot.toString()));
+  }
+
+  @Test
+  void humanSlKeepsAWorkingExternalAnalysisCommandUntouched() throws Exception {
+    Path engine = writeFile(tempDir.resolve("自定义引擎/katago"));
+    Path config = writeFile(tempDir.resolve("自定义引擎/analysis.cfg"));
+    Path weight = writeFile(tempDir.resolve("自定义权重/model.bin.gz"));
+    String customCommand =
+        quote(engine)
+            + " analysis -model "
+            + quote(weight)
+            + " -config "
+            + quote(config)
+            + " -custom-option enabled";
+
+    AnalysisEngineCommandHelper.Result result =
+        AnalysisEngineCommandHelper.resolveHumanSlCommand(
+            customCommand,
+            tempDir.resolve("unused/engines/katago/katago"),
+            tempDir.resolve("unused/analysis.cfg"),
+            tempDir.resolve("unused/default.bin.gz"));
+
+    assertTrue(result.isSuccess(), result.getMessage());
+    assertEquals(customCommand, result.getCommand());
+  }
+
+  @Test
+  void humanSlDoesNotReplaceAUserExternalCommandThatCannotBeFound() {
+    String customCommand =
+        quote(tempDir.resolve("missing custom/katago"))
+            + " analysis -model missing.bin.gz -config missing.cfg";
+
+    AnalysisEngineCommandHelper.Result result =
+        AnalysisEngineCommandHelper.resolveHumanSlCommand(
+            customCommand,
+            tempDir.resolve("current/engines/katago/katago"),
+            tempDir.resolve("current/analysis.cfg"),
+            tempDir.resolve("current/default.bin.gz"));
+
+    assertTrue(result.isSuccess(), result.getMessage());
+    assertEquals(customCommand, result.getCommand());
+  }
+
+  @Test
+  void humanSlReportsNoEngineWhenBundledRecoveryIsIncomplete() {
+    String staleCommand =
+        quote(tempDir.resolve("old/engines/katago/macos-arm64/katago"))
+            + " analysis -model "
+            + quote(tempDir.resolve("old/weights/default.bin.gz"))
+            + " -config "
+            + quote(tempDir.resolve("old/engines/katago/configs/analysis.cfg"));
+
+    AnalysisEngineCommandHelper.Result result =
+        AnalysisEngineCommandHelper.resolveHumanSlCommand(
+            staleCommand,
+            tempDir.resolve("current/engines/katago/katago"),
+            tempDir.resolve("current/analysis.cfg"),
+            tempDir.resolve("current/default.bin.gz"));
+
+    assertFalse(result.isSuccess());
+    assertTrue(result.getCommand().isEmpty());
+  }
+
+  @Test
   void bundledAnalysisConfigTemplateIsAvailable() throws Exception {
     assertNotNull(
         AnalysisEngineCommandHelperTest.class
@@ -228,5 +343,10 @@ class AnalysisEngineCommandHelperTest {
 
   private static String quote(Path path) {
     return "\"" + path.toString() + "\"";
+  }
+
+  private static Path writeFile(Path path) throws Exception {
+    Files.createDirectories(path.getParent());
+    return Files.write(path, new byte[] {1});
   }
 }


### PR DESCRIPTION
## Summary

- Recover HumanSL startup when a portable or macOS app upgrade leaves the saved analysis command pointing at a removed previous bundle.
- Rebuild the HumanSL command atomically from the current local KataGo executable, active weight, and analysis configuration.
- Preserve valid or user-managed external engine commands without rewriting the saved engine configuration.
- Add regression coverage for stale bundled paths, mixed old/new paths, incomplete recovery, external engines, spaces, and Chinese paths.

## Root cause

The HumanSL model itself was valid, but the HumanSL game dialog launched the saved analysis command verbatim. After an app or portable-package upgrade, that command could still contain an absolute path to an old app bundle that no longer existed, so starting a ranked HumanSL game failed before the model could be used.

## Validation

- `git diff --check`: passed
- `python3 scripts/check_line_endings.py`: passed
- `python3 scripts/test_check_line_endings.py`: 6 passed
- `python3 scripts/check_markdown_links.py`: passed
- Focused HumanSL and command-helper tests: 25 passed
- Full Maven test suite: 2350 tests, 0 failures, 0 errors, 1 skipped
- `mvn -B -Dfmt.skip=true -DskipTests package`: passed
- macOS production resolver smoke: stale app-bundle command was rebased to the installed KataGo, weight, and analysis config
- Real KataGo 1.17.1 Metal + HumanSL request: model loaded and returned valid `humanPolicy`, `moveInfos`, and `rootInfo`

## Compatibility

This fix does not mutate the saved default engine, auto-load mode, or custom external KataGo command. It only recovers missing bundled paths for the HumanSL session.