### PR TITLE
fix(gma): reauthorize play color switch without exclusive popup

### DIFF
--- a/src/main/java/featurecat/lizzie/analysis/ReadBoard.java
+++ b/src/main/java/featurecat/lizzie/analysis/ReadBoard.java
@@ -882,10 +882,19 @@ public class ReadBoard implements ReadBoardTrackingEligibilityAdapter.Eligibilit
         int firstPlayouts = Integer.parseInt(playParams[2]);
         int time = Integer.parseInt(playParams[0]);
         boolean useGma = isReadBoardGmaPlayMode(playParams);
+        boolean alreadyArmedGma = useGma && readBoardGmaAutoPlayActive;
         Leelaz currentForegroundEngine = useGma ? Lizzie.leelaz : null;
-        if (currentForegroundEngine != null && !currentForegroundEngine.canArmReadBoardGma()) {
+        if (!alreadyArmedGma
+            && currentForegroundEngine != null
+            && !currentForegroundEngine.canArmReadBoardGma()) {
           showForegroundEngineLeaseConflict();
           return;
+        }
+        if (alreadyArmedGma
+            && autoPlayColor != null
+            && !autoPlayColor.isEmpty()
+            && autoPlayColor != readBoardGmaAutoPlayColor) {
+          invalidateReadBoardGmaPhysicalRequestIfPending("play-color-switch");
         }
         clearFailedLocalMoveStateIfAutoPlaySideChanged(autoPlayColor);
         if (hasFailedLocalMoveStateToPreserve()) {

--- a/src/test/java/featurecat/lizzie/analysis/ReadBoardEngineResumeTest.java
+++ b/src/test/java/featurecat/lizzie/analysis/ReadBoardEngineResumeTest.java
@@ -1085,6 +1085,80 @@ class ReadBoardEngineResumeTest {
   }
 
   @Test
+  void readBoardGmaPlayLineColorSwitchUpdatesAuthorizationWhenAlreadyArmed() throws Exception {
+    try (EngineResumeHarness harness =
+        EngineResumeHarness.create(rootHistory(emptyStones(), true))) {
+      RecordingLifecycleLeelaz foreground = new RecordingLifecycleLeelaz();
+      Lizzie.leelaz = foreground;
+
+      harness.readBoard.parseLine("play>white>5 12 34 gma");
+
+      assertTrue(harness.readBoard.isReadBoardGmaAutoPlayActive());
+      assertEquals(Stone.WHITE, getField(harness.readBoard, "readBoardGmaAutoPlayColor"));
+      assertTrue(LizzieFrame.toolbar.chkAutoPlayWhite.isSelected());
+      assertFalse(LizzieFrame.toolbar.chkAutoPlayBlack.isSelected());
+
+      foreground.allowArm = false;
+      harness.readBoard.parseLine("play>black>5 12 34 gma");
+
+      assertTrue(
+          harness.readBoard.isReadBoardGmaAutoPlayActive(),
+          "color switch must keep the existing GMA autoplay authorization");
+      assertEquals(
+          Stone.BLACK,
+          getField(harness.readBoard, "readBoardGmaAutoPlayColor"),
+          "already-armed GMA must accept play> color changes instead of treating itself as a foreign exclusive task");
+      assertTrue(getBooleanField(harness.readBoard, "readBoardGmaAwaitingSyncedBoard"));
+      assertTrue(LizzieFrame.toolbar.chkAutoPlayBlack.isSelected());
+      assertFalse(LizzieFrame.toolbar.chkAutoPlayWhite.isSelected());
+      assertEquals(5, getIntField(harness.readBoard, "readBoardGmaTimeSeconds"));
+      assertEquals(12, getIntField(harness.readBoard, "readBoardGmaMaxVisits"));
+    }
+  }
+
+  @Test
+  void readBoardGmaPlayLineColorSwitchInvalidatesInFlightWhiteResult() throws Exception {
+    try (EngineResumeHarness harness =
+        EngineResumeHarness.create(rootHistory(emptyStones(), true))) {
+      RecordingLifecycleLeelaz foreground = new RecordingLifecycleLeelaz();
+      Lizzie.leelaz = foreground;
+
+      harness.readBoard.parseLine("play>white>5 12 34 gma");
+      Object helperIdentity = new Object();
+      long generation = ((Number) getField(harness.readBoard, "readBoardGmaSessionGeneration")).longValue();
+      setField(harness.readBoard, "readBoardGmaPending", true);
+      setField(harness.readBoard, "readBoardGmaPendingIdentity", helperIdentity);
+      setField(harness.readBoard, "readBoardGmaPendingGeneration", generation);
+      setField(harness.readBoard, "trackingEligibilityIdentity", helperIdentity);
+
+      foreground.allowArm = false;
+      harness.readBoard.parseLine("play>black>5 12 34 gma");
+
+      assertEquals(Stone.BLACK, getField(harness.readBoard, "readBoardGmaAutoPlayColor"));
+      assertTrue(getBooleanField(harness.readBoard, "readBoardGmaPendingLogicallyInvalid"));
+
+      boolean consumed =
+          harness.readBoard.handleReadBoardGmaEnginePlay(helperIdentity, generation, "A1");
+
+      assertTrue(consumed, "stale white GMA must be consumed as an invalidated result");
+      assertFalse(
+          getBooleanField(harness.readBoard, "readBoardGmaPending"),
+          "invalidated white GMA must not stay pending after its late result");
+      int occupied = 0;
+      for (Stone stone : harness.board.getHistory().getStones()) {
+        if (!stone.isEmpty()) {
+          occupied++;
+        }
+      }
+      assertEquals(
+          0,
+          occupied,
+          "a late white GMA play must not be placed after switching to black");
+    }
+  }
+
+
+  @Test
   void activatedReadBoardGmaBlocksForegroundAnalysisLease() throws Exception {
     try (EngineResumeHarness harness =
         EngineResumeHarness.create(rootHistory(emptyStones(), true))) {


### PR DESCRIPTION
## Why

After ReadBoard has already armed engine-decision autoplay (GMA), switching from White to Black sends another `play>black>… gma`. The host treated **its own GMA lease** as a foreign exclusive task: `canArmReadBoardGma()` failed, showed "The engine is already in exclusive use", and returned before updating color. ReadBoard's UI was already Black, but the host kept playing White.

Per `docs/specs/2026-06-24-readboard-gma-engine-decision-design.md`, a color change must invalidate logical authorization. An in-flight `kata-genmove_analyze` may run to a terminal, but a stale result must not be placed.

## What

- Treat a later `play>… gma` on an already-armed GMA as re-authorization, not a new `canArm` / exclusive-task popup
- On color change, call `invalidateReadBoardGmaPhysicalRequestIfPending("play-color-switch")`, then update Black/White and wait for the next synced board
- First-time arming still rejects a real foreign exclusive task
- Add two regression tests: color-switch authorization update, and discarding a late White result so it is not placed

## How

Do not `stopAutoPlay` on the ReadBoard side and immediately resend `play>`. GMA lease release is asynchronous, so a follow-up arm still hits `canArm`. The host treats a new `play>` on an already-armed session as a parameter/color update.

## Test Plan

- [x] `ReadBoardEngineResumeTest#readBoardGmaPlayLineColorSwitchUpdatesAuthorizationWhenAlreadyArmed`
- [x] `ReadBoardEngineResumeTest#readBoardGmaPlayLineColorSwitchInvalidatesInFlightWhiteResult`
- [x] `ReadBoardEngineResumeTest#readBoardGma*` (25 passed)
- [x] Manual: Fox background + engine-decision autoplay, switch White to Black while autoplay is running — no exclusive-task dialog, and it must not keep placing White

## Related

- Spec: `docs/specs/2026-06-24-readboard-gma-engine-decision-design.md`
