### PR TITLE
refactor(startup): make initial engine sync admission owner-scoped

### DIFF
--- a/src/main/java/featurecat/lizzie/analysis/EngineManager.java
+++ b/src/main/java/featurecat/lizzie/analysis/EngineManager.java
@@ -37,6 +37,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Supplier;
 import javax.swing.SwingUtilities;
 import javax.swing.Timer;
 import org.json.JSONException;
@@ -3868,13 +3869,58 @@ public class EngineManager {
   }
 
   /**
-   * Engine lifecycle board restore barrier (Issue #223).
+   * Owner-scoped 初始引擎同步准入. One instance is created at capture, shared by the captured
+   * target and mirror, and stays active across the frozen route, catch-up routes and final
+   * handoff. It is not {@link Leelaz.ExactSnapshotRestoreAdmission}.
+   */
+  static final class InitialEngineSyncAdmission {
+    private final AtomicBoolean active = new AtomicBoolean(false);
+
+    boolean isActive() {
+      return active.get();
+    }
+
+    void activate() {
+      active.set(true);
+    }
+
+    void deactivate() {
+      active.set(false);
+    }
+  }
+
+  /**
+   * Ordinary live-board forwarding submitted by Board. The startup owner decides whether the
+   * action runs; Leelaz still enforces enqueue races on the command queue.
+   */
+  public static final class OrdinaryLiveBoardForwardingIntent {
+    private final Supplier<Boolean> action;
+
+    private OrdinaryLiveBoardForwardingIntent(Supplier<Boolean> action) {
+      this.action = action;
+    }
+
+    public static OrdinaryLiveBoardForwardingIntent of(Supplier<Boolean> action) {
+      if (action == null) {
+        throw new IllegalArgumentException("action");
+      }
+      return new OrdinaryLiveBoardForwardingIntent(action);
+    }
+
+    boolean execute() {
+      return Boolean.TRUE.equals(action.get());
+    }
+  }
+
+  /**
+   * Engine lifecycle board restore barrier (Issue #223) and the sole owner of 初始引擎同步准入.
    *
-   * <p>Owns one lifecycle owner identity, owner-local previous/target reservations, captured
-   * target/mirror gates and immutable restore routes. Navigation remains available while ordinary
-   * live-board updates are suppressed on the captured targets. Each completed route releases its
-   * reservations before comparing a new Board frame and, when stale, captures and reserves a new
-   * catch-up route under the same owner.
+   * <p>Owns one lifecycle owner identity, the shared startup admission, owner-local
+   * previous/target reservations, captured target/mirror gates and immutable restore routes.
+   * Navigation remains available while ordinary live-board updates are suppressed on the captured
+   * targets. Each completed route releases its reservations before comparing a new Board frame
+   * and, when stale, captures and reserves a new catch-up route under the same owner and
+   * admission.
    */
   static final class InitialEngineStartupSynchronization implements AutoCloseable {
     private final Leelaz previousEngine;
@@ -3895,6 +3941,7 @@ public class EngineManager {
     private final AtomicBoolean barriersEnded = new AtomicBoolean(false);
     private final AtomicBoolean closed = new AtomicBoolean(false);
     private final AtomicBoolean initialized = new AtomicBoolean(false);
+    private final InitialEngineSyncAdmission admission = new InitialEngineSyncAdmission();
 
     /** Test seam: runs outside the board lock before each restore route execution. */
     Runnable beforeRestore;
@@ -4138,9 +4185,10 @@ public class EngineManager {
     }
 
     private void beginSynchronizationBarriers() {
-      targetEngine.beginInitialBoardSynchronization();
+      admission.activate();
+      targetEngine.attachAndBeginInitialEngineSyncAdmission(admission);
       if (mirrorEngine != null) {
-        mirrorEngine.beginInitialBoardSynchronization();
+        mirrorEngine.attachAndBeginInitialEngineSyncAdmission(admission);
       }
     }
 
@@ -4166,12 +4214,23 @@ public class EngineManager {
     private void endSynchronizationBarriers() {
       if (barriersEnded.compareAndSet(false, true)) {
         try {
-          targetEngine.endInitialBoardSynchronization();
+          targetEngine.endInitialEngineSyncAdmission(admission);
         } finally {
-          if (mirrorEngine != null) {
-            mirrorEngine.endInitialBoardSynchronization();
+          try {
+            if (mirrorEngine != null) {
+              mirrorEngine.endInitialEngineSyncAdmission(admission);
+            }
+          } finally {
+            admission.deactivate();
           }
         }
+      }
+    }
+
+    private void detachSynchronizationAdmission() {
+      targetEngine.detachInitialEngineSyncAdmission(admission);
+      if (mirrorEngine != null) {
+        mirrorEngine.detachInitialEngineSyncAdmission(admission);
       }
     }
 
@@ -4322,10 +4381,14 @@ public class EngineManager {
               interactionGate.close();
             }
           } finally {
-            endSynchronizationBarriers();
-            Leelaz.LifecycleCompletionClaim claim = completionClaim;
-            if (claim != null) {
-              claim.abandonBeforeFence();
+            try {
+              endSynchronizationBarriers();
+            } finally {
+              detachSynchronizationAdmission();
+              Leelaz.LifecycleCompletionClaim claim = completionClaim;
+              if (claim != null) {
+                claim.abandonBeforeFence();
+              }
             }
           }
         }

--- a/src/main/java/featurecat/lizzie/analysis/EngineManager.java
+++ b/src/main/java/featurecat/lizzie/analysis/EngineManager.java
@@ -4008,8 +4008,8 @@ public class EngineManager {
       InitialEngineStartupSynchronization coordination =
           new InitialEngineStartupSynchronization(
               previousEngine, targetEngine, mirrorEngine, board, resumePonder, false, null);
-      coordination.beginSynchronizationBarriers();
       try {
+        coordination.beginSynchronizationBarriers();
         coordination.acquireReservation();
         synchronized (board) {
           coordination.pendingRoute = coordination.captureRoute(forceRootReplay);
@@ -4066,15 +4066,19 @@ public class EngineManager {
               resumePonder,
               true,
               retainedLifecycleOwner);
-      coordination.beginSynchronizationBarriers();
       try {
+        coordination.beginSynchronizationBarriers();
         synchronized (board) {
           coordination.pendingRoute = coordination.captureRoute(forceRootReplay);
           coordination.capturedFrame = BoardFrame.capture(board);
         }
         return coordination;
       } catch (RuntimeException failure) {
-        coordination.close();
+        try {
+          coordination.close();
+        } catch (RuntimeException cleanupFailure) {
+          failure.addSuppressed(cleanupFailure);
+        }
         throw failure;
       }
     }

--- a/src/main/java/featurecat/lizzie/analysis/EngineManager.java
+++ b/src/main/java/featurecat/lizzie/analysis/EngineManager.java
@@ -3892,19 +3892,33 @@ public class EngineManager {
   /**
    * Ordinary live-board forwarding submitted by Board. The startup owner decides whether the
    * action runs; Leelaz still enforces enqueue races on the command queue.
+   *
+   * <p>History-overwrite plans capture occupancy at mutation time. If the startup owner already
+   * occupied the engine then, the action stays suppressed even after handoff.
    */
   public static final class OrdinaryLiveBoardForwardingIntent {
     private final Supplier<Boolean> action;
+    private final boolean occupiedAtMutation;
 
-    private OrdinaryLiveBoardForwardingIntent(Supplier<Boolean> action) {
+    private OrdinaryLiveBoardForwardingIntent(Supplier<Boolean> action, boolean occupiedAtMutation) {
       this.action = action;
+      this.occupiedAtMutation = occupiedAtMutation;
     }
 
     public static OrdinaryLiveBoardForwardingIntent of(Supplier<Boolean> action) {
+      return capturedAtMutation(false, action);
+    }
+
+    public static OrdinaryLiveBoardForwardingIntent capturedAtMutation(
+        boolean occupiedAtMutation, Supplier<Boolean> action) {
       if (action == null) {
         throw new IllegalArgumentException("action");
       }
-      return new OrdinaryLiveBoardForwardingIntent(action);
+      return new OrdinaryLiveBoardForwardingIntent(action, occupiedAtMutation);
+    }
+
+    boolean occupiedAtMutation() {
+      return occupiedAtMutation;
     }
 
     boolean execute() {

--- a/src/main/java/featurecat/lizzie/analysis/EngineManager.java
+++ b/src/main/java/featurecat/lizzie/analysis/EngineManager.java
@@ -4200,9 +4200,14 @@ public class EngineManager {
 
     private void beginSynchronizationBarriers() {
       admission.activate();
-      targetEngine.attachAndBeginInitialEngineSyncAdmission(admission);
-      if (mirrorEngine != null) {
-        mirrorEngine.attachAndBeginInitialEngineSyncAdmission(admission);
+      if (!targetEngine.attachAndBeginInitialEngineSyncAdmission(admission)) {
+        throw new InitialStartupReservationException(
+            "Engine lifecycle target admission was rejected");
+      }
+      if (mirrorEngine != null
+          && !mirrorEngine.attachAndBeginInitialEngineSyncAdmission(admission)) {
+        throw new InitialStartupReservationException(
+            "Engine lifecycle mirror admission was rejected");
       }
     }
 

--- a/src/main/java/featurecat/lizzie/analysis/Leelaz.java
+++ b/src/main/java/featurecat/lizzie/analysis/Leelaz.java
@@ -331,6 +331,7 @@ public class Leelaz {
   public volatile boolean isDownWithError = false;
   public volatile boolean isLoaded = false;
   private volatile int initialBoardSynchronizationDepth = 0;
+  private volatile EngineManager.InitialEngineSyncAdmission initialEngineSyncAdmission;
   private volatile Object initialBoardSynchronizationLock = new Object();
   private volatile long bundledStartupToken = 0L;
   private volatile boolean openClFp32CompatibilityActive = false;
@@ -13047,6 +13048,58 @@ public class Leelaz {
         initialBoardSynchronizationDepth--;
       }
     }
+  }
+
+  /**
+   * Attaches the shared startup admission and begins one public barrier on this engine. Target and
+   * mirror receive the same admission instance. The owner activates and deactivates that instance.
+   */
+  void attachAndBeginInitialEngineSyncAdmission(
+      EngineManager.InitialEngineSyncAdmission admission) {
+    if (admission == null) {
+      throw new IllegalArgumentException("admission");
+    }
+    synchronized (initialBoardSynchronizationLock()) {
+      initialEngineSyncAdmission = admission;
+      initialBoardSynchronizationDepth++;
+    }
+  }
+
+  void endInitialEngineSyncAdmission(EngineManager.InitialEngineSyncAdmission admission) {
+    synchronized (initialBoardSynchronizationLock()) {
+      if (admission != null && initialEngineSyncAdmission != admission) {
+        return;
+      }
+      if (initialBoardSynchronizationDepth > 0) {
+        initialBoardSynchronizationDepth--;
+      }
+    }
+  }
+
+  void detachInitialEngineSyncAdmission(EngineManager.InitialEngineSyncAdmission admission) {
+    synchronized (initialBoardSynchronizationLock()) {
+      if (initialEngineSyncAdmission == admission) {
+        initialEngineSyncAdmission = null;
+      }
+    }
+  }
+
+  /**
+   * Submits an ordinary live-board forwarding intent. Returns false without running the action
+   * while the attached startup admission is active; enqueue races stay with the command queue.
+   */
+  public boolean submitOrdinaryLiveBoardForwarding(
+      EngineManager.OrdinaryLiveBoardForwardingIntent intent) {
+    if (intent == null) {
+      throw new IllegalArgumentException("intent");
+    }
+    synchronized (initialBoardSynchronizationLock()) {
+      EngineManager.InitialEngineSyncAdmission admission = initialEngineSyncAdmission;
+      if (admission != null && admission.isActive()) {
+        return false;
+      }
+    }
+    return intent.execute();
   }
 
   public boolean isInitialBoardSynchronizationActive() {

--- a/src/main/java/featurecat/lizzie/analysis/Leelaz.java
+++ b/src/main/java/featurecat/lizzie/analysis/Leelaz.java
@@ -13085,8 +13085,28 @@ public class Leelaz {
   }
 
   /**
+   * Captures ordinary forwarding occupancy at mutation time. Occupied when the startup admission
+   * is active or the existing public board-synchronization barrier is still held (restart fence
+   * until that surface is retired).
+   */
+  public EngineManager.OrdinaryLiveBoardForwardingIntent captureOrdinaryLiveBoardForwarding(
+      Supplier<Boolean> action) {
+    synchronized (initialBoardSynchronizationLock()) {
+      return EngineManager.OrdinaryLiveBoardForwardingIntent.capturedAtMutation(
+          isOrdinaryForwardingOccupied(), action);
+    }
+  }
+
+  public EngineManager.OrdinaryLiveBoardForwardingIntent captureOrdinaryLiveBoardForwarding(
+      EngineManager.OrdinaryLiveBoardForwardingIntent occupancySource, Supplier<Boolean> action) {
+    boolean occupied = occupancySource != null && occupancySource.occupiedAtMutation();
+    return EngineManager.OrdinaryLiveBoardForwardingIntent.capturedAtMutation(occupied, action);
+  }
+
+  /**
    * Submits an ordinary live-board forwarding intent. Returns false without running the action
-   * while the attached startup admission is active; enqueue races stay with the command queue.
+   * when the plan was occupied at mutation or the engine is occupied now; enqueue races stay
+   * with the command queue.
    */
   public boolean submitOrdinaryLiveBoardForwarding(
       EngineManager.OrdinaryLiveBoardForwardingIntent intent) {
@@ -13094,12 +13114,16 @@ public class Leelaz {
       throw new IllegalArgumentException("intent");
     }
     synchronized (initialBoardSynchronizationLock()) {
-      EngineManager.InitialEngineSyncAdmission admission = initialEngineSyncAdmission;
-      if (admission != null && admission.isActive()) {
+      if (intent.occupiedAtMutation() || isOrdinaryForwardingOccupied()) {
         return false;
       }
     }
     return intent.execute();
+  }
+
+  private boolean isOrdinaryForwardingOccupied() {
+    EngineManager.InitialEngineSyncAdmission admission = initialEngineSyncAdmission;
+    return (admission != null && admission.isActive()) || initialBoardSynchronizationDepth > 0;
   }
 
   public boolean isInitialBoardSynchronizationActive() {

--- a/src/main/java/featurecat/lizzie/analysis/Leelaz.java
+++ b/src/main/java/featurecat/lizzie/analysis/Leelaz.java
@@ -13051,8 +13051,9 @@ public class Leelaz {
   }
 
   /**
-   * Attaches the shared startup admission and begins one public barrier on this engine. Target and
-   * mirror receive the same admission instance. The owner activates and deactivates that instance.
+   * Attaches the shared startup admission and begins one board-synchronization barrier on this
+   * engine. Target and mirror receive the same admission instance. The owner activates and
+   * deactivates that instance.
    */
   void attachAndBeginInitialEngineSyncAdmission(
       EngineManager.InitialEngineSyncAdmission admission) {
@@ -13086,8 +13087,7 @@ public class Leelaz {
 
   /**
    * Captures ordinary forwarding occupancy at mutation time. Occupied when the startup admission
-   * is active or the existing public board-synchronization barrier is still held (restart fence
-   * until that surface is retired).
+   * is active or a lifecycle board-synchronization barrier is still held.
    */
   public EngineManager.OrdinaryLiveBoardForwardingIntent captureOrdinaryLiveBoardForwarding(
       Supplier<Boolean> action) {
@@ -13126,7 +13126,7 @@ public class Leelaz {
     return (admission != null && admission.isActive()) || initialBoardSynchronizationDepth > 0;
   }
 
-  public boolean isInitialBoardSynchronizationActive() {
+  private boolean isInitialBoardSynchronizationActive() {
     return initialBoardSynchronizationDepth > 0;
   }
 

--- a/src/main/java/featurecat/lizzie/analysis/Leelaz.java
+++ b/src/main/java/featurecat/lizzie/analysis/Leelaz.java
@@ -253,6 +253,9 @@ public class Leelaz {
       exactSnapshotRestoreAdmissionContext = new ThreadLocal<>();
   private static final ThreadLocal<LifecycleCompletionClaim> lifecycleCompletionCommandContext =
       new ThreadLocal<>();
+  private static final ThreadLocal<OrdinaryLiveBoardForwardingExecution>
+      ordinaryLiveBoardForwardingContext = new ThreadLocal<>();
+
   private final ThreadLocal<AtomicReference<RuntimeException>> deferredDefaultMirrorFailure =
       new ThreadLocal<>();
   private volatile boolean foregroundRestoreInProgress;
@@ -5509,13 +5512,21 @@ public class Leelaz {
   }
 
   private boolean shouldDropCommandDuringInitialBoardSynchronization(String command) {
+    if (isExactSnapshotRestoreAdmissionContextActive()) {
+      return false;
+    }
+    OrdinaryLiveBoardForwardingExecution execution = ordinaryLiveBoardForwardingContext.get();
+    if (execution != null && isOrdinaryForwardingOccupied()) {
+      execution.rejectedByStartupAdmission = true;
+      return true;
+    }
     return isInitialBoardSynchronizationActive()
-        && !isExactSnapshotRestoreAdmissionContextActive()
         && isInitialBoardSynchronizationLiveUpdateCommand(command);
   }
 
   private boolean shouldDropCommandDuringInitialBoardSynchronizationAtAdmission(String command) {
-    if (!isInitialBoardSynchronizationLiveUpdateCommand(command)) {
+    if (!isInitialBoardSynchronizationLiveUpdateCommand(command)
+        && ordinaryLiveBoardForwardingContext.get() == null) {
       return false;
     }
     synchronized (initialBoardSynchronizationLock()) {
@@ -13053,16 +13064,22 @@ public class Leelaz {
   /**
    * Attaches the shared startup admission and begins one board-synchronization barrier on this
    * engine. Target and mirror receive the same admission instance. The owner activates and
-   * deactivates that instance.
+   * deactivates that instance. Returns false without writing the binding or increasing depth when
+   * another active admission already occupies this endpoint. The same admission may reattach.
    */
-  void attachAndBeginInitialEngineSyncAdmission(
+  boolean attachAndBeginInitialEngineSyncAdmission(
       EngineManager.InitialEngineSyncAdmission admission) {
     if (admission == null) {
       throw new IllegalArgumentException("admission");
     }
     synchronized (initialBoardSynchronizationLock()) {
+      EngineManager.InitialEngineSyncAdmission current = initialEngineSyncAdmission;
+      if (current != null && current != admission && current.isActive()) {
+        return false;
+      }
       initialEngineSyncAdmission = admission;
       initialBoardSynchronizationDepth++;
+      return true;
     }
   }
 
@@ -13105,8 +13122,11 @@ public class Leelaz {
 
   /**
    * Submits an ordinary live-board forwarding intent. Returns false without running the action
-   * when the plan was occupied at mutation or the engine is occupied now; enqueue races stay
-   * with the command queue.
+   * when the plan was occupied at mutation or the engine is occupied now. The current thread is
+   * marked as this intent's execution for the synchronous action; startup occupancy then rejects
+   * every command from that context instead of handshake-whitelisting komi/boardsize. Returns
+   * false if startup rejects a command or still occupies the engine when the action ends;
+   * otherwise returns the action result.
    */
   public boolean submitOrdinaryLiveBoardForwarding(
       EngineManager.OrdinaryLiveBoardForwardingIntent intent) {
@@ -13118,7 +13138,31 @@ public class Leelaz {
         return false;
       }
     }
-    return intent.execute();
+    OrdinaryLiveBoardForwardingExecution previous = ordinaryLiveBoardForwardingContext.get();
+    OrdinaryLiveBoardForwardingExecution execution = new OrdinaryLiveBoardForwardingExecution();
+    ordinaryLiveBoardForwardingContext.set(execution);
+    try {
+      boolean result = intent.execute();
+      if (execution.rejectedByStartupAdmission) {
+        return false;
+      }
+      synchronized (initialBoardSynchronizationLock()) {
+        if (isOrdinaryForwardingOccupied()) {
+          return false;
+        }
+      }
+      return result;
+    } finally {
+      if (previous == null) {
+        ordinaryLiveBoardForwardingContext.remove();
+      } else {
+        ordinaryLiveBoardForwardingContext.set(previous);
+      }
+    }
+  }
+
+  private static final class OrdinaryLiveBoardForwardingExecution {
+    private boolean rejectedByStartupAdmission;
   }
 
   private boolean isOrdinaryForwardingOccupied() {

--- a/src/main/java/featurecat/lizzie/rules/Board.java
+++ b/src/main/java/featurecat/lizzie/rules/Board.java
@@ -89,6 +89,8 @@ public class Board {
   private volatile int movelistRefreshGeneration = 0;
   private volatile long lastMoveNavigationAt = 0L;
   private volatile long contextRevision = 0L;
+  /** Test seam: after history-overwrite mutation, before engine forwarding. */
+  public static volatile Runnable beforeHistoryOverwriteEngineForward;
 
   public boolean isMouseOnStone = false;
   private boolean preMouseOnStone = false;
@@ -823,13 +825,8 @@ public class Board {
       forceRefresh2 = true;
     }
     // Engine forwarding and render work run outside the board monitor (no board -> engine lock
-    // nesting); the board-size resync is deferred while the initial startup barrier is active.
-    forwarding.forward();
-    if (!forwarding.barrierActiveAtMutation()
-        && !Lizzie.leelaz.isInitialBoardSynchronizationActive()) {
-      Lizzie.leelaz.boardSizeForEngine(boardWidth, boardHeight);
-      Lizzie.leelaz.ponder();
-    }
+    // nesting); resize stays on the mutation-captured occupancy plan.
+    forwarding.withEngineResize(boardWidth, boardHeight).forward();
     Lizzie.frame.redrawBoardrendererBackground();
     Lizzie.frame.refresh();
   }
@@ -2811,7 +2808,7 @@ public class Board {
       List<extraMoveForTsumego> extraStones,
       double komi) {
     List<extraMoveForTsumego> collectedExtraStones;
-    boolean barrierActiveAtMutation;
+    EngineManager.OrdinaryLiveBoardForwardingIntent flattenIntent;
     synchronized (this) {
       history =
           new BoardHistoryList(
@@ -2849,18 +2846,9 @@ public class Board {
       }
       history.getGameInfo().setKomi(komi);
       history.getGameInfo().changeKomi();
-      barrierActiveAtMutation = Lizzie.leelaz.isInitialBoardSynchronizationActive();
+      flattenIntent = captureFlattenEngineForwarding(collectedExtraStones, komi, true);
     }
-    // Engine feeds run after the board monitor; when the initial startup restore barrier owned
-    // the board at mutation time they stay suppressed permanently (the catch-up route reconciles
-    // the engine), and the live flag is re-checked for a barrier that began afterwards.
-    if (!barrierActiveAtMutation && !Lizzie.leelaz.isInitialBoardSynchronizationActive()) {
-      for (extraMoveForTsumego stone : collectedExtraStones) {
-        feedEngineForMainlineMove(stone.color, convertCoordinatesToName(stone.x, stone.y));
-      }
-      Lizzie.leelaz.sendCommand("komi " + komi);
-      Lizzie.leelaz.ponder();
-    }
+    submitFlattenEngineForwarding(flattenIntent);
   }
 
   public void flattenWithCondition(
@@ -2869,7 +2857,7 @@ public class Board {
     //	    Stone[] stones = history.getStones();
     //	    boolean blackToPlay = history.isBlacksTurn();
     List<extraMoveForTsumego> collectedExtraStones;
-    boolean barrierActiveAtMutation;
+    EngineManager.OrdinaryLiveBoardForwardingIntent flattenIntent;
     synchronized (this) {
       history =
           new BoardHistoryList(
@@ -2905,17 +2893,9 @@ public class Board {
           moveNum++;
         }
       }
-      barrierActiveAtMutation = Lizzie.leelaz.isInitialBoardSynchronizationActive();
+      flattenIntent = captureFlattenEngineForwarding(collectedExtraStones, 0, false);
     }
-    // Engine feeds run after the board monitor; suppressed permanently when the initial startup
-    // restore barrier owned the board at mutation time, with a live re-check for a barrier that
-    // began afterwards.
-    if (!barrierActiveAtMutation && !Lizzie.leelaz.isInitialBoardSynchronizationActive()) {
-      for (extraMoveForTsumego stone : collectedExtraStones) {
-        feedEngineForMainlineMove(stone.color, convertCoordinatesToName(stone.x, stone.y));
-      }
-      Lizzie.leelaz.ponder();
-    }
+    submitFlattenEngineForwarding(flattenIntent);
   }
 
   //  private void addExtraStoneNow(int x, int y, Stone color) {
@@ -4608,7 +4588,6 @@ public class Board {
     movelistwr.clear();
     initialize(isEngineGame);
     isKataBoard = false;
-    boolean barrierActive = Lizzie.leelaz.isInitialBoardSynchronizationActive();
     if (!isEngineGame) {
       cleanedittemp();
       isPkBoard = false;
@@ -4620,7 +4599,7 @@ public class Board {
         komi = Lizzie.leelaz.orikomi;
         Lizzie.board.getHistory().getGameInfo().resetAllNoKomi();
       }
-      return EngineForwardingPlan.clearEngine(komi, barrierActive)
+      return EngineForwardingPlan.clearEngine(komi)
           .defer(this::notifyReadBoardHistoryOverwritten)
           .defer(() -> Lizzie.frame.clearKataEstimate())
           .defer(urlSgfStopSyncAction());
@@ -4645,9 +4624,8 @@ public class Board {
   /**
    * Engine/external forwarding work deferred until after the board monitor is released, so no
    * board -> engine (Leelaz monitor) / ReadBoard lock nesting is introduced by
-   * history-overwrite entries. The barrier-active state is recorded at mutation time: if the
-   * initial startup barrier owned the engine then, the forwarding stays suppressed even if the
-   * barrier ends before the plan executes (the catch-up route reconciles the engine).
+   * history-overwrite entries. The plan records startup occupancy at mutation time: if the owner
+   * already occupied the engine then, this forwarding stays suppressed even after handoff.
    */
   private static final class EngineForwardingPlan {
     private final List<Runnable> deferredActions = new ArrayList<>();
@@ -4655,35 +4633,47 @@ public class Board {
     private String komiCommand;
     private double komi;
     private boolean applyKomiSideEffects;
-    private boolean barrierActiveAtMutation;
+    private boolean resizeEngine;
+    private int resizeWidth;
+    private int resizeHeight;
+
+    private EngineManager.OrdinaryLiveBoardForwardingIntent capturedIntent;
+    private EngineManager.OrdinaryLiveBoardForwardingIntent resizeIntent;
 
     private EngineForwardingPlan() {}
 
-    private static EngineForwardingPlan clearEngine(double komi, boolean barrierActiveAtMutation) {
+    private void captureForwardingIntent() {
+      if (Lizzie.leelaz == null) {
+        return;
+      }
+      capturedIntent =
+          Lizzie.leelaz.captureOrdinaryLiveBoardForwarding(this::forwardClearOnly);
+    }
+
+    private static EngineForwardingPlan clearEngine(double komi) {
       EngineForwardingPlan plan = new EngineForwardingPlan();
       plan.forwardClear = true;
       plan.komiCommand = "komi " + (komi == 0.0 ? "0" : komi);
       plan.komi = komi;
       plan.applyKomiSideEffects = true;
-      plan.barrierActiveAtMutation = barrierActiveAtMutation;
+      plan.captureForwardingIntent();
       return plan;
     }
 
     /** Clear variant for online resync preserving the original float komi serialization. */
-    private static EngineForwardingPlan clearEngineWithPlainKomi(
-        float komi, boolean barrierActiveAtMutation) {
-      EngineForwardingPlan plan = clearEngine(komi, barrierActiveAtMutation);
+    private static EngineForwardingPlan clearEngineWithPlainKomi(float komi) {
+      EngineForwardingPlan plan = clearEngine(komi);
       plan.komiCommand = "komi " + komi;
       plan.applyKomiSideEffects = false;
       return plan;
     }
 
     /** Clear-only variant (SGF editor path): clear_board with no komi forwarding. */
-    private static EngineForwardingPlan clearEngineOnly(boolean barrierActiveAtMutation) {
+    private static EngineForwardingPlan clearEngineOnly() {
       EngineForwardingPlan plan = new EngineForwardingPlan();
       plan.forwardClear = true;
       plan.komiCommand = null;
-      plan.barrierActiveAtMutation = barrierActiveAtMutation;
+      plan.captureForwardingIntent();
       return plan;
     }
 
@@ -4698,26 +4688,78 @@ public class Board {
       return this;
     }
 
-    private boolean barrierActiveAtMutation() {
-      return barrierActiveAtMutation;
+    private EngineForwardingPlan withEngineResize(int width, int height) {
+      resizeEngine = true;
+      resizeWidth = width;
+      resizeHeight = height;
+      if (Lizzie.leelaz != null) {
+        resizeIntent =
+            Lizzie.leelaz.captureOrdinaryLiveBoardForwarding(
+                capturedIntent, this::forwardEngineResize);
+      }
+      return this;
     }
 
     private void forward() {
+      runBeforeHistoryOverwriteEngineForward();
       // Engine reset runs first (outside the board monitor) so a failing callback can never
       // skip the required engine clear; board-overwrite notifications follow.
-      if (forwardClear && Lizzie.leelaz != null) {
-        if (!barrierActiveAtMutation && !Lizzie.leelaz.isInitialBoardSynchronizationActive()) {
-          Lizzie.leelaz.forwardBoardClearWithKomi(
-              komiCommand, komi, applyKomiSideEffects);
-        } else {
-          // The initial startup restore barrier owned the engine when the board changed (or
-          // began afterwards); the catch-up route reconciles komi and size after it settles.
+      if (Lizzie.leelaz != null) {
+        if (capturedIntent != null) {
+          Lizzie.leelaz.submitOrdinaryLiveBoardForwarding(capturedIntent);
+        }
+        if (resizeIntent != null) {
+          Lizzie.leelaz.submitOrdinaryLiveBoardForwarding(resizeIntent);
         }
       }
       for (Runnable action : deferredActions) {
         action.run();
       }
     }
+
+    private boolean forwardClearOnly() {
+      return Lizzie.leelaz.forwardBoardClearWithKomi(komiCommand, komi, applyKomiSideEffects);
+    }
+
+    private boolean forwardEngineResize() {
+      Lizzie.leelaz.boardSizeForEngine(resizeWidth, resizeHeight);
+      Lizzie.leelaz.ponder();
+      return true;
+    }
+  }
+
+  private static void runBeforeHistoryOverwriteEngineForward() {
+    Runnable hook = beforeHistoryOverwriteEngineForward;
+    if (hook != null) {
+      hook.run();
+    }
+  }
+
+  private EngineManager.OrdinaryLiveBoardForwardingIntent captureFlattenEngineForwarding(
+      List<extraMoveForTsumego> collectedExtraStones, double komi, boolean forwardKomi) {
+    if (Lizzie.leelaz == null) {
+      return null;
+    }
+    return Lizzie.leelaz.captureOrdinaryLiveBoardForwarding(
+        () -> {
+          for (extraMoveForTsumego stone : collectedExtraStones) {
+            feedEngineForMainlineMove(stone.color, convertCoordinatesToName(stone.x, stone.y));
+          }
+          if (forwardKomi) {
+            Lizzie.leelaz.sendCommand("komi " + komi);
+          }
+          Lizzie.leelaz.ponder();
+          return true;
+        });
+  }
+
+  private void submitFlattenEngineForwarding(
+      EngineManager.OrdinaryLiveBoardForwardingIntent intent) {
+    runBeforeHistoryOverwriteEngineForward();
+    if (intent == null || Lizzie.leelaz == null) {
+      return;
+    }
+    Lizzie.leelaz.submitOrdinaryLiveBoardForwarding(intent);
   }
 
   public void clearForOnline() {
@@ -4741,8 +4783,7 @@ public class Board {
       Lizzie.board.getHistory().getGameInfo().resetAllNoKomi();
       Lizzie.board.getHistory().getGameInfo().setKomi(Lizzie.leelaz.orikomi);
       forwarding =
-          EngineForwardingPlan.clearEngineWithPlainKomi(
-                  Lizzie.leelaz.orikomi, Lizzie.leelaz.isInitialBoardSynchronizationActive())
+          EngineForwardingPlan.clearEngineWithPlainKomi(Lizzie.leelaz.orikomi)
               .defer(() -> Lizzie.frame.clearKataEstimate())
               .defer(this::notifyReadBoardHistoryOverwritten);
     }
@@ -4755,8 +4796,7 @@ public class Board {
     synchronized (this) {
       initialize(false);
       forwarding =
-          EngineForwardingPlan.clearEngineOnly(
-                  Lizzie.leelaz.isInitialBoardSynchronizationActive())
+          EngineForwardingPlan.clearEngineOnly()
               .defer(this::notifyReadBoardHistoryOverwritten);
     }
     forwarding.forward();

--- a/src/main/java/featurecat/lizzie/rules/Board.java
+++ b/src/main/java/featurecat/lizzie/rules/Board.java
@@ -29,6 +29,7 @@ import java.util.Stack;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.function.BiConsumer;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.swing.*;
@@ -1590,13 +1591,25 @@ public class Board {
     return true;
   }
 
-  public boolean trySyncCurrentPositionToPrimaryEngineIncrementally(
-      BoardData previousPosition, int previousBoardWidth, int previousBoardHeight) {
-    if (Lizzie.leelaz != null && Lizzie.leelaz.isInitialBoardSynchronizationActive()) {
-      // The initial engine startup restore barrier owns the primary engine; a live resync must
-      // not interleave komi/play commands with the frozen or catch-up restore route.
+  private boolean submitOrdinaryEngineForwarding(Leelaz engine, Supplier<Boolean> action) {
+    if (engine == null) {
       return false;
     }
+    return engine.submitOrdinaryLiveBoardForwarding(
+        EngineManager.OrdinaryLiveBoardForwardingIntent.of(action));
+  }
+
+  public boolean trySyncCurrentPositionToPrimaryEngineIncrementally(
+      BoardData previousPosition, int previousBoardWidth, int previousBoardHeight) {
+    return submitOrdinaryEngineForwarding(
+        Lizzie.leelaz,
+        () ->
+            forwardCurrentPositionToPrimaryEngineIncrementally(
+                previousPosition, previousBoardWidth, previousBoardHeight));
+  }
+
+  private boolean forwardCurrentPositionToPrimaryEngineIncrementally(
+      BoardData previousPosition, int previousBoardWidth, int previousBoardHeight) {
     if (previousPosition == null || !isPrimaryEngineReady()) {
       return false;
     }
@@ -3293,6 +3306,7 @@ public class Board {
     private final Runnable restore;
     private final Runnable discard;
     private final Runnable successfulDisposition;
+    private boolean skipSuccessfulDisposition;
 
     private HistoryNavigationRestore(
         Board owner,
@@ -3319,15 +3333,26 @@ public class Board {
         discard.run();
         return true;
       }
-      restore.run();
+      boolean submitted =
+          owner.submitOrdinaryEngineForwarding(
+              primaryEngine,
+              () -> {
+                restore.run();
+                return true;
+              });
+      if (!submitted) {
+        discard.run();
+        skipSuccessfulDisposition = true;
+        return false;
+      }
       return false;
     }
 
     private void applySuccessfulDisposition() {
-      if (successfulDisposition != null) {
-        Lizzie.runIfPrimaryEngine(
-            primaryEngine, primaryEngineGeneration, successfulDisposition);
+      if (skipSuccessfulDisposition || successfulDisposition == null) {
+        return;
       }
+      Lizzie.runIfPrimaryEngine(primaryEngine, primaryEngineGeneration, successfulDisposition);
     }
   }
   void beforeHistoryNavigationRestoreExecution() {}
@@ -3653,16 +3678,15 @@ public class Board {
   }
 
   private boolean isCapturedPrimaryReady(Leelaz engine) {
-    return engine != null
-        && Lizzie.leelaz == engine
-        && isPrimaryEngineReady()
-        && !engine.isInitialBoardSynchronizationActive();
+    return engine != null && Lizzie.leelaz == engine && isPrimaryEngineReady();
   }
 
   private HistoryNavigationRestore prepareHistoryNavigationRestore(boolean stepIn) {
     Leelaz engine = Lizzie.leelaz;
     long primaryEngineGeneration = Lizzie.capturePrimaryEngineGeneration(engine);
-    if (primaryEngineGeneration < 0 || !isCapturedPrimaryReady(engine)) {
+    if (primaryEngineGeneration < 0
+        || !isCapturedPrimaryReady(engine)
+        || !submitOrdinaryEngineForwarding(engine, () -> true)) {
       return null;
     }
     if (!stepIn && KataGoRuntimeHelper.isBenchmarkEngineSyncSuppressed()) {
@@ -3766,9 +3790,19 @@ public class Board {
       if (isPrimaryEngineReady() && data.get().isMoveNode()) {
         int[] lastMove = data.get().lastMove.get();
         String name = convertCoordinatesToName(lastMove[0], lastMove[1]);
-        Lizzie.leelaz.playMove(data.get().lastMoveColor, name, true, data.get().blackToPlay);
+        submitOrdinaryEngineForwarding(
+            Lizzie.leelaz,
+            () -> {
+              Lizzie.leelaz.playMove(data.get().lastMoveColor, name, true, data.get().blackToPlay);
+              return true;
+            });
       } else if (isPrimaryEngineReady() && isKnownPass(data.get())) {
-        Lizzie.leelaz.playMove(data.get().lastMoveColor, "pass", true, data.get().blackToPlay);
+        submitOrdinaryEngineForwarding(
+            Lizzie.leelaz,
+            () -> {
+              Lizzie.leelaz.playMove(data.get().lastMoveColor, "pass", true, data.get().blackToPlay);
+              return true;
+            });
       }
       if (expectedChild == null) {
         history.next();
@@ -3846,13 +3880,16 @@ public class Board {
   }
 
   private void restoreEnginePosition(Leelaz engine, ArrayList<Movelist> fallbackMoves) {
-    if (engine != null && engine.isInitialBoardSynchronizationActive()) {
-      // The initial engine startup restore barrier owns this engine; ordinary board-following
-      // restores must not interleave with the frozen startup route. The startup coordination
-      // performs an immutable catch-up restore for the current position before releasing the
-      // barrier.
-      return;
-    }
+    submitOrdinaryEngineForwarding(
+        engine,
+        () -> {
+          forwardOrdinaryEnginePositionRestore(engine, fallbackMoves);
+          return true;
+        });
+  }
+
+  private void forwardOrdinaryEnginePositionRestore(
+      Leelaz engine, ArrayList<Movelist> fallbackMoves) {
     boolean wasPondering = engine.isPonderingOrWasPonderingBeforeTracking();
     BoardHistoryNode currentNode = getHistory().getCurrentHistoryNode();
     Leelaz.ExactSnapshotRestoreAdmission admission =
@@ -4075,9 +4112,19 @@ public class Board {
         } else if (currentData.isMoveNode()) {
           int[] lastMove = currentData.lastMove.get();
           String name = convertCoordinatesToName(lastMove[0], lastMove[1]);
-          feedEngineForMainlineMove(currentData.lastMoveColor, name);
+          submitOrdinaryEngineForwarding(
+              Lizzie.leelaz,
+              () -> {
+                feedEngineForMainlineMove(currentData.lastMoveColor, name);
+                return true;
+              });
         } else if (isKnownPass(currentData)) {
-          feedEngineForMainlineMove(currentData.lastMoveColor, "pass");
+          submitOrdinaryEngineForwarding(
+              Lizzie.leelaz,
+              () -> {
+                feedEngineForMainlineMove(currentData.lastMoveColor, "pass");
+                return true;
+              });
         }
         modifyEnd();
         Lizzie.frame.refresh();
@@ -4759,7 +4806,14 @@ public class Board {
         if (!Lizzie.leelaz.isKatago || Lizzie.leelaz.isSai) {
           if (isPass && history.getCurrentHistoryNode().previous().isPresent()) nopass = true;
         }
-        if (!nopass) Lizzie.leelaz.undo(true, history.getPrevious().get().blackToPlay);
+        if (!nopass) {
+          submitOrdinaryEngineForwarding(
+              Lizzie.leelaz,
+              () -> {
+                Lizzie.leelaz.undo(true, history.getPrevious().get().blackToPlay);
+                return true;
+              });
+        }
         else modifyEnd();
       }
       if (!needSync && isPrimaryEngineReady()) {

--- a/src/main/java/featurecat/lizzie/rules/Board.java
+++ b/src/main/java/featurecat/lizzie/rules/Board.java
@@ -1570,11 +1570,15 @@ public class Board {
   }
 
   public boolean resendCurrentPositionToPrimaryEngine() {
-    if (Lizzie.leelaz != null && Lizzie.leelaz.isInitialBoardSynchronizationActive()) {
-      // The initial engine startup restore barrier owns the primary engine; a live resync must
-      // not interleave komi/boardsize/play commands with the frozen or catch-up restore route.
+    if (Lizzie.leelaz == null) {
       return false;
     }
+    return Lizzie.leelaz.submitOrdinaryLiveBoardForwarding(
+        EngineManager.OrdinaryLiveBoardForwardingIntent.of(
+            this::forwardCurrentPositionToPrimaryEngine));
+  }
+
+  private boolean forwardCurrentPositionToPrimaryEngine() {
     if (!isPrimaryEngineReady()) {
       return false;
     }

--- a/src/main/java/featurecat/lizzie/rules/Board.java
+++ b/src/main/java/featurecat/lizzie/rules/Board.java
@@ -4629,11 +4629,9 @@ public class Board {
    */
   private static final class EngineForwardingPlan {
     private final List<Runnable> deferredActions = new ArrayList<>();
-    private boolean forwardClear;
     private String komiCommand;
     private double komi;
     private boolean applyKomiSideEffects;
-    private boolean resizeEngine;
     private int resizeWidth;
     private int resizeHeight;
 
@@ -4652,7 +4650,6 @@ public class Board {
 
     private static EngineForwardingPlan clearEngine(double komi) {
       EngineForwardingPlan plan = new EngineForwardingPlan();
-      plan.forwardClear = true;
       plan.komiCommand = "komi " + (komi == 0.0 ? "0" : komi);
       plan.komi = komi;
       plan.applyKomiSideEffects = true;
@@ -4671,7 +4668,6 @@ public class Board {
     /** Clear-only variant (SGF editor path): clear_board with no komi forwarding. */
     private static EngineForwardingPlan clearEngineOnly() {
       EngineForwardingPlan plan = new EngineForwardingPlan();
-      plan.forwardClear = true;
       plan.komiCommand = null;
       plan.captureForwardingIntent();
       return plan;
@@ -4689,7 +4685,6 @@ public class Board {
     }
 
     private EngineForwardingPlan withEngineResize(int width, int height) {
-      resizeEngine = true;
       resizeWidth = width;
       resizeHeight = height;
       if (Lizzie.leelaz != null) {

--- a/src/main/java/featurecat/lizzie/rules/BoardHistoryNode.java
+++ b/src/main/java/featurecat/lizzie/rules/BoardHistoryNode.java
@@ -768,12 +768,19 @@ public class BoardHistoryNode {
   }
 
   public void clearAndSyncBoard(boolean stepIn) {
-    if (Lizzie.leelaz != null && Lizzie.leelaz.isInitialBoardSynchronizationActive()) {
-      // The initial engine startup restore barrier owns the engine; skip the ordinary
-      // board-following resync. The startup coordination's catch-up restore converges on the
-      // current position before the barrier ends.
+    if (Lizzie.leelaz != null) {
+      Lizzie.leelaz.submitOrdinaryLiveBoardForwarding(
+          EngineManager.OrdinaryLiveBoardForwardingIntent.of(
+              () -> {
+                performClearAndSyncBoard(stepIn);
+                return true;
+              }));
       return;
     }
+    performClearAndSyncBoard(stepIn);
+  }
+
+  private void performClearAndSyncBoard(boolean stepIn) {
     if (stepIn) {
       Leelaz engine = Lizzie.leelaz;
       boolean resumePonder = engine.isPonderingOrWasPonderingBeforeTracking();
@@ -784,7 +791,6 @@ public class BoardHistoryNode {
       engine.notPondering();
       executePreparedRestore(engine, preparedRestore, resumePonder);
     } else {
-      //  System.out.println("out");
       Lizzie.board.resendMoveToEngine(Lizzie.leelaz, false);
     }
   }

--- a/src/test/java/featurecat/lizzie/analysis/EngineManagerInitialStartupSynchronizationTest.java
+++ b/src/test/java/featurecat/lizzie/analysis/EngineManagerInitialStartupSynchronizationTest.java
@@ -315,6 +315,90 @@ class EngineManagerInitialStartupSynchronizationTest {
     }
   }
 
+  @Test
+  void rejectedOverlappingStartupOwnerLeavesNoAdmissionOccupancy() throws Exception {
+    try (StartupTestEnvironment env = StartupTestEnvironment.open()) {
+      StartupSyncLeelaz engine = new StartupSyncLeelaz();
+      Board board = boardWithHistory(emptyRootHistory(0));
+      env.publish(engine, board);
+      engine.startEngine(0);
+
+      EngineManager.InitialEngineStartupSynchronization first = captureStartup(engine, board);
+      try {
+        assertThrows(
+            IllegalStateException.class,
+            () -> captureStartup(engine, board),
+            "the overlapping owner must lose the existing lifecycle reservation");
+      } finally {
+        first.close();
+      }
+
+      assertLifecycleReservationReleased(engine);
+      engine.sendCommand("play B Q16");
+      assertTrue(
+          engine.containsCommand("play B Q16"),
+          "the rejected owner must not leave command admission occupied");
+    }
+  }
+
+  @Test
+  void admissionStartingAfterSubmitPrecheckRejectsAllOrdinaryForwardingCommands()
+      throws Exception {
+    try (StartupTestEnvironment env = StartupTestEnvironment.open()) {
+      StartupSyncLeelaz engine = new StartupSyncLeelaz();
+      Board board = boardWithHistory(emptyRootHistory(0));
+      env.publish(engine, board);
+      engine.startEngine(0);
+
+      CountDownLatch actionEntered = new CountDownLatch(1);
+      CountDownLatch continueAction = new CountDownLatch(1);
+      AtomicReference<Boolean> submitResult = new AtomicReference<>();
+      AtomicReference<Throwable> submitFailure = new AtomicReference<>();
+      Thread forwardingThread =
+          new Thread(
+              () -> {
+                try {
+                  submitResult.set(
+                      engine.submitOrdinaryLiveBoardForwarding(
+                          EngineManager.OrdinaryLiveBoardForwardingIntent.of(
+                              () -> {
+                                actionEntered.countDown();
+                                awaitLatch(continueAction);
+                                engine.sendCommand("komi 9.5");
+                                engine.sendCommand("boardsize 13");
+                                engine.sendCommand("clear_board");
+                                return true;
+                              })));
+                } catch (Throwable failure) {
+                  submitFailure.set(failure);
+                }
+              },
+              "startup-admission-submit-execute-race");
+      forwardingThread.start();
+
+      assertTrue(
+          actionEntered.await(2, TimeUnit.SECONDS),
+          "ordinary forwarding must pass submit precheck before startup begins");
+      EngineManager.InitialEngineStartupSynchronization startup = captureStartup(engine, board);
+      try {
+        continueAction.countDown();
+        forwardingThread.join(2_000L);
+
+        assertFalse(forwardingThread.isAlive(), "ordinary forwarding race must settle");
+        assertNull(submitFailure.get(), "ordinary forwarding rejection must not throw");
+        assertEquals(Boolean.FALSE, submitResult.get(), "raced ordinary forwarding is rejected");
+        assertFalse(engine.containsCommand("komi 9.5"));
+        assertFalse(engine.containsCommand("boardsize 13"));
+        assertFalse(engine.containsCommand("clear_board"));
+      } finally {
+        continueAction.countDown();
+        startup.close();
+      }
+
+      assertLifecycleReservationReleased(engine);
+    }
+  }
+
   private static Stream<Arguments> ordinaryCommandsRejectedDuringStartupAdmission() {
     return Stream.of(
         Arguments.of("play B Q4"),

--- a/src/test/java/featurecat/lizzie/analysis/EngineManagerInitialStartupSynchronizationTest.java
+++ b/src/test/java/featurecat/lizzie/analysis/EngineManagerInitialStartupSynchronizationTest.java
@@ -88,9 +88,6 @@ class EngineManagerInitialStartupSynchronizationTest {
       assertEquals(1, engine.ponderCount, "ponder must run exactly once");
       assertEquals(1, engine.responseFreshenedCount, "response freshening must run exactly once");
       assertEquals(1, env.readyTransitions.get() - readyBaseline, "markEngineReady exactly once");
-      assertFalse(
-          engine.isInitialBoardSynchronizationActive(),
-          "barrier must be ended after the stable restore point");
       assertTrue(engine.isLoaded, "engine must stay available on success");
       assertLifecycleReservationReleased(engine);
     }
@@ -409,7 +406,6 @@ class EngineManagerInitialStartupSynchronizationTest {
           "catch-up replay must rebuild the full position from the root");
       assertEquals(1, engine.ponderCount, "analysis must start only at the stable point");
       assertSame(board.getHistory().getCurrentHistoryNode(), board.getHistory().getEnd());
-      assertFalse(engine.isInitialBoardSynchronizationActive());
     }
   }
 
@@ -517,7 +513,6 @@ class EngineManagerInitialStartupSynchronizationTest {
       assertEquals(8, engine.analyzePosition(), "analysis position");
       assertEquals(1, engine.ponderCount, "analysis starts once at the stable position");
       assertEngineMatchesBoardWithoutKomi(engine, board, 19, 19);
-      assertFalse(engine.isInitialBoardSynchronizationActive());
       assertLifecycleReservationReleased(engine);
     }
   }
@@ -560,7 +555,6 @@ class EngineManagerInitialStartupSynchronizationTest {
       assertFenceBeforeAnalyze(engine);
       assertEquals(1, engine.ponderCount, "analysis starts once at the stable position");
       assertEngineMatchesBoardWithoutKomi(engine, board, 19, 19);
-      assertFalse(engine.isInitialBoardSynchronizationActive());
       assertLifecycleReservationReleased(engine);
     }
   }
@@ -605,7 +599,6 @@ class EngineManagerInitialStartupSynchronizationTest {
       assertEquals(1, target.boardSynchronizationConfirmations, "switch target fence");
       assertFenceBeforeAnalyze(target);
       assertEngineMatchesBoard(target, board, 19, 19);
-      assertFalse(target.isInitialBoardSynchronizationActive());
       assertLifecycleReservationReleased(current);
       assertLifecycleReservationReleased(target);
     }
@@ -659,8 +652,6 @@ class EngineManagerInitialStartupSynchronizationTest {
       assertEquals(1, targetSecondary.boardSynchronizationConfirmations, "secondary target fence");
       assertEngineMatchesBoard(primary, board, 19, 19);
       assertEngineMatchesBoard(targetSecondary, board, 19, 19);
-      assertFalse(primary.isInitialBoardSynchronizationActive());
-      assertFalse(targetSecondary.isInitialBoardSynchronizationActive());
       assertLifecycleReservationReleased(currentSecondary);
       assertLifecycleReservationReleased(targetSecondary);
     }
@@ -710,8 +701,6 @@ class EngineManagerInitialStartupSynchronizationTest {
       assertFenceBeforeAnalyze(primary);
       assertEngineMatchesBoard(primary, board, 19, 19);
       assertEngineMatchesBoard(secondary, board, 19, 19);
-      assertFalse(primary.isInitialBoardSynchronizationActive());
-      assertFalse(secondary.isInitialBoardSynchronizationActive());
       assertLifecycleReservationReleased(secondary);
     }
   }
@@ -740,7 +729,6 @@ class EngineManagerInitialStartupSynchronizationTest {
       assertTrue(manager.firstSynchronizationCompleted.await(2, TimeUnit.SECONDS));
       assertFalse(target.isLoaded(), "timed-out switch target remains unavailable");
       assertEquals(0, target.ponderCount, "no analysis after readiness timeout");
-      assertFalse(target.isInitialBoardSynchronizationActive());
       assertLifecycleReservationReleased(current);
       assertLifecycleReservationReleased(target);
     }
@@ -765,7 +753,6 @@ class EngineManagerInitialStartupSynchronizationTest {
 
       assertEquals(1, manager.leaseConflictCount);
       assertEquals(0, engine.ponderCount);
-      assertFalse(engine.isInitialBoardSynchronizationActive());
       assertLifecycleReservationReleased(engine);
     }
   }
@@ -806,7 +793,6 @@ class EngineManagerInitialStartupSynchronizationTest {
       assertFalse(target.isLoaded(), "failed catch-up target remains unavailable");
       assertEquals(0, target.ponderCount, "no analysis after catch-up failure");
       assertEquals(0, target.analyzeCount(), "no analyze command after catch-up failure");
-      assertFalse(target.isInitialBoardSynchronizationActive());
       assertLifecycleReservationReleased(current);
       assertLifecycleReservationReleased(target);
     }
@@ -836,7 +822,6 @@ class EngineManagerInitialStartupSynchronizationTest {
       assertSame(current, Lizzie.leelaz, "rejected switch keeps the current engine");
       assertEquals(0, target.boardSynchronizationConfirmations, "no success fence on abort");
       assertEquals(0, target.ponderCount, "aborted target never starts analysis");
-      assertFalse(target.isInitialBoardSynchronizationActive());
       assertLifecycleReservationReleased(current);
       assertLifecycleReservationReleased(target);
     }
@@ -945,7 +930,6 @@ class EngineManagerInitialStartupSynchronizationTest {
           engine.containsCommand("play W " + Board.convertCoordinatesToName(4, 4)),
           "snapshot static stones must not be faked as MOVE commands");
       assertEngineMatchesBoard(engine, board, 19, 19);
-      assertFalse(engine.isInitialBoardSynchronizationActive());
       assertLifecycleReservationReleased(engine);
     }
   }
@@ -1020,9 +1004,6 @@ class EngineManagerInitialStartupSynchronizationTest {
       assertEquals(1, engine.ponderCount, "analysis starts once after the stable restore point");
       assertEquals(Stone.EMPTY, engine.stoneAt(3, 3), "removed stone stays removed on the engine");
       assertEngineMatchesBoard(engine, board, 19, 19);
-      assertFalse(
-          engine.isInitialBoardSynchronizationActive(),
-          "the Board fence must end the barrier at the stable restore point");
       assertLifecycleReservationReleased(engine);
     }
   }
@@ -1039,33 +1020,33 @@ class EngineManagerInitialStartupSynchronizationTest {
       engine.startEngine(0);
 
       EngineManager.InitialEngineStartupSynchronization startup = captureStartup(engine, board);
-      AtomicBoolean fenceActiveWhenTailCommitted = new AtomicBoolean();
       AtomicReference<String> lastCommandBeforeFence = new AtomicReference<>();
+      AtomicBoolean ordinaryPlayDroppedAtTail = new AtomicBoolean();
       startup.beforeReservationRelease =
           () -> {
-            // The exact route (loadsgf + real tail) has just been committed; the Board fence must
-            // still be active and the last committed command must be the final tail action.
-            fenceActiveWhenTailCommitted.set(engine.isInitialBoardSynchronizationActive());
+            // The exact route (loadsgf + real tail) has just been committed; ordinary live-board
+            // play must still be dropped and the last committed command must be the final tail.
             List<String> commands = engine.commands;
             if (!commands.isEmpty()) {
               lastCommandBeforeFence.set(commands.get(commands.size() - 1));
             }
+            int before = commands.size();
+            engine.sendCommand("play B Q16");
+            ordinaryPlayDroppedAtTail.set(
+                engine.commands.size() == before && !engine.commands.contains("play B Q16"));
           };
 
       runStartupInThread(startup, engine);
 
       assertTrue(
-          fenceActiveWhenTailCommitted.get(),
-          "the tail must be committed before the Board fence ends the barrier");
+          ordinaryPlayDroppedAtTail.get(),
+          "ordinary play must stay dropped after the tail and before reservation release");
       assertEquals(
           "play B pass",
           lastCommandBeforeFence.get(),
           "the final tail action must be the last command before the fence");
       assertEquals(4, engine.analyzePosition(), "analyze must start after the fence");
       assertEquals(1, engine.ponderCount, "ponder must run exactly once after the fence");
-      assertFalse(
-          engine.isInitialBoardSynchronizationActive(),
-          "the fence must end the barrier only after the tail");
       assertLifecycleReservationReleased(engine);
     }
   }
@@ -1133,7 +1114,6 @@ class EngineManagerInitialStartupSynchronizationTest {
       assertEquals(4, engine.analyzePosition(), "engine must converge on the main-line tail PASS");
       assertEquals(1, engine.ponderCount, "analysis waits for the stable restore point");
       assertEngineMatchesBoard(engine, board, 19, 19);
-      assertFalse(engine.isInitialBoardSynchronizationActive());
       assertLifecycleReservationReleased(engine);
     }
   }
@@ -1167,7 +1147,6 @@ class EngineManagerInitialStartupSynchronizationTest {
       assertTrue(EngineManager.isEmpty, "failed snapshot restore must remain an empty owner");
       assertEquals(-1, EngineManager.currentEngineNo);
       assertFalse(failingEngine.isLoaded);
-      assertFalse(failingEngine.isInitialBoardSynchronizationActive());
       assertEquals(1, failingEngine.loadSgfCount.get(), "only the failed loadsgf attempt");
       assertEquals(0, failingEngine.ponderCount, "no analysis after a failed snapshot restore");
       assertEquals(0, failingEngine.analyzeCount(), "no analyze command after a failed restore");
@@ -1184,7 +1163,6 @@ class EngineManagerInitialStartupSynchronizationTest {
 
       assertFalse(EngineManager.isEmpty);
       assertEquals(1, EngineManager.currentEngineNo);
-      assertFalse(recoveryEngine.isInitialBoardSynchronizationActive());
       assertLifecycleReservationReleased(recoveryEngine);
     }
   }
@@ -1224,7 +1202,6 @@ class EngineManagerInitialStartupSynchronizationTest {
       assertTrue(EngineManager.isEmpty, "failed snapshot catch-up must remain an empty owner");
       assertEquals(-1, EngineManager.currentEngineNo);
       assertFalse(engine.isLoaded);
-      assertFalse(engine.isInitialBoardSynchronizationActive());
       assertEquals(0, engine.ponderCount, "no analysis after a failed catch-up restore");
       assertEquals(0, engine.analyzeCount(), "no analyze command after a failed catch-up");
       assertEquals(
@@ -1274,7 +1251,6 @@ class EngineManagerInitialStartupSynchronizationTest {
 
       assertNotNull(failure, "rejected snapshot catch-up reservation must fail closed");
       assertFalse(engine.isLoaded);
-      assertFalse(engine.isInitialBoardSynchronizationActive());
       assertEquals(0, engine.ponderCount);
       assertEquals(0, engine.analyzeCount());
       assertEquals(0, env.readyTransitions.get() - readyBaseline);
@@ -1304,7 +1280,6 @@ class EngineManagerInitialStartupSynchronizationTest {
       assertFalse(engine.isLoaded);
       assertTrue(EngineManager.isEmpty);
       assertEquals(-1, EngineManager.currentEngineNo);
-      assertFalse(engine.isInitialBoardSynchronizationActive());
       assertLifecycleReservationReleased(engine);
     }
   }
@@ -1336,7 +1311,6 @@ class EngineManagerInitialStartupSynchronizationTest {
       assertTrue(EngineManager.isEmpty, "failed first activation must remain an empty owner");
       assertEquals(-1, EngineManager.currentEngineNo);
       assertFalse(timedOutEngine.isLoaded);
-      assertFalse(timedOutEngine.isInitialBoardSynchronizationActive());
       assertLifecycleReservationReleased(timedOutEngine);
 
       assertTrue(manager.switchEngineIfAvailable(1, true), "a later activation must retry startup");
@@ -1347,7 +1321,6 @@ class EngineManagerInitialStartupSynchronizationTest {
       assertFalse(EngineManager.isEmpty);
       assertEquals(1, EngineManager.currentEngineNo);
       assertEquals(0, recoveryEngine.enginePosition.get());
-      assertFalse(recoveryEngine.isInitialBoardSynchronizationActive());
       assertLifecycleReservationReleased(recoveryEngine);
     }
   }
@@ -1378,7 +1351,6 @@ class EngineManagerInitialStartupSynchronizationTest {
       assertFalse(engine.isLoaded);
       assertEquals(1, engine.ponderCount);
       assertEquals(0, engine.analyzeCount());
-      assertFalse(engine.isInitialBoardSynchronizationActive());
       assertLifecycleReservationReleased(engine);
     }
   }
@@ -1415,7 +1387,6 @@ class EngineManagerInitialStartupSynchronizationTest {
       assertEquals(2, engine.analyzePosition(), "engine must converge on the final node (2)");
       assertEquals(1, engine.ponderCount);
       assertSame(expectedFinalNode, board.getHistory().getCurrentHistoryNode());
-      assertFalse(engine.isInitialBoardSynchronizationActive());
     }
   }
 
@@ -1453,7 +1424,6 @@ class EngineManagerInitialStartupSynchronizationTest {
       assertEquals(2, engine.analyzePosition(), "analysis must start from the snapshot position");
       assertEquals(1, engine.ponderCount);
       assertSame(history.getCurrentHistoryNode(), history.getStart());
-      assertFalse(engine.isInitialBoardSynchronizationActive());
     }
   }
 
@@ -1488,7 +1458,6 @@ class EngineManagerInitialStartupSynchronizationTest {
           "catch-up replay must select the branch child, not the same-number main-line node");
       assertEngineMatchesBoard(engine, board, 19, 19);
       assertEquals(1, engine.ponderCount);
-      assertFalse(engine.isInitialBoardSynchronizationActive());
     }
   }
 
@@ -1537,7 +1506,6 @@ class EngineManagerInitialStartupSynchronizationTest {
       assertEquals(0, engine.analyzePosition(), "converged on the resized empty board");
       assertEquals(1, engine.ponderCount);
       assertEquals(9, Board.boardWidth, "board resize itself must remain effective");
-      assertFalse(engine.isInitialBoardSynchronizationActive());
     }
   }
 
@@ -1573,7 +1541,6 @@ class EngineManagerInitialStartupSynchronizationTest {
           0.001f,
           "engine komi must converge to the cleared game komi");
       assertEquals(0, engine.analyzePosition(), "converged on the cleared empty board");
-      assertFalse(engine.isInitialBoardSynchronizationActive());
     }
   }
 
@@ -1587,21 +1554,23 @@ class EngineManagerInitialStartupSynchronizationTest {
 
       EngineManager.InitialEngineStartupSynchronization startup = captureStartup(engine, board);
       AtomicInteger handoffs = new AtomicInteger();
-      AtomicReference<Boolean> barrierActiveAfterRelease = new AtomicReference<>();
+      AtomicBoolean ordinaryPlayDroppedAfterRelease = new AtomicBoolean();
       startup.afterReservationRelease =
           () -> {
             if (handoffs.getAndIncrement() == 0) {
-              barrierActiveAfterRelease.set(engine.isInitialBoardSynchronizationActive());
+              int before = engine.commands.size();
+              engine.sendCommand("play B Q16");
+              ordinaryPlayDroppedAfterRelease.set(
+                  engine.commands.size() == before && !engine.commands.contains("play B Q16"));
               board.clear(false);
             }
           };
 
       runStartupInThread(startup, engine);
 
-      assertEquals(
-          Boolean.TRUE,
-          barrierActiveAfterRelease.get(),
-          "the initial-sync barrier must stay active until the post-release frame judgment");
+      assertTrue(
+          ordinaryPlayDroppedAfterRelease.get(),
+          "ordinary play must stay dropped after reservation release until frame judgment");
       assertEquals(
           2,
           engine.clearBoardCount.get(),
@@ -1611,7 +1580,6 @@ class EngineManagerInitialStartupSynchronizationTest {
       assertEquals(0, engine.analyzePosition(), "analysis must start on the cleared board");
       assertEquals(0, board.getHistory().getData().moveNumber);
       assertEquals(1, engine.ponderCount);
-      assertFalse(engine.isInitialBoardSynchronizationActive());
       assertLifecycleReservationReleased(engine);
     }
   }
@@ -1820,9 +1788,7 @@ class EngineManagerInitialStartupSynchronizationTest {
       } finally {
         barrierEnded.countDown();
         Board.beforeHistoryOverwriteEngineForward = null;
-        if (engine.isInitialBoardSynchronizationActive()) {
-          engine.endInitialBoardSynchronization();
-        }
+        engine.endInitialBoardSynchronization();
       }
     }
   }
@@ -1951,7 +1917,6 @@ class EngineManagerInitialStartupSynchronizationTest {
 
       assertNotNull(failure, "rejected catch-up reservation must fail closed");
       assertFalse(engine.isLoaded);
-      assertFalse(engine.isInitialBoardSynchronizationActive());
       assertEquals(0, engine.ponderCount);
       assertEquals(0, engine.analyzeCount());
       assertEquals(0, env.readyTransitions.get() - readyBaseline);
@@ -1994,7 +1959,6 @@ class EngineManagerInitialStartupSynchronizationTest {
 
       assertEquals(1, engine.loadSgfCount.get(), "only the frozen route executes");
       assertEquals(1, engine.ponderCount);
-      assertFalse(engine.isInitialBoardSynchronizationActive());
     }
   }
 
@@ -2080,9 +2044,6 @@ class EngineManagerInitialStartupSynchronizationTest {
 
       assertNotNull(failure, "initial restore failure must surface");
       assertFalse(engine.isLoaded, "target engine must be marked unavailable");
-      assertFalse(
-          engine.isInitialBoardSynchronizationActive(),
-          "initial synchronization state must end on failure");
       assertEquals(0, engine.ponderCount, "no analysis after failure");
       assertEquals(0, engine.analyzeCount(), "no analysis command after failure");
       assertEquals(0, env.readyTransitions.get() - readyBaseline, "never marked ready");
@@ -2129,15 +2090,19 @@ class EngineManagerInitialStartupSynchronizationTest {
             Thread.State.BLOCKED,
             cleanupThread.getState(),
             "failure cleanup must reach the blocked reservation-release phase");
-        assertTrue(
-            engine.isInitialBoardSynchronizationActive(),
-            "the barrier must remain active while failure cleanup still holds the reservation");
+        assertFalse(
+            engine.submitOrdinaryLiveBoardForwarding(
+                EngineManager.OrdinaryLiveBoardForwardingIntent.of(() -> true)),
+            "ordinary forwarding must stay occupied while failure cleanup still holds the reservation");
       }
 
       cleanupThread.join(2_000L);
       assertFalse(cleanupThread.isAlive(), "failure cleanup must settle after reservation release");
       assertNotNull(failure.get(), "controlled startup failure must surface");
-      assertFalse(engine.isInitialBoardSynchronizationActive());
+      assertTrue(
+          engine.submitOrdinaryLiveBoardForwarding(
+              EngineManager.OrdinaryLiveBoardForwardingIntent.of(() -> true)),
+          "ordinary forwarding must reopen after failure cleanup releases the reservation");
       assertLifecycleReservationReleased(engine);
     }
   }
@@ -2160,9 +2125,6 @@ class EngineManagerInitialStartupSynchronizationTest {
       assertTrue(
           failure.getMessage().contains("Failed to send GTP command"),
           "reservation release failure must propagate");
-      assertFalse(
-          engine.isInitialBoardSynchronizationActive(),
-          "cleanup must end the startup barrier even when reservation release fails");
       assertLifecycleReservationReleased(engine);
     }
   }
@@ -2196,7 +2158,6 @@ class EngineManagerInitialStartupSynchronizationTest {
       assertTrue(
           failure.getSuppressed()[0].getMessage().contains("Failed to send GTP command"),
           "reservation cleanup failure must remain diagnosable");
-      assertFalse(engine.isInitialBoardSynchronizationActive());
       assertLifecycleReservationReleased(engine);
     }
   }
@@ -2225,7 +2186,6 @@ class EngineManagerInitialStartupSynchronizationTest {
 
       assertNotNull(failure, "catch-up restore failure must surface");
       assertFalse(engine.isLoaded, "target engine must be marked unavailable");
-      assertFalse(engine.isInitialBoardSynchronizationActive());
       assertEquals(0, engine.ponderCount);
       assertEquals(0, env.readyTransitions.get() - readyBaseline);
       assertEquals(2, engine.loadSgfCount.get(), "frozen route then failed catch-up route");
@@ -2260,7 +2220,6 @@ class EngineManagerInitialStartupSynchronizationTest {
       assertEquals(3, engine.clearBoardCount.get(), "frozen route plus two catch-up rounds");
       assertEquals(2, engine.analyzePosition(), "final convergence at node 2");
       assertEquals(1, engine.ponderCount, "analysis must wait for the final stable point");
-      assertFalse(engine.isInitialBoardSynchronizationActive());
     }
   }
 
@@ -2314,7 +2273,6 @@ class EngineManagerInitialStartupSynchronizationTest {
       } finally {
         startup.close();
       }
-      assertFalse(engine.isInitialBoardSynchronizationActive());
       assertLifecycleReservationReleased(engine);
     }
   }
@@ -2365,6 +2323,10 @@ class EngineManagerInitialStartupSynchronizationTest {
   }
 
   private static void assertLifecycleReservationReleased(StartupSyncLeelaz engine) {
+    assertTrue(
+        engine.submitOrdinaryLiveBoardForwarding(
+            EngineManager.OrdinaryLiveBoardForwardingIntent.of(() -> true)),
+        "ordinary live-board forwarding must reopen after the barrier ends");
     Leelaz.ExclusiveGtpLifecycleReservation reservation =
         engine.beginExclusiveGtpLifecycleReservation();
     assertNotNull(reservation, "lifecycle reservation must be released after the barrier");

--- a/src/test/java/featurecat/lizzie/analysis/EngineManagerInitialStartupSynchronizationTest.java
+++ b/src/test/java/featurecat/lizzie/analysis/EngineManagerInitialStartupSynchronizationTest.java
@@ -24,6 +24,7 @@ import featurecat.lizzie.rules.BoardHistoryNode;
 import featurecat.lizzie.rules.SGFParser;
 import featurecat.lizzie.rules.Stone;
 import featurecat.lizzie.rules.Zobrist;
+import featurecat.lizzie.rules.extraMoveForTsumego;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.lang.reflect.Field;
@@ -1616,6 +1617,308 @@ class EngineManagerInitialStartupSynchronizationTest {
   }
 
   @Test
+  void historyOverwriteOccupiedAtMutationDoesNotReplayAfterHandoff() throws Exception {
+    try (StartupTestEnvironment env = StartupTestEnvironment.open()) {
+      StartupSyncLeelaz engine = new StartupSyncLeelaz();
+      Board board = boardWithHistory(emptyRootHistory(1));
+      env.publish(engine, board);
+      engine.startEngine(0);
+
+      CountDownLatch reachedForward = new CountDownLatch(1);
+      CountDownLatch handoffFinished = new CountDownLatch(1);
+      AtomicInteger commandsWhenForwardReached = new AtomicInteger();
+      AtomicReference<Throwable> mutationFailure = new AtomicReference<>();
+      Board.beforeHistoryOverwriteEngineForward =
+          () -> {
+            commandsWhenForwardReached.set(engine.commands.size());
+            reachedForward.countDown();
+            awaitLatch(handoffFinished);
+          };
+
+      EngineManager.InitialEngineStartupSynchronization startup = captureStartup(engine, board);
+      Thread mutationThread =
+          new Thread(
+              () -> {
+                try {
+                  board.clear(false);
+                } catch (Throwable failure) {
+                  mutationFailure.set(failure);
+                }
+              },
+              "ticket03-occupied-overwrite-forward");
+      try {
+        mutationThread.start();
+        assertTrue(reachedForward.await(5, TimeUnit.SECONDS), "mutation must reach forwarding");
+
+        runStartupInThread(startup, engine);
+        int commandsAfterHandoff = engine.commands.size();
+        handoffFinished.countDown();
+        mutationThread.join(5_000L);
+
+        assertFalse(mutationThread.isAlive(), "delayed overwrite forwarding must settle");
+        assertNull(mutationFailure.get(), "occupied overwrite must not throw");
+        assertEquals(
+            commandsAfterHandoff,
+            engine.commands.size(),
+            "stale clear/komi captured while the owner occupied must not replay after handoff");
+        assertTrue(
+            commandsWhenForwardReached.get() <= commandsAfterHandoff,
+            "catch-up may enqueue while the occupied plan is held");
+        assertEquals(
+            (float) board.getHistory().getGameInfo().getKomi(),
+            engine.komi,
+            0.001f,
+            "engine komi must converge from catch-up, not the stale plan");
+        assertEquals(0, engine.analyzePosition(), "analysis starts on the overwritten board");
+        assertEquals(1, engine.ponderCount);
+        assertLifecycleReservationReleased(engine);
+      } finally {
+        handoffFinished.countDown();
+        Board.beforeHistoryOverwriteEngineForward = null;
+      }
+    }
+  }
+
+  @Test
+  void historyOverwriteAfterMutationLosesRaceToAdmissionStart() throws Exception {
+    try (StartupTestEnvironment env = StartupTestEnvironment.open()) {
+      StartupSyncLeelaz engine = new StartupSyncLeelaz();
+      Board board = boardWithHistory(emptyRootHistory(1));
+      env.publish(engine, board);
+      engine.startEngine(0);
+
+      CountDownLatch reachedForward = new CountDownLatch(1);
+      CountDownLatch admissionStarted = new CountDownLatch(1);
+      AtomicReference<Throwable> mutationFailure = new AtomicReference<>();
+      Board.beforeHistoryOverwriteEngineForward =
+          () -> {
+            reachedForward.countDown();
+            awaitLatch(admissionStarted);
+          };
+
+      Thread mutationThread =
+          new Thread(
+              () -> {
+                try {
+                  board.clear(false);
+                } catch (Throwable failure) {
+                  mutationFailure.set(failure);
+                }
+              },
+              "ticket03-stale-overwrite-enqueue");
+      EngineManager.InitialEngineStartupSynchronization startup = null;
+      try {
+        mutationThread.start();
+        assertTrue(
+            reachedForward.await(5, TimeUnit.SECONDS),
+            "mutation must finish before ordinary forwarding enqueues");
+
+        startup = captureStartup(engine, board);
+        admissionStarted.countDown();
+        mutationThread.join(5_000L);
+
+        assertFalse(mutationThread.isAlive(), "stale overwrite forwarding must settle");
+        assertNull(mutationFailure.get(), "raced overwrite must not throw");
+        assertFalse(
+            engine.commands.contains("clear_board"),
+            "stale ordinary clear must not enter the queue after admission starts");
+        assertFalse(
+            engine.commands.stream().anyMatch(command -> command.startsWith("komi ")),
+            "stale ordinary komi must not enter the queue after admission starts");
+
+        runStartupInThread(startup, engine);
+
+        assertEquals(
+            (float) board.getHistory().getGameInfo().getKomi(),
+            engine.komi,
+            0.001f,
+            "final komi must converge from the startup route");
+        assertEquals(0, engine.analyzePosition(), "analysis starts on the overwritten board");
+        assertEquals(1, engine.ponderCount);
+        assertLifecycleReservationReleased(engine);
+      } finally {
+        admissionStarted.countDown();
+        Board.beforeHistoryOverwriteEngineForward = null;
+        if (startup != null) {
+          startup.close();
+        }
+      }
+    }
+  }
+
+  @Test
+  void historyOverwriteHonorsDepthOnlyBoardBarrierWithoutAdmission() throws Exception {
+    try (StartupTestEnvironment env = StartupTestEnvironment.open()) {
+      StartupSyncLeelaz engine = new StartupSyncLeelaz();
+      Board board = boardWithHistory(emptyRootHistory(1));
+      env.publish(engine, board);
+      engine.startEngine(0);
+
+      engine.beginInitialBoardSynchronization();
+      try {
+        int before = engine.commands.size();
+        board.clear(false);
+        board.reopen(9, 9);
+        flattenWithExtraStones(board, true);
+        assertEquals(
+            before,
+            engine.commands.size(),
+            "a depth-only restart/startup barrier must suppress ordinary overwrite");
+      } finally {
+        engine.endInitialBoardSynchronization();
+      }
+
+      board.clear(false);
+      assertTrue(
+          engine.commands.contains("clear_board"),
+          "ordinary clear must forward after the depth-only barrier ends");
+    }
+  }
+
+  @Test
+  void depthOnlyBarrierOccupancyDoesNotReplayAfterBarrierEnds() throws Exception {
+    try (StartupTestEnvironment env = StartupTestEnvironment.open()) {
+      StartupSyncLeelaz engine = new StartupSyncLeelaz();
+      Board board = boardWithHistory(emptyRootHistory(1));
+      env.publish(engine, board);
+      engine.startEngine(0);
+
+      CountDownLatch reachedForward = new CountDownLatch(1);
+      CountDownLatch barrierEnded = new CountDownLatch(1);
+      AtomicReference<Throwable> mutationFailure = new AtomicReference<>();
+      Board.beforeHistoryOverwriteEngineForward =
+          () -> {
+            reachedForward.countDown();
+            awaitLatch(barrierEnded);
+          };
+
+      engine.beginInitialBoardSynchronization();
+      Thread mutationThread =
+          new Thread(
+              () -> {
+                try {
+                  board.clear(false);
+                } catch (Throwable failure) {
+                  mutationFailure.set(failure);
+                }
+              },
+              "ticket03-depth-only-occupied-forward");
+      try {
+        mutationThread.start();
+        assertTrue(reachedForward.await(5, TimeUnit.SECONDS), "mutation must reach forwarding");
+        int commandsBeforeRelease = engine.commands.size();
+        engine.endInitialBoardSynchronization();
+        barrierEnded.countDown();
+        mutationThread.join(5_000L);
+
+        assertFalse(mutationThread.isAlive(), "delayed depth-only overwrite must settle");
+        assertNull(mutationFailure.get(), "depth-only occupied overwrite must not throw");
+        assertEquals(
+            commandsBeforeRelease,
+            engine.commands.size(),
+            "stale overwrite captured under a depth-only barrier must not replay after it ends");
+      } finally {
+        barrierEnded.countDown();
+        Board.beforeHistoryOverwriteEngineForward = null;
+        if (engine.isInitialBoardSynchronizationActive()) {
+          engine.endInitialBoardSynchronization();
+        }
+      }
+    }
+  }
+
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("historyOverwriteMutations")
+  void historyOverwriteDuringAdmissionStaysOutOfQueueAndConverges(
+      String name, HistoryOverwriteMutation mutation) throws Exception {
+    try (StartupTestEnvironment env = StartupTestEnvironment.open()) {
+      StartupSyncLeelaz engine = new StartupSyncLeelaz();
+      Board board = boardWithHistory(emptyRootHistory(1));
+      env.publish(engine, board);
+      engine.startEngine(0);
+
+      EngineManager.InitialEngineStartupSynchronization startup = captureStartup(engine, board);
+      AtomicInteger rounds = new AtomicInteger();
+      AtomicReference<Throwable> mutationFailure = new AtomicReference<>();
+      startup.beforeRestore =
+          () -> {
+            if (rounds.getAndIncrement() != 0) {
+              return;
+            }
+            int before = engine.commands.size();
+            try {
+              mutation.apply(board);
+            } catch (Throwable failure) {
+              mutationFailure.set(failure);
+              return;
+            }
+            assertEquals(
+                before,
+                engine.commands.size(),
+                name + " must not enqueue ordinary overwrite commands while admission is active");
+          };
+
+      runStartupInThread(startup, engine);
+
+      assertNull(mutationFailure.get(), name + " must not throw");
+      assertEquals(1, engine.ponderCount, name + " must wait for READY/ponder");
+      assertEquals(
+          (float) board.getHistory().getGameInfo().getKomi(),
+          engine.komi,
+          0.001f,
+          name + " must converge komi");
+      assertEquals(
+          Board.boardWidth,
+          engine.engineBoardWidth,
+          name + " must converge board width");
+      assertEquals(
+          Board.boardHeight,
+          engine.engineBoardHeight,
+          name + " must converge board height");
+      assertEquals(
+          0,
+          engine.analyzePosition(),
+          name + " must analyze the overwritten position");
+      assertLifecycleReservationReleased(engine);
+    }
+  }
+
+  @Test
+  void historyOverwriteForwardsWhenAdmissionIsInactive() throws Exception {
+    try (StartupTestEnvironment env = StartupTestEnvironment.open()) {
+      StartupSyncLeelaz engine = new StartupSyncLeelaz();
+      Board board = boardWithHistory(emptyRootHistory(1));
+      env.publish(engine, board);
+      engine.startEngine(0);
+
+      board.clear(false);
+      assertTrue(engine.commands.contains("clear_board"), "clear must forward when idle");
+      assertTrue(
+          engine.commands.stream().anyMatch(command -> command.startsWith("komi ")),
+          "clear must forward komi when idle");
+
+      board.reopen(13, 13);
+      assertTrue(
+          engine.commands.contains("boardsize 13"),
+          "reopen must forward boardsize when idle");
+
+      flattenWithExtraStones(board, true);
+      assertTrue(
+          engine.containsCommand(play("B", 3, 3)),
+          "flatten extra-stone feeds must reach the engine when idle");
+      assertTrue(
+          engine.commands.stream().anyMatch(command -> command.startsWith("komi ")),
+          "flatten must forward komi when idle");
+
+      board.reopen(13, 13);
+      long boardSizeCount =
+          engine.commands.stream().filter(command -> command.equals("boardsize 13")).count();
+      assertEquals(1, boardSizeCount, "same-size reopen must be a no-op");
+    }
+  }
+
+
+  @Test
   void catchUpReservationReacquisitionFailureFailsClosed() throws Exception {
     try (StartupTestEnvironment env = StartupTestEnvironment.open()) {
       StartupSyncLeelaz engine = new StartupSyncLeelaz();
@@ -2084,6 +2387,50 @@ class EngineManagerInitialStartupSynchronizationTest {
     Field field = Leelaz.class.getDeclaredField(name);
     field.setAccessible(true);
     field.set(engine, value);
+  }
+
+  private static void awaitLatch(CountDownLatch latch) {
+    try {
+      if (!latch.await(10, TimeUnit.SECONDS)) {
+        throw new IllegalStateException("timed out waiting for overwrite forwarding latch");
+      }
+    } catch (InterruptedException interrupted) {
+      Thread.currentThread().interrupt();
+      throw new IllegalStateException("overwrite forwarding latch interrupted", interrupted);
+    }
+  }
+
+  @FunctionalInterface
+  private interface HistoryOverwriteMutation {
+    void apply(Board board);
+  }
+
+  private static Stream<Arguments> historyOverwriteMutations() {
+    return Stream.of(
+        Arguments.of("clear", (HistoryOverwriteMutation) board -> board.clear(false)),
+        Arguments.of("clearForOnline", (HistoryOverwriteMutation) Board::clearForOnline),
+        Arguments.of("clearforedit", (HistoryOverwriteMutation) Board::clearforedit),
+        Arguments.of("reopen", (HistoryOverwriteMutation) board -> board.reopen(9, 9)),
+        Arguments.of(
+            "flattenWithKomi",
+            (HistoryOverwriteMutation) board -> flattenWithExtraStones(board, true)),
+        Arguments.of(
+            "flattenExtraStones",
+            (HistoryOverwriteMutation) board -> flattenWithExtraStones(board, false)));
+  }
+
+  private static void flattenWithExtraStones(Board board, boolean withKomi) {
+    Stone[] stones = board.getHistory().getStones().clone();
+    Zobrist zobrist = board.getHistory().getZobrist().clone();
+    extraMoveForTsumego extra = new extraMoveForTsumego();
+    extra.x = 3;
+    extra.y = 3;
+    extra.color = Stone.BLACK;
+    if (withKomi) {
+      board.flattenWithCondition(stones, zobrist, true, List.of(extra), 7.5);
+    } else {
+      board.flattenWithCondition(stones, zobrist, true, List.of(extra));
+    }
   }
 
   private static void sendFailOnErrorCommand(Leelaz engine, String command) throws Exception {
@@ -2699,6 +3046,7 @@ class EngineManagerInitialStartupSynchronizationTest {
     protected void showContributingEngineSwitchUnavailable() {}
   }
 
+
   private static final class StartupTestEnvironment implements AutoCloseable {
     private final Leelaz previousPrimary = Lizzie.leelaz;
     private final Leelaz previousSecondary = Lizzie.leelaz2;
@@ -2730,6 +3078,7 @@ class EngineManagerInitialStartupSynchronizationTest {
       Lizzie.frame = allocate(SilentStartupFrame.class);
       LizzieFrame.toolbar = allocate(SilentStartupToolbar.class);
       LizzieFrame.menu = allocate(SilentStartupMenu.class);
+      LizzieFrame.menu.txtKomi = new javax.swing.JTextField();
       Menu.engineMenu = allocate(SilentStartupEngineMenu.class);
       Menu.engineMenu2 = allocate(SilentStartupEngineMenu.class);
       LizzieFrame.boardRenderer2 = new BoardRenderer(true);

--- a/src/test/java/featurecat/lizzie/analysis/EngineManagerInitialStartupSynchronizationTest.java
+++ b/src/test/java/featurecat/lizzie/analysis/EngineManagerInitialStartupSynchronizationTest.java
@@ -42,8 +42,12 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Stream;
 import javax.swing.SwingUtilities;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 /**
  * Focused tests for the initial engine startup restore barrier (Issue #223): frozen immutable
@@ -130,6 +134,208 @@ class EngineManagerInitialStartupSynchronizationTest {
           "a live update crossing barrier start must not enter the command queue");
       engine.endInitialBoardSynchronization();
     }
+  }
+
+  @ParameterizedTest
+  @MethodSource("ordinaryCommandsRejectedDuringStartupAdmission")
+  void startupAdmissionRejectsOrdinaryLiveBoardCommand(String command) throws Exception {
+    try (StartupTestEnvironment env = StartupTestEnvironment.open()) {
+      StartupSyncLeelaz engine = new StartupSyncLeelaz();
+      Board board = boardWithHistory(emptyRootHistory(0));
+      env.publish(engine, board);
+      engine.startEngine(0);
+
+      EngineManager.InitialEngineStartupSynchronization startup = captureStartup(engine, board);
+      AtomicBoolean probed = new AtomicBoolean();
+      startup.beforeRestore =
+          () -> {
+            int commandsBefore = engine.commands.size();
+            engine.sendCommand(command);
+            assertFalse(
+                engine.commands.subList(commandsBefore, engine.commands.size()).contains(command),
+                command + " must not enter the queue while startup admission is active");
+            probed.set(true);
+          };
+
+      runStartupInThread(startup, engine);
+
+      assertTrue(probed.get(), "admission probe must run during the frozen route");
+      assertEquals(1, engine.ponderCount, "ponder waits for the stable restore point");
+      assertLifecycleReservationReleased(engine);
+    }
+  }
+
+  @ParameterizedTest
+  @MethodSource("handshakeAndSizeCommandsAllowedDuringStartupAdmission")
+  void startupAdmissionAllowsHandshakeAndSizeConvergenceCommand(String command) throws Exception {
+    try (StartupTestEnvironment env = StartupTestEnvironment.open()) {
+      StartupSyncLeelaz engine = new StartupSyncLeelaz();
+      Board board = boardWithHistory(emptyRootHistory(0));
+      env.publish(engine, board);
+      engine.startEngine(0);
+
+      EngineManager.InitialEngineStartupSynchronization startup = captureStartup(engine, board);
+      AtomicBoolean probed = new AtomicBoolean();
+      startup.beforeRestore =
+          () -> {
+            engine.sendCommand(command);
+            assertTrue(
+                engine.commands.contains(command),
+                command + " must keep flowing while startup admission is active");
+            probed.set(true);
+          };
+
+      runStartupInThread(startup, engine);
+
+      assertTrue(probed.get(), "admission probe must run during the frozen route");
+      assertEquals(1, engine.ponderCount, "ponder waits for the stable restore point");
+      assertLifecycleReservationReleased(engine);
+    }
+  }
+
+  @Test
+  void startupAdmissionAllowsExactRestoreRoutePlayWhileRejectingOrdinaryPlay() throws Exception {
+    try (StartupTestEnvironment env = StartupTestEnvironment.open()) {
+      StartupSyncLeelaz engine = new StartupSyncLeelaz();
+      Board board = boardWithHistory(emptyRootHistory(1));
+      env.publish(engine, board);
+      engine.startEngine(0);
+
+      EngineManager.InitialEngineStartupSynchronization startup = captureStartup(engine, board);
+      startup.beforeRestore = () -> engine.sendCommand("play B Q4");
+
+      runStartupInThread(startup, engine);
+
+      assertFalse(engine.containsCommand("play B Q4"), "ordinary play must stay out of the queue");
+      assertTrue(
+          engine.containsCommand(play("B", 4, 3)),
+          "exact restore route play must still reach the engine");
+      assertEquals(1, engine.enginePosition.get(), "engine must converge on the restored move");
+      assertEquals(1, engine.ponderCount, "ponder waits for the stable restore point");
+      assertLifecycleReservationReleased(engine);
+    }
+  }
+
+  @Test
+  void capturedTargetAndMirrorShareStartupAdmission() throws Exception {
+    try (StartupTestEnvironment env = StartupTestEnvironment.open()) {
+      StartupSyncLeelaz target = new StartupSyncLeelaz();
+      StartupSyncLeelaz mirror = new StartupSyncLeelaz();
+      Board board = boardWithHistory(emptyRootHistory(0));
+      env.publish(target, board);
+      target.startEngine(0);
+      mirror.startEngine(1);
+      int readyBaseline = env.readyTransitions.get();
+
+      EngineManager.InitialEngineStartupSynchronization startup =
+          EngineManager.InitialEngineStartupSynchronization.capture(
+              null, target, mirror, board, false, false);
+      AtomicInteger readyDuringAdmission = new AtomicInteger(-1);
+      startup.beforeRestore =
+          () -> {
+            target.sendCommand("play B Q4");
+            mirror.sendCommand("play B Q4");
+            target.sendCommand("name");
+            mirror.sendCommand("name");
+            assertFalse(target.containsCommand("play B Q4"));
+            assertFalse(mirror.containsCommand("play B Q4"));
+            assertTrue(target.containsCommand("name"), "handshake must flow on the target");
+            assertTrue(mirror.containsCommand("name"), "handshake must flow on the mirror");
+            assertEquals(0, target.ponderCount, "target must not ponder before stable handoff");
+            assertEquals(0, mirror.ponderCount, "mirror must not ponder before stable handoff");
+            readyDuringAdmission.set(env.readyTransitions.get());
+          };
+
+      runStartupInThread(startup, target);
+
+      assertEquals(
+          readyBaseline,
+          readyDuringAdmission.get(),
+          "READY must wait for the shared admission handoff");
+      assertEquals(1, env.readyTransitions.get() - readyBaseline, "READY publishes once");
+      assertEquals(1, target.ponderCount, "target ponders only after the shared handoff");
+      target.sendCommand("play B Q16");
+      mirror.sendCommand("play B Q16");
+      assertTrue(target.containsCommand("play B Q16"), "target admission must reopen");
+      assertTrue(mirror.containsCommand("play B Q16"), "mirror admission must reopen");
+      assertLifecycleReservationReleased(target);
+      assertLifecycleReservationReleased(mirror);
+    }
+  }
+
+  @Test
+  void representativeLiveBoardResyncLosesRaceToAdmissionStart() throws Exception {
+    try (StartupTestEnvironment env = StartupTestEnvironment.open()) {
+      StartupSyncLeelaz engine = new StartupSyncLeelaz();
+      Board board = boardWithHistory(emptyRootHistory(0));
+      env.publish(engine, board);
+      engine.startEngine(0);
+
+      BlockingStartupConfig config = allocate(BlockingStartupConfig.class);
+      config.doubleEngineQueryEntered = new CountDownLatch(1);
+      config.allowDoubleEngineQuery = new CountDownLatch(1);
+      Lizzie.config = config;
+      AtomicReference<Throwable> resyncFailure = new AtomicReference<>();
+      Thread resyncThread =
+          new Thread(
+              () -> {
+                try {
+                  board.resendCurrentPositionToPrimaryEngine();
+                } catch (Throwable failure) {
+                  resyncFailure.set(failure);
+                }
+              },
+              "startup-admission-representative-resync-race");
+      resyncThread.start();
+
+      assertTrue(
+          config.doubleEngineQueryEntered.await(2, TimeUnit.SECONDS),
+          "the representative resync must pass precheck before admission starts");
+      EngineManager.InitialEngineStartupSynchronization startup = captureStartup(engine, board);
+      try {
+        config.allowDoubleEngineQuery.countDown();
+        resyncThread.join(2_000L);
+
+        assertFalse(resyncThread.isAlive(), "the representative resync race must settle");
+        assertNull(resyncFailure.get(), "the representative resync must not throw");
+        assertFalse(engine.containsCommand("play B Q4"));
+        assertFalse(engine.containsCommand("undo"));
+        assertFalse(
+            engine.commands.contains("clear_board"),
+            "ordinary clear from the raced resync must not enter the queue");
+        engine.sendCommand("name");
+        assertTrue(engine.commands.contains("name"), "handshake must still flow");
+      } finally {
+        startup.close();
+      }
+
+      engine.sendCommand("play B Q16");
+      assertTrue(
+          engine.containsCommand("play B Q16"),
+          "ordinary play must enter after admission reopens");
+      assertLifecycleReservationReleased(engine);
+    }
+  }
+
+  private static Stream<Arguments> ordinaryCommandsRejectedDuringStartupAdmission() {
+    return Stream.of(
+        Arguments.of("play B Q4"),
+        Arguments.of("undo"),
+        Arguments.of("clear_board"),
+        Arguments.of("lz-analyze 99"),
+        Arguments.of("kata-analyze 99"),
+        Arguments.of("analyze 99"),
+        Arguments.of("kata-raw-nn 0"),
+        Arguments.of("heat"));
+  }
+
+  private static Stream<Arguments> handshakeAndSizeCommandsAllowedDuringStartupAdmission() {
+    return Stream.of(
+        Arguments.of("name"),
+        Arguments.of("version"),
+        Arguments.of("list_commands"),
+        Arguments.of("komi 6.5"),
+        Arguments.of("boardsize 19"));
   }
 
   @Test

--- a/src/test/java/featurecat/lizzie/analysis/EngineManagerInitialStartupSynchronizationTest.java
+++ b/src/test/java/featurecat/lizzie/analysis/EngineManagerInitialStartupSynchronizationTest.java
@@ -1104,6 +1104,8 @@ class EngineManagerInitialStartupSynchronizationTest {
                 tailMove.addOrGoto(
                     moveNode(tailMove.getData(), 8, 8, Stone.WHITE, true, 4), true, false, false);
                 assertTrue(board.nextVariation(1));
+                assertTrue(board.goToMoveNumber(3), "jump must return to the tail MOVE");
+                assertTrue(board.goToMoveNumber(4), "jump must reach the main-line tail PASS");
                 // Ordinary live-board sync must be refused by the barrier, not admitted.
                 assertFalse(board.resendCurrentPositionToPrimaryEngine());
                 assertFalse(
@@ -1125,7 +1127,9 @@ class EngineManagerInitialStartupSynchronizationTest {
       assertNull(
           navigationFailure.get(),
           "snapshot navigation and ordinary sync during the barrier must never throw");
-      assertEquals(4, engine.analyzePosition(), "engine must converge on the branch child");
+      assertEquals(4, board.getHistory().getMoveNumber(), "history cursor at the tail PASS");
+      assertSame(admissionHistory.getEnd(), board.getHistory().getCurrentHistoryNode());
+      assertEquals(4, engine.analyzePosition(), "engine must converge on the main-line tail PASS");
       assertEquals(1, engine.ponderCount, "analysis waits for the stable restore point");
       assertEngineMatchesBoard(engine, board, 19, 19);
       assertFalse(engine.isInitialBoardSynchronizationActive());
@@ -1688,6 +1692,71 @@ class EngineManagerInitialStartupSynchronizationTest {
       assertEquals(1, engine.loadSgfCount.get(), "only the frozen route executes");
       assertEquals(1, engine.ponderCount);
       assertFalse(engine.isInitialBoardSynchronizationActive());
+    }
+  }
+
+  @Test
+  void ordinaryMoveNavigationDuringAdmissionConvergesWithoutOrdinaryCommandsOrException()
+      throws Exception {
+    try (StartupTestEnvironment env = StartupTestEnvironment.open()) {
+      StartupSyncLeelaz engine = new StartupSyncLeelaz();
+      BoardHistoryList history = emptyRootHistory(3);
+      history.toStart();
+      Board board = boardWithHistory(history);
+      env.publish(engine, board);
+      BoardHistoryNode node1 = history.getCurrentHistoryNode().next().orElseThrow();
+      node1.addOrGoto(moveNode(node1.getData(), 6, 3, Stone.WHITE, true, 2), true, false, false);
+      engine.startEngine(0);
+      assertTrue(engine.isLoaded, "fixture must keep the primary engine ready during admission");
+
+      EngineManager.InitialEngineStartupSynchronization startup = captureStartup(engine, board);
+      AtomicInteger rounds = new AtomicInteger();
+      AtomicReference<Throwable> navigationFailure = new AtomicReference<>();
+      startup.beforeRestore =
+          () -> {
+            if (rounds.getAndIncrement() == 0) {
+              try {
+                int commandsBefore = engine.commands.size();
+                assertTrue(board.nextMove(false), "next must reach move 1");
+                assertTrue(board.nextMove(false), "next must reach move 2");
+                assertTrue(board.previousMove(false), "previous must return to move 1");
+                assertTrue(board.nextVariation(1), "variation must enter the branch child");
+                assertTrue(board.goToMoveNumber(1), "jump must return to move 1");
+                assertTrue(board.goToMoveNumber(3), "jump must reach the main-line tail");
+                assertFalse(
+                    board.resendCurrentPositionToPrimaryEngine(),
+                    "full current-position resync must stay refused during admission");
+                assertFalse(
+                    board.trySyncCurrentPositionToPrimaryEngineIncrementally(
+                        board.getHistory().getData(), 19, 19),
+                    "incremental current-position sync must stay refused during admission");
+                board.resendMoveToEngine(engine, false);
+                board.getHistory().getCurrentHistoryNode().clearAndSyncBoard(false);
+                assertEquals(
+                    commandsBefore,
+                    engine.commands.size(),
+                    "ordinary MOVE navigation must not inject live-board commands during admission");
+              } catch (Throwable failure) {
+                navigationFailure.set(failure);
+              }
+            }
+          };
+
+      runStartupInThread(startup, engine);
+
+      assertNull(
+          navigationFailure.get(),
+          "ordinary MOVE navigation and sync during admission must not throw");
+      assertEquals(3, board.getHistory().getMoveNumber(), "history cursor at the main-line tail");
+      assertSame(history.getEnd(), board.getHistory().getCurrentHistoryNode());
+      assertEquals(3, engine.analyzePosition(), "catch-up must converge on the final MOVE");
+      assertEquals(
+          List.of(play("B", 4, 3), play("W", 5, 3), play("B", 6, 3)),
+          engine.playsAfterLastClear(),
+          "catch-up replay must rebuild the main-line tail from the root");
+      assertEquals(1, engine.ponderCount, "analysis waits for the stable restore point");
+      assertEngineMatchesBoard(engine, board, 19, 19);
+      assertLifecycleReservationReleased(engine);
     }
   }
 

--- a/src/test/java/featurecat/lizzie/analysis/EngineManagerInitialStartupSynchronizationTest.java
+++ b/src/test/java/featurecat/lizzie/analysis/EngineManagerInitialStartupSynchronizationTest.java
@@ -342,6 +342,50 @@ class EngineManagerInitialStartupSynchronizationTest {
   }
 
   @Test
+  void rejectedMirrorAdmissionRollsBackAcceptedTargetAdmission() throws Exception {
+    try (StartupTestEnvironment env = StartupTestEnvironment.open()) {
+      StartupSyncLeelaz target = new StartupSyncLeelaz();
+      StartupSyncLeelaz occupiedMirror = new StartupSyncLeelaz();
+      Board board = boardWithHistory(emptyRootHistory(0));
+      env.publish(target, board);
+      target.startEngine(0);
+      occupiedMirror.startEngine(1);
+
+      EngineManager.InitialEngineStartupSynchronization existingMirrorOwner =
+          captureStartup(occupiedMirror, board);
+      try {
+        assertThrows(
+            IllegalStateException.class,
+            () ->
+                EngineManager.InitialEngineStartupSynchronization.capture(
+                    null, target, occupiedMirror, board, false, false),
+            "the occupied mirror must reject the second startup owner");
+
+        assertTrue(
+            target.submitOrdinaryLiveBoardForwarding(
+                EngineManager.OrdinaryLiveBoardForwardingIntent.of(() -> true)),
+            "a mirror rejection must roll back the target admission accepted earlier");
+
+        assertThrows(
+            IllegalStateException.class,
+            () ->
+                EngineManager.InitialEngineStartupSynchronization.capturePrepared(
+                    null, target, occupiedMirror, board, false, false),
+            "the occupied mirror must also reject a prepared startup owner");
+        assertTrue(
+            target.submitOrdinaryLiveBoardForwarding(
+                EngineManager.OrdinaryLiveBoardForwardingIntent.of(() -> true)),
+            "a prepared mirror rejection must also roll back its accepted target admission");
+      } finally {
+        existingMirrorOwner.close();
+      }
+
+      assertLifecycleReservationReleased(target);
+      assertLifecycleReservationReleased(occupiedMirror);
+    }
+  }
+
+  @Test
   void admissionStartingAfterSubmitPrecheckRejectsAllOrdinaryForwardingCommands()
       throws Exception {
     try (StartupTestEnvironment env = StartupTestEnvironment.open()) {

--- a/src/test/java/featurecat/lizzie/analysis/LeelazAutomaticRestartConvergenceTest.java
+++ b/src/test/java/featurecat/lizzie/analysis/LeelazAutomaticRestartConvergenceTest.java
@@ -90,12 +90,6 @@ class LeelazAutomaticRestartConvergenceTest {
       assertTrue(
           firstLoadSgfReceived.await(2, TimeUnit.SECONDS),
           "the frozen restore route must reach the engine first");
-      assertTrue(
-          engine.isInitialBoardSynchronizationActive(),
-          "the restart board fence must stay active while the frozen route is in flight");
-      assertTrue(
-          mirror.isInitialBoardSynchronizationActive(),
-          "the captured mirror must share the automatic restart barrier");
       engine.sendCommand("play B Q4");
       assertFalse(
           engine.transport.commands().contains("play B Q4"),
@@ -128,12 +122,6 @@ class LeelazAutomaticRestartConvergenceTest {
           engine.beginEngineModeReservation(),
           "the completion gate must reject unrelated engine-mode owners while the fences are"
               + " pending");
-      assertFalse(
-          engine.isInitialBoardSynchronizationActive(),
-          "the board fence must end the barrier at the stable restore point");
-      assertFalse(
-          mirror.isInitialBoardSynchronizationActive(),
-          "the captured mirror barrier must close at the same stable point");
       engine.sendCommand("play W D4");
       assertFalse(
           engine.transport.commands().contains("play W D4"),
@@ -207,9 +195,6 @@ class LeelazAutomaticRestartConvergenceTest {
           engine.beginEngineModeReservation(),
           "the completion gate must reject unrelated engine-mode owners while the remote fence is"
               + " pending");
-      assertFalse(
-          engine.isInitialBoardSynchronizationActive(),
-          "the board fence must end the remote barrier at the stable restore point");
 
       history.getCurrentHistoryNode().clearAndSyncBoard(true);
       assertEquals(
@@ -398,7 +383,6 @@ class LeelazAutomaticRestartConvergenceTest {
 
       assertTrue(waitForCount(engine.readyCount, 1, 1, TimeUnit.SECONDS));
       assertTrue(engine.isLoaded(), "the recovered engine must stay available");
-      assertFalse(engine.isInitialBoardSynchronizationActive());
       assertEngineMatchesBoard(engine, board, 19, 19);
       Leelaz.EngineModeReservation afterFence = engine.beginEngineModeReservation();
       assertNotNull(afterFence, "the OpenCL reservation must be released after the fence");
@@ -453,12 +437,6 @@ class LeelazAutomaticRestartConvergenceTest {
           "a failed catch-up must release the reservation and settle the callback");
       assertFalse(engine.isLoaded(), "the failed catch-up target must remain unavailable");
       assertFalse(mirror.isLoaded(), "the captured mirror must fail closed with the authority");
-      assertFalse(
-          engine.isInitialBoardSynchronizationActive(),
-          "a failed catch-up must end the board fence");
-      assertFalse(
-          mirror.isInitialBoardSynchronizationActive(),
-          "a failed catch-up must end the captured mirror barrier");
       assertEquals(0, engine.analyzeCount.get(), "no analyze after catch-up failure");
       assertEquals(0, engine.resumeCount.get(), "no ponder resume after catch-up failure");
       assertEquals(
@@ -473,6 +451,9 @@ class LeelazAutomaticRestartConvergenceTest {
           afterFailure,
           "a failed catch-up must clear the completion gate and release the lifecycle reservation");
       afterFailure.close();
+      assertOrdinaryForwardingReopened(engine);
+      assertOrdinaryForwardingReopened(mirror);
+      assertAutomaticRestartRetryAvailable(engine);
     }
   }
 
@@ -507,9 +488,6 @@ class LeelazAutomaticRestartConvergenceTest {
       assertEquals(
           1, engine.loadSgfCount.get(), "the frozen route fails before any catch-up route");
       assertFalse(engine.isLoaded(), "the failed frozen restore must leave the engine unavailable");
-      assertFalse(
-          engine.isInitialBoardSynchronizationActive(),
-          "a frozen restore failure must end the board fence");
       assertEquals(0, engine.readyCount.get(), "no ready after a frozen restore failure");
       assertEquals(0, engine.resumeCount.get(), "no ponder resume after a frozen restore failure");
       assertEquals(0, engine.analyzeCount.get(), "no analysis after a frozen restore failure");
@@ -521,6 +499,8 @@ class LeelazAutomaticRestartConvergenceTest {
           afterFailure,
           "a frozen restore failure must clear the completion claim and reopen admission");
       afterFailure.close();
+      assertOrdinaryForwardingReopened(engine);
+      assertAutomaticRestartRetryAvailable(engine);
     }
   }
 
@@ -546,11 +526,12 @@ class LeelazAutomaticRestartConvergenceTest {
       assertTrue(completed.await(2, TimeUnit.SECONDS));
       assertFalse(engine.isLoaded(), "the authority must fail closed after readiness timeout");
       assertFalse(mirror.isLoaded(), "the captured mirror must fail closed after readiness timeout");
-      assertFalse(engine.isInitialBoardSynchronizationActive());
-      assertFalse(mirror.isInitialBoardSynchronizationActive());
       Leelaz.EngineModeReservation afterFailure = engine.beginEngineModeReservation();
       assertNotNull(afterFailure, "readiness failure must release the completion claim");
       afterFailure.close();
+      assertOrdinaryForwardingReopened(engine);
+      assertOrdinaryForwardingReopened(mirror);
+      assertAutomaticRestartRetryAvailable(engine);
     }
   }
 
@@ -602,12 +583,6 @@ class LeelazAutomaticRestartConvergenceTest {
           "only the frozen route executes before the rejected reacquire");
       assertFalse(engine.isLoaded(), "the rejected reacquire must fail closed");
       assertFalse(mirror.isLoaded(), "a rejected reacquire must fail the captured mirror closed");
-      assertFalse(
-          engine.isInitialBoardSynchronizationActive(),
-          "a rejected reacquire must end the board fence");
-      assertFalse(
-          mirror.isInitialBoardSynchronizationActive(),
-          "a rejected reacquire must end the captured mirror barrier");
       assertEquals(0, engine.readyCount.get(), "no ready after a rejected reacquire");
       assertEquals(0, engine.resumeCount.get(), "no ponder resume after a rejected reacquire");
       assertEquals(0, engine.analyzeCount.get(), "no analysis after a rejected reacquire");
@@ -622,6 +597,9 @@ class LeelazAutomaticRestartConvergenceTest {
           afterFailure,
           "a rejected reacquire must clear the completion claim and reopen admission");
       afterFailure.close();
+      assertOrdinaryForwardingReopened(engine);
+      assertOrdinaryForwardingReopened(mirror);
+      assertAutomaticRestartRetryAvailable(engine);
     } finally {
       Lizzie.webBoardManager = previousWebBoardManager;
     }
@@ -683,9 +661,6 @@ class LeelazAutomaticRestartConvergenceTest {
       assertNull(
           engine.beginEngineModeReservation(),
           "the completion gate must reject unrelated owners while the fence is pending");
-      assertFalse(
-          engine.isInitialBoardSynchronizationActive(),
-          "the barrier must close at the stable restore point");
 
       invokeFenceResponse(engine);
 
@@ -844,12 +819,6 @@ class LeelazAutomaticRestartConvergenceTest {
       assertFalse(
           mirror.isLoaded(),
           "the failed mirror fence must not leave the captured mirror loaded");
-      assertFalse(
-          engine.isInitialBoardSynchronizationActive(),
-          "a mirror fence failure must end the board barrier");
-      assertFalse(
-          mirror.isInitialBoardSynchronizationActive(),
-          "a mirror fence failure must end the mirror barrier");
 
       // Late responses to the retired fence legs must be isolated.
       invokeFenceResponse(engine);
@@ -864,6 +833,9 @@ class LeelazAutomaticRestartConvergenceTest {
           afterFailure,
           "a mirror fence failure must clear the completion gate and release reservations");
       afterFailure.close();
+      assertOrdinaryForwardingReopened(engine);
+      assertOrdinaryForwardingReopened(mirror);
+      assertAutomaticRestartRetryAvailable(engine);
     }
   }
 
@@ -1013,23 +985,11 @@ class LeelazAutomaticRestartConvergenceTest {
       assertTrue(
           firstLoadSgfReceived.await(2, TimeUnit.SECONDS),
           "the frozen restore route must reach the engine first");
-      assertTrue(
-          engine.isInitialBoardSynchronizationActive(),
-          "the first restart must hold the authority barrier while the frozen route is in flight");
-      assertTrue(
-          mirror.isInitialBoardSynchronizationActive(),
-          "the first restart must hold the mirror barrier while the frozen route is in flight");
 
       assertThrows(
           IllegalStateException.class,
           () -> engine.restartClosedEngine(0),
           "a duplicate restart during the blocked restore must be rejected");
-      assertTrue(
-          engine.isInitialBoardSynchronizationActive(),
-          "a rejected duplicate restart must not close the first owner's authority barrier");
-      assertTrue(
-          mirror.isInitialBoardSynchronizationActive(),
-          "a rejected duplicate restart must not close the first owner's mirror barrier");
       engine.sendCommand("play B Q4");
       assertFalse(
           engine.transport.commands().contains("play B Q4"),
@@ -1052,9 +1012,6 @@ class LeelazAutomaticRestartConvergenceTest {
       assertTrue(
           waitForRawCommandPrefix(mirror.transport, "name", 2, TimeUnit.SECONDS),
           "the captured mirror must receive the final board fence");
-      assertFalse(
-          engine.isInitialBoardSynchronizationActive(),
-          "the first owner must close the barrier at the stable restore point");
       invokeFenceResponse(engine);
       assertEquals(
           0,
@@ -1198,17 +1155,14 @@ class LeelazAutomaticRestartConvergenceTest {
       assertFalse(
           mirror.isLoaded(),
           "the unconfirmed captured mirror must fail closed with the authority");
-      assertFalse(
-          engine.isInitialBoardSynchronizationActive(),
-          "an authority fence error must end the board barrier");
-      assertFalse(
-          mirror.isInitialBoardSynchronizationActive(),
-          "an authority fence error must end the mirror barrier");
       Leelaz.EngineModeReservation afterFailure = engine.beginEngineModeReservation();
       assertNotNull(
           afterFailure,
           "an authority fence error must clear the completion gate and release reservations");
       afterFailure.close();
+      assertOrdinaryForwardingReopened(engine);
+      assertOrdinaryForwardingReopened(mirror);
+      assertAutomaticRestartRetryAvailable(engine);
     }
   }
 
@@ -1233,11 +1187,12 @@ class LeelazAutomaticRestartConvergenceTest {
       assertTrue(completed.await(2, TimeUnit.SECONDS));
       assertFalse(engine.isLoaded());
       assertFalse(mirror.isLoaded());
-      assertFalse(engine.isInitialBoardSynchronizationActive());
-      assertFalse(mirror.isInitialBoardSynchronizationActive());
       Leelaz.EngineModeReservation afterFailure = engine.beginEngineModeReservation();
       assertNotNull(afterFailure, "a synchronous fence start failure must release the claim");
       afterFailure.close();
+      assertOrdinaryForwardingReopened(engine);
+      assertOrdinaryForwardingReopened(mirror);
+      assertAutomaticRestartRetryAvailable(engine);
     }
   }
 
@@ -1316,12 +1271,6 @@ class LeelazAutomaticRestartConvergenceTest {
       assertFalse(
           mirror.isLoaded(),
           "the unconfirmed captured mirror must be unavailable after the fence timeout");
-      assertFalse(
-          engine.isInitialBoardSynchronizationActive(),
-          "the fence timeout must end the board barrier");
-      assertFalse(
-          mirror.isInitialBoardSynchronizationActive(),
-          "the fence timeout must end the mirror barrier");
 
       // Late responses to the retired fence legs must be isolated.
       invokeFenceResponse(engine);
@@ -1336,6 +1285,9 @@ class LeelazAutomaticRestartConvergenceTest {
           afterTimeout,
           "the fence timeout must clear the completion gate and release reservations");
       afterTimeout.close();
+      assertOrdinaryForwardingReopened(engine);
+      assertOrdinaryForwardingReopened(mirror);
+      assertAutomaticRestartRetryAvailable(engine);
     }
   }
 
@@ -1583,6 +1535,19 @@ class LeelazAutomaticRestartConvergenceTest {
     board.hasStartStone = false;
     board.setHistory(history);
     return board;
+  }
+
+  private static void assertOrdinaryForwardingReopened(Leelaz engine) {
+    assertTrue(
+        engine.submitOrdinaryLiveBoardForwarding(
+            EngineManager.OrdinaryLiveBoardForwardingIntent.of(() -> true)),
+        "ordinary live-board forwarding must reopen after the barrier ends");
+  }
+
+  private static void assertAutomaticRestartRetryAvailable(ConvergingRestartLeelaz engine) {
+    Leelaz.AutomaticRestartAttempt retry = engine.beginAutomaticEngineRestartAttempt();
+    assertNotNull(retry, "a later automatic restart must be admissible after fail-closed");
+    retry.close();
   }
 
   private static void assertEngineMatchesBoard(

--- a/src/test/java/featurecat/lizzie/analysis/LeelazOpenClRecoveryTest.java
+++ b/src/test/java/featurecat/lizzie/analysis/LeelazOpenClRecoveryTest.java
@@ -274,9 +274,6 @@ class LeelazOpenClRecoveryTest {
       assertTrue(
           engine.transport.commands().isEmpty(),
           "no ponder or analyze commands after the async recovery failure");
-      assertFalse(
-          engine.isInitialBoardSynchronizationActive(),
-          "the async recovery failure must release the board synchronization barriers");
       assertNotNull(
           engine.diagnosticMessage,
           "the diagnostic path must receive the OpenCL recovery failure detail");

--- a/src/test/java/featurecat/lizzie/rules/BoardNodeKindHistoryPipelineTest.java
+++ b/src/test/java/featurecat/lizzie/rules/BoardNodeKindHistoryPipelineTest.java
@@ -4350,7 +4350,6 @@ class BoardNodeKindHistoryPipelineTest {
       activatePrimaryEngine(replacement);
       Lizzie.setPrimaryEngine(replacement);
       board.releaseBlockedHistoryNavigationRestoreExecution();
-      original.releaseBlockedInitialBoardSynchronizationCheck();
       awaitHistoryNavigationIdle(Lizzie.board);
       List<String> staleCommands =
           new ArrayList<>(
@@ -4367,7 +4366,6 @@ class BoardNodeKindHistoryPipelineTest {
       assertFalse(frame.failureHandlingWasRequested());
     } finally {
       ((TrackingBoard) Lizzie.board).releaseBlockedHistoryNavigationRestoreExecution();
-      original.releaseBlockedInitialBoardSynchronizationCheck();
       Lizzie.setPrimaryEngine(original);
       awaitHistoryNavigationIdle(Lizzie.board);
       env.close();
@@ -6036,8 +6034,6 @@ class BoardNodeKindHistoryPipelineTest {
     private volatile CountDownLatch blockedNotPonderingRelease;
     private volatile CountDownLatch blockedFrozenClearStarted;
     private volatile CountDownLatch blockedFrozenClearRelease;
-    private volatile CountDownLatch blockedInitialBoardSynchronizationCheckStarted;
-    private volatile CountDownLatch blockedInitialBoardSynchronizationCheckRelease;
     private List<Stone[]> undoStones;
     private List<Boolean> undoBlackToPlay;
     private String lastLoadedSgfContent = "";
@@ -6082,13 +6078,6 @@ class BoardNodeKindHistoryPipelineTest {
       super.notPondering();
     }
 
-    @Override
-    public boolean isInitialBoardSynchronizationActive() {
-      if (Thread.currentThread().getName().equals("lizzie-history-restore")) {
-        waitForBlockedInitialBoardSynchronizationCheckRelease();
-      }
-      return super.isInitialBoardSynchronizationActive();
-    }
     @Override
     public void ponder() {
       if (trackPonderCalls) {
@@ -6202,47 +6191,6 @@ class BoardNodeKindHistoryPipelineTest {
     }
     private int notPonderingCallCount() {
       return notPonderingCallCount;
-    }
-
-    private void blockNextInitialBoardSynchronizationCheck() {
-      blockedInitialBoardSynchronizationCheckStarted = new CountDownLatch(1);
-      blockedInitialBoardSynchronizationCheckRelease = new CountDownLatch(1);
-    }
-
-    private boolean awaitBlockedInitialBoardSynchronizationCheck() throws InterruptedException {
-      CountDownLatch started = blockedInitialBoardSynchronizationCheckStarted;
-      return started != null && started.await(2, TimeUnit.SECONDS);
-    }
-
-    private void releaseBlockedInitialBoardSynchronizationCheck() {
-      CountDownLatch release = blockedInitialBoardSynchronizationCheckRelease;
-      if (release != null) {
-        release.countDown();
-      }
-    }
-
-    private void waitForBlockedInitialBoardSynchronizationCheckRelease() {
-      CountDownLatch started = blockedInitialBoardSynchronizationCheckStarted;
-      CountDownLatch release = blockedInitialBoardSynchronizationCheckRelease;
-      if (started == null || release == null) {
-        return;
-      }
-      started.countDown();
-      try {
-        if (!release.await(2, TimeUnit.SECONDS)) {
-          throw new IllegalStateException(
-              "Timed out waiting to release blocked initial synchronization check");
-        }
-      } catch (InterruptedException failure) {
-        Thread.currentThread().interrupt();
-        throw new IllegalStateException(
-            "Interrupted while blocking initial synchronization check", failure);
-      } finally {
-        if (blockedInitialBoardSynchronizationCheckStarted == started) {
-          blockedInitialBoardSynchronizationCheckStarted = null;
-          blockedInitialBoardSynchronizationCheckRelease = null;
-        }
-      }
     }
 
     private void blockNextPonder() {


### PR DESCRIPTION
## Summary

- Replace public initial-sync barrier polling with owner-scoped startup admissions attached before any startup side effects and released by owner identity.
- Route ordinary navigation and history-overwrite board forwarding through `submitOrdinaryLiveBoardForwarding`; reject every command from that ordinary intent when startup admission becomes active between submission and execution.
- Preserve external handshake commands, the exact snapshot restore bypass, restart depth, READY/ponder semantics, and remove the obsolete public barrier surface and test seams.
- Add regression coverage for overlapping startup owners, submit/execute races, and restart convergence.

This change is needed because caller-side barrier polling exposed startup lifecycle ownership to `Board` and left a TOCTOU window before command execution. Overlapping startup owners could also overwrite endpoint bindings and leave admission depth occupied.

## Type Of Change

- [x] Bug fix
- [ ] Feature
- [ ] Packaging / release update
- [ ] Docs / translation
- [x] Refactor

## Testing

- [x] Tested locally
  - After rebasing: `mvn -Dtest=EngineManagerInitialStartupSynchronizationTest,LeelazAutomaticRestartConvergenceTest test` — 89 tests, 0 failures.
  - Final pre-rebase gate: `mvn test` — 2375 tests, 0 failures, 1 skipped.
- [ ] Verified package contents if packaging changed — N/A; packaging is unchanged.
- [ ] Verified Fox sync flow if related — N/A; Fox sync is unchanged.
- [ ] Added screenshots if UI changed — N/A; no UI changes.
- [ ] Updated README / docs if user-facing behavior changed — N/A; no user-facing contract changes.
- [ ] Noted affected platforms if the change is platform-specific — N/A; not platform-specific.
- [x] Verified there is no unrelated formatting or line-ending churn
- [x] Ran `python3 scripts/check_line_endings.py`

## Notes

Please focus review on identity-safe startup owner cleanup and the ordinary-intent submit-to-execute race. The SNAPSHOT/PASS and exact restore semantics defined by `docs/SNAPSHOT_NODE_KIND.md` remain unchanged.

The final standards and specification reviews reported no findings. The existing readiness-timeout test still lacks ponder/analyze counters; this remains a non-blocking test enhancement.