### PR TITLE
fix(sgf): normalize Fox scaled komi

### DIFF
--- a/src/main/java/featurecat/lizzie/rules/SGFParser.java
+++ b/src/main/java/featurecat/lizzie/rules/SGFParser.java
@@ -202,37 +202,81 @@ public class SGFParser {
     if (Utils.isBlank(rawKomi)) {
       rawKomi = start.getData().getProperty("KO");
     }
-    return parseSgfKomi(rawKomi);
+    return parseSgfKomi(rawKomi, start.getData().getProperties());
   }
 
   private static Optional<Double> parseSgfKomi(String rawKomi) {
+    return parseSgfKomi(rawKomi, null);
+  }
+
+  private static Optional<Double> parseSgfKomi(String rawKomi, Map<String, String> rootProperties) {
     if (Utils.isBlank(rawKomi)) {
       return Optional.empty();
     }
     try {
       Double komi = Double.parseDouble(rawKomi.trim());
-      return normalizeSgfKomi(komi);
+      return normalizeSgfKomi(komi, rootProperties);
     } catch (NumberFormatException ignored) {
       return Optional.empty();
     }
   }
 
   private static Optional<Double> normalizeSgfKomi(Double komi) {
+    return normalizeSgfKomi(komi, null);
+  }
+
+  private static Optional<Double> normalizeSgfKomi(Double komi, Map<String, String> rootProperties) {
     if (komi == null) {
       return Optional.empty();
     }
+    komi =
+        isFoxSgf(rootProperties)
+            ? normalizeFoxSgfKomi(komi, rootProperties)
+            : normalizeLegacySgfKomi(komi);
+    return Math.abs(komi) < Board.boardWidth * Board.boardHeight
+        ? Optional.of(komi)
+        : Optional.empty();
+  }
+
+  private static double normalizeLegacySgfKomi(double komi) {
     if (komi >= 200) {
       komi = komi / 100;
       if (komi <= 4 && komi >= -4) {
         komi = komi * 2;
       }
     }
-    if (komi.toString().endsWith(".75") || komi.toString().endsWith(".25")) {
+    String komiText = Double.toString(komi);
+    if (komiText.endsWith(".75") || komiText.endsWith(".25")) {
       komi = komi * 2;
     }
-    return Math.abs(komi) < Board.boardWidth * Board.boardHeight
-        ? Optional.of(komi)
-        : Optional.empty();
+    return komi;
+  }
+
+  private static double normalizeFoxSgfKomi(double komi, Map<String, String> rootProperties) {
+    if (Math.abs(komi) >= 50) {
+      komi = komi / 100;
+      if (isChineseRules(rootProperties) && komi <= 4 && komi >= -4) {
+        komi = komi * 2;
+      }
+    }
+    return komi;
+  }
+
+  private static boolean isFoxSgf(Map<String, String> rootProperties) {
+    return rootPropertyContains(rootProperties, "AP", "foxwq");
+  }
+
+  private static boolean isChineseRules(Map<String, String> rootProperties) {
+    return rootPropertyContains(rootProperties, "RU", "chinese");
+  }
+
+  private static boolean rootPropertyContains(
+      Map<String, String> rootProperties, String propertyName, String needle) {
+    if (rootProperties == null) {
+      return false;
+    }
+    String value = rootProperties.get(propertyName);
+    return value != null && value.toLowerCase(Locale.ROOT).contains(needle);
   }
 
   private static void clearImportedAnalysisPayloads(BoardHistoryNode start) {
@@ -768,7 +812,8 @@ public class SGFParser {
       }
     }
     flushPendingSetupMetadataToCurrentNode(Lizzie.board.getHistory(), pendingSetupMetadata);
-    Optional<Double> parsedKomi = parsedKomiTag ? normalizeSgfKomi(komi) : Optional.empty();
+    Optional<Double> parsedKomi =
+        parsedKomiTag ? normalizeSgfKomi(komi, gameProperties) : Optional.empty();
     if (parsedKomi.isPresent()
         && (Lizzie.config.readKomi
             || isSetupOrHandicapGame(Lizzie.board.getHistory())
@@ -3730,8 +3775,8 @@ public class SGFParser {
     }
 
     String blackPlayer = "", whitePlayer = "";
-    Optional<Double> parsedKomi = Optional.empty();
-
+    Double komi = null;
+    boolean parsedKomiTag = false;
     // Support unicode characters (UTF-8)
     for (int i = 0; i < value.length(); i++) {
       char c = value.charAt(i);
@@ -3895,10 +3940,8 @@ public class SGFParser {
             if (firstTime) {
               try {
                 if (!tagContent.trim().isEmpty()) {
-                  parsedKomi = normalizeSgfKomi(Double.parseDouble(tagContent));
-                  if (Lizzie.config.readKomi && parsedKomi.isPresent()) {
-                    history.getGameInfo().setKomiNoMenu(parsedKomi.get());
-                  }
+                  komi = Double.parseDouble(tagContent);
+                  parsedKomiTag = true;
                 }
               } catch (NumberFormatException e) {
                 e.printStackTrace();
@@ -4035,9 +4078,12 @@ public class SGFParser {
         history.getData().addProperties(gameProperties);
       }
       stabilizeRootSetupSideToPlay(history);
-      if (!Lizzie.config.readKomi
-          && parsedKomi.isPresent()
-          && (isSetupOrHandicapGame(history) || parseHandicapProperty(gameProperties.get("HA")) > 0)) {
+      Optional<Double> parsedKomi =
+          parsedKomiTag ? normalizeSgfKomi(komi, gameProperties) : Optional.empty();
+      if (parsedKomi.isPresent()
+          && (Lizzie.config.readKomi
+              || isSetupOrHandicapGame(history)
+              || parseHandicapProperty(gameProperties.get("HA")) > 0)) {
         history.getGameInfo().setKomiNoMenu(parsedKomi.get());
       }
     }

--- a/src/test/java/featurecat/lizzie/rules/BoardNodeKindHistoryPipelineTest.java
+++ b/src/test/java/featurecat/lizzie/rules/BoardNodeKindHistoryPipelineTest.java
@@ -20,6 +20,7 @@ import featurecat.lizzie.gui.BoardRenderer;
 import featurecat.lizzie.gui.Input;
 import featurecat.lizzie.gui.LizzieFrame;
 import featurecat.lizzie.gui.Menu;
+import featurecat.lizzie.gui.SubBoardRenderer;
 import featurecat.lizzie.gui.VariationTree;
 import featurecat.lizzie.gui.VariationTreeBig;
 import featurecat.lizzie.gui.WinrateGraph;
@@ -451,6 +452,53 @@ class BoardNodeKindHistoryPipelineTest {
     } finally {
       env.close();
     }
+  }
+
+  @Test
+  void liveLoadFoxScaledKomiUsesSourceMetadataWithoutChangingStandardSgf() throws Exception {
+    TestEnvironment env = TestEnvironment.open();
+    BoardRenderer previousBoardRenderer = LizzieFrame.boardRenderer;
+    SubBoardRenderer previousSubBoardRenderer = LizzieFrame.subBoardRenderer;
+    try {
+      LizzieFrame.boardRenderer = new BoardRenderer(false);
+      LizzieFrame.subBoardRenderer = allocate(SubBoardRenderer.class);
+      Lizzie.config.readKomi = true;
+
+      assertLiveLoadedKomi("(;SZ[19]AP[foxwq]RU[Japanese]KM[50]HA[2])", 0.5);
+      assertLiveLoadedKomi("(;SZ[19]AP[foxwq]RU[Chinese]KM[375]HA[0])", 7.5);
+      assertLiveLoadedKomi("(;SZ[19]AP[foxwq]RU[Japanese]KM[650])", 6.5);
+      assertLiveLoadedKomi("(;SZ[19]AP[GNU Go:3.8]RU[Japanese]KM[50])", 50.0);
+    } finally {
+      LizzieFrame.boardRenderer = previousBoardRenderer;
+      LizzieFrame.subBoardRenderer = previousSubBoardRenderer;
+      env.close();
+    }
+  }
+
+  @Test
+  void detachedFoxScaledKomiUsesSourceMetadataWithoutChangingStandardSgf() throws Exception {
+    TestEnvironment env = TestEnvironment.open();
+    try {
+      Lizzie.config.readKomi = true;
+
+      assertDetachedParsedKomi("(;SZ[19]AP[foxwq]RU[Japanese]KM[50]HA[2])", 0.5);
+      assertDetachedParsedKomi("(;SZ[19]AP[foxwq]RU[Chinese]KM[375]HA[0])", 7.5);
+      assertDetachedParsedKomi("(;SZ[19]AP[foxwq]RU[Japanese]KM[650])", 6.5);
+      assertDetachedParsedKomi("(;SZ[19]AP[GNU Go:3.8]RU[Japanese]KM[50])", 50.0);
+    } finally {
+      env.close();
+    }
+  }
+
+  private static void assertLiveLoadedKomi(String sgf, double expectedKomi) {
+    assertTrue(SGFParser.loadFromString(sgf), "loadFromString should parse SGF: " + sgf);
+    assertEquals(expectedKomi, Lizzie.board.getHistory().getGameInfo().getKomi(), 0.001);
+  }
+
+  private static void assertDetachedParsedKomi(String sgf, double expectedKomi) {
+    BoardHistoryList history = SGFParser.parseSgf(sgf, true);
+    assertTrue(history != null, "parseSgf should parse SGF: " + sgf);
+    assertEquals(expectedKomi, history.getGameInfo().getKomi(), 0.001);
   }
 
   @Test


### PR DESCRIPTION
## Summary

- Fix Fox SGF scaled komi normalization using root source metadata (`AP[foxwq]`).
- Preserve non-Fox `KM[50]` as literal `50.0` instead of lowering the global normalization threshold.
- Delay detached-parser komi normalization until root properties are available, matching the live parser path.
- Add live and detached parser regression coverage for Fox and non-Fox komi cases.

## Type Of Change

- [x] Bug fix
- [ ] Feature
- [ ] Packaging / release update
- [ ] Docs / translation
- [ ] Refactor

## Testing

- [x] Tested locally
- [ ] Verified package contents if packaging changed
- [ ] Verified Fox sync flow if related
- [ ] Added screenshots if UI changed
- [ ] Updated README / docs if user-facing behavior changed
- [x] Noted affected platforms if the change is platform-specific
- [x] Verified there is no unrelated formatting or line-ending churn
- [x] Ran `python3 scripts/check_line_endings.py` (or equivalent `python` on Windows)

Commands run:

- `unset DISPLAY && mvn -q -Dtest=featurecat.lizzie.rules.BoardNodeKindHistoryPipelineTest#liveLoadFoxScaledKomiUsesSourceMetadataWithoutChangingStandardSgf+detachedFoxScaledKomiUsesSourceMetadataWithoutChangingStandardSgf test`
- `unset DISPLAY && mvn -q -Dtest=featurecat.lizzie.rules.BoardNodeKindHistoryPipelineTest#liveLoadFoxHandicapGameReadsZeroKomi+liveLoadFoxScaledKomiUsesSourceMetadataWithoutChangingStandardSgf+detachedFoxScaledKomiUsesSourceMetadataWithoutChangingStandardSgf,featurecat.lizzie.analysis.GetFoxRequestTest test`
- `unset DISPLAY && mvn -q -Dtest=featurecat.lizzie.rules.BoardNodeKindHistoryPipelineTest,featurecat.lizzie.analysis.AnalysisEngineRequestTest#foxHandicapSgfAnalysisRequestKeepsSetupStonesAndZeroKomi test`
- `python3 scripts/check_line_endings.py && git diff --check 4bc60c222f318f5cd8378d61760ffd561ba30b51..1d7215bca2947e950b4d83396eddb9892f32f419`
- Windows build: `D:\dev\weiqi\lizzieyzy-next\.tools\apache-maven-3.9.10\bin\mvn.cmd -B -DskipTests package`
- Windows smoke launch: `target\lizzie-yzy2.5.3-shaded.jar` at `1d7215bca2947e950b4d83396eddb9892f32f419`, PID `21908`, visible window handle `0x140D3C`

## Notes

- Closes #262.
- Fox sync flow itself is not changed; this PR only changes SGF komi parsing and parser regression coverage.
- Affected behavior is parser-level and cross-platform.
