### PR TITLE
feat(time-control): add engine-owned time for human and engine games

### DIFF
--- a/src/main/java/featurecat/lizzie/Lizzie.java
+++ b/src/main/java/featurecat/lizzie/Lizzie.java
@@ -8,6 +8,7 @@ import featurecat.lizzie.analysis.LeelazEngineCommandSink;
 import featurecat.lizzie.analysis.remote.RemoteComputeConfig;
 import featurecat.lizzie.gui.AppleStyleSupport;
 import featurecat.lizzie.gui.BottomToolbar;
+import featurecat.lizzie.gui.DesktopTimeControl;
 import featurecat.lizzie.gui.EngineData;
 import featurecat.lizzie.gui.FirstUseSettings;
 import featurecat.lizzie.gui.GtpConsolePane;
@@ -965,8 +966,9 @@ public class Lizzie {
               && currentFrame.readBoard != null
               && currentFrame.readBoard.isReadBoardGmaAutoPlayActive();
       if (currentFrame != null
-          && (currentFrame.isPlayingAgainstLeelaz
-              || (currentFrame.isAnaPlayingAgainstLeelaz && !readBoardGmaActive))) {
+          && DesktopTimeControl.shouldSendHumanTimeOnEngineReady(
+              currentFrame.isPlayingAgainstLeelaz,
+              currentFrame.isAnaPlayingAgainstLeelaz && !readBoardGmaActive)) {
         LizzieFrame.sendAiTime(false, engine, false);
       }
       if (currentMenu != null) currentMenu.showPda(engine.isKataGoPda);

--- a/src/main/java/featurecat/lizzie/analysis/EngineGameInfo.java
+++ b/src/main/java/featurecat/lizzie/analysis/EngineGameInfo.java
@@ -1,5 +1,6 @@
 package featurecat.lizzie.analysis;
 
+import featurecat.lizzie.gui.DesktopTimeControl;
 import featurecat.lizzie.gui.LizzieFrame;
 import featurecat.lizzie.gui.SgfWinLossList;
 import featurecat.lizzie.rules.Board;
@@ -34,6 +35,11 @@ public class EngineGameInfo {
 
   public int timeBlack;
   public int timeWhite;
+  public DesktopTimeControl.SideMode blackTimeMode;
+  public DesktopTimeControl.SideMode whiteTimeMode;
+  public String advanceBlackTimeCmd;
+  public String advanceWhiteTimeCmd;
+
   public int playoutsBlack;
   public int playoutsWhite;
   public int firstPlayoutsBlack;
@@ -135,6 +141,16 @@ public class EngineGameInfo {
 
   public boolean isFirstEnginePlayBlack() {
     return firstEngineIndex == blackEngineIndex;
+  }
+
+  public void applyCapturedTime(Leelaz engine, int engineIndex) {
+    if (engineIndex == blackEngineIndex) {
+      DesktopTimeControl.applyEngineGameTime(
+          engine, blackTimeMode, timeBlack, advanceBlackTimeCmd);
+    } else if (engineIndex == whiteEngineIndex) {
+      DesktopTimeControl.applyEngineGameTime(
+          engine, whiteTimeMode, timeWhite, advanceWhiteTimeCmd);
+    }
   }
 
   public int getMaxGameMoves() {

--- a/src/main/java/featurecat/lizzie/analysis/EngineManager.java
+++ b/src/main/java/featurecat/lizzie/analysis/EngineManager.java
@@ -281,6 +281,12 @@ public class EngineManager {
     engineGameInfo.whiteEngineIndex = engineWhite;
     engineGameInfo.firstEngineIndex = engineBlack;
     engineGameInfo.secondEngineIndex = engineWhite;
+    if (isGenmove) {
+      timeBlack =
+          DesktopTimeControl.fixedSecondsForToolbar(blackTimeMode, timeBlack > 0, timeBlack);
+      timeWhite =
+          DesktopTimeControl.fixedSecondsForToolbar(whiteTimeMode, timeWhite > 0, timeWhite);
+    }
     engineGameInfo.timeBlack = timeBlack;
     engineGameInfo.timeWhite = timeWhite;
     engineGameInfo.timeFirstEngine = timeBlack;
@@ -289,14 +295,6 @@ public class EngineManager {
     engineGameInfo.whiteTimeMode = whiteTimeMode;
     engineGameInfo.advanceBlackTimeCmd = Lizzie.config.advanceBlackTimeTxt;
     engineGameInfo.advanceWhiteTimeCmd = Lizzie.config.advanceWhiteTimeTxt;
-    if (isGenmove) {
-      if (blackTimeMode != DesktopTimeControl.SideMode.FIXED) {
-        engineGameInfo.timeBlack = -1;
-      }
-      if (whiteTimeMode != DesktopTimeControl.SideMode.FIXED) {
-        engineGameInfo.timeWhite = -1;
-      }
-    }
     engineGameInfo.playoutsBlack = playoutsBlack;
     engineGameInfo.playoutsWhite = playoutsWhite;
     engineGameInfo.playoutsFirstEngine = playoutsBlack;

--- a/src/main/java/featurecat/lizzie/analysis/EngineManager.java
+++ b/src/main/java/featurecat/lizzie/analysis/EngineManager.java
@@ -471,14 +471,18 @@ public class EngineManager {
 
     Lizzie.config.isAutoAna = false;
     Lizzie.board.isPkBoard = true;
+    startNewEngineGame(true);
+    if (!isEngineGame && !isPreEngineGame) {
+      Lizzie.board.isPkBoard = false;
+      Lizzie.frame.addInput(true);
+      return false;
+    }
     LizzieFrame.toolbar.lblenginePkResult.setText("0:0");
     Menu.engineMenu.setText(resourceBundle.getString("EngineManager.engineGamePlaying")); // 对战中
     LizzieFrame.menu.toggleEngineMenuStatus(true, false);
-    // 禁用某些按钮
     LizzieFrame.toolbar.enableDisabelForEngineGame(false);
-    // 开始新的一局
-    startNewEngineGame(true);
     return true;
+
   }
 
   public ArrayList<Movelist> getStartListForEnginePk() {
@@ -936,7 +940,11 @@ public class EngineManager {
   public void stopEngineGame(int resgnEngineIndex, boolean mannul) {
     SGFParser.appendComment();
     isPreEngineGame = false;
-    if (!isEngineGame) return;
+    if (!isEngineGame) {
+      restoreUiAfterEngineGameStartAbort();
+      return;
+    }
+
     isEngineGame = false;
     isSaveingEngineSGF = true;
     stopCountDown();
@@ -1300,6 +1308,7 @@ public class EngineManager {
     if (rejectForegroundEngineStartDuringSetup(true)) return;
     Leelaz currentForegroundEngine = Lizzie.leelaz;
     if (currentForegroundEngine != null) {
+      currentForegroundEngine.notPondering();
       if (!currentForegroundEngine.beginExclusiveGtpLifecycleTransition()) {
         showForegroundEngineLeaseInUse();
         return;
@@ -1312,6 +1321,7 @@ public class EngineManager {
     } else {
       isPreEngineGame = true;
     }
+
     // engineGameInfo
     Lizzie.frame.setResult("");
     if (firstTime) {
@@ -2635,6 +2645,19 @@ public class EngineManager {
       LizzieFrame.toolbar.isPkStop = false;
     }
   }
+
+  private void restoreUiAfterEngineGameStartAbort() {
+    if (Lizzie.frame != null) {
+      Lizzie.frame.addInput(true);
+    }
+    if (LizzieFrame.toolbar != null) {
+      LizzieFrame.toolbar.enableDisabelForEngineGame(true);
+    }
+    if (Menu.engineMenu != null) {
+      Menu.engineMenu.setEnabled(true);
+    }
+  }
+
 
   public void restartEngineForPk(int index) {
     if (rejectForegroundEngineStartDuringSetup(true)) return;

--- a/src/main/java/featurecat/lizzie/analysis/EngineManager.java
+++ b/src/main/java/featurecat/lizzie/analysis/EngineManager.java
@@ -243,9 +243,13 @@ public class EngineManager {
       boolean isExchange,
       boolean checkGameMaxMove,
       int maxGameMoves) {
+    DesktopTimeControl.SideMode blackTimeMode =
+        DesktopTimeControl.loadEngineGameSideMode(Lizzie.config, true);
+    DesktopTimeControl.SideMode whiteTimeMode =
+        DesktopTimeControl.loadEngineGameSideMode(Lizzie.config, false);
     if (isGenmove
         && DesktopTimeControl.rejectsEngineGame(
-            engineList, engineBlack, engineWhite, Lizzie.config.pkAdvanceTimeSettings)) {
+            engineList, engineBlack, engineWhite, blackTimeMode, whiteTimeMode)) {
       Lizzie.frame.showUnsupportedWebSocketAdvancedClock();
       return false;
     }
@@ -281,6 +285,18 @@ public class EngineManager {
     engineGameInfo.timeWhite = timeWhite;
     engineGameInfo.timeFirstEngine = timeBlack;
     engineGameInfo.timeSecondEngine = timeWhite;
+    engineGameInfo.blackTimeMode = blackTimeMode;
+    engineGameInfo.whiteTimeMode = whiteTimeMode;
+    engineGameInfo.advanceBlackTimeCmd = Lizzie.config.advanceBlackTimeTxt;
+    engineGameInfo.advanceWhiteTimeCmd = Lizzie.config.advanceWhiteTimeTxt;
+    if (isGenmove) {
+      if (blackTimeMode != DesktopTimeControl.SideMode.FIXED) {
+        engineGameInfo.timeBlack = -1;
+      }
+      if (whiteTimeMode != DesktopTimeControl.SideMode.FIXED) {
+        engineGameInfo.timeWhite = -1;
+      }
+    }
     engineGameInfo.playoutsBlack = playoutsBlack;
     engineGameInfo.playoutsWhite = playoutsWhite;
     engineGameInfo.playoutsFirstEngine = playoutsBlack;
@@ -310,57 +326,61 @@ public class EngineManager {
       engineGameInfo.engineGameSgfWinLoss = Lizzie.frame.enginePkSgfWinLoss;
     isEmpty = false;
     if (isGenmove) {
+      clearFirstSecondEngineCountDown();
       engineGameInfo.settingFirst =
           resourceBundle.getString("EngineGameInfo.settingFirst"); // "第一引擎设置:";
-      if (Lizzie.config.pkAdvanceTimeSettings) {
+      engineGameInfo.settingSecond =
+          resourceBundle.getString("EngineGameInfo.settingSecond"); // "第二引擎设置:";
+      if (engineGameInfo.blackTimeMode == DesktopTimeControl.SideMode.RAW_ADVANCED) {
         engineGameInfo.settingFirst +=
-            resourceBundle.getString("EngineGameInfo.time") + Lizzie.config.advanceBlackTimeTxt;
+            resourceBundle.getString("EngineGameInfo.time") + engineGameInfo.advanceBlackTimeCmd;
+      } else if (engineGameInfo.timeFirstEngine > 0) {
+        engineGameInfo.settingFirst +=
+            resourceBundle.getString("EngineGameInfo.time")
+                + engineGameInfo.timeFirstEngine
+                + resourceBundle.getString("SGFParse.seconds");
+      }
+      engineGameInfo.settingFirst +=
+          "\r\n"
+              + resourceBundle.getString("EngineGameInfo.command")
+              + engineList.get(engineGameInfo.firstEngineIndex).getEngineCommand();
+      if (engineGameInfo.whiteTimeMode == DesktopTimeControl.SideMode.RAW_ADVANCED) {
         engineGameInfo.settingSecond +=
-            resourceBundle.getString("EngineGameInfo.time") + Lizzie.config.advanceWhiteTimeTxt;
+            resourceBundle.getString("EngineGameInfo.time") + engineGameInfo.advanceWhiteTimeCmd;
+      } else if (engineGameInfo.timeSecondEngine > 0) {
+        engineGameInfo.settingSecond +=
+            resourceBundle.getString("EngineGameInfo.time")
+                + engineGameInfo.timeSecondEngine
+                + resourceBundle.getString("SGFParse.seconds");
+      }
+      engineGameInfo.settingSecond +=
+          "\r\n"
+              + resourceBundle.getString("EngineGameInfo.command")
+              + engineList.get(engineGameInfo.secondEngineIndex).getEngineCommand();
+
+      if (engineGameInfo.blackTimeMode == DesktopTimeControl.SideMode.RAW_ADVANCED) {
         firstEngineCountDown = new EngineCountDown();
         boolean firstEngineParseSucess =
             firstEngineCountDown.setEngineCountDown(
-                Lizzie.config.advanceBlackTimeTxt, engineList.get(engineGameInfo.firstEngineIndex));
-        secondEngineCountDown = new EngineCountDown();
-        boolean secondEngineParseSucess =
-            secondEngineCountDown.setEngineCountDown(
-                Lizzie.config.advanceWhiteTimeTxt,
-                engineList.get(engineGameInfo.secondEngineIndex));
+                engineGameInfo.advanceBlackTimeCmd,
+                engineList.get(engineGameInfo.firstEngineIndex));
         if (!firstEngineParseSucess) {
           firstEngineCountDown = null;
           Utils.showMsgNoModal(
               resourceBundle.getString("EngineManager.parseAdvcanceTimeSettingsFailed"));
         }
+      }
+      if (engineGameInfo.whiteTimeMode == DesktopTimeControl.SideMode.RAW_ADVANCED) {
+        secondEngineCountDown = new EngineCountDown();
+        boolean secondEngineParseSucess =
+            secondEngineCountDown.setEngineCountDown(
+                engineGameInfo.advanceWhiteTimeCmd,
+                engineList.get(engineGameInfo.secondEngineIndex));
         if (!secondEngineParseSucess) {
           secondEngineCountDown = null;
           Utils.showMsgNoModal(
               resourceBundle.getString("EngineManager.parseAdvcanceTimeSettingsFailed"));
         }
-
-      } else {
-        if (engineGameInfo.timeFirstEngine > 0)
-          engineGameInfo.settingFirst +=
-              resourceBundle.getString("EngineGameInfo.time")
-                  + engineGameInfo.timeFirstEngine
-                  + resourceBundle.getString("SGFParse.seconds");
-
-        engineGameInfo.settingFirst +=
-            "\r\n"
-                + resourceBundle.getString("EngineGameInfo.command")
-                + engineList.get(engineGameInfo.firstEngineIndex).getEngineCommand();
-
-        engineGameInfo.settingSecond =
-            resourceBundle.getString("EngineGameInfo.settingSecond"); // "第二引擎设置:";
-        if (engineGameInfo.timeSecondEngine > 0)
-          engineGameInfo.settingSecond +=
-              resourceBundle.getString("EngineGameInfo.time")
-                  + engineGameInfo.timeSecondEngine
-                  + resourceBundle.getString("SGFParse.seconds");
-
-        engineGameInfo.settingSecond +=
-            "\r\n"
-                + resourceBundle.getString("EngineGameInfo.command")
-                + engineList.get(engineGameInfo.secondEngineIndex).getEngineCommand();
       }
     } else {
       engineGameInfo.settingFirst =
@@ -1471,29 +1491,18 @@ public class EngineManager {
               engineList.get(engineGameInfo.whiteEngineIndex).nameCmd();
               engineList.get(engineGameInfo.whiteEngineIndex).notPondering();
 
-              if (Lizzie.config.pkAdvanceTimeSettings) {
-                Lizzie.engineManager
-                    .engineList
-                    .get(engineGameInfo.blackEngineIndex)
-                    .sendCommand(Lizzie.config.advanceBlackTimeTxt);
-                Lizzie.engineManager
-                    .engineList
-                    .get(engineGameInfo.whiteEngineIndex)
-                    .sendCommand(Lizzie.config.advanceWhiteTimeTxt);
-                if (firstEngineCountDown != null || secondEngineCountDown != null) {
-                  if (firstEngineCountDown != null)
-                    firstEngineCountDown.initialize(engineGameInfo.isFirstEnginePlayBlack());
-                  if (secondEngineCountDown != null)
-                    secondEngineCountDown.initialize(!engineGameInfo.isFirstEnginePlayBlack());
-                  StartCountDown();
-                }
-              } else {
-                DesktopTimeControl.sendEngineGameFixedTime(
-                    Lizzie.engineManager.engineList.get(engineGameInfo.whiteEngineIndex),
-                    engineGameInfo.timeWhite);
-                DesktopTimeControl.sendEngineGameFixedTime(
-                    Lizzie.engineManager.engineList.get(engineGameInfo.blackEngineIndex),
-                    engineGameInfo.timeBlack);
+              engineGameInfo.applyCapturedTime(
+                  Lizzie.engineManager.engineList.get(engineGameInfo.blackEngineIndex),
+                  engineGameInfo.blackEngineIndex);
+              engineGameInfo.applyCapturedTime(
+                  Lizzie.engineManager.engineList.get(engineGameInfo.whiteEngineIndex),
+                  engineGameInfo.whiteEngineIndex);
+              if (firstEngineCountDown != null || secondEngineCountDown != null) {
+                if (firstEngineCountDown != null)
+                  firstEngineCountDown.initialize(engineGameInfo.isFirstEnginePlayBlack());
+                if (secondEngineCountDown != null)
+                  secondEngineCountDown.initialize(!engineGameInfo.isFirstEnginePlayBlack());
+                StartCountDown();
               }
               Lizzie.engineManager
                   .engineList
@@ -2684,17 +2693,7 @@ public class EngineManager {
                   newEng.nameCmd();
                   newEng.setResponseUpToDate();
                   if (engineGameInfo.isGenmove) {
-                    if (Lizzie.config.pkAdvanceTimeSettings) {
-                      newEng.sendCommand(Lizzie.config.advanceBlackTimeTxt);
-                    } else if (index == engineGameInfo.whiteEngineIndex
-                        && engineGameInfo.timeWhite > 0) {
-                      DesktopTimeControl.sendEngineGameFixedTime(
-                          newEng, engineGameInfo.timeWhite);
-                    } else if (index == engineGameInfo.blackEngineIndex
-                        && engineGameInfo.timeBlack > 0) {
-                      DesktopTimeControl.sendEngineGameFixedTime(
-                          newEng, engineGameInfo.timeBlack);
-                    }
+                    engineGameInfo.applyCapturedTime(newEng, index);
                     if (Lizzie.board.getHistory().isBlacksTurn()) {
                       Lizzie.setPrimaryEngine(engineList.get(engineGameInfo.blackEngineIndex));
                       Lizzie.leelaz.genmoveForPk("b");

--- a/src/main/java/featurecat/lizzie/gui/DesktopTimeControl.java
+++ b/src/main/java/featurecat/lizzie/gui/DesktopTimeControl.java
@@ -85,6 +85,10 @@ public final class DesktopTimeControl {
     return mode != Mode.ENGINE_OWNED;
   }
 
+  static boolean usesFixedMoveSeconds(Mode mode) {
+    return mode == Mode.FIXED;
+  }
+
   public static boolean shouldSendHumanTimeOnEngineReady(
       boolean genmovePlaying, boolean analysisPlaying) {
     return genmovePlaying && !analysisPlaying;
@@ -103,7 +107,6 @@ public final class DesktopTimeControl {
     config.uiConfig.put("pk-advance-time-settings", config.pkAdvanceTimeSettings);
   }
 
-
   static SideMode selectedEngineGameSideMode(boolean advanced, boolean engineOwned) {
     if (engineOwned) return SideMode.ENGINE_OWNED;
     if (advanced) return SideMode.RAW_ADVANCED;
@@ -112,8 +115,9 @@ public final class DesktopTimeControl {
 
   public static SideMode loadEngineGameSideMode(Config config, boolean black) {
     String key = black ? "pk-black-time-mode" : "pk-white-time-mode";
-    if (config.uiConfig.has(key)) {
-      return SideMode.valueOf(config.uiConfig.getString(key));
+    String savedMode = config.uiConfig.optString(key, "").trim();
+    for (SideMode mode : SideMode.values()) {
+      if (mode.name().equalsIgnoreCase(savedMode)) return mode;
     }
     return config.pkAdvanceTimeSettings ? SideMode.RAW_ADVANCED : SideMode.FIXED;
   }
@@ -128,7 +132,7 @@ public final class DesktopTimeControl {
     engine.sendCommand(advancedCommand);
   }
 
-  static int fixedSecondsForToolbar(
+  public static int fixedSecondsForToolbar(
       SideMode mode, boolean toolbarTimeSelected, int parsedSeconds) {
     return mode == SideMode.FIXED && toolbarTimeSelected ? parsedSeconds : -1;
   }

--- a/src/main/java/featurecat/lizzie/gui/DesktopTimeControl.java
+++ b/src/main/java/featurecat/lizzie/gui/DesktopTimeControl.java
@@ -13,6 +13,12 @@ public final class DesktopTimeControl {
     KATAGO_ADVANCED
   }
 
+  public enum SideMode {
+    ENGINE_OWNED,
+    FIXED,
+    RAW_ADVANCED
+  }
+
   private DesktopTimeControl() {}
 
   static Mode selectedMode(boolean rawAdvanced, boolean kataGoAdvanced) {
@@ -35,9 +41,18 @@ public final class DesktopTimeControl {
 
   public static boolean rejectsEngineGame(
       List<Leelaz> engines, int blackEngineIndex, int whiteEngineIndex, boolean advancedClock) {
-    return advancedClock
-        && (isWebSocket(engines.get(blackEngineIndex))
-            || isWebSocket(engines.get(whiteEngineIndex)));
+    SideMode mode = advancedClock ? SideMode.RAW_ADVANCED : SideMode.FIXED;
+    return rejectsEngineGame(engines, blackEngineIndex, whiteEngineIndex, mode, mode);
+  }
+
+  public static boolean rejectsEngineGame(
+      List<Leelaz> engines,
+      int blackEngineIndex,
+      int whiteEngineIndex,
+      SideMode black,
+      SideMode white) {
+    return (black == SideMode.RAW_ADVANCED && isWebSocket(engines.get(blackEngineIndex)))
+        || (white == SideMode.RAW_ADVANCED && isWebSocket(engines.get(whiteEngineIndex)));
   }
 
   static boolean submitHumanSelection(
@@ -78,6 +93,44 @@ public final class DesktopTimeControl {
   static void commitEngineGameSelection(Config config, boolean advancedClock) {
     config.pkAdvanceTimeSettings = advancedClock;
     config.uiConfig.put("pk-advance-time-settings", advancedClock);
+  }
+
+  public static void commitEngineGameSelection(Config config, SideMode black, SideMode white) {
+    config.uiConfig.put("pk-black-time-mode", black.name());
+    config.uiConfig.put("pk-white-time-mode", white.name());
+    config.pkAdvanceTimeSettings =
+        black == SideMode.RAW_ADVANCED && white == SideMode.RAW_ADVANCED;
+    config.uiConfig.put("pk-advance-time-settings", config.pkAdvanceTimeSettings);
+  }
+
+
+  static SideMode selectedEngineGameSideMode(boolean advanced, boolean engineOwned) {
+    if (engineOwned) return SideMode.ENGINE_OWNED;
+    if (advanced) return SideMode.RAW_ADVANCED;
+    return SideMode.FIXED;
+  }
+
+  public static SideMode loadEngineGameSideMode(Config config, boolean black) {
+    String key = black ? "pk-black-time-mode" : "pk-white-time-mode";
+    if (config.uiConfig.has(key)) {
+      return SideMode.valueOf(config.uiConfig.getString(key));
+    }
+    return config.pkAdvanceTimeSettings ? SideMode.RAW_ADVANCED : SideMode.FIXED;
+  }
+
+  public static void applyEngineGameTime(
+      Leelaz engine, SideMode mode, int fixedSeconds, String advancedCommand) {
+    if (mode == SideMode.ENGINE_OWNED) return;
+    if (mode == SideMode.FIXED) {
+      sendEngineGameFixedTime(engine, fixedSeconds);
+      return;
+    }
+    engine.sendCommand(advancedCommand);
+  }
+
+  static int fixedSecondsForToolbar(
+      SideMode mode, boolean toolbarTimeSelected, int parsedSeconds) {
+    return mode == SideMode.FIXED && toolbarTimeSelected ? parsedSeconds : -1;
   }
 
   public static void sendEngineGameFixedTime(Leelaz engine, int seconds) {

--- a/src/main/java/featurecat/lizzie/gui/DesktopTimeControl.java
+++ b/src/main/java/featurecat/lizzie/gui/DesktopTimeControl.java
@@ -7,6 +7,7 @@ import java.util.List;
 
 public final class DesktopTimeControl {
   public enum Mode {
+    ENGINE_OWNED,
     FIXED,
     RAW_ADVANCED,
     KATAGO_ADVANCED
@@ -15,13 +16,21 @@ public final class DesktopTimeControl {
   private DesktopTimeControl() {}
 
   static Mode selectedMode(boolean rawAdvanced, boolean kataGoAdvanced) {
+    return selectedMode(rawAdvanced, kataGoAdvanced, false);
+  }
+
+  static Mode selectedMode(boolean rawAdvanced, boolean kataGoAdvanced, boolean engineOwned) {
+    if (engineOwned) return Mode.ENGINE_OWNED;
     if (rawAdvanced) return Mode.RAW_ADVANCED;
     if (kataGoAdvanced) return Mode.KATAGO_ADVANCED;
     return Mode.FIXED;
   }
 
   static boolean rejectsHumanGame(Leelaz engine, Mode mode, boolean noClock) {
-    return !noClock && mode != Mode.FIXED && isWebSocket(engine);
+    return !noClock
+        && mode != Mode.ENGINE_OWNED
+        && mode != Mode.FIXED
+        && isWebSocket(engine);
   }
 
   public static boolean rejectsEngineGame(
@@ -49,10 +58,21 @@ public final class DesktopTimeControl {
   static void commitHumanSelection(Config config, Mode mode, int kataTimeType) {
     config.advanceTimeSettings = mode == Mode.RAW_ADVANCED;
     config.kataTimeSettings = mode == Mode.KATAGO_ADVANCED;
+    config.genmoveGameNoTime = mode == Mode.ENGINE_OWNED;
     config.kataTimeType = kataTimeType;
     config.uiConfig.put("advance-time-settings", config.advanceTimeSettings);
     config.uiConfig.put("kata-time-settings", config.kataTimeSettings);
+    config.uiConfig.put("genmove-game-notime", config.genmoveGameNoTime);
     config.uiConfig.put("kata-time-type", config.kataTimeType);
+  }
+
+  public static boolean shouldEmitClientTimeOverride(Mode mode) {
+    return mode != Mode.ENGINE_OWNED;
+  }
+
+  public static boolean shouldSendHumanTimeOnEngineReady(
+      boolean genmovePlaying, boolean analysisPlaying) {
+    return genmovePlaying && !analysisPlaying;
   }
 
   static void commitEngineGameSelection(Config config, boolean advancedClock) {

--- a/src/main/java/featurecat/lizzie/gui/LizzieFrame.java
+++ b/src/main/java/featurecat/lizzie/gui/LizzieFrame.java
@@ -3891,7 +3891,9 @@ public class LizzieFrame extends JFrame {
 
   private static DesktopTimeControl.Mode configuredTimeControlMode() {
     return DesktopTimeControl.selectedMode(
-        Lizzie.config.advanceTimeSettings, Lizzie.config.kataTimeSettings);
+        Lizzie.config.advanceTimeSettings,
+        Lizzie.config.kataTimeSettings,
+        Lizzie.config.genmoveGameNoTime);
   }
 
   private static void installPlayingAgainstHumanCountDown(
@@ -3910,6 +3912,12 @@ public class LizzieFrame extends JFrame {
   }
 
   public static void sendAiTime(boolean needCountDown, Leelaz engine, boolean showTimeMsg) {
+    if (!DesktopTimeControl.shouldEmitClientTimeOverride(configuredTimeControlMode())) {
+      if (needCountDown) {
+        Lizzie.engineManager.clearPlayingAgainstHumanEngineCountDown();
+      }
+      return;
+    }
     if (Lizzie.config.advanceTimeSettings) {
       engine.sendCommand(Lizzie.config.advanceTimeTxt);
       installPlayingAgainstHumanCountDown(Lizzie.config.advanceTimeTxt, engine, needCountDown);

--- a/src/main/java/featurecat/lizzie/gui/NewEngineGameDialog.java
+++ b/src/main/java/featurecat/lizzie/gui/NewEngineGameDialog.java
@@ -61,7 +61,8 @@ public class NewEngineGameDialog extends JDialog {
   private JComboBox<String> cbxRandomSgf;
 
   private JCheckBox chkDisableWRNInGame;
-  private JCheckBox chkUseAdvanceTime;
+  private JComboBox<String> cmbBlackTimeMode;
+  private JComboBox<String> cmbWhiteTimeMode;
   private JCheckBox chkSGFstart;
   private JFontCheckBox chkContinuePlay;
   private JFontButton btnSGFstart;
@@ -297,6 +298,7 @@ public class NewEngineGameDialog extends JDialog {
     JFontLabel lblTime =
         new JFontLabel(
             Lizzie.resourceBundle.getString("NewEngineGameDialog.lblTime")); // ("每手时间(秒)");
+    LizzieFrame.toolbar.chkenginePkTime.setEnabled(true);
     if (!LizzieFrame.toolbar.chkenginePkTime.isSelected()) {
       LizzieFrame.toolbar.txtenginePkTime.setEnabled(false);
       LizzieFrame.toolbar.txtenginePkTimeWhite.setEnabled(false);
@@ -407,32 +409,8 @@ public class NewEngineGameDialog extends JDialog {
     aboutAdvanceTimeSettings.setPreferredSize(new Dimension(controlHeight(), controlHeight()));
     aboutAdvanceTimeSettings.setFocusable(false);
 
-    chkUseAdvanceTime = new JFontCheckBox(); // $NON-NLS-1$
-    if (!LizzieFrame.toolbar.isGenmoveToolbar) chkUseAdvanceTime.setEnabled(false);
-
-    chkUseAdvanceTime.addActionListener(
-        new ActionListener() {
-          @Override
-          public void actionPerformed(ActionEvent e) {
-            // TODO Auto-generated method stub
-            if (chkUseAdvanceTime.isSelected()) {
-              LizzieFrame.toolbar.chkenginePkTime.setEnabled(false);
-              LizzieFrame.toolbar.txtenginePkTime.setEnabled(false);
-              LizzieFrame.toolbar.txtenginePkTimeWhite.setEnabled(false);
-              txtBlackAdvanceTime.setEnabled(true);
-              txtWhiteAdvanceTime.setEnabled(true);
-            } else {
-              LizzieFrame.toolbar.chkenginePkTime.setEnabled(true);
-              if (LizzieFrame.toolbar.chkenginePkTime.isSelected()) {
-                LizzieFrame.toolbar.txtenginePkTime.setEnabled(true);
-                LizzieFrame.toolbar.txtenginePkTimeWhite.setEnabled(true);
-              }
-              txtBlackAdvanceTime.setEnabled(false);
-              txtWhiteAdvanceTime.setEnabled(false);
-            }
-          }
-        });
-    chkUseAdvanceTime.setSelected(Lizzie.config.pkAdvanceTimeSettings);
+    cmbBlackTimeMode = createEngineGameTimeModeCombo(true);
+    cmbWhiteTimeMode = createEngineGameTimeModeCombo(false);
 
     JCheckBox checkBoxAllowPonder =
         new JFontCheckBox(
@@ -518,6 +496,8 @@ public class NewEngineGameDialog extends JDialog {
     setPreferredControlWidth(enginePkWhite, engineColumnWidth);
     setPreferredControlWidth(LizzieFrame.toolbar.txtenginePkTime, engineColumnWidth);
     setPreferredControlWidth(LizzieFrame.toolbar.txtenginePkTimeWhite, engineColumnWidth);
+    setPreferredControlWidth(cmbBlackTimeMode, engineColumnWidth);
+    setPreferredControlWidth(cmbWhiteTimeMode, engineColumnWidth);
     setPreferredControlWidth(txtBlackAdvanceTime, engineColumnWidth);
     setPreferredControlWidth(txtWhiteAdvanceTime, engineColumnWidth);
     setPreferredControlWidth(LizzieFrame.toolbar.txtenginePkPlayputs, engineColumnWidth);
@@ -538,20 +518,27 @@ public class NewEngineGameDialog extends JDialog {
     addEngineRow(
         enginePanel,
         3,
+        new JFontLabel(""),
+        null,
+        cmbBlackTimeMode,
+        cmbWhiteTimeMode);
+    addEngineRow(
+        enginePanel,
+        4,
         inlinePanel(lblAdvanceTime, aboutAdvanceTimeSettings),
-        chkUseAdvanceTime,
+        null,
         txtBlackAdvanceTime,
         txtWhiteAdvanceTime);
     addEngineRow(
         enginePanel,
-        4,
+        5,
         lblPlayout,
         LizzieFrame.toolbar.chkenginePkPlayouts,
         LizzieFrame.toolbar.txtenginePkPlayputs,
         LizzieFrame.toolbar.txtenginePkPlayputsWhite);
     addEngineRow(
         enginePanel,
-        5,
+        6,
         lblFirstPlayout,
         LizzieFrame.toolbar.chkenginePkFirstPlayputs,
         LizzieFrame.toolbar.txtenginePkFirstPlayputs,
@@ -837,27 +824,48 @@ public class NewEngineGameDialog extends JDialog {
     chkDisableWRNInGame.setVisible(!genmoveMode);
     resignControls.setVisible(!genmoveMode);
     resignThresoldHint.setVisible(genmoveMode);
-    chkUseAdvanceTime.setEnabled(genmoveMode);
-
-    if (genmoveMode && chkUseAdvanceTime.isSelected()) {
-      LizzieFrame.toolbar.chkenginePkTime.setEnabled(false);
-      LizzieFrame.toolbar.txtenginePkTime.setEnabled(false);
-      LizzieFrame.toolbar.txtenginePkTimeWhite.setEnabled(false);
-      txtBlackAdvanceTime.setEnabled(true);
-      txtWhiteAdvanceTime.setEnabled(true);
-    } else {
-      LizzieFrame.toolbar.chkenginePkTime.setEnabled(true);
-      boolean standardTimeEnabled = LizzieFrame.toolbar.chkenginePkTime.isSelected();
-      LizzieFrame.toolbar.txtenginePkTime.setEnabled(standardTimeEnabled);
-      LizzieFrame.toolbar.txtenginePkTimeWhite.setEnabled(standardTimeEnabled);
-      txtBlackAdvanceTime.setEnabled(false);
-      txtWhiteAdvanceTime.setEnabled(false);
-    }
-    if (!genmoveMode) {
-      chkUseAdvanceTime.setEnabled(false);
-    }
+    cmbBlackTimeMode.setEnabled(genmoveMode);
+    cmbWhiteTimeMode.setEnabled(genmoveMode);
+    LizzieFrame.toolbar.chkenginePkTime.setEnabled(true);
+    boolean standardTimeEnabled = LizzieFrame.toolbar.chkenginePkTime.isSelected();
+    LizzieFrame.toolbar.txtenginePkTime.setEnabled(standardTimeEnabled);
+    LizzieFrame.toolbar.txtenginePkTimeWhite.setEnabled(standardTimeEnabled);
+    updateAdvanceTimeFieldEnabled();
     contentPanel.revalidate();
     contentPanel.repaint();
+  }
+
+  private JComboBox<String> createEngineGameTimeModeCombo(boolean black) {
+    JComboBox<String> combo = new JFontComboBox<String>();
+    combo.addItem(Lizzie.resourceBundle.getString("NewGameDialog.engineOwnedTime"));
+    combo.addItem(Lizzie.resourceBundle.getString("NewGameDialog.time"));
+    combo.addItem(Lizzie.resourceBundle.getString("NewEngineGameDialog.lblAdvanceTime"));
+    DesktopTimeControl.SideMode mode =
+        DesktopTimeControl.loadEngineGameSideMode(Lizzie.config, black);
+    int index = 1;
+    if (mode == DesktopTimeControl.SideMode.ENGINE_OWNED) {
+      index = 0;
+    } else if (mode == DesktopTimeControl.SideMode.RAW_ADVANCED) {
+      index = 2;
+    }
+    combo.setSelectedIndex(index);
+    combo.addActionListener(e -> updateAdvanceTimeFieldEnabled());
+    return combo;
+  }
+
+  private DesktopTimeControl.SideMode selectedSideMode(JComboBox<String> combo) {
+    return DesktopTimeControl.selectedEngineGameSideMode(
+        combo.getSelectedIndex() == 2, combo.getSelectedIndex() == 0);
+  }
+
+  private void updateAdvanceTimeFieldEnabled() {
+    boolean genmoveMode = LizzieFrame.toolbar.isGenmoveToolbar;
+    txtBlackAdvanceTime.setEnabled(
+        genmoveMode
+            && selectedSideMode(cmbBlackTimeMode) == DesktopTimeControl.SideMode.RAW_ADVANCED);
+    txtWhiteAdvanceTime.setEnabled(
+        genmoveMode
+            && selectedSideMode(cmbWhiteTimeMode) == DesktopTimeControl.SideMode.RAW_ADVANCED);
   }
 
   private static class ViewportWidthPanel extends JPanel implements Scrollable {
@@ -950,13 +958,15 @@ public class NewEngineGameDialog extends JDialog {
             && !LizzieFrame.toolbar.chkenginePkBatch.isSelected())
           Utils.showMsg(Lizzie.resourceBundle.getString("NewEngineGameDialog.multiSgfNotBatch"));
       }
-      boolean advancedClock = chkUseAdvanceTime.isSelected();
+      DesktopTimeControl.SideMode blackTimeMode = selectedSideMode(cmbBlackTimeMode);
+      DesktopTimeControl.SideMode whiteTimeMode = selectedSideMode(cmbWhiteTimeMode);
       if (LizzieFrame.toolbar.isGenmoveToolbar
           && DesktopTimeControl.rejectsEngineGame(
               Lizzie.engineManager.engineList,
               LizzieFrame.toolbar.engineBlackToolbar,
               LizzieFrame.toolbar.engineWhiteToolbar,
-              advancedClock)) {
+              blackTimeMode,
+              whiteTimeMode)) {
         Lizzie.frame.showUnsupportedWebSocketAdvancedClock();
         return;
       }
@@ -979,7 +989,7 @@ public class NewEngineGameDialog extends JDialog {
           !textFieldHandicap.isEnabled()
               ? 0
               : FORMAT_HANDICAP.parse(textFieldHandicap.getText()).intValue();
-      DesktopTimeControl.commitEngineGameSelection(Lizzie.config, advancedClock);
+      DesktopTimeControl.commitEngineGameSelection(Lizzie.config, blackTimeMode, whiteTimeMode);
       try {
         Lizzie.config.firstEngineResignMoveCounts =
             Integer.parseInt(txtresignSettingBlack.getText());
@@ -1027,10 +1037,12 @@ public class NewEngineGameDialog extends JDialog {
           "second-engine-resign-winrate", Lizzie.config.secondEngineResignWinrate);
       Lizzie.config.uiConfig.put("second-engine-min-move", Lizzie.config.secondEngineMinMove);
 
-      if (Lizzie.config.pkAdvanceTimeSettings) {
+      if (blackTimeMode == DesktopTimeControl.SideMode.RAW_ADVANCED) {
         Lizzie.config.advanceBlackTimeTxt = txtBlackAdvanceTime.getText().trim();
-        Lizzie.config.advanceWhiteTimeTxt = txtWhiteAdvanceTime.getText().trim();
         Lizzie.config.uiConfig.put("advance-black-time-txt", txtBlackAdvanceTime.getText().trim());
+      }
+      if (whiteTimeMode == DesktopTimeControl.SideMode.RAW_ADVANCED) {
+        Lizzie.config.advanceWhiteTimeTxt = txtWhiteAdvanceTime.getText().trim();
         Lizzie.config.uiConfig.put("advance-white-time-txt", txtWhiteAdvanceTime.getText().trim());
       }
       // apply new values

--- a/src/main/java/featurecat/lizzie/gui/NewGameDialog.java
+++ b/src/main/java/featurecat/lizzie/gui/NewGameDialog.java
@@ -50,7 +50,6 @@ public class NewGameDialog extends JDialog {
   private JTextField textTime;
   private JFontCheckBox chkPonder;
   private JFontCheckBox chkUsePlayMode;
-  private JFontCheckBox chkNoTime;
   JFontCheckBox chkLimitMyTime;
   JFontComboBox<String> textSaveTime;
   JFontComboBox<String> texByoSeconds;
@@ -59,6 +58,7 @@ public class NewGameDialog extends JDialog {
   JFontCheckBox chkNormalTime;
   JFontCheckBox chkKataTime;
   JFontCheckBox chkUseAdvTime;
+  JFontCheckBox chkEngineOwned;
 
   JFontComboBox<String> kataTimeComboBox;
 
@@ -639,14 +639,6 @@ public class NewGameDialog extends JDialog {
             chkTimeChanged();
           }
         });
-    chkKataTime.setSelected(Lizzie.config.kataTimeSettings);
-    chkNormalTime.setSelected(
-        !Lizzie.config.advanceTimeSettings && !Lizzie.config.kataTimeSettings);
-
-    ButtonGroup chkTimeGroup = new ButtonGroup();
-    chkTimeGroup.add(chkNormalTime);
-    chkTimeGroup.add(chkKataTime);
-    chkTimeGroup.add(chkUseAdvTime);
 
     panel = new JPanel();
     GridBagConstraints gbc_panel2 = new GridBagConstraints();
@@ -705,28 +697,36 @@ public class NewGameDialog extends JDialog {
     setKataAdvStatus();
 
     GridBagConstraints gbc_4 = new GridBagConstraints();
-    gbc_4.fill = GridBagConstraints.BOTH;
+    gbc_4.anchor = GridBagConstraints.WEST;
+    gbc_4.fill = GridBagConstraints.VERTICAL;
     gbc_4.insets = new Insets(0, 0, 5, 5);
     gbc_4.gridx = 0;
     gbc_4.gridy = 10;
-    JFontLabel label_4 = new JFontLabel(resourceBundle.getString("NewGameDialog.noTime"));
-    contentPanel.add(label_4, gbc_4);
-    chkNoTime = new JFontCheckBox();
-    chkNoTime.addActionListener(
+    JPanel engineOwnedPanel = new JPanel();
+    chkEngineOwned =
+        new JFontCheckBox(resourceBundle.getString("NewGameDialog.engineOwnedTime"));
+    engineOwnedPanel.add(chkEngineOwned);
+    contentPanel.add(engineOwnedPanel, gbc_4);
+    chkEngineOwned.addActionListener(
         new ActionListener() {
-          @Override
           public void actionPerformed(ActionEvent e) {
-            // TODO Auto-generated method stub
-            setNoTimeStatus(chkNoTime.isSelected());
+            chkTimeChanged();
           }
         });
-    GridBagConstraints gbc_chkNoTime = new GridBagConstraints();
-    gbc_chkNoTime.fill = GridBagConstraints.BOTH;
-    gbc_chkNoTime.insets = new Insets(0, 0, 5, 0);
-    gbc_chkNoTime.gridx = 1;
-    gbc_chkNoTime.gridy = 10;
-    contentPanel.add(chkNoTime, gbc_chkNoTime);
-    AccessibilitySupport.labelFor(label_4, chkNoTime, label_4.getText());
+    ButtonGroup chkTimeGroup = new ButtonGroup();
+    chkTimeGroup.add(chkNormalTime);
+    chkTimeGroup.add(chkKataTime);
+    chkTimeGroup.add(chkUseAdvTime);
+    chkTimeGroup.add(chkEngineOwned);
+    if (Lizzie.config.genmoveGameNoTime) {
+      chkEngineOwned.setSelected(true);
+    } else if (Lizzie.config.advanceTimeSettings) {
+      chkUseAdvTime.setSelected(true);
+    } else if (Lizzie.config.kataTimeSettings) {
+      chkKataTime.setSelected(true);
+    } else {
+      chkNormalTime.setSelected(true);
+    }
 
     GridBagConstraints gbc_5 = new GridBagConstraints();
     gbc_5.fill = GridBagConstraints.BOTH;
@@ -844,8 +844,6 @@ public class NewGameDialog extends JDialog {
     gbc_chkAutoSave.gridy = 15;
     contentPanel.add(chkAutoSave, gbc_chkAutoSave);
     chkTimeChanged();
-    chkNoTime.setSelected(Lizzie.config.genmoveGameNoTime);
-    setNoTimeStatus(Lizzie.config.genmoveGameNoTime);
   }
 
   protected void setKataAdvStatus() {
@@ -854,34 +852,8 @@ public class NewGameDialog extends JDialog {
     txtKataVisits.setEnabled(chkUseKataAdvSettings.isSelected());
   }
 
-  private void setNoTimeStatus(boolean selected) {
-    // TODO Auto-generated method stub
-    if (selected) {
-      kataTimeComboBox.setEnabled(false);
-      txtKataTimeSaveMins.setEnabled(false);
-      txtKataTimeByoyomiSecs.setEnabled(false);
-      txtKataTimeByoyomiTimes.setEnabled(false);
-      chkKataTime.setEnabled(false);
-      chkNormalTime.setEnabled(false);
-      textTime.setEnabled(false);
-      chkUseAdvTime.setEnabled(false);
-      btnAboutAdvTime.setEnabled(false);
-      txtAdvanceTime.setEnabled(false);
-    } else {
-      kataTimeComboBox.setEnabled(true);
-      txtKataTimeSaveMins.setEnabled(true);
-      txtKataTimeByoyomiSecs.setEnabled(true);
-      txtKataTimeByoyomiTimes.setEnabled(true);
-      chkKataTime.setEnabled(true);
-      chkNormalTime.setEnabled(true);
-      textTime.setEnabled(true);
-      chkUseAdvTime.setEnabled(true);
-      btnAboutAdvTime.setEnabled(true);
-      txtAdvanceTime.setEnabled(true);
-    }
-  }
-
   private void chkTimeChanged() {
+    boolean engineOwnedSelected = chkEngineOwned.isSelected();
     boolean kataTimeSelected = chkKataTime.isSelected();
     boolean advancedTimeSelected = chkUseAdvTime.isSelected();
     kataTimeComboBox.setEnabled(kataTimeSelected);
@@ -890,11 +862,7 @@ public class NewGameDialog extends JDialog {
     txtKataTimeByoyomiTimes.setEnabled(kataTimeSelected);
     txtKataTimeFisherIncrementSecs.setEnabled(kataTimeSelected);
     txtAdvanceTime.setEnabled(advancedTimeSelected);
-    if (kataTimeSelected || advancedTimeSelected) {
-      textTime.setEnabled(false);
-    } else {
-      textTime.setEnabled(true);
-    }
+    textTime.setEnabled(!kataTimeSelected && !advancedTimeSelected && !engineOwnedSelected);
   }
 
   private void initButtonBar() {
@@ -925,10 +893,11 @@ public class NewGameDialog extends JDialog {
         return;
       }
       DesktopTimeControl.Mode timeMode =
-          DesktopTimeControl.selectedMode(chkUseAdvTime.isSelected(), chkKataTime.isSelected());
+          DesktopTimeControl.selectedMode(
+              chkUseAdvTime.isSelected(), chkKataTime.isSelected(), chkEngineOwned.isSelected());
       Leelaz selectedEngine = Lizzie.engineManager.engineList.get(engine.getSelectedIndex());
       if (DesktopTimeControl.rejectsHumanGame(
-          selectedEngine, timeMode, chkNoTime.isSelected())) {
+          selectedEngine, timeMode, timeMode == DesktopTimeControl.Mode.ENGINE_OWNED)) {
         Lizzie.frame.showUnsupportedWebSocketAdvancedClock();
         return;
       }
@@ -963,7 +932,6 @@ public class NewGameDialog extends JDialog {
         Lizzie.board.tempmovelistForGenMoveGame = null;
       } else Lizzie.board.tempmovelistForGenMoveGame = Lizzie.board.getMoveList();
       Lizzie.config.playponder = chkPonder.isSelected();
-      // if (!chkNoTime.isSelected()) {
       Lizzie.config.maxGameThinkingTimeSeconds =
           FORMAT_HANDICAP.parse(textTime.getText().trim()).intValue();
       Lizzie.config.leelazConfig.putOpt(
@@ -993,7 +961,6 @@ public class NewGameDialog extends JDialog {
 
       Lizzie.config.checkPlayBlack = checkBoxPlayerIsBlack.getSelectedIndex() == 0;
       Lizzie.config.checkContinuePlay = checkContinuePlay.isSelected();
-      Lizzie.config.genmoveGameNoTime = chkNoTime.isSelected();
       Lizzie.config.newGameKomi = komi;
       Lizzie.config.newGameHandicap = textFieldHandicap.getSelectedIndex();
       Lizzie.config.limitMyTime = chkLimitMyTime.isSelected();
@@ -1005,7 +972,6 @@ public class NewGameDialog extends JDialog {
 
       Lizzie.config.uiConfig.put("check-play-black", Lizzie.config.checkPlayBlack);
       Lizzie.config.uiConfig.put("check-continue-play", Lizzie.config.checkContinuePlay);
-      Lizzie.config.uiConfig.put("genmove-game-notime", Lizzie.config.genmoveGameNoTime);
       Lizzie.config.uiConfig.put("new-game-komi", Lizzie.config.newGameKomi);
       Lizzie.config.uiConfig.put("new-game-handicap", Lizzie.config.newGameHandicap);
 

--- a/src/main/java/featurecat/lizzie/gui/NewGameDialog.java
+++ b/src/main/java/featurecat/lizzie/gui/NewGameDialog.java
@@ -932,10 +932,11 @@ public class NewGameDialog extends JDialog {
         Lizzie.board.tempmovelistForGenMoveGame = null;
       } else Lizzie.board.tempmovelistForGenMoveGame = Lizzie.board.getMoveList();
       Lizzie.config.playponder = chkPonder.isSelected();
-      Lizzie.config.maxGameThinkingTimeSeconds =
-          FORMAT_HANDICAP.parse(textTime.getText().trim()).intValue();
-      Lizzie.config.leelazConfig.putOpt(
-          "max-game-thinking-time-seconds", FORMAT_HANDICAP.parse(textTime.getText()).intValue());
+      if (DesktopTimeControl.usesFixedMoveSeconds(timeMode)) {
+        int fixedMoveSeconds = FORMAT_HANDICAP.parse(textTime.getText().trim()).intValue();
+        Lizzie.config.maxGameThinkingTimeSeconds = fixedMoveSeconds;
+        Lizzie.config.leelazConfig.putOpt("max-game-thinking-time-seconds", fixedMoveSeconds);
+      }
       Lizzie.config.leelazConfig.putOpt("play-ponder", Lizzie.config.playponder);
 
       Lizzie.config.advanceTimeTxt = txtAdvanceTime.getText();

--- a/src/main/java/featurecat/lizzie/gui/SetAiTimes.java
+++ b/src/main/java/featurecat/lizzie/gui/SetAiTimes.java
@@ -48,6 +48,7 @@ public class SetAiTimes extends JDialog {
   JCheckBox chkUseNormal;
   JCheckBox chkUseAdvTime;
   JCheckBox chkUseKataTime;
+  JCheckBox chkUseEngineOwned;
   JComboBox<String> kataTimeComboBox;
   private JTextField txtKataTimeSaveMins;
   private JTextField txtKataTimeByoyomiSecs;
@@ -156,6 +157,15 @@ public class SetAiTimes extends JDialog {
         21,
         23);
     buttonPane.add(chkUseAdvTime);
+
+    JFontLabel lblEngineOwnedTime =
+        new JFontLabel(resourceBundle.getString("NewGameDialog.engineOwnedTime"));
+    lblEngineOwnedTime.setBounds(31, 75, 112, 20);
+    buttonPane.add(lblEngineOwnedTime);
+
+    chkUseEngineOwned = new JCheckBox();
+    chkUseEngineOwned.setBounds(10, 75, 21, 23);
+    buttonPane.add(chkUseEngineOwned);
 
     JFontLabel lblKataTimes = new JFontLabel(resourceBundle.getString("SetAiTimes.lblKataTime"));
     lblKataTimes.setBounds(165, 103, 227, 20);
@@ -412,14 +422,28 @@ public class SetAiTimes extends JDialog {
             chkTimeChanged();
           }
         });
-    chkUseAdvTime.setSelected(Lizzie.config.advanceTimeSettings);
-    chkUseKataTime.setSelected(Lizzie.config.kataTimeSettings);
-    chkUseNormal.setSelected(!Lizzie.config.advanceTimeSettings && !Lizzie.config.kataTimeSettings);
-    chkTimeChanged();
+    chkUseEngineOwned.addActionListener(
+        new ActionListener() {
+          @Override
+          public void actionPerformed(ActionEvent e) {
+            chkTimeChanged();
+          }
+        });
     ButtonGroup chkTimeGroup = new ButtonGroup();
     chkTimeGroup.add(chkUseNormal);
     chkTimeGroup.add(chkUseKataTime);
     chkTimeGroup.add(chkUseAdvTime);
+    chkTimeGroup.add(chkUseEngineOwned);
+    if (Lizzie.config.genmoveGameNoTime) {
+      chkUseEngineOwned.setSelected(true);
+    } else if (Lizzie.config.advanceTimeSettings) {
+      chkUseAdvTime.setSelected(true);
+    } else if (Lizzie.config.kataTimeSettings) {
+      chkUseKataTime.setSelected(true);
+    } else {
+      chkUseNormal.setSelected(true);
+    }
+    chkTimeChanged();
 
     try {
       this.setIconImage(ImageIO.read(MoreEngines.class.getResourceAsStream("/assets/logo.png")));
@@ -430,6 +454,7 @@ public class SetAiTimes extends JDialog {
   }
 
   private void chkTimeChanged() {
+    boolean engineOwnedSelected = chkUseEngineOwned.isSelected();
     boolean kataTimeSelected = chkUseKataTime.isSelected();
     boolean advancedTimeSelected = chkUseAdvTime.isSelected();
     kataTimeComboBox.setEnabled(kataTimeSelected);
@@ -438,11 +463,7 @@ public class SetAiTimes extends JDialog {
     txtKataTimeByoyomiTimes.setEnabled(kataTimeSelected);
     txtKataTimeFisherIncrementSecs.setEnabled(kataTimeSelected);
     txtAdvanceTime.setEnabled(advancedTimeSelected);
-    if (kataTimeSelected || advancedTimeSelected) {
-      txtSetTime.setEnabled(false);
-    } else {
-      txtSetTime.setEnabled(true);
-    }
+    txtSetTime.setEnabled(!kataTimeSelected && !advancedTimeSelected && !engineOwnedSelected);
   }
 
   private class DigitOnlyFilter extends DocumentFilter {
@@ -469,13 +490,15 @@ public class SetAiTimes extends JDialog {
   private boolean applyChange() {
     DesktopTimeControl.Mode timeMode =
         DesktopTimeControl.selectedMode(
-            chkUseAdvTime.isSelected(), chkUseKataTime.isSelected());
+            chkUseAdvTime.isSelected(),
+            chkUseKataTime.isSelected(),
+            chkUseEngineOwned.isSelected());
     if (!DesktopTimeControl.submitHumanSelection(
         Lizzie.config,
         Lizzie.leelaz,
         timeMode,
         kataTimeComboBox.getSelectedIndex(),
-        false,
+        timeMode == DesktopTimeControl.Mode.ENGINE_OWNED,
         Lizzie.frame::showUnsupportedWebSocketAdvancedClock)) {
       return false;
     }

--- a/src/main/resources/l10n/DisplayStrings.properties
+++ b/src/main/resources/l10n/DisplayStrings.properties
@@ -2187,6 +2187,8 @@ NewGameDialog.chkUsePlayModeDescribe=(No winRate,variation etc)
 NewGameDialog.chooseBlackWhite=Choose My Side
 NewGameDialog.lblAdvanceTime=Advance Time Settings
 NewGameDialog.noTime=Don't Use Time Settings
+NewGameDialog.engineOwnedTime=Use the engine's own settings
+
 NewGameDialog.okButton=Confirm
 NewGameDialog.playBlack=Play Black
 NewGameDialog.playWhite=Play White

--- a/src/main/resources/l10n/DisplayStrings_en_US.properties
+++ b/src/main/resources/l10n/DisplayStrings_en_US.properties
@@ -2187,6 +2187,8 @@ NewGameDialog.chkUsePlayModeDescribe=(No winRate,variation etc)
 NewGameDialog.chooseBlackWhite=Choose My Side
 NewGameDialog.lblAdvanceTime=Advance Time Settings
 NewGameDialog.noTime=Don't Use Time Settings
+NewGameDialog.engineOwnedTime=Use the engine's own settings
+
 NewGameDialog.okButton=Confirm
 NewGameDialog.playBlack=Play Black
 NewGameDialog.playWhite=Play White

--- a/src/main/resources/l10n/DisplayStrings_ja_JP.properties
+++ b/src/main/resources/l10n/DisplayStrings_ja_JP.properties
@@ -2187,6 +2187,8 @@ NewGameDialog.chkUsePlayModeDescribe=(\u52DD\u7387\u3084\u76EE\u5DEE\u7B49\u3092
 NewGameDialog.chooseBlackWhite=\u4EBA\u9593\u5074\u306E\u624B\u756A\u3092\u9078\u629E
 NewGameDialog.lblAdvanceTime=\u9AD8\u5EA6\u306A\u6642\u9593\u8A2D\u5B9A
 NewGameDialog.noTime=\u6642\u9593\u8A2D\u5B9A\u3092\u4F7F\u7528\u3057\u306A\u3044
+NewGameDialog.engineOwnedTime=\u30A8\u30F3\u30B8\u30F3\u81EA\u8EAB\u306E\u8A2D\u5B9A\u3092\u4F7F\u7528
+
 NewGameDialog.okButton=\u5BFE\u5C40\u958B\u59CB
 NewGameDialog.playBlack=\u9ED2\u756A
 NewGameDialog.playWhite=\u767D\u756A

--- a/src/main/resources/l10n/DisplayStrings_ko.properties
+++ b/src/main/resources/l10n/DisplayStrings_ko.properties
@@ -2187,6 +2187,8 @@ NewGameDialog.chkUsePlayModeDescribe=(\uC2B9\uB960, \uBCC0\uD654\uB3C4 \uB4F1 \u
 NewGameDialog.chooseBlackWhite=\uB0B4\uAC00 \uB458 \uC0C9\uAE54 \uC120\uD0DD
 NewGameDialog.lblAdvanceTime=\uCD08\uC77D\uAE30 \uC124\uC815
 NewGameDialog.noTime=\uC2DC\uAC04\uC124\uC815 \uC0AC\uC6A9\uC548\uD568
+NewGameDialog.engineOwnedTime=\uc5d4\uc9c4 \uc790\uccb4 \uc124\uc815 \uc0ac\uc6a9
+
 NewGameDialog.okButton=\uD655\uC778
 NewGameDialog.playBlack=\uD751\uBC88\uC73C\uB85C \uB460
 NewGameDialog.playWhite=\uBC31\uBC88\uC73C\uB85C \uB460

--- a/src/main/resources/l10n/DisplayStrings_th_TH.properties
+++ b/src/main/resources/l10n/DisplayStrings_th_TH.properties
@@ -2187,6 +2187,8 @@ NewGameDialog.chkUsePlayModeDescribe=(ไม่มี winRate, การเป�
 NewGameDialog.chooseBlackWhite=เลือกข้างของฉัน
 NewGameDialog.lblAdvanceTime=การตั้งค่าเวลาล่วงหน้า
 NewGameDialog.noTime=อย่าใช้การตั้งค่าเวลา
+NewGameDialog.engineOwnedTime=\u0e43\u0e0a\u0e49\u0e01\u0e32\u0e23\u0e15\u0e31\u0e49\u0e07\u0e04\u0e48\u0e32\u0e02\u0e2d\u0e07\u0e40\u0e04\u0e23\u0e37\u0e48\u0e2d\u0e07\u0e2d\u0e07\u0e04\u0e4c
+
 NewGameDialog.okButton=ยืนยัน
 NewGameDialog.playBlack=เล่นสีดำ
 NewGameDialog.playWhite=เล่นไวท์

--- a/src/main/resources/l10n/DisplayStrings_zh_CN.properties
+++ b/src/main/resources/l10n/DisplayStrings_zh_CN.properties
@@ -2187,6 +2187,8 @@ NewGameDialog.chkUsePlayModeDescribe=(\u4E0D\u663E\u793A\u80DC\u7387,\u53D8\u531
 NewGameDialog.chooseBlackWhite=\u9009\u62E9\u9ED1\u767D(\u6211)
 NewGameDialog.lblAdvanceTime=\u9AD8\u7EA7\u65F6\u95F4\u8BBE\u7F6E
 NewGameDialog.noTime=\u4E0D\u4F7F\u7528\u65F6\u95F4\u8BBE\u7F6E
+NewGameDialog.engineOwnedTime=\u4f7f\u7528\u5f15\u64ce\u81ea\u8eab\u8bbe\u7f6e
+
 NewGameDialog.okButton=\u786E\u5B9A
 NewGameDialog.playBlack=\u6267\u9ED1
 NewGameDialog.playWhite=\u6267\u767D

--- a/src/main/resources/l10n/DisplayStrings_zh_HK.properties
+++ b/src/main/resources/l10n/DisplayStrings_zh_HK.properties
@@ -2187,6 +2187,8 @@ NewGameDialog.chkUsePlayModeDescribe=(\u4E0D\u986F\u793A\u52DD\u7387,\u8B8A\u531
 NewGameDialog.chooseBlackWhite=\u9078\u64C7\u9ED1\u767D(\u6211)
 NewGameDialog.lblAdvanceTime=\u9AD8\u7D1A\u6642\u9593\u8A2D\u7F6E
 NewGameDialog.noTime=\u4E0D\u4F7F\u7528\u6642\u9593\u8A2D\u7F6E
+NewGameDialog.engineOwnedTime=\u4f7f\u7528\u5f15\u64ce\u81ea\u8eab\u8a2d\u7f6e
+
 NewGameDialog.okButton=\u78BA\u5B9A
 NewGameDialog.playBlack=\u57F7\u9ED1
 NewGameDialog.playWhite=\u57F7\u767D

--- a/src/main/resources/l10n/DisplayStrings_zh_TW.properties
+++ b/src/main/resources/l10n/DisplayStrings_zh_TW.properties
@@ -2187,6 +2187,8 @@ NewGameDialog.chkUsePlayModeDescribe=(\u4E0D\u986F\u793A\u52DD\u7387,\u8B8A\u531
 NewGameDialog.chooseBlackWhite=\u9078\u64C7\u9ED1\u767D(\u6211)
 NewGameDialog.lblAdvanceTime=\u9AD8\u968E\u6642\u9593\u8A2D\u5B9A
 NewGameDialog.noTime=\u4E0D\u4F7F\u7528\u6642\u9593\u8A2D\u5B9A
+NewGameDialog.engineOwnedTime=\u4f7f\u7528\u5f15\u64ce\u81ea\u8eab\u8a2d\u5b9a
+
 NewGameDialog.okButton=\u78BA\u5B9A
 NewGameDialog.playBlack=\u57F7\u9ED1
 NewGameDialog.playWhite=\u57F7\u767D

--- a/src/test/java/featurecat/lizzie/LizzieInitializationTimeControlTest.java
+++ b/src/test/java/featurecat/lizzie/LizzieInitializationTimeControlTest.java
@@ -25,15 +25,15 @@ class LizzieInitializationTimeControlTest {
   }
 
   @Test
-  void automaticGameInitializationKeepsGameMoveTime() throws Exception {
+  void automaticGameInitializationDoesNotInstallGameMoveTime() throws Exception {
     try (Harness harness = Harness.open()) {
       harness.frame.isAnaPlayingAgainstLeelaz = true;
       harness.initialize(false);
 
-      assertEquals(
-          List.of("kata-time_settings none", "kata-set-param maxTime 2"), harness.engine.commands);
+      assertEquals(List.of(), harness.engine.commands);
     }
   }
+
 
   @Test
   void readBoardGmaInitializationDoesNotOverwriteGmaTime() throws Exception {
@@ -56,6 +56,18 @@ class LizzieInitializationTimeControlTest {
           List.of("kata-time_settings none", "kata-set-param maxTime 2"), harness.engine.commands);
     }
   }
+
+  @Test
+  void humanEngineOwnedInitializationSendsNoClientTimeOverride() throws Exception {
+    try (Harness harness = Harness.open()) {
+      Lizzie.config.genmoveGameNoTime = true;
+      harness.frame.isPlayingAgainstLeelaz = true;
+      harness.initialize(false);
+
+      assertEquals(List.of(), harness.engine.commands);
+    }
+  }
+
 
   private static final class Harness implements AutoCloseable {
     private final Config previousConfig;

--- a/src/test/java/featurecat/lizzie/analysis/EngineManagerEngineGameStartTest.java
+++ b/src/test/java/featurecat/lizzie/analysis/EngineManagerEngineGameStartTest.java
@@ -1,0 +1,93 @@
+package featurecat.lizzie.analysis;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import featurecat.lizzie.Lizzie;
+import featurecat.lizzie.gui.LizzieFrame;
+import java.lang.reflect.Field;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class EngineManagerEngineGameStartTest {
+  @Test
+  void startNewEngineGameDoesNotEnterPreGameWhenLifecycleTransitionIsRejected() throws Exception {
+    LizzieFrame previousFrame = Lizzie.frame;
+    Leelaz previousEngine = Lizzie.leelaz;
+    boolean previousEngineGame = EngineManager.isEngineGame;
+    boolean previousPreEngineGame = EngineManager.isPreEngineGame;
+    try {
+      RejectingLifecycleLeelaz engine = new RejectingLifecycleLeelaz();
+      CountingLeaseEngineManager manager = new CountingLeaseEngineManager(List.of(engine));
+      Lizzie.frame = allocate(SilentFrame.class);
+      Lizzie.leelaz = engine;
+      EngineManager.isEngineGame = false;
+      EngineManager.isPreEngineGame = false;
+
+      manager.startNewEngineGame(true);
+
+      assertFalse(EngineManager.isPreEngineGame);
+      assertFalse(EngineManager.isEngineGame);
+      assertTrue(engine.stoppedPondering);
+      assertEqualsOneLeaseConflict(manager);
+    } finally {
+      Lizzie.frame = previousFrame;
+      Lizzie.leelaz = previousEngine;
+      EngineManager.isEngineGame = previousEngineGame;
+      EngineManager.isPreEngineGame = previousPreEngineGame;
+    }
+  }
+
+  private static void assertEqualsOneLeaseConflict(CountingLeaseEngineManager manager) {
+    if (manager.leaseConflictCount != 1) {
+      throw new AssertionError("expected one lease conflict, got " + manager.leaseConflictCount);
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  private static <T> T allocate(Class<T> type) throws Exception {
+    Field unsafeField = sun.misc.Unsafe.class.getDeclaredField("theUnsafe");
+    unsafeField.setAccessible(true);
+    sun.misc.Unsafe unsafe = (sun.misc.Unsafe) unsafeField.get(null);
+    return (T) unsafe.allocateInstance(type);
+  }
+
+  private static final class CountingLeaseEngineManager extends EngineManager {
+    private int leaseConflictCount;
+
+    private CountingLeaseEngineManager(List<Leelaz> engines) {
+      super(engines);
+    }
+
+    @Override
+    protected void showForegroundEngineLeaseInUse() {
+      leaseConflictCount++;
+    }
+  }
+
+  private static final class RejectingLifecycleLeelaz extends Leelaz {
+    private boolean stoppedPondering;
+
+    private RejectingLifecycleLeelaz() throws Exception {
+      super("");
+    }
+
+    @Override
+    public void notPondering() {
+      stoppedPondering = true;
+    }
+
+    @Override
+    public synchronized boolean beginExclusiveGtpLifecycleTransition() {
+      return false;
+    }
+  }
+
+  private static final class SilentFrame extends LizzieFrame {
+    @Override
+    public void addInput(boolean shouldAdd) {}
+
+    @Override
+    public void setResult(String result) {}
+  }
+}

--- a/src/test/java/featurecat/lizzie/gui/DesktopTimeControlTest.java
+++ b/src/test/java/featurecat/lizzie/gui/DesktopTimeControlTest.java
@@ -152,6 +152,62 @@ class DesktopTimeControlTest {
     assertEquals(List.of(), websocket.commands);
   }
 
+  @Test
+  void engineOwnedModeWinsOverOtherHumanClockFlags() {
+    assertEquals(
+        DesktopTimeControl.Mode.ENGINE_OWNED,
+        DesktopTimeControl.selectedMode(true, true, true));
+    assertEquals(
+        DesktopTimeControl.Mode.FIXED, DesktopTimeControl.selectedMode(false, false, false));
+  }
+
+  @Test
+  void commitHumanEngineOwnedPersistsNoTimeFlagAndClearsClientClockModes() throws Exception {
+    Config config =
+        ConfigTestHelper.createForTests(Files.createTempDirectory("lizzie-time-engine-owned"));
+    config.uiConfig = new JSONObject();
+    config.advanceTimeSettings = true;
+    config.kataTimeSettings = true;
+
+    DesktopTimeControl.commitHumanSelection(config, DesktopTimeControl.Mode.ENGINE_OWNED, 1);
+
+    assertTrue(config.genmoveGameNoTime);
+    assertFalse(config.advanceTimeSettings);
+    assertFalse(config.kataTimeSettings);
+    assertTrue(config.uiConfig.getBoolean("genmove-game-notime"));
+    assertFalse(config.uiConfig.getBoolean("advance-time-settings"));
+    assertFalse(config.uiConfig.getBoolean("kata-time-settings"));
+  }
+
+  @Test
+  void websocketAllowsHumanEngineOwnedTime() throws Exception {
+    Leelaz websocket = new Leelaz(RemoteComputeConfig.COMMAND_CUSTOM_WS);
+
+    assertFalse(
+        DesktopTimeControl.rejectsHumanGame(
+            websocket, DesktopTimeControl.Mode.ENGINE_OWNED, false));
+  }
+
+  @Test
+  void engineOwnedModeDoesNotEmitClientTimeOverride() {
+    assertFalse(
+        DesktopTimeControl.shouldEmitClientTimeOverride(DesktopTimeControl.Mode.ENGINE_OWNED));
+    assertTrue(DesktopTimeControl.shouldEmitClientTimeOverride(DesktopTimeControl.Mode.FIXED));
+    assertTrue(
+        DesktopTimeControl.shouldEmitClientTimeOverride(DesktopTimeControl.Mode.RAW_ADVANCED));
+    assertTrue(
+        DesktopTimeControl.shouldEmitClientTimeOverride(DesktopTimeControl.Mode.KATAGO_ADVANCED));
+  }
+
+  @Test
+  void automaticEngineReadySendsHumanTimeOnlyForGenmoveGames() {
+    assertTrue(DesktopTimeControl.shouldSendHumanTimeOnEngineReady(true, false));
+    assertFalse(DesktopTimeControl.shouldSendHumanTimeOnEngineReady(false, true));
+    assertFalse(DesktopTimeControl.shouldSendHumanTimeOnEngineReady(false, false));
+    assertFalse(DesktopTimeControl.shouldSendHumanTimeOnEngineReady(true, true));
+  }
+
+
   private static final class RecordingLeelaz extends Leelaz {
     private final List<String> commands = new ArrayList<>();
 

--- a/src/test/java/featurecat/lizzie/gui/DesktopTimeControlTest.java
+++ b/src/test/java/featurecat/lizzie/gui/DesktopTimeControlTest.java
@@ -207,6 +207,142 @@ class DesktopTimeControlTest {
     assertFalse(DesktopTimeControl.shouldSendHumanTimeOnEngineReady(true, true));
   }
 
+  @Test
+  void engineOwnedSideModeWinsOverAdvancedFlag() {
+    assertEquals(
+        DesktopTimeControl.SideMode.ENGINE_OWNED,
+        DesktopTimeControl.selectedEngineGameSideMode(true, true));
+    assertEquals(
+        DesktopTimeControl.SideMode.FIXED,
+        DesktopTimeControl.selectedEngineGameSideMode(false, false));
+  }
+
+  @Test
+  void commitEngineGameSidesPersistsIndependentlyAndMigratesLegacyFlag() throws Exception {
+    Config config =
+        ConfigTestHelper.createForTests(Files.createTempDirectory("lizzie-pk-side-mode"));
+    config.uiConfig = new JSONObject();
+    config.pkAdvanceTimeSettings = true;
+
+    assertEquals(
+        DesktopTimeControl.SideMode.RAW_ADVANCED,
+        DesktopTimeControl.loadEngineGameSideMode(config, true));
+    assertEquals(
+        DesktopTimeControl.SideMode.RAW_ADVANCED,
+        DesktopTimeControl.loadEngineGameSideMode(config, false));
+
+    DesktopTimeControl.commitEngineGameSelection(
+        config,
+        DesktopTimeControl.SideMode.ENGINE_OWNED,
+        DesktopTimeControl.SideMode.FIXED);
+
+    assertEquals(
+        DesktopTimeControl.SideMode.ENGINE_OWNED,
+        DesktopTimeControl.loadEngineGameSideMode(config, true));
+    assertEquals(
+        DesktopTimeControl.SideMode.FIXED,
+        DesktopTimeControl.loadEngineGameSideMode(config, false));
+    assertFalse(config.pkAdvanceTimeSettings);
+    assertFalse(config.uiConfig.getBoolean("pk-advance-time-settings"));
+
+  }
+
+  @Test
+  void websocketEngineGameRejectsOnlyRawAdvancedSides() throws Exception {
+    Leelaz local = new Leelaz("katago gtp");
+    Leelaz websocket = new Leelaz(RemoteComputeConfig.COMMAND_CUSTOM_WS);
+
+    assertTrue(
+        DesktopTimeControl.rejectsEngineGame(
+            List.of(local, websocket),
+            0,
+            1,
+            DesktopTimeControl.SideMode.FIXED,
+            DesktopTimeControl.SideMode.RAW_ADVANCED));
+    assertFalse(
+        DesktopTimeControl.rejectsEngineGame(
+            List.of(local, websocket),
+            0,
+            1,
+            DesktopTimeControl.SideMode.ENGINE_OWNED,
+            DesktopTimeControl.SideMode.FIXED));
+  }
+
+  @Test
+  void mixedEngineGameApplySendsOnlyClientOwnedSide() throws Exception {
+    RecordingLeelaz black = new RecordingLeelaz("zen gtp");
+    RecordingLeelaz white = new RecordingLeelaz("katago gtp");
+
+    DesktopTimeControl.applyEngineGameTime(
+        black, DesktopTimeControl.SideMode.ENGINE_OWNED, 10, "time_settings 120 2 1");
+    DesktopTimeControl.applyEngineGameTime(
+        white, DesktopTimeControl.SideMode.FIXED, 10, "time_settings 120 2 1");
+
+    assertEquals(List.of(), black.commands);
+    assertEquals(List.of("time_settings 0 10 1"), white.commands);
+  }
+
+  @Test
+  void toolbarSecondsAffectOnlyFixedSides() {
+    assertEquals(
+        -1,
+        DesktopTimeControl.fixedSecondsForToolbar(
+            DesktopTimeControl.SideMode.ENGINE_OWNED, true, 10));
+    assertEquals(
+        -1,
+        DesktopTimeControl.fixedSecondsForToolbar(DesktopTimeControl.SideMode.FIXED, false, 10));
+    assertEquals(
+        10,
+        DesktopTimeControl.fixedSecondsForToolbar(DesktopTimeControl.SideMode.FIXED, true, 10));
+  }
+
+  @Test
+  void rawAdvancedApplyUsesThatSideCommandOnly() throws Exception {
+    RecordingLeelaz white = new RecordingLeelaz("katago gtp");
+
+    DesktopTimeControl.applyEngineGameTime(
+        white,
+        DesktopTimeControl.SideMode.RAW_ADVANCED,
+        10,
+        "time_settings 30 5 1");
+
+    assertEquals(List.of("time_settings 30 5 1"), white.commands);
+  }
+
+  @Test
+  void capturedEngineGameTimeIgnoresLaterLiveConfig() throws Exception {
+    RecordingLeelaz white = new RecordingLeelaz("katago gtp");
+    featurecat.lizzie.analysis.EngineGameInfo game =
+        new featurecat.lizzie.analysis.EngineGameInfo();
+    game.whiteEngineIndex = 7;
+    game.blackEngineIndex = 3;
+    game.whiteTimeMode = DesktopTimeControl.SideMode.RAW_ADVANCED;
+    game.advanceWhiteTimeCmd = "time_settings 30 5 1";
+    game.timeWhite = 10;
+
+    game.applyCapturedTime(white, 7);
+
+    assertEquals(List.of("time_settings 30 5 1"), white.commands);
+  }
+
+  @Test
+  void capturedEngineOwnedRestartStaysSilent() throws Exception {
+    RecordingLeelaz black = new RecordingLeelaz("zen gtp");
+    featurecat.lizzie.analysis.EngineGameInfo game =
+        new featurecat.lizzie.analysis.EngineGameInfo();
+    game.blackEngineIndex = 1;
+    game.whiteEngineIndex = 2;
+    game.blackTimeMode = DesktopTimeControl.SideMode.ENGINE_OWNED;
+    game.advanceBlackTimeCmd = "time_settings 120 2 1";
+    game.timeBlack = 10;
+
+    game.applyCapturedTime(black, 1);
+
+    assertEquals(List.of(), black.commands);
+  }
+
+
+
 
   private static final class RecordingLeelaz extends Leelaz {
     private final List<String> commands = new ArrayList<>();

--- a/src/test/java/featurecat/lizzie/gui/DesktopTimeControlTest.java
+++ b/src/test/java/featurecat/lizzie/gui/DesktopTimeControlTest.java
@@ -200,6 +200,14 @@ class DesktopTimeControlTest {
   }
 
   @Test
+  void onlyFixedModeConsumesThePerMoveSecondsField() {
+    assertTrue(DesktopTimeControl.usesFixedMoveSeconds(DesktopTimeControl.Mode.FIXED));
+    assertFalse(DesktopTimeControl.usesFixedMoveSeconds(DesktopTimeControl.Mode.ENGINE_OWNED));
+    assertFalse(DesktopTimeControl.usesFixedMoveSeconds(DesktopTimeControl.Mode.RAW_ADVANCED));
+    assertFalse(DesktopTimeControl.usesFixedMoveSeconds(DesktopTimeControl.Mode.KATAGO_ADVANCED));
+  }
+
+  @Test
   void automaticEngineReadySendsHumanTimeOnlyForGenmoveGames() {
     assertTrue(DesktopTimeControl.shouldSendHumanTimeOnEngineReady(true, false));
     assertFalse(DesktopTimeControl.shouldSendHumanTimeOnEngineReady(false, true));
@@ -244,7 +252,40 @@ class DesktopTimeControlTest {
         DesktopTimeControl.loadEngineGameSideMode(config, false));
     assertFalse(config.pkAdvanceTimeSettings);
     assertFalse(config.uiConfig.getBoolean("pk-advance-time-settings"));
+  }
 
+  @Test
+  void engineGameSideModeAcceptsCaseInsensitiveSavedValues() throws Exception {
+    Config config =
+        ConfigTestHelper.createForTests(Files.createTempDirectory("lizzie-pk-side-mode-case"));
+    config.uiConfig = new JSONObject();
+    config.uiConfig.put("pk-black-time-mode", " engine_owned ");
+
+    assertEquals(
+        DesktopTimeControl.SideMode.ENGINE_OWNED,
+        DesktopTimeControl.loadEngineGameSideMode(config, true));
+  }
+
+  @Test
+  void invalidEngineGameSideModeFallsBackToLegacySelection() throws Exception {
+    Config config =
+        ConfigTestHelper.createForTests(Files.createTempDirectory("lizzie-pk-side-mode-invalid"));
+    config.uiConfig = new JSONObject();
+    config.uiConfig.put("pk-black-time-mode", "UNKNOWN_MODE");
+    config.uiConfig.put("pk-white-time-mode", 42);
+    config.pkAdvanceTimeSettings = true;
+
+    assertEquals(
+        DesktopTimeControl.SideMode.RAW_ADVANCED,
+        DesktopTimeControl.loadEngineGameSideMode(config, true));
+    assertEquals(
+        DesktopTimeControl.SideMode.RAW_ADVANCED,
+        DesktopTimeControl.loadEngineGameSideMode(config, false));
+
+    config.pkAdvanceTimeSettings = false;
+    assertEquals(
+        DesktopTimeControl.SideMode.FIXED,
+        DesktopTimeControl.loadEngineGameSideMode(config, true));
   }
 
   @Test

--- a/src/test/java/featurecat/lizzie/gui/LizzieFrameAiTimeControlTest.java
+++ b/src/test/java/featurecat/lizzie/gui/LizzieFrameAiTimeControlTest.java
@@ -71,6 +71,49 @@ class LizzieFrameAiTimeControlTest {
     }
   }
 
+  @Test
+  void engineOwnedAiTimeSendsNoClientTimeOverrideForKataGo() throws Exception {
+    Config previousConfig = Lizzie.config;
+    try {
+      Lizzie.config =
+          ConfigTestHelper.createForTests(Files.createTempDirectory("lizzie-ai-time-owned-kata"));
+      Lizzie.config.advanceTimeSettings = false;
+      Lizzie.config.kataTimeSettings = false;
+      Lizzie.config.genmoveGameNoTime = true;
+      Lizzie.config.maxGameThinkingTimeSeconds = 4;
+      RecordingLeelaz engine = new RecordingLeelaz();
+      engine.isKatago = true;
+
+      LizzieFrame.sendAiTime(false, engine, false);
+
+      assertEquals(List.of(), engine.commands);
+    } finally {
+      Lizzie.config = previousConfig;
+    }
+  }
+
+  @Test
+  void engineOwnedAiTimeSendsNoClientTimeOverrideForOrdinaryGtp() throws Exception {
+    Config previousConfig = Lizzie.config;
+    try {
+      Lizzie.config =
+          ConfigTestHelper.createForTests(Files.createTempDirectory("lizzie-ai-time-owned-gtp"));
+      Lizzie.config.advanceTimeSettings = false;
+      Lizzie.config.kataTimeSettings = false;
+      Lizzie.config.genmoveGameNoTime = true;
+      Lizzie.config.maxGameThinkingTimeSeconds = 4;
+      RecordingLeelaz engine = new RecordingLeelaz();
+      engine.isKatago = false;
+
+      LizzieFrame.sendAiTime(false, engine, false);
+
+      assertEquals(List.of(), engine.commands);
+    } finally {
+      Lizzie.config = previousConfig;
+    }
+  }
+
+
   private static final class RecordingLeelaz extends Leelaz {
     private final List<String> commands = new ArrayList<>();
 


### PR DESCRIPTION
## Why

#255: starting a game still sent client time overrides (`time_settings`, `time_left`, `kata-time_settings`, `kata-set-param maxTime`) after a GTP configuration profile was applied. Rank profiles were silently mixed with the dialog's per-move seconds.

## What

- Human genmove: fourth radio **Use the engine's own settings**. Removes the old "don't use time settings" overlay.
- That mode sends no client time override on start, continue, engine-ready/restart, or mid-game Apply. Switching back to fixed/advanced still sends those commands.
- Analysis-game dialog is unchanged; automatic engine-ready during analysis no longer sends a genmove time override.
- Engine-vs-engine genmove: Black and White choose engine-owned / fixed / raw advanced independently in the engine-game dialog. Toolbar layout is unchanged; seconds apply only to FIXED sides.
- Restart uses the start-of-game per-side snapshot (White no longer receives Black's advanced command).
- Default remains fixed per-move time.
- Also: do not paint "playing" / disable the engine menu before the exclusive start reservation succeeds; aborting start returns false and `stopEngineGame` restores the UI.

## How

`DesktopTimeControl` owns emit-vs-silence. Engine-owned is silence, not unlimited `maxTime`. Saved `genmove-game-notime` opens as the new radio. New engine-game keys migrate from the old global advanced flag.

## Test

- [x] `DesktopTimeControlTest`, `LizzieFrameAiTimeControlTest`, `LizzieInitializationTimeControlTest`, `EngineManagerEngineGameStartTest`
- [x] Windows desktop cases 1–9 (GTP console)
- [ ] Case 10 (restart White mid engine game) — no GUI; covered by `applyCapturedTime` tests
- [ ] Re-test engine-game OK after this start-abort fix (commit `437f67532`)

## Related

- Closes #255