### PR TITLE
Fix Windows model switching and harden release pipeline

### DIFF
--- a/.github/release-notes/next-2026-08-19.1.md
+++ b/.github/release-notes/next-2026-08-19.1.md
@@ -1,0 +1,329 @@
+# LizzieYzy Next next-2026-08-19.1
+
+## 中文
+
+这是 `next-2026-08-14.1` 之后的功能与稳定性预览更新，重点修复模型切换状态延迟，并系统加固 AI 教练、引擎启动与棋盘同步、对局计时和 Windows 高缩放体验。
+
+### 本版主要更新
+
+- 在 KataGo 一键设置里，模型切换一经受理，目标模型会立即显示“使用中”，无需等待最长约 35 秒的引擎就绪轮询。只有硬失败或前台引擎已离开目标时才按权威本地状态回滚；若只是就绪等待达到 35 秒软超时，而目标仍是前台引擎且进程存活，则继续保留目标状态，让合法的慢启动完成。
+- 完善 AI 教练训练流程，并修复思考期间切换棋谱节点后旧 HumanSL 响应落到错误局面、与普通/分析/引擎对局并发，以及键盘 `P` 绕过教练状态机的问题。
+- 加固引擎启动、切换、重启、棋盘导航与精确快照同步；异步引擎对局启动失败后会恢复输入、工具栏和引擎菜单，Windows 引擎生命周期测试也已改为跨平台 Java 夹具。
+- 新增由引擎独立管理的黑白用时与重启恢复；包含 `AB`、`AW`、`PL` 的 SGF 初始局面能沿棋盘、引擎和导出链路一致保留。
+- 修复 HumanSL 便携版引擎路径，并让 AI 教练设置与训练报告窗口受当前显示器可用区域约束；小屏或高 DPI 下可滚动访问全部操作。
+- 修复野狐棋谱贴目处理、GMA 自动落子换色，并改进 AI 老师提示词。感谢 `qiyi71w` 与 `Fly143` 的持续贡献。
+
+### 下载前先看这几句
+
+- 已有 Windows 免安装版可以下载 `windows64.core-update.zip` 更新主程序；完整包继续使用现有官方引擎、权重和运行库，发布审计更严格。
+- 普通 Windows 用户优先选择 OpenCL 免安装版；NVIDIA 用户按显卡代际选择 NVIDIA 或 RTX 50 CUDA 版。
+- AI 教练需要兼容的 KataGo 与 HumanSL 模型；一键设置会识别便携版路径，开始训练前仍请确认模型状态显示为可用。
+- 这是预发布版。建议先覆盖到副本，并备份现有 `user-data`、自定义权重和棋谱。
+
+### 下载建议
+
+| 你的电脑 | 直接下载这个 |
+| --- | --- |
+| Windows 64 位，OpenCL 版，推荐，免安装 | [`2026-08-19-windows64.opencl.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-19.1/2026-08-19-windows64.opencl.portable.zip) |
+| 已有 Windows 免安装版，只更新主程序 | [`2026-08-19-windows64.core-update.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-19.1/2026-08-19-windows64.core-update.zip) |
+| Windows 64 位，OpenCL 安装版 | [`2026-08-19-windows64.opencl.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-19.1/2026-08-19-windows64.opencl.installer.exe) |
+| Windows 64 位，CPU 兼容版，免安装 | [`2026-08-19-windows64.with-katago.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-19.1/2026-08-19-windows64.with-katago.portable.zip) |
+| Windows 64 位，CPU 兼容安装版 | [`2026-08-19-windows64.with-katago.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-19.1/2026-08-19-windows64.with-katago.installer.exe) |
+| Windows 64 位，NVIDIA CUDA 版，免安装 | [`2026-08-19-windows64.nvidia.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-19.1/2026-08-19-windows64.nvidia.portable.zip) |
+| Windows 64 位，NVIDIA CUDA 安装版 | [`2026-08-19-windows64.nvidia.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-19.1/2026-08-19-windows64.nvidia.installer.exe) |
+| Windows 64 位，RTX 5070/5080/5090，免安装 | [`2026-08-19-windows64.nvidia50.cuda.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-19.1/2026-08-19-windows64.nvidia50.cuda.portable.zip) |
+| 高级可选：TensorRT 预装分卷包，需下载全部分卷 | [`2026-08-19-windows64.nvidia.tensorrt.portable.7z.001`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-19.1/2026-08-19-windows64.nvidia.tensorrt.portable.7z.001)<br>[`2026-08-19-windows64.nvidia.tensorrt.portable.7z.002`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-19.1/2026-08-19-windows64.nvidia.tensorrt.portable.7z.002) |
+| Windows 64 位，RTX 50 CUDA 安装版 | [`2026-08-19-windows64.nvidia50.cuda.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-19.1/2026-08-19-windows64.nvidia50.cuda.installer.exe) |
+| Windows 64 位，自行配置引擎，免安装 | [`2026-08-19-windows64.without.engine.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-19.1/2026-08-19-windows64.without.engine.portable.zip) |
+| Windows 64 位，自行配置引擎，安装版 | [`2026-08-19-windows64.without.engine.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-19.1/2026-08-19-windows64.without.engine.installer.exe) |
+| macOS Apple Silicon | [`2026-08-19-mac-apple-silicon.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-19.1/2026-08-19-mac-apple-silicon.with-katago.dmg) |
+| macOS Intel | [`2026-08-19-mac-intel.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-19.1/2026-08-19-mac-intel.with-katago.dmg) |
+| Linux 64 位，CPU 兼容版 | [`2026-08-19-linux64.with-katago.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-19.1/2026-08-19-linux64.with-katago.zip) |
+| Linux 64 位，OpenCL 版 | [`2026-08-19-linux64.opencl.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-19.1/2026-08-19-linux64.opencl.zip) |
+| Linux 64 位，NVIDIA CUDA 版 | [`2026-08-19-linux64.nvidia.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-19.1/2026-08-19-linux64.nvidia.zip) |
+
+### 这一版为什么值得测试
+
+- Windows JDK 21 headless 完整测试共运行 `2451` 项：`2443` 通过、`8` 跳过、`0` 失败、`0` 错误；Python 发布脚本套件运行 `165` 项：`163` 通过、`2` 跳过、`0` 失败、`0` 错误。模型切换、AI 教练、引擎生命周期、高 DPI 尺寸和发布防护均有针对性回归。
+- 原先在 Windows 稳定失败的 6 个引擎替换/快照围栏用例，在跨平台夹具修复后连续 3 轮全部通过，完整生命周期测试 80/80 通过。
+- Windows 11 真机在 4K（3840×2160）、150% 缩放下复测：点击切换后 315.3 ms 时仍显示旧状态，565.4 ms 时目标模型已显示“使用中”（这是本次观测区间，不是性能 SLA），而引擎约 33.1 s 后才 ready；重复点击防护、切回模型和重启后的选择持久化均正常。AI 教练窗口无裁切；引擎失败窗口受屏幕约束、内容可滚动，关闭后主界面与主引擎仍可继续使用。凭据脱敏另由受控自动化测试验证，并非在普通真机流程中输入真实凭据。
+- 构建步骤检查精确文件清单、版本与运行时结构；配置 Apple Developer 凭据时，macOS 签名与公证失败会中止发布。每个平台还生成绑定目标 commit SHA、workflow run/attempt 及逐资产大小与 SHA-256 的 provenance；公开前，发布器逐项比对 GitHub Release 远端资产的精确清单、uploaded 状态、大小与 SHA-256。
+
+### 交流
+
+- QQ 群：`299419120`
+
+---
+
+## 繁體中文
+
+這是 `next-2026-08-14.1` 之後的功能與穩定性預覽更新，重點修正 model 切換狀態延遲，並全面強化 AI 教練、engine 啟動與棋盤同步、對局計時及 Windows 高縮放體驗。
+
+### 本版主要更新
+
+- 在 KataGo 一鍵設定裡，model 切換一經受理，目標 model 會立即顯示「使用中」，不必等待最長約 35 秒的 engine ready 輪詢。只有硬失敗或前景 engine 已離開目標時，才依權威本機狀態回滾；若只是 ready 等待達到 35 秒軟性逾時，而目標仍是前景 engine 且 process 存活，則繼續保留目標狀態，讓正常但較慢的啟動完成。
+- 完善 AI 教練訓練流程，並修正思考期間切換棋譜節點後舊 HumanSL 回應落到錯誤局面、與一般/分析/engine 對局並行，以及鍵盤 `P` 繞過教練狀態機。
+- 強化 engine 啟動、切換、重啟、棋盤導覽與精確 snapshot 同步；非同步 engine 對局啟動失敗後會恢復輸入、toolbar 與 engine menu，Windows lifecycle test 也改為跨平台 Java fixture。
+- 新增 engine 獨立管理的黑白用時與重啟恢復；含 `AB`、`AW`、`PL` 的 SGF 起始局面可在棋盤、engine 與匯出流程一致保留。
+- 修正 HumanSL portable engine 路徑，AI 教練設定與訓練報告也會限制在目前螢幕可用範圍內，小畫面或 high DPI 仍可捲動操作。
+- 修正野狐棋譜貼目、GMA 自動落子換色，並改進 AI 老師 prompt。感謝 `qiyi71w` 與 `Fly143` 的持續貢獻。
+
+### 下載前先看這幾句
+
+- 既有 Windows portable 可下載 `windows64.core-update.zip` 更新主程式；完整 package 延續現有官方 engine、weight 與 runtime，發布 audit 更嚴格。
+- 一般 Windows 使用者優先選擇 OpenCL portable；NVIDIA 使用者依顯示卡世代選擇 NVIDIA 或 RTX 50 CUDA 版。
+- AI 教練需要相容的 KataGo 與 HumanSL model；一鍵設定會辨識 portable 路徑，開始前仍請確認 model 狀態可用。
+- 這是預覽版，建議先更新副本並備份既有 `user-data`、自訂權重與棋譜。
+
+### 下載建議
+
+| 你的電腦 | 直接下載這個 |
+| --- | --- |
+| Windows 64 位，OpenCL 推薦版，免安裝 | [`2026-08-19-windows64.opencl.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-19.1/2026-08-19-windows64.opencl.portable.zip) |
+| 既有 Windows portable，只更新主程式 | [`2026-08-19-windows64.core-update.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-19.1/2026-08-19-windows64.core-update.zip) |
+| Windows 64 位，OpenCL 安裝版 | [`2026-08-19-windows64.opencl.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-19.1/2026-08-19-windows64.opencl.installer.exe) |
+| Windows 64 位，CPU 相容版，免安裝 | [`2026-08-19-windows64.with-katago.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-19.1/2026-08-19-windows64.with-katago.portable.zip) |
+| Windows 64 位，CPU 相容安裝版 | [`2026-08-19-windows64.with-katago.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-19.1/2026-08-19-windows64.with-katago.installer.exe) |
+| Windows 64 位，NVIDIA CUDA，免安裝 | [`2026-08-19-windows64.nvidia.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-19.1/2026-08-19-windows64.nvidia.portable.zip) |
+| Windows 64 位，NVIDIA CUDA 安裝版 | [`2026-08-19-windows64.nvidia.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-19.1/2026-08-19-windows64.nvidia.installer.exe) |
+| Windows 64 位，RTX 5070/5080/5090，免安裝 | [`2026-08-19-windows64.nvidia50.cuda.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-19.1/2026-08-19-windows64.nvidia50.cuda.portable.zip) |
+| 進階可選：TensorRT 預裝分卷，需下載全部檔案 | [`2026-08-19-windows64.nvidia.tensorrt.portable.7z.001`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-19.1/2026-08-19-windows64.nvidia.tensorrt.portable.7z.001)<br>[`2026-08-19-windows64.nvidia.tensorrt.portable.7z.002`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-19.1/2026-08-19-windows64.nvidia.tensorrt.portable.7z.002) |
+| Windows 64 位，RTX 50 CUDA 安裝版 | [`2026-08-19-windows64.nvidia50.cuda.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-19.1/2026-08-19-windows64.nvidia50.cuda.installer.exe) |
+| Windows 64 位，自行設定 engine，免安裝 | [`2026-08-19-windows64.without.engine.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-19.1/2026-08-19-windows64.without.engine.portable.zip) |
+| Windows 64 位，自行設定 engine，安裝版 | [`2026-08-19-windows64.without.engine.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-19.1/2026-08-19-windows64.without.engine.installer.exe) |
+| macOS Apple Silicon | [`2026-08-19-mac-apple-silicon.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-19.1/2026-08-19-mac-apple-silicon.with-katago.dmg) |
+| macOS Intel | [`2026-08-19-mac-intel.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-19.1/2026-08-19-mac-intel.with-katago.dmg) |
+| Linux 64 位，CPU 相容版 | [`2026-08-19-linux64.with-katago.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-19.1/2026-08-19-linux64.with-katago.zip) |
+| Linux 64 位，OpenCL 版 | [`2026-08-19-linux64.opencl.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-19.1/2026-08-19-linux64.opencl.zip) |
+| Linux 64 位，NVIDIA CUDA 版 | [`2026-08-19-linux64.nvidia.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-19.1/2026-08-19-linux64.nvidia.zip) |
+
+### 這一版為什麼值得測試
+
+- Windows JDK 21 headless 完整測試共執行 `2451` 項：`2443` 通過、`8` skipped、`0` failure、`0` error；Python 發布 script suite 執行 `165` 項：`163` 通過、`2` skipped、`0` failure、`0` error。model 切換、AI 教練、engine lifecycle、high-DPI 尺寸與發布防護皆有針對性回歸。
+- 原本在 Windows 穩定失敗的 6 個 engine replacement/snapshot fence 測試，在跨平台 fixture 修正後連續 3 輪全部通過，完整 lifecycle test 為 80/80。
+- Windows 11 實機於 4K（3840×2160）、150% 縮放下複測：點擊切換後 315.3 ms 時仍顯示舊狀態，565.4 ms 時目標 model 已顯示「使用中」（這是本次觀測區間，不是效能 SLA），而 engine 約 33.1 s 後才 ready；重複點擊防護、切回 model 與重啟後的選擇保留均正常。AI 教練視窗沒有裁切；engine failure 視窗受螢幕範圍限制、內容可捲動，關閉後主畫面與主 engine 仍可繼續使用。credential redaction 另由受控自動化測試驗證，並非在一般實機流程輸入真實 credential。
+- Build step 會檢查精確檔案清單、版本與 runtime 結構；設定 Apple Developer credential 時，macOS 簽章或 notarization 失敗會中止發布。每個平台也會產生綁定目標 commit SHA、workflow run/attempt，以及逐項 asset 大小與 SHA-256 的 provenance；公開前，publisher 會逐項比對 GitHub Release 遠端 asset 的精確清單、uploaded 狀態、大小與 SHA-256。
+
+### 交流
+
+- QQ 群：`299419120`
+
+---
+
+## English
+
+This feature and stability pre-release follows `next-2026-08-14.1`. It fixes delayed model-switch status and hardens AI Coach, engine startup and board synchronization, game clocks, and Windows high-DPI behavior.
+
+### Release Highlights
+
+- After a model switch is accepted in KataGo One-Click Setup, the target is marked current immediately instead of waiting up to about 35 seconds for engine readiness. It rolls back to authoritative local state only on a hard failure or when the foreground engine has moved away from the target; if only the 35-second readiness wait times out while the target remains the live foreground engine, it stays current so a valid slow startup can finish.
+- Completed the AI Coach training flow and fixed stale HumanSL responses applying after navigation, overlapping normal/analysis/engine games, and the `P` shortcut bypassing the coach state machine.
+- Hardened engine startup, switching, restart, navigation, and exact-snapshot synchronization. An asynchronous engine-game start failure now restores input, toolbar, and engine menu controls, and the Windows lifecycle fixture is cross-platform Java.
+- Added engine-owned clocks for both colors with restart recovery. SGF starting positions containing `AB`, `AW`, and `PL` now remain consistent across the board, engines, and export pipeline.
+- Fixed portable HumanSL engine discovery and bounded AI Coach setup/report dialogs to the active monitor, with scrolling so every action stays reachable on small or high-DPI screens.
+- Fixed Fox kifu komi handling and GMA autoplay color switching, and improved the AI Teacher prompt. Thanks to `qiyi71w` and `Fly143` for their continued contributions.
+
+### Read Before Downloading
+
+- Existing Windows portable users may install `windows64.core-update.zip` for the application fixes. Full packages retain the current official engines, weights, and runtimes with stricter release auditing.
+- Most Windows users should choose the OpenCL portable package. NVIDIA users should select the NVIDIA or RTX 50 CUDA package matching their GPU generation.
+- AI Coach requires compatible KataGo and HumanSL models. One-Click Setup recognizes portable paths, but confirm that the model is shown as available before starting a session.
+- This is a pre-release. Upgrade a copy first and back up existing `user-data`, custom weights, and kifu.
+
+### Download Guide
+
+| Your computer | Download this file |
+| --- | --- |
+| Windows 64-bit, OpenCL, recommended, portable | [`2026-08-19-windows64.opencl.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-19.1/2026-08-19-windows64.opencl.portable.zip) |
+| Existing Windows portable install, application-only update | [`2026-08-19-windows64.core-update.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-19.1/2026-08-19-windows64.core-update.zip) |
+| Windows 64-bit, OpenCL installer | [`2026-08-19-windows64.opencl.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-19.1/2026-08-19-windows64.opencl.installer.exe) |
+| Windows 64-bit, CPU fallback, portable | [`2026-08-19-windows64.with-katago.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-19.1/2026-08-19-windows64.with-katago.portable.zip) |
+| Windows 64-bit, CPU fallback installer | [`2026-08-19-windows64.with-katago.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-19.1/2026-08-19-windows64.with-katago.installer.exe) |
+| Windows 64-bit, NVIDIA CUDA, portable | [`2026-08-19-windows64.nvidia.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-19.1/2026-08-19-windows64.nvidia.portable.zip) |
+| Windows 64-bit, NVIDIA CUDA installer | [`2026-08-19-windows64.nvidia.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-19.1/2026-08-19-windows64.nvidia.installer.exe) |
+| Windows 64-bit, RTX 5070/5080/5090, portable | [`2026-08-19-windows64.nvidia50.cuda.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-19.1/2026-08-19-windows64.nvidia50.cuda.portable.zip) |
+| Advanced optional TensorRT split package; download every part | [`2026-08-19-windows64.nvidia.tensorrt.portable.7z.001`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-19.1/2026-08-19-windows64.nvidia.tensorrt.portable.7z.001)<br>[`2026-08-19-windows64.nvidia.tensorrt.portable.7z.002`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-19.1/2026-08-19-windows64.nvidia.tensorrt.portable.7z.002) |
+| Windows 64-bit, RTX 50 CUDA installer | [`2026-08-19-windows64.nvidia50.cuda.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-19.1/2026-08-19-windows64.nvidia50.cuda.installer.exe) |
+| Windows 64-bit, configure your own engine, portable | [`2026-08-19-windows64.without.engine.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-19.1/2026-08-19-windows64.without.engine.portable.zip) |
+| Windows 64-bit, configure your own engine, installer | [`2026-08-19-windows64.without.engine.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-19.1/2026-08-19-windows64.without.engine.installer.exe) |
+| macOS Apple Silicon | [`2026-08-19-mac-apple-silicon.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-19.1/2026-08-19-mac-apple-silicon.with-katago.dmg) |
+| macOS Intel | [`2026-08-19-mac-intel.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-19.1/2026-08-19-mac-intel.with-katago.dmg) |
+| Linux 64-bit, CPU fallback | [`2026-08-19-linux64.with-katago.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-19.1/2026-08-19-linux64.with-katago.zip) |
+| Linux 64-bit, OpenCL | [`2026-08-19-linux64.opencl.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-19.1/2026-08-19-linux64.opencl.zip) |
+| Linux 64-bit, NVIDIA CUDA | [`2026-08-19-linux64.nvidia.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-19.1/2026-08-19-linux64.nvidia.zip) |
+
+### Why Test This Release
+
+- The full Windows JDK 21 headless suite ran `2451` tests: `2443` passed, `8` skipped, `0` failed, and `0` errored. The Python release-script suite ran `165` tests: `163` passed, `2` skipped, `0` failed, and `0` errored. Focused regressions cover model switching, AI Coach, engine lifecycle, high-DPI sizing, and publication safeguards.
+- The six replacement/snapshot-fence tests that previously failed consistently on Windows passed three consecutive rounds after the cross-platform fixture fix; the complete lifecycle class passed 80/80.
+- A Windows 11 hardware retest at 4K (3840×2160) and 150% scaling still showed the old status at 315.3 ms and the target model as current by 565.4 ms after the click (an observed interval, not a performance SLA), while engine readiness took about 33.1 s; duplicate-click protection, switching back, and selection persistence after restart all held. AI Coach dialogs were not clipped; the bounded, scrollable engine-failure dialog closed back to a usable main window with the main engine still running. Credential redaction was verified separately in controlled automation, not by entering live secrets in the ordinary GUI journey.
+- Build jobs validate the exact inventory, versions, and runtime structure; when Apple Developer credentials are configured, any macOS signing or notarization failure stops publication. Each platform also produces provenance binding the target commit SHA, workflow run/attempt, and every asset’s size and SHA-256. Before publication, the publisher matches the exact GitHub Release remote-asset inventory, uploaded state, size, and SHA-256 against that provenance.
+
+### Contact
+
+- QQ group: `299419120`
+
+---
+
+## 日本語
+
+`next-2026-08-14.1` に続く機能・安定性プレリリースです。model 切替状態の遅延を修正し、AI Coach、engine 起動と棋盤同期、対局時計、Windows high-DPI 動作を強化しました。
+
+### 主な更新
+
+- KataGo 一括設定で model 切替が受理されると、engine ready を最長約 35 秒待たず、対象 model を直ちに「使用中」と表示します。hard failure が起きた場合、または foreground engine が対象から切り替わった場合に限って authoritative local state に戻します。35 秒の ready 待ちが soft timeout になっても、対象が foreground のままで process が生きていれば表示を維持し、正常だが遅い起動を完了させます。
+- AI Coach の training flow を完成させ、思考中に棋譜を移動した後の古い HumanSL 応答、通常/解析/engine 対局との二重起動、`P` shortcut の state machine 迂回を修正しました。
+- engine 起動・切替・再起動・navigation・exact snapshot 同期を強化しました。engine game の非同期起動失敗時は入力、toolbar、engine menu を復元し、Windows lifecycle fixture は cross-platform Java になりました。
+- 黒白それぞれを engine が管理する対局時計と restart recovery を追加しました。`AB`、`AW`、`PL` を含む SGF 初期局面は棋盤、engine、export 全体で一貫して保持されます。
+- portable HumanSL engine path を修正し、AI Coach の setup/report dialog を active monitor 内に収めました。小画面/high DPI では scroll ですべての操作に到達できます。
+- Fox 棋譜の komi、GMA autoplay の色切替、AI Teacher prompt を修正しました。継続的に貢献してくださった `qiyi71w` と `Fly143` に感謝します。
+
+### ダウンロード前に
+
+- 既存 Windows portable は `windows64.core-update.zip` でアプリを更新できます。full package は現在の公式 engine、weight、runtime を維持し、release audit を強化しています。
+- 多くの Windows 利用者には OpenCL portable を推奨します。NVIDIA は GPU 世代に合う NVIDIA または RTX 50 CUDA package を選んでください。
+- AI Coach には対応する KataGo と HumanSL model が必要です。一括設定は portable path を検出しますが、開始前に model が利用可能と表示されることを確認してください。
+- これは pre-release です。まずコピーを更新し、`user-data`、custom weight、棋譜を backup してください。
+
+### ダウンロード案内
+
+| お使いの環境 | ダウンロードするファイル |
+| --- | --- |
+| Windows 64-bit、OpenCL 推奨 portable | [`2026-08-19-windows64.opencl.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-19.1/2026-08-19-windows64.opencl.portable.zip) |
+| 既存 Windows portable、アプリ本体のみ更新 | [`2026-08-19-windows64.core-update.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-19.1/2026-08-19-windows64.core-update.zip) |
+| Windows 64-bit、OpenCL installer | [`2026-08-19-windows64.opencl.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-19.1/2026-08-19-windows64.opencl.installer.exe) |
+| Windows 64-bit、CPU fallback portable | [`2026-08-19-windows64.with-katago.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-19.1/2026-08-19-windows64.with-katago.portable.zip) |
+| Windows 64-bit、CPU fallback installer | [`2026-08-19-windows64.with-katago.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-19.1/2026-08-19-windows64.with-katago.installer.exe) |
+| Windows 64-bit、NVIDIA CUDA portable | [`2026-08-19-windows64.nvidia.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-19.1/2026-08-19-windows64.nvidia.portable.zip) |
+| Windows 64-bit、NVIDIA CUDA installer | [`2026-08-19-windows64.nvidia.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-19.1/2026-08-19-windows64.nvidia.installer.exe) |
+| Windows 64-bit、RTX 5070/5080/5090 portable | [`2026-08-19-windows64.nvidia50.cuda.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-19.1/2026-08-19-windows64.nvidia50.cuda.portable.zip) |
+| 上級者向け TensorRT 分割 package、全 part が必要 | [`2026-08-19-windows64.nvidia.tensorrt.portable.7z.001`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-19.1/2026-08-19-windows64.nvidia.tensorrt.portable.7z.001)<br>[`2026-08-19-windows64.nvidia.tensorrt.portable.7z.002`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-19.1/2026-08-19-windows64.nvidia.tensorrt.portable.7z.002) |
+| Windows 64-bit、RTX 50 CUDA installer | [`2026-08-19-windows64.nvidia50.cuda.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-19.1/2026-08-19-windows64.nvidia50.cuda.installer.exe) |
+| Windows 64-bit、engine を自分で設定、portable | [`2026-08-19-windows64.without.engine.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-19.1/2026-08-19-windows64.without.engine.portable.zip) |
+| Windows 64-bit、engine を自分で設定、installer | [`2026-08-19-windows64.without.engine.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-19.1/2026-08-19-windows64.without.engine.installer.exe) |
+| macOS Apple Silicon | [`2026-08-19-mac-apple-silicon.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-19.1/2026-08-19-mac-apple-silicon.with-katago.dmg) |
+| macOS Intel | [`2026-08-19-mac-intel.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-19.1/2026-08-19-mac-intel.with-katago.dmg) |
+| Linux 64-bit、CPU fallback | [`2026-08-19-linux64.with-katago.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-19.1/2026-08-19-linux64.with-katago.zip) |
+| Linux 64-bit、OpenCL | [`2026-08-19-linux64.opencl.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-19.1/2026-08-19-linux64.opencl.zip) |
+| Linux 64-bit、NVIDIA CUDA | [`2026-08-19-linux64.nvidia.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-19.1/2026-08-19-linux64.nvidia.zip) |
+
+### このリリースを試す理由
+
+- Windows JDK 21 headless full suite は `2451` tests を実行し、`2443` passed、`8` skipped、`0` failure、`0` error でした。Python release-script suite は `165` tests を実行し、`163` passed、`2` skipped、`0` failure、`0` error でした。model switching、AI Coach、engine lifecycle、high-DPI sizing、公開処理の safeguard を個別に回帰しています。
+- Windows で常に失敗していた 6 件の replacement/snapshot-fence test は cross-platform fixture 修正後に 3 回連続で成功し、lifecycle class 全体も 80/80 でした。
+- Windows 11 実機を 4K（3840×2160）、150% scaling で再検証したところ、click 後 315.3 ms 時点では旧状態、565.4 ms 時点では対象 model が「使用中」と表示されました（今回の観測区間であり、性能 SLA ではありません）。engine ready までは約 33.1 s でした。重複 click 防止、切り戻し、再起動後の選択保持も確認済みです。AI Coach dialog に裁切はなく、engine failure dialog は画面内に収まり scroll 可能で、閉じた後も main window と主 engine を継続利用できました。credential redaction は通常の実機 GUI flow で実 credential を入力したものではなく、別の controlled automation で検証しています。
+- Build job は正確な asset inventory、version、runtime 構造を検査し、Apple Developer credential が設定されている場合は macOS の署名または notarization の失敗時に公開を停止します。各 platform は target commit SHA、workflow run/attempt、各 asset の size と SHA-256 を結び付けた provenance も生成します。公開前に publisher が GitHub Release 上の remote asset の正確な一覧、uploaded 状態、size、SHA-256 を provenance と照合します。
+
+### 連絡先
+
+- QQ group: `299419120`
+
+---
+
+## 한국어
+
+`next-2026-08-14.1` 이후의 기능 및 안정성 pre-release입니다. model 전환 상태 지연을 수정하고 AI Coach, engine 시작과 바둑판 동기화, 대국 시계, Windows high-DPI 동작을 강화했습니다.
+
+### 주요 업데이트
+
+- KataGo 원클릭 설정에서 model 전환이 수락되면 engine ready를 최대 약 35초 기다리지 않고 대상 model을 즉시 사용 중으로 표시합니다. hard failure가 발생하거나 foreground engine이 대상을 벗어난 경우에만 authoritative local state로 되돌립니다. 35초 readiness 대기만 soft timeout되고 대상이 여전히 foreground이며 process가 살아 있으면 상태를 유지해 정상적인 느린 시작이 완료되도록 합니다.
+- AI Coach training flow를 완성하고 생각 중 기보 이동 뒤 오래된 HumanSL 응답이 잘못 적용되는 문제, 일반/분석/engine 대국과의 중복 실행, `P` shortcut의 coach state machine 우회를 수정했습니다.
+- engine 시작, 전환, 재시작, navigation, exact snapshot 동기화를 강화했습니다. engine game 비동기 시작 실패 시 입력, toolbar, engine menu가 복구되며 Windows lifecycle fixture는 cross-platform Java를 사용합니다.
+- 흑백 각각을 engine이 소유하는 대국 시계와 restart recovery를 추가했습니다. `AB`, `AW`, `PL`을 포함한 SGF 시작 배치는 바둑판, engine, export 전 구간에서 유지됩니다.
+- portable HumanSL engine path를 수정하고 AI Coach setup/report dialog를 active monitor 안에 맞췄습니다. 작은 화면/high DPI에서도 scroll로 모든 동작에 접근할 수 있습니다.
+- Fox 기보 komi 처리, GMA autoplay 색 전환, AI Teacher prompt를 수정했습니다. 계속 기여해 주신 `qiyi71w`, `Fly143` 님께 감사드립니다.
+
+### 다운로드 전 확인
+
+- 기존 Windows portable은 `windows64.core-update.zip`으로 앱을 업데이트할 수 있습니다. full package는 현재 공식 engine, weight, runtime을 유지하면서 release audit을 강화했습니다.
+- 대부분의 Windows 사용자는 OpenCL portable을 권장합니다. NVIDIA 사용자는 GPU 세대에 맞는 NVIDIA 또는 RTX 50 CUDA package를 선택하세요.
+- AI Coach에는 호환되는 KataGo와 HumanSL model이 필요합니다. 원클릭 설정이 portable path를 찾지만 시작 전 model이 사용 가능으로 표시되는지 확인하세요.
+- 이것은 pre-release입니다. 먼저 복사본을 업데이트하고 `user-data`, custom weight, 기보를 backup하세요.
+
+### 다운로드 안내
+
+| 환경 | 다운로드할 파일 |
+| --- | --- |
+| Windows 64-bit, OpenCL 권장 portable | [`2026-08-19-windows64.opencl.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-19.1/2026-08-19-windows64.opencl.portable.zip) |
+| 기존 Windows portable, 앱만 업데이트 | [`2026-08-19-windows64.core-update.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-19.1/2026-08-19-windows64.core-update.zip) |
+| Windows 64-bit, OpenCL installer | [`2026-08-19-windows64.opencl.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-19.1/2026-08-19-windows64.opencl.installer.exe) |
+| Windows 64-bit, CPU portable | [`2026-08-19-windows64.with-katago.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-19.1/2026-08-19-windows64.with-katago.portable.zip) |
+| Windows 64-bit, CPU installer | [`2026-08-19-windows64.with-katago.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-19.1/2026-08-19-windows64.with-katago.installer.exe) |
+| Windows 64-bit, NVIDIA CUDA portable | [`2026-08-19-windows64.nvidia.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-19.1/2026-08-19-windows64.nvidia.portable.zip) |
+| Windows 64-bit, NVIDIA CUDA installer | [`2026-08-19-windows64.nvidia.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-19.1/2026-08-19-windows64.nvidia.installer.exe) |
+| Windows 64-bit, RTX 5070/5080/5090 portable | [`2026-08-19-windows64.nvidia50.cuda.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-19.1/2026-08-19-windows64.nvidia50.cuda.portable.zip) |
+| 고급 선택: TensorRT 분할 package, 모든 part 필요 | [`2026-08-19-windows64.nvidia.tensorrt.portable.7z.001`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-19.1/2026-08-19-windows64.nvidia.tensorrt.portable.7z.001)<br>[`2026-08-19-windows64.nvidia.tensorrt.portable.7z.002`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-19.1/2026-08-19-windows64.nvidia.tensorrt.portable.7z.002) |
+| Windows 64-bit, RTX 50 CUDA installer | [`2026-08-19-windows64.nvidia50.cuda.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-19.1/2026-08-19-windows64.nvidia50.cuda.installer.exe) |
+| Windows 64-bit, 직접 engine 설정, portable | [`2026-08-19-windows64.without.engine.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-19.1/2026-08-19-windows64.without.engine.portable.zip) |
+| Windows 64-bit, 직접 engine 설정, installer | [`2026-08-19-windows64.without.engine.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-19.1/2026-08-19-windows64.without.engine.installer.exe) |
+| macOS Apple Silicon | [`2026-08-19-mac-apple-silicon.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-19.1/2026-08-19-mac-apple-silicon.with-katago.dmg) |
+| macOS Intel | [`2026-08-19-mac-intel.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-19.1/2026-08-19-mac-intel.with-katago.dmg) |
+| Linux 64-bit, CPU | [`2026-08-19-linux64.with-katago.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-19.1/2026-08-19-linux64.with-katago.zip) |
+| Linux 64-bit, OpenCL | [`2026-08-19-linux64.opencl.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-19.1/2026-08-19-linux64.opencl.zip) |
+| Linux 64-bit, NVIDIA CUDA | [`2026-08-19-linux64.nvidia.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-19.1/2026-08-19-linux64.nvidia.zip) |
+
+### 이 릴리스를 테스트할 이유
+
+- Windows JDK 21 headless full suite는 `2451` tests를 실행해 `2443` passed, `8` skipped, `0` failure, `0` error를 기록했습니다. Python release-script suite는 `165` tests를 실행해 `163` passed, `2` skipped, `0` failure, `0` error를 기록했습니다. model switching, AI Coach, engine lifecycle, high-DPI sizing, release safeguard를 집중 회귀했습니다.
+- Windows에서 항상 실패하던 replacement/snapshot-fence 6개 test는 cross-platform fixture 수정 후 3회 연속 통과했고 lifecycle class 전체도 80/80을 통과했습니다.
+- Windows 11 실제 PC를 4K(3840×2160), 150% scaling에서 재검증한 결과 click 후 315.3 ms에는 이전 상태가 남아 있었고 565.4 ms에는 대상 model이 사용 중으로 표시됐습니다(이번 테스트의 관측 구간이며 성능 SLA가 아닙니다). engine ready까지는 약 33.1 s가 걸렸으며 중복 click 방지, 원래 model로 전환, restart 후 선택 유지도 정상 동작했습니다. AI Coach dialog는 잘리지 않았고 engine failure dialog는 화면 안에 제한되고 scroll 가능했으며, 닫은 뒤에도 main window와 main engine을 계속 사용할 수 있었습니다. credential redaction은 일반 실제 GUI flow에서 실제 credential을 입력한 것이 아니라 별도의 controlled automation으로 검증했습니다.
+- Build job은 정확한 asset 목록, version, runtime 구조를 검사하며 Apple Developer credential이 설정된 경우 macOS 서명 또는 notarization 실패 시 공개를 중단합니다. 각 platform은 target commit SHA, workflow run/attempt, 각 asset의 size와 SHA-256을 연결한 provenance도 생성합니다. 공개 전 publisher는 GitHub Release remote asset의 정확한 목록, uploaded 상태, size, SHA-256을 provenance와 대조합니다.
+
+### 연락처
+
+- QQ 그룹：`299419120`
+
+---
+
+## ภาษาไทย
+
+นี่คือ feature และ stability pre-release หลัง `next-2026-08-14.1` แก้สถานะการสลับ model ที่อัปเดตช้า และเสริมความแข็งแรงให้ AI Coach, การเริ่ม engine/การ sync กระดาน, นาฬิกาเกม และ Windows high-DPI
+
+### ไฮไลต์ของเวอร์ชันนี้
+
+- เมื่อ One-Click Setup ยอมรับการสลับ model ระบบจะแสดง model เป้าหมายว่าใช้งานอยู่ทันที โดยไม่รอ engine ready นานถึงประมาณ 35 วินาที ระบบจะย้อนกลับไปตาม authoritative local state เฉพาะเมื่อเกิด hard failure หรือ foreground engine เปลี่ยนออกจากเป้าหมายเท่านั้น หากเป็นเพียง soft timeout ของการรอ readiness 35 วินาที ขณะที่เป้าหมายยังเป็น foreground และ process ยังทำงานอยู่ ระบบจะคงสถานะเป้าหมายไว้เพื่อให้การเริ่มทำงานที่ช้าแต่ปกติดำเนินจนเสร็จ
+- ทำ AI Coach training flow ให้ครบ และแก้ HumanSL response เก่าถูกใช้หลังเลื่อน kifu, การเปิดซ้อนกับเกมปกติ/analysis/engine และปุ่ม `P` ที่ข้าม coach state machine
+- เสริม engine startup, switch, restart, navigation และ exact snapshot sync หาก engine game เริ่มแบบ async แล้วล้มเหลว ระบบจะคืน input, toolbar และ engine menu พร้อมเปลี่ยน Windows lifecycle fixture เป็น Java แบบ cross-platform
+- เพิ่มนาฬิกาฝั่งดำ/ขาวที่ engine เป็นเจ้าของพร้อม restart recovery และคง SGF starting position ที่มี `AB`, `AW`, `PL` ให้ตรงกันทั้ง board, engine และ export
+- แก้ portable HumanSL engine path และจำกัด AI Coach setup/report dialog ให้อยู่ใน active monitor พร้อม scroll เพื่อเข้าถึงทุก action บนจอเล็กหรือ high DPI
+- แก้ Fox kifu komi, การสลับสีของ GMA autoplay และ AI Teacher prompt ขอบคุณ `qiyi71w` และ `Fly143` สำหรับการพัฒนาอย่างต่อเนื่อง
+
+### ก่อนดาวน์โหลด
+
+- ผู้ใช้ Windows portable เดิมอัปเดตแอปด้วย `windows64.core-update.zip` ได้ ส่วน full package ยังคง official engine, weight และ runtime ปัจจุบัน พร้อม release audit ที่เข้มงวดขึ้น
+- ผู้ใช้ Windows ส่วนใหญ่แนะนำ OpenCL portable ส่วน NVIDIA ให้เลือก NVIDIA หรือ RTX 50 CUDA ตามรุ่น GPU
+- AI Coach ต้องใช้ KataGo และ HumanSL model ที่เข้ากันได้ One-Click Setup จะหา portable path แต่ควรตรวจว่า model พร้อมใช้งานก่อนเริ่ม
+- นี่คือ pre-release ควรอัปเดตสำเนาก่อน และ backup `user-data`, custom weight และ kifu
+
+### คู่มือดาวน์โหลด
+
+| คอมพิวเตอร์ของคุณ | ดาวน์โหลดไฟล์นี้ |
+| --- | --- |
+| Windows 64-bit, OpenCL แนะนำ, portable | [`2026-08-19-windows64.opencl.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-19.1/2026-08-19-windows64.opencl.portable.zip) |
+| มี Windows portable แล้ว อัปเดตเฉพาะโปรแกรม | [`2026-08-19-windows64.core-update.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-19.1/2026-08-19-windows64.core-update.zip) |
+| Windows 64-bit, OpenCL installer | [`2026-08-19-windows64.opencl.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-19.1/2026-08-19-windows64.opencl.installer.exe) |
+| Windows 64-bit, CPU portable | [`2026-08-19-windows64.with-katago.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-19.1/2026-08-19-windows64.with-katago.portable.zip) |
+| Windows 64-bit, CPU installer | [`2026-08-19-windows64.with-katago.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-19.1/2026-08-19-windows64.with-katago.installer.exe) |
+| Windows 64-bit, NVIDIA CUDA portable | [`2026-08-19-windows64.nvidia.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-19.1/2026-08-19-windows64.nvidia.portable.zip) |
+| Windows 64-bit, NVIDIA CUDA installer | [`2026-08-19-windows64.nvidia.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-19.1/2026-08-19-windows64.nvidia.installer.exe) |
+| Windows 64-bit, RTX 5070/5080/5090 portable | [`2026-08-19-windows64.nvidia50.cuda.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-19.1/2026-08-19-windows64.nvidia50.cuda.portable.zip) |
+| ตัวเลือกขั้นสูง TensorRT แบบแบ่งส่วน ต้องดาวน์โหลดทุกส่วน | [`2026-08-19-windows64.nvidia.tensorrt.portable.7z.001`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-19.1/2026-08-19-windows64.nvidia.tensorrt.portable.7z.001)<br>[`2026-08-19-windows64.nvidia.tensorrt.portable.7z.002`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-19.1/2026-08-19-windows64.nvidia.tensorrt.portable.7z.002) |
+| Windows 64-bit, RTX 50 CUDA installer | [`2026-08-19-windows64.nvidia50.cuda.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-19.1/2026-08-19-windows64.nvidia50.cuda.installer.exe) |
+| Windows 64-bit, ตั้งค่า engine เอง, portable | [`2026-08-19-windows64.without.engine.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-19.1/2026-08-19-windows64.without.engine.portable.zip) |
+| Windows 64-bit, ตั้งค่า engine เอง, installer | [`2026-08-19-windows64.without.engine.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-19.1/2026-08-19-windows64.without.engine.installer.exe) |
+| macOS Apple Silicon | [`2026-08-19-mac-apple-silicon.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-19.1/2026-08-19-mac-apple-silicon.with-katago.dmg) |
+| macOS Intel | [`2026-08-19-mac-intel.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-19.1/2026-08-19-mac-intel.with-katago.dmg) |
+| Linux 64-bit, CPU | [`2026-08-19-linux64.with-katago.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-19.1/2026-08-19-linux64.with-katago.zip) |
+| Linux 64-bit, OpenCL | [`2026-08-19-linux64.opencl.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-19.1/2026-08-19-linux64.opencl.zip) |
+| Linux 64-bit, NVIDIA CUDA | [`2026-08-19-linux64.nvidia.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-19.1/2026-08-19-linux64.nvidia.zip) |
+
+### ทำไมควรทดสอบเวอร์ชันนี้
+
+- Windows JDK 21 headless full suite รัน `2451` tests: ผ่าน `2443`, skipped `8`, `0` failure และ `0` error ส่วน Python release-script suite รัน `165` tests: ผ่าน `163`, skipped `2`, `0` failure และ `0` error พร้อม focused regression สำหรับ model switching, AI Coach, engine lifecycle, high-DPI sizing และ release safeguard
+- test replacement/snapshot-fence 6 รายการที่เคยล้มเหลวสม่ำเสมอบน Windows ผ่าน 3 รอบติดหลังแก้ cross-platform fixture และ lifecycle class ผ่านครบ 80/80
+- การทดสอบซ้ำบนเครื่องจริง Windows 11 ที่ 4K (3840×2160) และ scaling 150% พบว่า 315.3 ms หลัง click ยังแสดงสถานะเดิม และภายใน 565.4 ms model เป้าหมายแสดงว่าใช้งานอยู่ (เป็นช่วงที่สังเกตได้จากการทดสอบครั้งนี้ ไม่ใช่ performance SLA) ขณะที่ engine ready หลังประมาณ 33.1 s การป้องกัน click ซ้ำ การสลับกลับ และการคง model ที่เลือกหลัง restart ทำงานปกติ dialog ของ AI Coach ไม่ถูกตัด ส่วน engine failure dialog อยู่ภายในจอ เลื่อนได้ และหลังปิด main window กับ main engine ยังใช้งานต่อได้ การทำ credential redaction ตรวจแยกด้วย controlled automation ไม่ได้กรอก secret จริงใน GUI flow ปกติ
+- Build job ตรวจ exact asset inventory, version และ runtime structure; หากตั้งค่า Apple Developer credential แล้ว การ sign หรือ notarize macOS ที่ล้มเหลวจะหยุดการเผยแพร่ แต่ละ platform ยังสร้าง provenance ที่ผูก target commit SHA, workflow run/attempt, size และ SHA-256 ของทุก asset ก่อนเผยแพร่ publisher จะเทียบ exact inventory, uploaded state, size และ SHA-256 ของ remote asset บน GitHub Release กับ provenance นี้
+
+### ติดต่อ
+
+- กลุ่ม QQ: `299419120`

--- a/.github/workflows/build-linux-release.yml
+++ b/.github/workflows/build-linux-release.yml
@@ -1,4 +1,5 @@
 name: Build Linux Release
+run-name: "Linux release ${{ inputs.release_tag }} | ${{ inputs.date_tag }} | prerelease=${{ inputs.release_prerelease }}"
 
 on:
   workflow_dispatch:
@@ -6,18 +7,36 @@ on:
       date_tag:
         description: Release date tag, for example 2026-03-24
         required: true
-        default: 2026-05-06
       release_tag:
         description: Existing GitHub release tag to upload into
         required: true
-        default: next-2026-05-06.1
+      release_prerelease:
+        description: Exact pre-release state of the existing draft release
+        required: true
+        type: choice
+        options:
+          - 'true'
+          - 'false'
 
 permissions:
   contents: write
 
+concurrency:
+  group: release-${{ github.workflow }}-${{ inputs.release_tag }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      RELEASE_DATE_TAG: ${{ inputs.date_tag }}
+      RELEASE_TAG: ${{ inputs.release_tag }}
+      RELEASE_PRERELEASE: ${{ inputs.release_prerelease }}
+      RELEASE_REPOSITORY: ${{ github.repository }}
+      RELEASE_TARGET_SHA: ${{ github.sha }}
+      RELEASE_GITHUB_REF: ${{ github.ref }}
+      RELEASE_RUN_ID: ${{ github.run_id }}
+      RELEASE_RUN_ATTEMPT: ${{ github.run_attempt }}
 
     steps:
       - name: Checkout
@@ -34,6 +53,19 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: '3.x'
+
+      - name: Validate release upload identity
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: >-
+          python3 scripts/validate_release_workflow_identity.py
+          --date-tag "$RELEASE_DATE_TAG"
+          --release-tag "$RELEASE_TAG"
+          --prerelease "$RELEASE_PRERELEASE"
+          --repository "$RELEASE_REPOSITORY"
+          --target-sha "$RELEASE_TARGET_SHA"
+          --github-ref "$RELEASE_GITHUB_REF"
+          --require-draft
 
       - name: Install build tools
         run: |
@@ -63,24 +95,24 @@ jobs:
             MODEL_SOURCE="$MODEL_SOURCE" ./scripts/prepare_bundled_katago.sh
 
       - name: Build Linux package
-        run: ./scripts/package_release.sh "${{ inputs.date_tag }}" target/lizzie-yzy2.5.3-shaded.jar "${{ inputs.release_tag }}"
+        run: ./scripts/package_release.sh "$RELEASE_DATE_TAG" target/lizzie-yzy2.5.3-shaded.jar "$RELEASE_TAG"
 
       - name: Audit Linux display version
         run: |
           for flavor in with-katago opencl nvidia; do
-            grep -q -- "-Dlizzie.next.version=\"${{ inputs.release_tag }}\"" \
-              "dist/stage/${{ inputs.date_tag }}-linux64.${flavor}/start-linux64.sh"
+            grep -q -- "-Dlizzie.next.version=\"$RELEASE_TAG\"" \
+              "dist/stage/${RELEASE_DATE_TAG}-linux64.${flavor}/start-linux64.sh"
             grep -q -- "-Xshare:auto" \
-              "dist/stage/${{ inputs.date_tag }}-linux64.${flavor}/start-linux64.sh"
+              "dist/stage/${RELEASE_DATE_TAG}-linux64.${flavor}/start-linux64.sh"
             ! grep -q -- "SharedArchiveFile" \
-              "dist/stage/${{ inputs.date_tag }}-linux64.${flavor}/start-linux64.sh"
-            test ! -f "dist/stage/${{ inputs.date_tag }}-linux64.${flavor}/Lizzieyzy/lizzieyzy-next-cds.jsa"
+              "dist/stage/${RELEASE_DATE_TAG}-linux64.${flavor}/start-linux64.sh"
+            test ! -f "dist/stage/${RELEASE_DATE_TAG}-linux64.${flavor}/Lizzieyzy/lizzieyzy-next-cds.jsa"
           done
-          grep -q -- "Release display version: ${{ inputs.release_tag }}" \
-            "dist/release-meta/${{ inputs.date_tag }}-linux64-install.txt"
-          test -f "dist/release-meta/${{ inputs.date_tag }}-linux64-runtime.json"
-          grep -q '"optimized": true' "dist/release-meta/${{ inputs.date_tag }}-linux64-runtime.json"
-          grep -q '"created": true' "dist/release-meta/${{ inputs.date_tag }}-linux64-runtime.json"
+          grep -q -- "Release display version: $RELEASE_TAG" \
+            "dist/release-meta/${RELEASE_DATE_TAG}-linux64-install.txt"
+          test -f "dist/release-meta/${RELEASE_DATE_TAG}-linux64-runtime.json"
+          grep -q '"optimized": true' "dist/release-meta/${RELEASE_DATE_TAG}-linux64-runtime.json"
+          grep -q '"created": true' "dist/release-meta/${RELEASE_DATE_TAG}-linux64-runtime.json"
 
       - name: Audit Linux KataGo backends
         run: |
@@ -91,12 +123,12 @@ jobs:
             [nvidia]=nvidia
           )
           for flavor in with-katago opencl nvidia; do
-            engine_dir="dist/stage/${{ inputs.date_tag }}-linux64.${flavor}/Lizzieyzy/engines/katago/linux-x64"
+            engine_dir="dist/stage/${RELEASE_DATE_TAG}-linux64.${flavor}/Lizzieyzy/engines/katago/linux-x64"
             test -x "$engine_dir/katago"
             test -f "$engine_dir/lizzieyzy-next-engine-backend.txt"
             grep -qx "${expected_backend[$flavor]}" "$engine_dir/lizzieyzy-next-engine-backend.txt"
           done
-          manifest="dist/stage/${{ inputs.date_tag }}-linux64.with-katago/Lizzieyzy/engines/katago/VERSION.txt"
+          manifest="dist/stage/${RELEASE_DATE_TAG}-linux64.with-katago/Lizzieyzy/engines/katago/VERSION.txt"
           grep -qx "KataGo release: v1.17.1" "$manifest"
           grep -qx "Linux bundle: katago-v1.17.1-eigen-linux-x64.zip" "$manifest"
           grep -qx "Linux OpenCL bundle: katago-v1.17.1-opencl-linux-x64.zip" "$manifest"
@@ -104,20 +136,20 @@ jobs:
           grep -qx "Model source: b10c512h8nbt3tflrs-fson-silu-rsnh.bin.gz" "$manifest"
           grep -qx "Model architecture: transformer" "$manifest"
           grep -qx "Minimum KataGo version: 1.17.0" "$manifest"
-          test "$(sha256sum "dist/stage/${{ inputs.date_tag }}-linux64.with-katago/Lizzieyzy/weights/default.bin.gz" | awk '{print $1}')" = \
+          test "$(sha256sum "dist/stage/${RELEASE_DATE_TAG}-linux64.with-katago/Lizzieyzy/weights/default.bin.gz" | awk '{print $1}')" = \
             "c04db4a503721d948bb720324f3cbdac6088cc9eb243632f020e4b6846f58995"
-          cpu_version="$(dist/stage/${{ inputs.date_tag }}-linux64.with-katago/Lizzieyzy/engines/katago/linux-x64/katago version 2>&1)"
+          cpu_version="$("dist/stage/${RELEASE_DATE_TAG}-linux64.with-katago/Lizzieyzy/engines/katago/linux-x64/katago" version 2>&1)"
           echo "$cpu_version"
           echo "$cpu_version" | grep -q "KataGo v1.17.1"
           echo "$cpu_version" | grep -q "Using Eigen"
 
       - name: Validate public Linux assets
-        run: bash ./scripts/validate_release_assets.sh linux dist/release "${{ inputs.date_tag }}"
+        run: bash ./scripts/validate_release_assets.sh linux dist/release "$RELEASE_DATE_TAG"
 
       - name: Summarize Linux package size audit
         if: always()
         run: |
-          audit="dist/release-meta/${{ inputs.date_tag }}-linux64-package-size-audit.md"
+          audit="dist/release-meta/${RELEASE_DATE_TAG}-linux64-package-size-audit.md"
           if [[ -f "$audit" ]]; then
             cat "$audit" >> "$GITHUB_STEP_SUMMARY"
           fi
@@ -131,11 +163,40 @@ jobs:
             dist/release-meta/*linux64*.json
             dist/release-meta/*linux64*.md
 
-      - name: Upload assets to release
+      - name: Create run-bound release asset provenance
+        run: |
+          python3 scripts/release_asset_provenance.py \
+            --release-dir dist/release \
+            --platform linux \
+            --date-tag "$RELEASE_DATE_TAG" \
+            --release-tag "$RELEASE_TAG" \
+            --target-sha "$RELEASE_TARGET_SHA" \
+            --run-id "$RELEASE_RUN_ID" \
+            --run-attempt "$RELEASE_RUN_ATTEMPT" \
+            --output dist/release-meta/release-asset-provenance.json
+
+      - name: Upload run-bound release asset provenance
+        uses: actions/upload-artifact@v6
+        with:
+          name: release-asset-provenance-linux-attempt-${{ github.run_attempt }}
+          path: dist/release-meta/release-asset-provenance.json
+          if-no-files-found: error
+          retention-days: 7
+
+      - name: Upload verified assets to draft release
         env:
           GH_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
-          gh release upload "${{ inputs.release_tag }}" \
+          python3 scripts/validate_release_workflow_identity.py \
+            --date-tag "$RELEASE_DATE_TAG" \
+            --release-tag "$RELEASE_TAG" \
+            --prerelease "$RELEASE_PRERELEASE" \
+            --repository "$RELEASE_REPOSITORY" \
+            --target-sha "$RELEASE_TARGET_SHA" \
+            --github-ref "$RELEASE_GITHUB_REF" \
+            --require-draft
+          gh release upload "$RELEASE_TAG" \
             dist/release/*linux64*.zip \
-            --repo "${{ github.repository }}" \
+            --repo "$RELEASE_REPOSITORY" \
             --clobber

--- a/.github/workflows/build-macos-amd64-release.yml
+++ b/.github/workflows/build-macos-amd64-release.yml
@@ -1,4 +1,5 @@
 name: Build macOS amd64 Release
+run-name: "macOS Intel release ${{ inputs.release_tag }} | ${{ inputs.date_tag }} | prerelease=${{ inputs.release_prerelease }}"
 
 on:
   workflow_dispatch:
@@ -6,18 +7,36 @@ on:
       date_tag:
         description: Release date tag, for example 2026-03-24
         required: true
-        default: 2026-05-06
       release_tag:
         description: Existing GitHub release tag to upload into
         required: true
-        default: next-2026-05-06.1
+      release_prerelease:
+        description: Exact pre-release state of the existing draft release
+        required: true
+        type: choice
+        options:
+          - 'true'
+          - 'false'
 
 permissions:
   contents: write
 
+concurrency:
+  group: release-${{ github.workflow }}-${{ inputs.release_tag }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: macos-15-intel
+    env:
+      RELEASE_DATE_TAG: ${{ inputs.date_tag }}
+      RELEASE_TAG: ${{ inputs.release_tag }}
+      RELEASE_PRERELEASE: ${{ inputs.release_prerelease }}
+      RELEASE_REPOSITORY: ${{ github.repository }}
+      RELEASE_TARGET_SHA: ${{ github.sha }}
+      RELEASE_GITHUB_REF: ${{ github.ref }}
+      RELEASE_RUN_ID: ${{ github.run_id }}
+      RELEASE_RUN_ATTEMPT: ${{ github.run_attempt }}
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -33,6 +52,19 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: '3.x'
+
+      - name: Validate release upload identity
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: >-
+          python3 scripts/validate_release_workflow_identity.py
+          --date-tag "$RELEASE_DATE_TAG"
+          --release-tag "$RELEASE_TAG"
+          --prerelease "$RELEASE_PRERELEASE"
+          --repository "$RELEASE_REPOSITORY"
+          --target-sha "$RELEASE_TARGET_SHA"
+          --github-ref "$RELEASE_GITHUB_REF"
+          --require-draft
 
       - name: Install build tools
         run: |
@@ -68,7 +100,7 @@ jobs:
             MODEL_SOURCE="$MODEL_SOURCE" ./scripts/prepare_bundled_katago.sh
 
       - name: Build macOS amd64 package
-        run: ./scripts/package_macos_dmg.sh "${{ inputs.date_tag }}" 1.0.0 target/lizzie-yzy2.5.3-shaded.jar "${{ inputs.release_tag }}"
+        run: ./scripts/package_macos_dmg.sh "$RELEASE_DATE_TAG" 1.0.0 target/lizzie-yzy2.5.3-shaded.jar "$RELEASE_TAG"
 
       - name: Audit macOS amd64 display version
         run: |
@@ -79,7 +111,7 @@ jobs:
           grep -qx "Minimum KataGo version: 1.17.0" "$app_root/engines/katago/VERSION.txt"
           test "$(shasum -a 256 "$app_root/weights/default.bin.gz" | awk '{print $1}')" = \
             "c04db4a503721d948bb720324f3cbdac6088cc9eb243632f020e4b6846f58995"
-          grep -q -- "java-options=-Dlizzie.next.version=${{ inputs.release_tag }}" \
+          grep -q -- "java-options=-Dlizzie.next.version=$RELEASE_TAG" \
             "dist/macos/app-image/LizzieYzy Next.app/Contents/app/LizzieYzy Next.cfg"
           grep -q -- "java-options=-Xshare:auto" \
             "dist/macos/app-image/LizzieYzy Next.app/Contents/app/LizzieYzy Next.cfg"
@@ -93,19 +125,19 @@ jobs:
           ! grep -q -- "SharedArchiveFile" \
             "dist/macos/app-image/LizzieYzy Next.app/Contents/app/LizzieYzy Next.cfg"
           test ! -f "dist/macos/app-image/LizzieYzy Next.app/Contents/app/lizzieyzy-next-cds.jsa"
-          grep -q -- "Release display version: ${{ inputs.release_tag }}" \
-            "dist/release-meta/${{ inputs.date_tag }}-mac-intel-install.txt"
+          grep -q -- "Release display version: $RELEASE_TAG" \
+            "dist/release-meta/${RELEASE_DATE_TAG}-mac-intel-install.txt"
           bundle_version="$(python3 scripts/macos_bundle_version.py \
-            --release-tag "${{ inputs.release_tag }}" \
-            --date-tag "${{ inputs.date_tag }}" \
+            --release-tag "$RELEASE_TAG" \
+            --date-tag "$RELEASE_DATE_TAG" \
             --field build)"
           test "$(/usr/libexec/PlistBuddy -c 'Print :CFBundleVersion' \
             'dist/macos/app-image/LizzieYzy Next.app/Contents/Info.plist')" = "$bundle_version"
           test "$(/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' \
             'dist/macos/app-image/LizzieYzy Next.app/Contents/Info.plist')" = "$bundle_version"
-          test -f "dist/release-meta/${{ inputs.date_tag }}-mac-intel-runtime.json"
-          grep -q '"optimized": true' "dist/release-meta/${{ inputs.date_tag }}-mac-intel-runtime.json"
-          grep -q '"created": true' "dist/release-meta/${{ inputs.date_tag }}-mac-intel-runtime.json"
+          test -f "dist/release-meta/${RELEASE_DATE_TAG}-mac-intel-runtime.json"
+          grep -q '"optimized": true' "dist/release-meta/${RELEASE_DATE_TAG}-mac-intel-runtime.json"
+          grep -q '"created": true' "dist/release-meta/${RELEASE_DATE_TAG}-mac-intel-runtime.json"
           jcef="dist/macos/app-image/LizzieYzy Next.app/Contents/app/jcef-bundle"
           test -f "$jcef/build_meta.json"
           test -f "$jcef/install.lock"
@@ -126,15 +158,15 @@ jobs:
           APPLE_APP_PASSWORD: ${{ secrets.APPLE_APP_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
           APPLE_SIGN_IDENTITY: ${{ secrets.APPLE_SIGN_IDENTITY }}
-        run: bash ./scripts/sign_macos_release_with_retry.sh dist/release mac-amd64 "${{ inputs.release_tag }}"
+        run: bash ./scripts/sign_macos_release_with_retry.sh dist/release mac-amd64 "$RELEASE_TAG"
 
       - name: Validate public macOS amd64 assets
-        run: bash ./scripts/validate_release_assets.sh mac-amd64 dist/release "${{ inputs.date_tag }}" "${{ inputs.release_tag }}"
+        run: bash ./scripts/validate_release_assets.sh mac-amd64 dist/release "$RELEASE_DATE_TAG" "$RELEASE_TAG"
 
       - name: Summarize macOS amd64 package size audit
         if: always()
         run: |
-          audit="dist/release-meta/${{ inputs.date_tag }}-mac-intel-package-size-audit.md"
+          audit="dist/release-meta/${RELEASE_DATE_TAG}-mac-intel-package-size-audit.md"
           if [[ -f "$audit" ]]; then
             cat "$audit" >> "$GITHUB_STEP_SUMMARY"
           fi
@@ -148,11 +180,40 @@ jobs:
             dist/release-meta/*mac-intel-*.json
             dist/release-meta/*mac-intel-*.md
 
-      - name: Upload assets to release
+      - name: Create run-bound release asset provenance
+        run: |
+          python3 scripts/release_asset_provenance.py \
+            --release-dir dist/release \
+            --platform mac-amd64 \
+            --date-tag "$RELEASE_DATE_TAG" \
+            --release-tag "$RELEASE_TAG" \
+            --target-sha "$RELEASE_TARGET_SHA" \
+            --run-id "$RELEASE_RUN_ID" \
+            --run-attempt "$RELEASE_RUN_ATTEMPT" \
+            --output dist/release-meta/release-asset-provenance.json
+
+      - name: Upload run-bound release asset provenance
+        uses: actions/upload-artifact@v6
+        with:
+          name: release-asset-provenance-mac-amd64-attempt-${{ github.run_attempt }}
+          path: dist/release-meta/release-asset-provenance.json
+          if-no-files-found: error
+          retention-days: 7
+
+      - name: Upload verified assets to draft release
         env:
           GH_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
-          gh release upload "${{ inputs.release_tag }}" \
+          python3 scripts/validate_release_workflow_identity.py \
+            --date-tag "$RELEASE_DATE_TAG" \
+            --release-tag "$RELEASE_TAG" \
+            --prerelease "$RELEASE_PRERELEASE" \
+            --repository "$RELEASE_REPOSITORY" \
+            --target-sha "$RELEASE_TARGET_SHA" \
+            --github-ref "$RELEASE_GITHUB_REF" \
+            --require-draft
+          gh release upload "$RELEASE_TAG" \
             dist/release/*mac-intel.with-katago.dmg \
-            --repo "${{ github.repository }}" \
+            --repo "$RELEASE_REPOSITORY" \
             --clobber

--- a/.github/workflows/build-macos-arm64-release.yml
+++ b/.github/workflows/build-macos-arm64-release.yml
@@ -1,4 +1,5 @@
 name: Build macOS arm64 Release
+run-name: "macOS Apple Silicon release ${{ inputs.release_tag }} | ${{ inputs.date_tag }} | prerelease=${{ inputs.release_prerelease }}"
 
 on:
   workflow_dispatch:
@@ -6,18 +7,36 @@ on:
       date_tag:
         description: Release date tag, for example 2026-03-24
         required: true
-        default: 2026-05-06
       release_tag:
         description: Existing GitHub release tag to upload into
         required: true
-        default: next-2026-05-06.1
+      release_prerelease:
+        description: Exact pre-release state of the existing draft release
+        required: true
+        type: choice
+        options:
+          - 'true'
+          - 'false'
 
 permissions:
   contents: write
 
+concurrency:
+  group: release-${{ github.workflow }}-${{ inputs.release_tag }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: macos-15
+    env:
+      RELEASE_DATE_TAG: ${{ inputs.date_tag }}
+      RELEASE_TAG: ${{ inputs.release_tag }}
+      RELEASE_PRERELEASE: ${{ inputs.release_prerelease }}
+      RELEASE_REPOSITORY: ${{ github.repository }}
+      RELEASE_TARGET_SHA: ${{ github.sha }}
+      RELEASE_GITHUB_REF: ${{ github.ref }}
+      RELEASE_RUN_ID: ${{ github.run_id }}
+      RELEASE_RUN_ATTEMPT: ${{ github.run_attempt }}
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -33,6 +52,19 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: '3.x'
+
+      - name: Validate release upload identity
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: >-
+          python3 scripts/validate_release_workflow_identity.py
+          --date-tag "$RELEASE_DATE_TAG"
+          --release-tag "$RELEASE_TAG"
+          --prerelease "$RELEASE_PRERELEASE"
+          --repository "$RELEASE_REPOSITORY"
+          --target-sha "$RELEASE_TARGET_SHA"
+          --github-ref "$RELEASE_GITHUB_REF"
+          --require-draft
 
       - name: Install build tools
         run: |
@@ -68,7 +100,7 @@ jobs:
             MODEL_SOURCE="$MODEL_SOURCE" ./scripts/prepare_bundled_katago.sh
 
       - name: Build macOS arm64 package
-        run: ./scripts/package_macos_dmg.sh "${{ inputs.date_tag }}" 1.0.0 target/lizzie-yzy2.5.3-shaded.jar "${{ inputs.release_tag }}"
+        run: ./scripts/package_macos_dmg.sh "$RELEASE_DATE_TAG" 1.0.0 target/lizzie-yzy2.5.3-shaded.jar "$RELEASE_TAG"
 
       - name: Audit macOS arm64 display version
         run: |
@@ -79,7 +111,7 @@ jobs:
           grep -qx "Minimum KataGo version: 1.17.0" "$app_root/engines/katago/VERSION.txt"
           test "$(shasum -a 256 "$app_root/weights/default.bin.gz" | awk '{print $1}')" = \
             "c04db4a503721d948bb720324f3cbdac6088cc9eb243632f020e4b6846f58995"
-          grep -q -- "java-options=-Dlizzie.next.version=${{ inputs.release_tag }}" \
+          grep -q -- "java-options=-Dlizzie.next.version=$RELEASE_TAG" \
             "dist/macos/app-image/LizzieYzy Next.app/Contents/app/LizzieYzy Next.cfg"
           grep -q -- "java-options=-Xshare:auto" \
             "dist/macos/app-image/LizzieYzy Next.app/Contents/app/LizzieYzy Next.cfg"
@@ -93,19 +125,19 @@ jobs:
           ! grep -q -- "SharedArchiveFile" \
             "dist/macos/app-image/LizzieYzy Next.app/Contents/app/LizzieYzy Next.cfg"
           test ! -f "dist/macos/app-image/LizzieYzy Next.app/Contents/app/lizzieyzy-next-cds.jsa"
-          grep -q -- "Release display version: ${{ inputs.release_tag }}" \
-            "dist/release-meta/${{ inputs.date_tag }}-mac-apple-silicon-install.txt"
+          grep -q -- "Release display version: $RELEASE_TAG" \
+            "dist/release-meta/${RELEASE_DATE_TAG}-mac-apple-silicon-install.txt"
           bundle_version="$(python3 scripts/macos_bundle_version.py \
-            --release-tag "${{ inputs.release_tag }}" \
-            --date-tag "${{ inputs.date_tag }}" \
+            --release-tag "$RELEASE_TAG" \
+            --date-tag "$RELEASE_DATE_TAG" \
             --field build)"
           test "$(/usr/libexec/PlistBuddy -c 'Print :CFBundleVersion' \
             'dist/macos/app-image/LizzieYzy Next.app/Contents/Info.plist')" = "$bundle_version"
           test "$(/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' \
             'dist/macos/app-image/LizzieYzy Next.app/Contents/Info.plist')" = "$bundle_version"
-          test -f "dist/release-meta/${{ inputs.date_tag }}-mac-apple-silicon-runtime.json"
-          grep -q '"optimized": true' "dist/release-meta/${{ inputs.date_tag }}-mac-apple-silicon-runtime.json"
-          grep -q '"created": true' "dist/release-meta/${{ inputs.date_tag }}-mac-apple-silicon-runtime.json"
+          test -f "dist/release-meta/${RELEASE_DATE_TAG}-mac-apple-silicon-runtime.json"
+          grep -q '"optimized": true' "dist/release-meta/${RELEASE_DATE_TAG}-mac-apple-silicon-runtime.json"
+          grep -q '"created": true' "dist/release-meta/${RELEASE_DATE_TAG}-mac-apple-silicon-runtime.json"
           jcef="dist/macos/app-image/LizzieYzy Next.app/Contents/app/jcef-bundle"
           test -f "$jcef/build_meta.json"
           test -f "$jcef/install.lock"
@@ -126,15 +158,15 @@ jobs:
           APPLE_APP_PASSWORD: ${{ secrets.APPLE_APP_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
           APPLE_SIGN_IDENTITY: ${{ secrets.APPLE_SIGN_IDENTITY }}
-        run: bash ./scripts/sign_macos_release_with_retry.sh dist/release mac-arm64 "${{ inputs.release_tag }}"
+        run: bash ./scripts/sign_macos_release_with_retry.sh dist/release mac-arm64 "$RELEASE_TAG"
 
       - name: Validate public macOS arm64 assets
-        run: bash ./scripts/validate_release_assets.sh mac-arm64 dist/release "${{ inputs.date_tag }}" "${{ inputs.release_tag }}"
+        run: bash ./scripts/validate_release_assets.sh mac-arm64 dist/release "$RELEASE_DATE_TAG" "$RELEASE_TAG"
 
       - name: Summarize macOS arm64 package size audit
         if: always()
         run: |
-          audit="dist/release-meta/${{ inputs.date_tag }}-mac-apple-silicon-package-size-audit.md"
+          audit="dist/release-meta/${RELEASE_DATE_TAG}-mac-apple-silicon-package-size-audit.md"
           if [[ -f "$audit" ]]; then
             cat "$audit" >> "$GITHUB_STEP_SUMMARY"
           fi
@@ -148,11 +180,40 @@ jobs:
             dist/release-meta/*mac-apple-silicon-*.json
             dist/release-meta/*mac-apple-silicon-*.md
 
-      - name: Upload assets to release
+      - name: Create run-bound release asset provenance
+        run: |
+          python3 scripts/release_asset_provenance.py \
+            --release-dir dist/release \
+            --platform mac-arm64 \
+            --date-tag "$RELEASE_DATE_TAG" \
+            --release-tag "$RELEASE_TAG" \
+            --target-sha "$RELEASE_TARGET_SHA" \
+            --run-id "$RELEASE_RUN_ID" \
+            --run-attempt "$RELEASE_RUN_ATTEMPT" \
+            --output dist/release-meta/release-asset-provenance.json
+
+      - name: Upload run-bound release asset provenance
+        uses: actions/upload-artifact@v6
+        with:
+          name: release-asset-provenance-mac-arm64-attempt-${{ github.run_attempt }}
+          path: dist/release-meta/release-asset-provenance.json
+          if-no-files-found: error
+          retention-days: 7
+
+      - name: Upload verified assets to draft release
         env:
           GH_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
-          gh release upload "${{ inputs.release_tag }}" \
+          python3 scripts/validate_release_workflow_identity.py \
+            --date-tag "$RELEASE_DATE_TAG" \
+            --release-tag "$RELEASE_TAG" \
+            --prerelease "$RELEASE_PRERELEASE" \
+            --repository "$RELEASE_REPOSITORY" \
+            --target-sha "$RELEASE_TARGET_SHA" \
+            --github-ref "$RELEASE_GITHUB_REF" \
+            --require-draft
+          gh release upload "$RELEASE_TAG" \
             dist/release/*mac-apple-silicon.with-katago.dmg \
-            --repo "${{ github.repository }}" \
+            --repo "$RELEASE_REPOSITORY" \
             --clobber

--- a/.github/workflows/build-windows-release.yml
+++ b/.github/workflows/build-windows-release.yml
@@ -1,4 +1,5 @@
 name: Build Windows Release
+run-name: "Windows release ${{ inputs.release_tag }} | ${{ inputs.date_tag }} | prerelease=${{ inputs.release_prerelease }}"
 
 on:
   workflow_dispatch:
@@ -6,24 +7,37 @@ on:
       date_tag:
         description: Release date tag, for example 2026-03-24
         required: true
-        default: 2026-05-06
       release_tag:
         description: Existing GitHub release tag to upload into
         required: true
-        default: next-2026-05-06.1
       release_prerelease:
-        description: Optional explicit pre-release state for draft release publishing
-        required: false
-        default: ''
-        type: string
+        description: Exact pre-release state of the existing draft release
+        required: true
+        type: choice
+        options:
+          - 'true'
+          - 'false'
 
 permissions:
   contents: write
 
+concurrency:
+  group: release-${{ github.workflow }}-${{ inputs.release_tag }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: windows-latest
-    timeout-minutes: 360
+    timeout-minutes: 280
+    env:
+      RELEASE_DATE_TAG: ${{ inputs.date_tag }}
+      RELEASE_TAG: ${{ inputs.release_tag }}
+      RELEASE_PRERELEASE: ${{ inputs.release_prerelease }}
+      RELEASE_REPOSITORY: ${{ github.repository }}
+      RELEASE_TARGET_SHA: ${{ github.sha }}
+      RELEASE_GITHUB_REF: ${{ github.ref }}
+      RELEASE_RUN_ID: ${{ github.run_id }}
+      RELEASE_RUN_ATTEMPT: ${{ github.run_attempt }}
 
     steps:
       - name: Checkout
@@ -40,6 +54,20 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: '3.x'
+
+      - name: Validate release upload identity
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        shell: bash
+        run: >-
+          python scripts/validate_release_workflow_identity.py
+          --date-tag "$RELEASE_DATE_TAG"
+          --release-tag "$RELEASE_TAG"
+          --prerelease "$RELEASE_PRERELEASE"
+          --repository "$RELEASE_REPOSITORY"
+          --target-sha "$RELEASE_TARGET_SHA"
+          --github-ref "$RELEASE_GITHUB_REF"
+          --require-draft
 
       - name: Generate app icons
         shell: powershell
@@ -73,12 +101,11 @@ jobs:
             MODEL_SOURCE="$MODEL_SOURCE" ./scripts/prepare_bundled_katago.sh
 
       - name: Build Windows installer and portable package
-        timeout-minutes: 300
+        id: release_metadata
+        timeout-minutes: 240
         shell: bash
         env:
           GITHUB_TOKEN: ${{ github.token }}
-          RELEASE_TAG: ${{ inputs.release_tag }}
-          RELEASE_PRERELEASE: ${{ inputs.release_prerelease }}
         run: |
           set -euo pipefail
           if [[ ! "$RELEASE_TAG" =~ ^next-[0-9]{4}-[0-9]{2}-[0-9]{2}\.[1-9][0-9]*$ ]]; then
@@ -87,19 +114,11 @@ jobs:
           fi
 
           release_prerelease="$RELEASE_PRERELEASE"
-          if [[ -z "$release_prerelease" ]]; then
-            # Draft releases are intentionally omitted by the releases/tags endpoint.
-            # The authenticated release listing includes both drafts and public releases.
-            release_prerelease="$(
-              gh api --paginate "repos/${GITHUB_REPOSITORY}/releases?per_page=100" |
-                jq -r --arg tag "$RELEASE_TAG" \
-                  'first(.[] | select(.tag_name == $tag)) | .prerelease'
-            )"
-          fi
           if [[ "$release_prerelease" != "true" && "$release_prerelease" != "false" ]]; then
             echo "Unable to determine pre-release state for $RELEASE_TAG" >&2
             exit 1
           fi
+          echo "release_prerelease=$release_prerelease" >> "$GITHUB_OUTPUT"
 
           serial="$RELEASE_TAG"
           serial="${serial##*.}"
@@ -107,20 +126,28 @@ jobs:
             serial="${GITHUB_RUN_ATTEMPT:-0}"
           fi
           WINDOWS_BUILD_SERIAL="$serial" LIZZIE_RELEASE_PRERELEASE="$release_prerelease" \
-            ./scripts/package_windows_exe.sh "${{ inputs.date_tag }}" 1.0.0 target/lizzie-yzy2.5.3-shaded.jar "$RELEASE_TAG"
+            ./scripts/package_windows_exe.sh "$RELEASE_DATE_TAG" 1.0.0 target/lizzie-yzy2.5.3-shaded.jar "$RELEASE_TAG"
 
       - name: Validate public Windows assets
         shell: bash
-        run: bash ./scripts/validate_release_assets.sh windows dist/release "${{ inputs.date_tag }}"
+        env:
+          RELEASE_METADATA_PRERELEASE: ${{ steps.release_metadata.outputs.release_prerelease }}
+        run: >-
+          bash ./scripts/validate_release_assets.sh
+          windows
+          dist/release
+          "$RELEASE_DATE_TAG"
+          "$RELEASE_TAG"
+          "$RELEASE_METADATA_PRERELEASE"
 
       - name: Audit Windows bundle UX checkpoints
         shell: bash
         run: |
           # Trace every assertion so a future packaging regression identifies the exact failed check.
           set -euxo pipefail
-          note_file="dist/release-meta/${{ inputs.date_tag }}-windows64-install.txt"
+          note_file="dist/release-meta/${RELEASE_DATE_TAG}-windows64-install.txt"
           test -f "$note_file"
-          grep -q "Release display version: ${{ inputs.release_tag }}" "$note_file"
+          grep -q "Release display version: $RELEASE_TAG" "$note_file"
           grep -q "Smart Optimize" "$note_file"
           grep -q "first launch should work offline" "$note_file"
           grep -q "qiyi71w/readboard v3.0.6" "$note_file"
@@ -154,7 +181,7 @@ jobs:
           grep -qx 'Windows OpenCL bundle: katago-v1.17.1-opencl-windows-x64.zip' "dist/windows/input-opencl/engines/katago/VERSION.txt"
           test -f "dist/windows/app-image-with-katago/LizzieYzy Next/LizzieYzy Next.exe"
           test -f "dist/windows/app-image-with-katago/LizzieYzy Next/app/PROJECT_INFO.txt"
-          grep -q "java-options=-Dlizzie.next.version=${{ inputs.release_tag }}" "dist/windows/app-image-with-katago/LizzieYzy Next/app/LizzieYzy Next.cfg"
+          grep -q "java-options=-Dlizzie.next.version=$RELEASE_TAG" "dist/windows/app-image-with-katago/LizzieYzy Next/app/LizzieYzy Next.cfg"
           test -f "dist/windows/app-image-with-katago/LizzieYzy Next/app/readboard/readboard.exe"
           test -f "dist/windows/app-image-with-katago/LizzieYzy Next/app/readboard/lizzieyzy-next-readboard-manifest.txt"
           test -f "dist/windows/app-image-with-katago/LizzieYzy Next/app/jcef-bundle/build_meta.json"
@@ -163,12 +190,12 @@ jobs:
           test -f "dist/windows/app-image-with-katago/LizzieYzy Next/app/jcef-bundle/lizzieyzy-next-jcef-manifest.txt"
           test -f "dist/windows/app-image-opencl/LizzieYzy Next OpenCL/LizzieYzy Next OpenCL.exe"
           test -f "dist/windows/app-image-opencl/LizzieYzy Next OpenCL/app/PROJECT_INFO.txt"
-          grep -q "java-options=-Dlizzie.next.version=${{ inputs.release_tag }}" "dist/windows/app-image-opencl/LizzieYzy Next OpenCL/app/LizzieYzy Next OpenCL.cfg"
+          grep -q "java-options=-Dlizzie.next.version=$RELEASE_TAG" "dist/windows/app-image-opencl/LizzieYzy Next OpenCL/app/LizzieYzy Next OpenCL.cfg"
           test -f "dist/windows/app-image-opencl/LizzieYzy Next OpenCL/app/readboard/readboard.exe"
           test -f "dist/windows/app-image-opencl/LizzieYzy Next OpenCL/runtime/bin/java.exe"
           test -f "dist/windows/app-image-nvidia/LizzieYzy Next NVIDIA/LizzieYzy Next NVIDIA.exe"
           test -f "dist/windows/app-image-nvidia/LizzieYzy Next NVIDIA/app/PROJECT_INFO.txt"
-          grep -q "java-options=-Dlizzie.next.version=${{ inputs.release_tag }}" "dist/windows/app-image-nvidia/LizzieYzy Next NVIDIA/app/LizzieYzy Next NVIDIA.cfg"
+          grep -q "java-options=-Dlizzie.next.version=$RELEASE_TAG" "dist/windows/app-image-nvidia/LizzieYzy Next NVIDIA/app/LizzieYzy Next NVIDIA.cfg"
           test -f "dist/windows/app-image-nvidia/LizzieYzy Next NVIDIA/app/readboard/readboard.exe"
           test -f "dist/windows/app-image-nvidia/LizzieYzy Next NVIDIA/runtime/bin/java.exe"
           test -f "dist/windows/input-nvidia/engines/katago/windows-x64/katago.exe"
@@ -179,7 +206,7 @@ jobs:
           test -f "dist/windows/input-nvidia/engines/katago/windows-x64/cublas64_12.dll"
           test -f "dist/windows/app-image-without.engine/LizzieYzy Next/LizzieYzy Next.exe"
           test -f "dist/windows/app-image-without.engine/LizzieYzy Next/app/PROJECT_INFO.txt"
-          grep -q "java-options=-Dlizzie.next.version=${{ inputs.release_tag }}" "dist/windows/app-image-without.engine/LizzieYzy Next/app/LizzieYzy Next.cfg"
+          grep -q "java-options=-Dlizzie.next.version=$RELEASE_TAG" "dist/windows/app-image-without.engine/LizzieYzy Next/app/LizzieYzy Next.cfg"
           test -f "dist/windows/input-nvidia/engines/katago/windows-x64/cublasLt64_12.dll"
           test -f "dist/windows/input-nvidia/engines/katago/windows-x64/cudnn64_9.dll"
           test -f "dist/windows/input-nvidia/engines/katago/windows-x64/z.dll"
@@ -195,7 +222,7 @@ jobs:
           find "dist/windows/app-image-nvidia/LizzieYzy Next NVIDIA/app/engines/katago/windows-x64" -maxdepth 1 -type f -name 'nvJitLink*.dll' | grep -q .
           test -f "dist/windows/app-image-nvidia50.cuda/LizzieYzy Next NVIDIA 50 CUDA/LizzieYzy Next NVIDIA 50 CUDA.exe"
           test -f "dist/windows/app-image-nvidia50.cuda/LizzieYzy Next NVIDIA 50 CUDA/app/PROJECT_INFO.txt"
-          grep -q "java-options=-Dlizzie.next.version=${{ inputs.release_tag }}" "dist/windows/app-image-nvidia50.cuda/LizzieYzy Next NVIDIA 50 CUDA/app/LizzieYzy Next NVIDIA 50 CUDA.cfg"
+          grep -q "java-options=-Dlizzie.next.version=$RELEASE_TAG" "dist/windows/app-image-nvidia50.cuda/LizzieYzy Next NVIDIA 50 CUDA/app/LizzieYzy Next NVIDIA 50 CUDA.cfg"
           test -f "dist/windows/app-image-nvidia50.cuda/LizzieYzy Next NVIDIA 50 CUDA/app/readboard/readboard.exe"
           test -f "dist/windows/app-image-nvidia50.cuda/LizzieYzy Next NVIDIA 50 CUDA/runtime/bin/java.exe"
           test -f "dist/windows/input-nvidia50.cuda/engines/katago/windows-x64/katago.exe"
@@ -217,10 +244,10 @@ jobs:
           test -f "dist/windows/app-image-nvidia50.cuda/LizzieYzy Next NVIDIA 50 CUDA/app/engines/katago/windows-x64/cudnn64_9.dll"
           test -f "dist/windows/app-image-nvidia50.cuda/LizzieYzy Next NVIDIA 50 CUDA/app/engines/katago/windows-x64/z.dll"
           find "dist/windows/app-image-nvidia50.cuda/LizzieYzy Next NVIDIA 50 CUDA/app/engines/katago/windows-x64" -maxdepth 1 -type f -name 'nvJitLink*.dll' | grep -q .
-          test -f "dist/release/${{ inputs.date_tag }}-windows64.nvidia.tensorrt.portable.7z.001"
-          test -f "dist/release/${{ inputs.date_tag }}-windows64.nvidia.tensorrt.portable.README.txt"
-          test -f "dist/release/${{ inputs.date_tag }}-windows64.nvidia.tensorrt.portable.manifest.json"
-          test -f "dist/release/${{ inputs.date_tag }}-windows64.nvidia.tensorrt.portable.sha256.txt"
+          test -f "dist/release/${RELEASE_DATE_TAG}-windows64.nvidia.tensorrt.portable.7z.001"
+          test -f "dist/release/${RELEASE_DATE_TAG}-windows64.nvidia.tensorrt.portable.README.txt"
+          test -f "dist/release/${RELEASE_DATE_TAG}-windows64.nvidia.tensorrt.portable.manifest.json"
+          test -f "dist/release/${RELEASE_DATE_TAG}-windows64.nvidia.tensorrt.portable.sha256.txt"
           test -f "engines/katago/windows-x64-nvidia-tensorrt/lizzieyzy-next-katago-engine-manifest.txt"
           grep -qx "KataGo release: v1.17.2" \
             "engines/katago/windows-x64-nvidia-tensorrt/lizzieyzy-next-katago-engine-manifest.txt"
@@ -230,8 +257,8 @@ jobs:
             "dist/windows/input-nvidia.tensorrt/engines/katago/VERSION.txt"
           grep -qx "Windows TensorRT bundle: katago-v1.17.2-trt10.9.0-cuda12.8-windows-x64.zip" \
             "dist/windows/input-nvidia.tensorrt/engines/katago/VERSION.txt"
-          grep -q "Advanced optional TensorRT split package" "dist/release/${{ inputs.date_tag }}-windows64.nvidia.tensorrt.portable.README.txt"
-          grep -q '"engineBackend": "nvidia-tensorrt"' "dist/release/${{ inputs.date_tag }}-windows64.nvidia.tensorrt.portable.manifest.json"
+          grep -q "Advanced optional TensorRT split package" "dist/release/${RELEASE_DATE_TAG}-windows64.nvidia.tensorrt.portable.README.txt"
+          grep -q '"engineBackend": "nvidia-tensorrt"' "dist/release/${RELEASE_DATE_TAG}-windows64.nvidia.tensorrt.portable.manifest.json"
           test -f "dist/windows/input-without.engine/PROJECT_INFO.txt"
           test -f "dist/windows/input-without.engine/readboard/readboard.exe"
           test -f "dist/windows/input-without.engine/readboard/lizzieyzy-next-readboard-manifest.txt"
@@ -272,9 +299,9 @@ jobs:
               exit 1
             fi
           done
-          test -f "dist/release-meta/${{ inputs.date_tag }}-windows64-runtime.json"
-          grep -q '"optimized": true' "dist/release-meta/${{ inputs.date_tag }}-windows64-runtime.json"
-          grep -q '"created": true' "dist/release-meta/${{ inputs.date_tag }}-windows64-runtime.json"
+          test -f "dist/release-meta/${RELEASE_DATE_TAG}-windows64-runtime.json"
+          grep -q '"optimized": true' "dist/release-meta/${RELEASE_DATE_TAG}-windows64-runtime.json"
+          grep -q '"created": true' "dist/release-meta/${RELEASE_DATE_TAG}-windows64-runtime.json"
           for app_dir in \
             "dist/windows/app-image-with-katago/LizzieYzy Next" \
             "dist/windows/app-image-opencl/LizzieYzy Next OpenCL" \
@@ -383,27 +410,10 @@ jobs:
         if: always()
         shell: bash
         run: |
-          audit="dist/release-meta/${{ inputs.date_tag }}-windows64-package-size-audit.md"
+          audit="dist/release-meta/${RELEASE_DATE_TAG}-windows64-package-size-audit.md"
           if [[ -f "$audit" ]]; then
             cat "$audit" >> "$GITHUB_STEP_SUMMARY"
           fi
-
-      - name: Upload assets to release
-        shell: bash
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          gh release upload "${{ inputs.release_tag }}" \
-            dist/release/*windows64*.installer.exe \
-            dist/release/*windows64*.portable.zip \
-            dist/release/*windows64.core-update.zip \
-            dist/release/lizzieyzy-next-update-manifest.json \
-            dist/release/*windows64.nvidia.tensorrt.portable.7z.* \
-            dist/release/*windows64.nvidia.tensorrt.portable.README.txt \
-            dist/release/*windows64.nvidia.tensorrt.portable.manifest.json \
-            dist/release/*windows64.nvidia.tensorrt.portable.sha256.txt \
-            --repo "${{ github.repository }}" \
-            --clobber
 
       - name: Smoke test Windows upgrade install path
         timeout-minutes: 25
@@ -437,3 +447,50 @@ jobs:
             ${{ runner.temp }}/lizzieyzy-next-msi-smoke/logs/*
             dist/windows/app-image-with-katago/LizzieYzy Next/LastConsoleLogs_*.txt
             dist/windows/app-image-with-katago/LizzieYzy Next/LastErrorLogs_*.txt
+
+      - name: Create run-bound release asset provenance
+        shell: bash
+        run: |
+          python scripts/release_asset_provenance.py \
+            --release-dir dist/release \
+            --platform windows \
+            --date-tag "$RELEASE_DATE_TAG" \
+            --release-tag "$RELEASE_TAG" \
+            --target-sha "$RELEASE_TARGET_SHA" \
+            --run-id "$RELEASE_RUN_ID" \
+            --run-attempt "$RELEASE_RUN_ATTEMPT" \
+            --output dist/release-meta/release-asset-provenance.json
+
+      - name: Upload run-bound release asset provenance
+        uses: actions/upload-artifact@v6
+        with:
+          name: release-asset-provenance-windows-attempt-${{ github.run_attempt }}
+          path: dist/release-meta/release-asset-provenance.json
+          if-no-files-found: error
+          retention-days: 7
+
+      - name: Upload verified assets to draft release
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          python scripts/validate_release_workflow_identity.py \
+            --date-tag "$RELEASE_DATE_TAG" \
+            --release-tag "$RELEASE_TAG" \
+            --prerelease "$RELEASE_PRERELEASE" \
+            --repository "$RELEASE_REPOSITORY" \
+            --target-sha "$RELEASE_TARGET_SHA" \
+            --github-ref "$RELEASE_GITHUB_REF" \
+            --require-draft
+          gh release upload "$RELEASE_TAG" \
+            dist/release/*windows64*.installer.exe \
+            dist/release/*windows64*.portable.zip \
+            dist/release/*windows64.core-update.zip \
+            dist/release/lizzieyzy-next-update-manifest.json \
+            dist/release/*windows64.nvidia.tensorrt.portable.7z.* \
+            dist/release/*windows64.nvidia.tensorrt.portable.README.txt \
+            dist/release/*windows64.nvidia.tensorrt.portable.manifest.json \
+            dist/release/*windows64.nvidia.tensorrt.portable.sha256.txt \
+            --repo "$RELEASE_REPOSITORY" \
+            --clobber

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,11 +16,16 @@ concurrency:
 jobs:
   windows-script-validation:
     runs-on: windows-latest
-    timeout-minutes: 15
+    timeout-minutes: 30
 
     steps:
       - name: Checkout
         uses: actions/checkout@v5
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.x'
 
       - name: Verify clean Windows checkout
         shell: pwsh
@@ -34,6 +39,10 @@ jobs:
       - name: Verify repository line endings
         shell: pwsh
         run: python scripts/check_line_endings.py
+
+      - name: Verify bundled JCEF logic on Windows
+        shell: pwsh
+        run: python scripts/test_prepare_bundled_jcef.py
 
       - name: Set up Java 21
         uses: actions/setup-java@v5
@@ -61,7 +70,16 @@ jobs:
         shell: pwsh
         run: >-
           mvn -B "-Dfmt.skip=true"
+          "-Dlizzie.work.dir=$env:RUNNER_TEMP\lizzieyzy-next-credential-tests"
           "-Dtest=PlatformCredentialStoreTest,RemoteComputeConfigTest,MigratingCredentialStoreTest"
+          test
+
+      - name: Run full Windows unit suite
+        shell: pwsh
+        run: >-
+          mvn -B "-Dfmt.skip=true"
+          "-Djava.awt.headless=true"
+          "-Dlizzie.work.dir=$env:RUNNER_TEMP\lizzieyzy-next-full-tests"
           test
 
   build:
@@ -107,8 +125,17 @@ jobs:
             scripts/test_macos_bundle_version.py \
             scripts/test_macos_katago_bundle.py \
             scripts/test_publish_release_request.py \
+            scripts/release_asset_provenance.py \
+            scripts/test_release_asset_provenance.py \
+            scripts/validate_release_notes.py \
+            scripts/test_validate_release_notes.py \
+            scripts/test_macos_signing_security.py \
             scripts/test_r2_release.py \
-            scripts/test_windows_launcher_packaging.py
+            scripts/test_windows_launcher_packaging.py \
+            scripts/test_validate_windows_release_assets.py \
+            scripts/validate_windows_release_assets.py \
+            scripts/test_validate_release_workflow_identity.py \
+            scripts/validate_release_workflow_identity.py
           python3 scripts/test_generate_release_notes.py
           python3 scripts/test_audit_katago_binary_version.py
           python3 scripts/test_audit_katago_package_metadata.py
@@ -117,9 +144,14 @@ jobs:
           python3 scripts/test_macos_katago_bundle.py
           bash scripts/test_prepare_bundled_katago.sh
           python3 scripts/test_prepare_bundled_jcef.py
-          python3 scripts/test_publish_release_request.py
+          python3 -m unittest scripts.test_publish_release_request
+          python3 -m unittest scripts.test_release_asset_provenance
+          python3 -m unittest scripts.test_validate_release_notes
+          python3 -m unittest scripts.test_macos_signing_security
           python3 -m unittest scripts.test_r2_release
           python3 scripts/test_windows_launcher_packaging.py
+          python3 -m unittest scripts.test_validate_windows_release_assets
+          python3 -m unittest scripts.test_validate_release_workflow_identity
           bash -n \
             scripts/create_macos_drag_dmg.sh \
             scripts/prepare_bundled_katago.sh \

--- a/.github/workflows/publish-requested-pre-release.yml
+++ b/.github/workflows/publish-requested-pre-release.yml
@@ -27,7 +27,7 @@ jobs:
     timeout-minutes: 360
 
     steps:
-      - name: Checkout exact release source
+      - name: Checkout request discovery source
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
@@ -62,19 +62,21 @@ jobs:
             request_file="${requests[0]}"
           fi
 
-          case "$request_file" in
-            .github/release-requests/*.json) ;;
-            *)
-              echo "Request must be a JSON file under .github/release-requests" >&2
-              exit 1
-              ;;
-          esac
+          if [[ ! "$request_file" =~ ^\.github/release-requests/[A-Za-z0-9._-]+\.json$ ]]; then
+            echo "Request must match .github/release-requests/[A-Za-z0-9._-]+.json" >&2
+            exit 1
+          fi
           test -f "$request_file"
           release_tag="$(
             python3 -c \
               'import json, sys; print(json.load(open(sys.argv[1], encoding="utf-8"))["release_tag"])' \
               "$request_file"
           )"
+          if [[ ! "$release_tag" =~ ^next-[0-9]{4}-[0-9]{2}-[0-9]{2}\.[1-9][0-9]*$ ]]; then
+            echo "Invalid release tag in $request_file" >&2
+            exit 1
+          fi
+          request_sha256="$(sha256sum "$request_file" | awk '{print $1}')"
           target_sha="$TARGET_SHA"
           if git show-ref --verify --quiet "refs/tags/$release_tag"; then
             target_sha="$(git rev-parse "refs/tags/${release_tag}^{commit}")"
@@ -83,19 +85,65 @@ jobs:
             exit 1
           fi
           echo "request_file=$request_file" >> "$GITHUB_OUTPUT"
+          echo "request_sha256=$request_sha256" >> "$GITHUB_OUTPUT"
+          echo "release_tag=$release_tag" >> "$GITHUB_OUTPUT"
           echo "target_sha=$target_sha" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout exact target SHA
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+          ref: ${{ steps.request.outputs.target_sha }}
+
+      - name: Revalidate request in exact target tree
+        shell: bash
+        env:
+          RELEASE_REQUEST_FILE: ${{ steps.request.outputs.request_file }}
+          EXPECTED_REQUEST_SHA256: ${{ steps.request.outputs.request_sha256 }}
+          EXPECTED_RELEASE_TAG: ${{ steps.request.outputs.release_tag }}
+          RELEASE_TARGET_SHA: ${{ steps.request.outputs.target_sha }}
+        run: |
+          set -euo pipefail
+          if [[ ! "$RELEASE_REQUEST_FILE" =~ ^\.github/release-requests/[A-Za-z0-9._-]+\.json$ ]]; then
+            echo "Request path changed after exact-target checkout" >&2
+            exit 1
+          fi
+          test "$(git rev-parse HEAD)" = "$RELEASE_TARGET_SHA"
+          test -f "$RELEASE_REQUEST_FILE"
+          actual_request_sha256="$(sha256sum "$RELEASE_REQUEST_FILE" | awk '{print $1}')"
+          if [[ "$actual_request_sha256" != "$EXPECTED_REQUEST_SHA256" ]]; then
+            echo "Release request content differs from the exact target tree" >&2
+            exit 1
+          fi
+          actual_release_tag="$(
+            python3 -c \
+              'import json, sys; print(json.load(open(sys.argv[1], encoding="utf-8"))["release_tag"])' \
+              "$RELEASE_REQUEST_FILE"
+          )"
+          if [[ "$actual_release_tag" != "$EXPECTED_RELEASE_TAG" ]]; then
+            echo "Release tag differs after exact-target checkout" >&2
+            exit 1
+          fi
 
       - name: Test release metadata and fail-closed publishing
         run: |
           python3 -m unittest \
             scripts.test_publish_release_request \
-            scripts.test_generate_release_notes
+            scripts.test_generate_release_notes \
+            scripts.test_release_asset_provenance \
+            scripts.test_validate_release_notes \
+            scripts.test_macos_signing_security \
+            scripts.test_validate_windows_release_assets \
+            scripts.test_validate_release_workflow_identity
 
       - name: Build, verify, and publish the pre-release
         env:
           GITHUB_TOKEN: ${{ github.token }}
+          RELEASE_REQUEST_FILE: ${{ steps.request.outputs.request_file }}
+          RELEASE_REPOSITORY: ${{ github.repository }}
+          RELEASE_TARGET_SHA: ${{ steps.request.outputs.target_sha }}
         run: |
           python3 scripts/publish_release_request.py \
-            --request "${{ steps.request.outputs.request_file }}" \
-            --repository "${{ github.repository }}" \
-            --target-sha "${{ steps.request.outputs.target_sha }}"
+            --request "$RELEASE_REQUEST_FILE" \
+            --repository "$RELEASE_REPOSITORY" \
+            --target-sha "$RELEASE_TARGET_SHA"

--- a/.github/workflows/update-release-notes.yml
+++ b/.github/workflows/update-release-notes.yml
@@ -1,4 +1,5 @@
 name: Update Release Notes
+run-name: "Update notes for ${{ inputs.release_tag }} | ${{ inputs.date_tag }} | prerelease=${{ inputs.release_prerelease }}"
 
 on:
   workflow_dispatch:
@@ -6,18 +7,33 @@ on:
       date_tag:
         description: Release date tag, for example 2026-03-23
         required: true
-        default: 2026-05-06
       release_tag:
         description: Existing GitHub release tag to update
         required: true
-        default: next-2026-05-06.1
+      release_prerelease:
+        description: Exact pre-release state of the existing release
+        required: true
+        type: choice
+        options:
+          - 'true'
+          - 'false'
 
 permissions:
   contents: write
 
+concurrency:
+  group: publish-requested-pre-release
+  cancel-in-progress: false
+
 jobs:
   update:
     runs-on: ubuntu-latest
+    env:
+      RELEASE_DATE_TAG: ${{ inputs.date_tag }}
+      RELEASE_TAG: ${{ inputs.release_tag }}
+      RELEASE_PRERELEASE: ${{ inputs.release_prerelease }}
+      RELEASE_REPOSITORY: ${{ github.repository }}
+      RELEASE_NOTES_PATH: dist/release-meta/${{ inputs.date_tag }}-release-notes.md
 
     steps:
       - name: Checkout
@@ -28,32 +44,68 @@ jobs:
         with:
           python-version: '3.x'
 
+      - name: Refuse audited release notes overwrite
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ "$RELEASE_TAG" == "next-2026-08-19.1" ]]; then
+            echo "The audited release notes for $RELEASE_TAG are immutable." >&2
+            exit 1
+          fi
+
+      - name: Validate release edit identity
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: >-
+          python3 scripts/validate_release_workflow_identity.py
+          --date-tag "$RELEASE_DATE_TAG"
+          --release-tag "$RELEASE_TAG"
+          --prerelease "$RELEASE_PRERELEASE"
+          --repository "$RELEASE_REPOSITORY"
+
       - name: Generate release notes
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           python3 scripts/generate_release_notes.py \
             --from-gh \
-            --repo "${{ github.repository }}" \
-            --release-tag "${{ inputs.release_tag }}" \
-            --date-tag "${{ inputs.date_tag }}" \
-            --output "dist/release-meta/${{ inputs.date_tag }}-release-notes.md"
+            --repo "$RELEASE_REPOSITORY" \
+            --release-tag "$RELEASE_TAG" \
+            --date-tag "$RELEASE_DATE_TAG" \
+            --output "$RELEASE_NOTES_PATH"
 
       - name: Upload generated notes artifact
         uses: actions/upload-artifact@v6
         with:
           name: release-notes
-          path: dist/release-meta/${{ inputs.date_tag }}-release-notes.md
+          path: ${{ env.RELEASE_NOTES_PATH }}
+          if-no-files-found: error
 
       - name: Update GitHub release body
         env:
           GH_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
-          release_title="LizzieYzy Next ${{ inputs.release_tag }}"
-          if [ "${{ inputs.release_tag }}" = "next-2026-06-29.1" ]; then
-            release_title="LizzieYzy Next 首冠版 ${{ inputs.release_tag }}"
+          set -euo pipefail
+          if [[ "$RELEASE_TAG" == "next-2026-08-19.1" ]]; then
+            echo "The audited release notes for $RELEASE_TAG are immutable." >&2
+            exit 1
           fi
-          gh release edit "${{ inputs.release_tag }}" \
-            --repo "${{ github.repository }}" \
+          python3 scripts/validate_release_workflow_identity.py \
+            --date-tag "$RELEASE_DATE_TAG" \
+            --release-tag "$RELEASE_TAG" \
+            --prerelease "$RELEASE_PRERELEASE" \
+            --repository "$RELEASE_REPOSITORY"
+          python3 scripts/validate_release_notes.py \
+            --notes-file "$RELEASE_NOTES_PATH" \
+            --date-tag "$RELEASE_DATE_TAG" \
+            --release-tag "$RELEASE_TAG" \
+            --repository "$RELEASE_REPOSITORY"
+          release_title="LizzieYzy Next $RELEASE_TAG"
+          if [[ "$RELEASE_TAG" == "next-2026-06-29.1" ]]; then
+            release_title="LizzieYzy Next 首冠版 $RELEASE_TAG"
+          fi
+          gh release edit "$RELEASE_TAG" \
+            --repo "$RELEASE_REPOSITORY" \
             --title "$release_title" \
-            --notes-file "dist/release-meta/${{ inputs.date_tag }}-release-notes.md"
+            --notes-file "$RELEASE_NOTES_PATH"

--- a/README_EN.md
+++ b/README_EN.md
@@ -114,7 +114,7 @@ Quick rule:
 - Windows: start with `*windows64.opencl.portable.zip`
 - Windows + RTX 20/30/40 NVIDIA GPU: start with `*windows64.nvidia.portable.zip`
 - Windows + RTX 5070/5080/5090: start with `*windows64.nvidia50.cuda.portable.zip`
-- Windows + RTX 20/30/40/50 and TensorRT testing: do not look for a separate release asset; install it on demand from KataGo Auto Setup after launching the matching NVIDIA/CUDA package; the app will detect GPU and Compute Capability before recommending it
+- Windows + RTX 20/30/40/50 and TensorRT testing: regular users should install it on demand from KataGo Auto Setup after launching the matching NVIDIA/CUDA package; advanced offline users may instead download every `*windows64.nvidia.tensorrt.portable.7z.00N` split asset from the Release and extract from `.001`
 - GTX 10 series and older NVIDIA cards: prefer CUDA/OpenCL instead of TensorRT
 - OpenCL unstable: switch to `*windows64.with-katago.portable.zip`
 - Mac: choose Apple Silicon or Intel first

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -52,7 +52,7 @@
 
 ### 历史 tag 说明
 
-部分旧 tag 还会看到早期的 zip 命名或兼容包，但当前维护版公开 release 已统一成 15 个主资产：10 个 Windows、2 个 macOS、3 个 Linux。TensorRT 加速不再作为 GitHub Release 资产发布，改为软件内按需安装。普通用户直接按上面的表选即可。
+部分旧 tag 还会看到早期的 zip 命名或兼容包，但当前维护版公开 release 已统一成 15 个首次下载主资产：10 个 Windows、2 个 macOS、3 个 Linux。TensorRT 的普通用户路径是软件内按需安装；Release 同时保留高级可选离线分卷及其 README、清单和校验文件。普通用户直接按上面的表选即可。
 
 ## Windows 安装
 
@@ -111,7 +111,7 @@ OpenCL 免安装包也能直接打开 `KataGo 一键设置`，点一次“智能
 2. 解压后运行 `LizzieYzy Next NVIDIA 50 CUDA.exe`。
 3. 如果你更喜欢安装流程，改用 `windows64.nvidia50.cuda.installer.exe`。
 
-TensorRT 加速不再单独发布巨大安装包。RTX 20/30/40/50 用户可以先打开对应 NVIDIA/CUDA 包，再进入 `KataGo 一键设置`，点击 `安装 TensorRT 加速`。安装界面会检测本机 NVIDIA GPU / Compute Capability，并显示推荐、可尝试、不推荐或未知状态。RTX 50 属于更新架构，是重点实验加速方向；GTX 10 系及更老显卡建议继续使用 CUDA/OpenCL。软件会从 KataGo / NVIDIA 官方源下载、校验并配置 TensorRT；不需要的用户不会被自动下载。
+TensorRT 不再作为普通用户优先下载的巨大单文件包。RTX 20/30/40/50 用户可以先打开对应 NVIDIA/CUDA 包，再进入 `KataGo 一键设置`，点击 `安装 TensorRT 加速`。安装界面会检测本机 NVIDIA GPU / Compute Capability，并显示推荐、可尝试、不推荐或未知状态。RTX 50 属于更新架构，是重点实验加速方向；GTX 10 系及更老显卡建议继续使用 CUDA/OpenCL。软件会从 KataGo / NVIDIA 官方源下载、校验并配置 TensorRT；不需要的用户不会被自动下载。需要完全离线安装的高级用户也可以从 Release 下载全部 `.7z.00N` 分卷，并按同名 README、清单和 SHA-256 文件校验后从 `.001` 解压。
 
 ### Windows 64 位无引擎包
 

--- a/docs/INSTALL_EN.md
+++ b/docs/INSTALL_EN.md
@@ -52,7 +52,7 @@ Quick rule:
 
 ### Legacy tag note
 
-Some older tags still show transitional zip names or compatibility packages, but the current maintained release now centers on 15 primary assets: 10 Windows, 2 macOS, and 3 Linux packages. TensorRT acceleration is no longer published as a GitHub Release asset; it is installed on demand inside the app.
+Some older tags still show transitional zip names or compatibility packages, but the current maintained release now centers on 15 first-download assets: 10 Windows, 2 macOS, and 3 Linux packages. In-app installation is the regular TensorRT path; the Release also retains an advanced optional offline split package with its README, manifest, and checksum file.
 
 ## Windows
 
@@ -108,7 +108,7 @@ If your GPU is an RTX 5070, RTX 5080, or RTX 5090:
 2. Extract it and run `LizzieYzy Next NVIDIA 50 CUDA.exe`.
 3. If you prefer an installer, use `windows64.nvidia50.cuda.installer.exe`.
 
-TensorRT acceleration is no longer shipped as a huge standalone package. RTX 20/30/40/50 users can launch the matching NVIDIA/CUDA package, open `KataGo Auto Setup`, and click `Install TensorRT acceleration`. The install UI detects the local NVIDIA GPU / Compute Capability and shows recommended, try, not recommended, or unknown status. RTX 50 is the newer architecture and remains the key experimental acceleration path; GTX 10 series and older cards should prefer CUDA/OpenCL. The app downloads, verifies, and configures files from official KataGo / NVIDIA sources only; users who do not click it will not download TensorRT.
+TensorRT acceleration is no longer a huge standalone package recommended to regular users. RTX 20/30/40/50 users can launch the matching NVIDIA/CUDA package, open `KataGo Auto Setup`, and click `Install TensorRT acceleration`. The install UI detects the local NVIDIA GPU / Compute Capability and shows recommended, try, not recommended, or unknown status. RTX 50 is the newer architecture and remains the key experimental acceleration path; GTX 10 series and older cards should prefer CUDA/OpenCL. The app downloads, verifies, and configures files from official KataGo / NVIDIA sources only; users who do not click it will not download TensorRT. Advanced users who need a fully offline install can instead download every `.7z.00N` split asset from the Release, verify it against the matching README, manifest, and SHA-256 file, and extract from `.001`.
 
 ### Windows x64 no-engine build
 

--- a/docs/MACOS_SIGNING.md
+++ b/docs/MACOS_SIGNING.md
@@ -2,7 +2,7 @@
 
 ## 需要的 GitHub Secrets
 
-在仓库的 `Settings → Secrets and variables → Actions` 里添加以下 secrets（缺任何一个都会自动跳过签名步骤，产物仍然是未签名的 DMG）：
+在仓库的 `Settings → Secrets and variables → Actions` 里添加以下 secrets。四个必需 secret 全部未配置时，脚本会明确打印“跳过签名”，方便本地构建；只配置了一部分时会直接失败，避免误把未签名 DMG 当成正式发布资产。
 
 | Secret | 作用 | 获取方式 |
 |---|---|---|
@@ -31,16 +31,16 @@
 
 ## Workflow 行为
 
-`build-macos-arm64-release.yml` 和 `build-macos-amd64-release.yml` 在 jpackage 生成 DMG 之后，如果以上 secrets 都已配置，会调用 `scripts/sign_macos_release.sh`：
+`build-macos-arm64-release.yml` 和 `build-macos-amd64-release.yml` 在 jpackage 生成 DMG 之后，如果 `APPLE_CERT_P12`、`APPLE_ID`、`APPLE_APP_PASSWORD`、`APPLE_TEAM_ID` 四个必需 secret 都已配置，会调用 `scripts/sign_macos_release.sh`：
 
-- 创建临时 keychain 导入证书
-- 把 DMG 里的 `.app` 解出，用 `codesign --options runtime --timestamp --deep` 签名所有 `.dylib` 和可执行文件
+- 在导入证书前安装清理 trap，创建仅本次运行使用的随机临时 keychain 和权限为 `0600` 的证书临时文件
+- 把 DMG 里的 `.app` 解出，按“内层原生库/辅助程序 → framework → 主程序 → 外层 `.app`”逐层执行 `codesign --options runtime --timestamp`；`--deep` 只用于签名后的递归验证，不用于签名
 - 重新打包成 DMG，再次签名 DMG
 - 用 `xcrun notarytool submit --wait` 提交公证
 - 用 `xcrun stapler staple` 附着公证票据
 - 用 `spctl --assess` 复查通过
 
-如果 secrets 没配置，脚本打印一行后 `exit 0`，构建流程完全不受影响。
+四个必需 secret 全部未配置时，脚本打印一行后 `exit 0`，本地构建不受影响。只要其中任意一个已配置，其余必需 secret 就必须全部存在；部分配置会 fail closed。`APPLE_CERT_PASSWORD` 可以为空，`APPLE_SIGN_IDENTITY` 仍是可选覆盖。
 
 ## 验证
 
@@ -49,7 +49,7 @@
 命令行验证：
 
 ```bash
-spctl --assess --type install -vvv path/to/LizzieYzy-Next.dmg
+spctl --assess --type open --context context:primary-signature -vvv path/to/LizzieYzy-Next.dmg
 # 应该显示:
 #   path: accepted
 #   source=Notarized Developer ID
@@ -57,7 +57,7 @@ spctl --assess --type install -vvv path/to/LizzieYzy-Next.dmg
 
 ## 失败兜底
 
-如果签名/公证失败，已上传到 GitHub Releases 的资产会是未签名版本（这步失败不会阻断 artifact 上传）。但 workflow 整体会标记失败，方便你看错误日志。
+如果证书导入、逐层签名、公证、票据附着、布局校验或最终 `spctl` Gatekeeper 评估失败，workflow 会在替换原始 DMG 和上传 Release asset 之前终止，因此不会把本次未通过完整校验的 DMG 上传到 GitHub Release。清理 trap 会在任何早期失败时删除 P12 临时文件、随机 keychain、挂载点和工作目录。只有全部校验成功后，工作目录中的已签名 DMG 才会替换原文件并进入 provenance 与 Release 上传步骤。
 
 常见问题：
 - `notarytool` 超时 → 重跑 workflow 即可

--- a/docs/MAINTENANCE.md
+++ b/docs/MAINTENANCE.md
@@ -47,7 +47,7 @@
 - Linux 64 位：`opencl.zip`
 - Linux 64 位：`nvidia.zip`
 
-TensorRT 加速不再进入公开资产矩阵。RTX 20/30/40/50 用户需要时在软件内 `KataGo 一键设置` 中显式安装；界面会检测 NVIDIA GPU / Compute Capability 后给出推荐状态。RTX 50 仍优先下载 `nvidia50.cuda` 包，GTX 10 系及更老显卡优先 CUDA/OpenCL。
+TensorRT 加速不计入 15 个首次下载主资产；RTX 20/30/40/50 用户的默认路径仍是在软件内 `KataGo 一键设置` 中显式安装，界面会检测 NVIDIA GPU / Compute Capability 后给出推荐状态。Release 同时保留高级可选离线分卷以及 README、清单和 SHA-256 文件，并纳入发布白名单与 provenance 校验。RTX 50 仍优先下载 `nvidia50.cuda` 包，GTX 10 系及更老显卡优先 CUDA/OpenCL。
 
 历史兼容包只有在明确需要时才通过额外开关构建，不再进入主 release 页面。
 

--- a/docs/PACKAGES_EN.md
+++ b/docs/PACKAGES_EN.md
@@ -16,7 +16,7 @@ This page describes the public release layout of the maintained `LizzieYzy Next`
 - If OpenCL behaves poorly, switch to `windows64.with-katago.portable.zip`
 - If you have an RTX 20/30/40 NVIDIA GPU and want more speed, switch to `windows64.nvidia.portable.zip`
 - RTX 5070/5080/5090 users should try `windows64.nvidia50.cuda.portable.zip` first; TensorRT acceleration is installed on demand from inside the app
-- TensorRT is no longer a giant release package; RTX 20/30/40/50 users can install it from `KataGo Auto Setup`. TensorRT is not recommended for GTX 10 series cards; the regular NVIDIA package requires driver `527.41` or newer, and users should switch to the OpenCL package if it still cannot start
+- In-app `KataGo Auto Setup` is the regular TensorRT path; the Release also keeps an advanced optional split offline package. TensorRT is not recommended for GTX 10 series cards; the regular NVIDIA package requires driver `527.41` or newer, and users should switch to the OpenCL package if it still cannot start
 - `KataGo Auto Setup` detects the local NVIDIA GPU / Compute Capability and shows recommended, try, not recommended, or unknown status before TensorRT install
 
 ## The 15 Primary Public Release Assets
@@ -107,7 +107,7 @@ Current bundled defaults:
 - Transformer performs best through CUDA or Metal; OpenCL remains fully offline-capable but is normally slower
 - `core-update.zip` updates only the application and does not include KataGo 1.17 or the new weight; install the latest full bundle to upgrade from the old default
 - Full-bundle migration changes only managed engines still using the old bundled `zhizi 28B` / `default.bin.gz`; custom weights, remote compute, and startup modes are preserved
-- TensorRT acceleration: no longer published as a giant GitHub Release package; RTX 20/30/40/50 users can install it on demand from `KataGo Auto Setup` inside the app
+- TensorRT acceleration: regular users install it on demand from `KataGo Auto Setup`; advanced offline users may download every Release split plus its README, manifest, and SHA-256 file, then extract from `.001`
 - RTX 50 users should still start with the `windows64.nvidia50.cuda` package, with TensorRT as an on-demand acceleration path for the newer architecture
 - The TensorRT install UI uses `nvidia-smi` to detect the local NVIDIA GPU, with a lightweight model-name fallback when Compute Capability is unavailable
 
@@ -129,7 +129,7 @@ From the new maintained releases onward:
 - the main Windows x64 package is `portable.zip`
 - Windows x64 now exposes OpenCL, CPU fallback, NVIDIA, and NVIDIA 50 CUDA variants in both portable and installer forms
 - the Windows x64 no-engine option now has both an installer and a portable `.zip`
-- the public release page keeps the 15 primary user-facing assets above as the main list; TensorRT acceleration is an in-app on-demand install, not a release asset
+- the public release page keeps the 15 primary first-download assets above as the main list; TensorRT uses in-app installation by default, while an advanced optional split offline package and its verification metadata remain Release assets
 - older compatibility zips now stay in historical tags instead of the main recommendation area
 
 ## Related Docs

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -11,14 +11,18 @@
 - 野狐棋谱同步仍然可用，而且明确写成“野狐昵称”
 - 普通 Windows 包支持“智能优化”的信息要写清楚
 - NVIDIA Windows 包“首次自动准备官方运行库”的信息要写清楚
-- RTX 50 系列用户要能明确看到 CUDA 12.8 包是默认下载项；RTX 20/30/40/50 TensorRT 加速是软件内按需安装项
+- RTX 50 系列用户要能明确看到 CUDA 12.8 包是默认下载项；RTX 20/30/40/50 普通用户通过软件内按需安装 TensorRT，高级离线分卷仍作为非默认推荐的发布资产
 - README、安装文档、发布页文案、真实资产名保持一致
 - 软件内“关于”、主窗口标题、安装包启动参数、GitHub release 标题必须显示同一个 release tag，不能停在 `1.0.0`，也不要再把 `1.0.0-` 作为公开 tag 前缀
 - 程序窗口图标、安装包图标、README 展示图标不要混成两套
 
-## 二、当前推荐的公开资产集合
+## 二、当前 fail-closed 公开资产集合
 
-新发布时，优先保留下面这组资产：
+当前预发布器会先保持 GitHub Release 为 draft，只有四个平台工作流全部成功、下面的
+强制资产完整且六语发布正文通过校验后才公开 pre-release。任何一项缺失都必须保持 draft。
+
+所有带日期的文件都使用 `<date>-` 前缀，例如
+`2026-08-19-windows64.opencl.portable.zip`。当前强制公开集合是：
 
 - `windows64.opencl.portable.zip`
 - `windows64.opencl.installer.exe`
@@ -30,12 +34,25 @@
 - `windows64.nvidia50.cuda.installer.exe`
 - `windows64.without.engine.portable.zip`
 - `windows64.without.engine.installer.exe`
-- `windows64-install.txt`
+- `windows64.core-update.zip`
+- `lizzieyzy-next-update-manifest.json`（唯一不带 `<date>-` 前缀的更新清单）
+- `windows64.nvidia.tensorrt.portable.7z.001`
+- `windows64.nvidia.tensorrt.portable.7z.002`
+- `windows64.nvidia.tensorrt.portable.README.txt`
+- `windows64.nvidia.tensorrt.portable.manifest.json`
+- `windows64.nvidia.tensorrt.portable.sha256.txt`
 - `mac-apple-silicon.with-katago.dmg`
-- `mac-apple-silicon-install.txt`
 - `mac-intel.with-katago.dmg`
-- `mac-intel-install.txt`
 - `linux64.with-katago.zip`
+- `linux64.opencl.zip`
+- `linux64.nvidia.zip`
+
+这里的“强制公开”不等于“普通用户默认推荐”。TensorRT 分卷只面向需要离线预装的高级
+用户，普通用户仍应从软件内按需安装；但在当前 fail-closed 预发布链路中，分卷及其 README、
+manifest、SHA-256 文件仍是缺一不可的强制资产。
+
+`windows64-install.txt`、`mac-apple-silicon-install.txt`、`mac-intel-install.txt` 等安装说明
+属于构建元数据，不在当前 GitHub Release 公开上传白名单中，不要把它们写成公开资产。
 
 不再建议重新上传的旧思路：
 
@@ -58,15 +75,19 @@
 - `scripts/macos_katago_bundle.py`
 - `scripts/package_windows_exe.sh`
 - `scripts/generate_release_notes.py`
+- `scripts/publish_release_request.py`
+- `scripts/r2_release.py`
 - `scripts/validate_release_assets.sh`
 
 GitHub Actions：
 
+- `.github/workflows/publish-requested-pre-release.yml`
 - `.github/workflows/build-windows-release.yml`
 - `.github/workflows/build-linux-release.yml`
 - `.github/workflows/build-macos-arm64-release.yml`
 - `.github/workflows/build-macos-amd64-release.yml`
 - `.github/workflows/update-release-notes.yml`
+- `.github/workflows/promote-stable-release.yml`
 
 ## 四、构建前检查
 
@@ -75,9 +96,11 @@ GitHub Actions：
 - `README.md` 和 `README_EN.md` 的包名与计划上传的文件完全一致
 - 安装文档里的 Windows 主路径仍然是 `portable.zip`
 - 如果提供 NVIDIA 极速包，要同时核对 `nvidia.installer.exe` 和 `nvidia.portable.zip`
-- 如果提供 RTX 50 包，要核对 `nvidia50.cuda.*`，并在发布说明里写清 TensorRT 只从软件内按需安装，不再作为 release asset，安装界面会检测 NVIDIA GPU / Compute Capability
+- 必须核对 `nvidia50.cuda.*`，并在发布说明里写清：普通用户从软件内按需安装 TensorRT，安装界面会检测 NVIDIA GPU / Compute Capability；Release 中的 TensorRT 分卷是高级离线选项，不是默认推荐，但仍是当前预发布链路的强制资产
 - 如果提供 OpenCL 包，要同时核对 `opencl.installer.exe` 和 `opencl.portable.zip`
 - 如果提供 Windows 无引擎包，要同时核对 `without.engine.installer.exe` 和 `without.engine.portable.zip`
+- 必须核对 `windows64.core-update.zip` 与 `lizzieyzy-next-update-manifest.json`，并确认更新清单中的 tag、资产名、大小和 SHA-256 对应本次构建
+- Linux 必须同时核对 `linux64.with-katago.zip`、`linux64.opencl.zip` 和 `linux64.nvidia.zip`
 - 界面里仍然写的是 `野狐棋谱（输入野狐昵称获取）`
 - 发布页最上面的中文说明里，要明确写“普通 Windows 包也支持智能优化”
 - 发布页最上面的中文说明里，要明确写“NVIDIA 包首次会自动准备官方运行库”
@@ -124,14 +147,14 @@ python3 scripts/generate_app_icons.py
 - 默认模型大小：`94,281,753` 字节；架构：`transformer`；最低 KataGo：`1.17.0`
 - Windows NVIDIA 包：官方 `cuda12.1-cudnn9.8.0` 构建
 - Windows RTX 50 CUDA 包：官方 `cuda12.8-cudnn9.8.0` 构建
-- Windows TensorRT：不打入主 release 包；RTX 20/30/40/50 用户由软件内 `KataGo 一键设置` 显式下载安装官方 KataGo `v1.17.2` `trt10.9.0-cuda12.8` 构建和所需运行库，并通过 NVIDIA GPU / Compute Capability 检测给出推荐状态；GTX 10 系不建议 TensorRT，普通 NVIDIA 包要求驱动 `527.41` 或更高，仍启动失败时使用 OpenCL 包
+- Windows TensorRT：不内嵌到普通 Windows 主推荐包；RTX 20/30/40/50 普通用户由软件内 `KataGo 一键设置` 显式下载安装官方 KataGo `v1.17.2` `trt10.9.0-cuda12.8` 构建和所需运行库，并通过 NVIDIA GPU / Compute Capability 检测给出推荐状态；当前预发布链路仍强制生成并上传高级离线 TensorRT 分卷及其 README、manifest、SHA-256 文件，缺少任一项都不能公开 pre-release；GTX 10 系不建议 TensorRT，普通 NVIDIA 包要求驱动 `527.41` 或更高，仍启动失败时使用 OpenCL 包
 - `core-update.zip` 必须确认不含 `engines/`、`weights/`、NVIDIA runtime 或 TensorRT
 
 ### 5. 构建 Windows 安装器和便携包
 
 ```bash
 ./scripts/package_windows_exe.sh 2026-04-24 1.0.0 target/lizzie-yzy2.5.3-shaded.jar next-2026-04-24.2
-./scripts/validate_release_assets.sh windows dist/release 2026-04-24
+./scripts/validate_release_assets.sh windows dist/release 2026-04-24 next-2026-04-24.2 true
 ```
 
 ### 6. 构建 Linux 主整合包
@@ -184,8 +207,13 @@ python3 scripts/generate_release_notes.py \
 ```bash
 gh workflow run update-release-notes.yml \
   -f date_tag=2026-04-24 \
-  -f release_tag=next-2026-04-24.2
+  -f release_tag=next-2026-04-24.2 \
+  -f release_prerelease=true
 ```
+
+该工作流要求显式提供 release 的 pre-release 身份，并会再次校验 tag、日期、目标提交、
+占位符和六种语言直链表。已人工审核的 `next-2026-08-19.1` 正文被设为不可覆盖；不要用
+此生成工作流修改它。
 
 ## 六、Release Notes 应该先写什么
 
@@ -222,6 +250,7 @@ R2 只保留当前正式版且设有 `9,000,000,000` 字节硬门禁。完整配
 - 不把免安装包和安装器压缩成同一行，也不使用 `portable / installer` 这类需要用户猜测的短标签。
 - TensorRT 的 `.7z.001` 与 `.7z.002` 是同一套分卷，可以在同一行连续列出，但必须同时显示完整文件名和直链。
 - `publish_release_request.py` 会检查六种语言的下载表；任何语言缺少完整文件名直链都不能发布。
+- `lizzieyzy-next-update-manifest.json` 以及 TensorRT 的 README、manifest、SHA-256 辅助文件不进入普通用户下载表，但必须作为公开 Release 资产存在并通过发布器校验。
 - pre-release 与 Release 正文中的文件直链都保持 GitHub；正式版正文顶部只额外推荐统一的官网下载页面。
 
 ## 七、上传前自查
@@ -231,8 +260,11 @@ R2 只保留当前正式版且设有 `9,000,000,000` 字节硬门禁。完整配
 - 文件名日期一致
 - Windows 主推荐资产确实是 `portable.zip`
 - Windows 无引擎包已经是 `.portable.zip`
+- `windows64.core-update.zip` 与 `lizzieyzy-next-update-manifest.json` 已生成且互相匹配
+- TensorRT `.7z.001`、`.7z.002`、README、manifest、SHA-256 文件全部存在，分卷连续且校验值正确
 - macOS 同时有 `arm64` 与 `amd64` 的 `.dmg`
-- 发布目录里没有把 `.txt`、校验文件或历史兼容包混进公开资产
+- Linux 同时有 `with-katago`、`opencl` 与 `nvidia` 三个 zip
+- 除 TensorRT README、manifest 和 SHA-256 文件外，没有把安装说明 `.txt`、其他校验辅助文件或历史兼容包混进公开资产
 - 没把历史兼容包重新混进主 release 页面
 
 ## 八、上传后，从用户视角复查

--- a/docs/TESTED_PLATFORMS.md
+++ b/docs/TESTED_PLATFORMS.md
@@ -36,7 +36,7 @@
 | `linux64.opencl.zip` | Linux x64 + OpenCL | `Build verified` | OpenCL 包继续提供 | 需要真实 Linux OpenCL 反馈 |
 | `linux64.nvidia.zip` | Linux x64 + NVIDIA | `Build verified` | NVIDIA CUDA 包继续提供 | 需要真实 Linux NVIDIA 反馈 |
 
-说明：TensorRT 加速现在是软件内按需安装功能，不再作为 GitHub Release 包验证；RTX 20/30/40/50 用户可按需安装，RTX 50 仍优先验证 CUDA 主包。
+说明：TensorRT 加速的普通用户路径是软件内按需安装；GitHub Release 同时保留高级可选离线分卷，并校验分卷数量、清单、大小和 SHA-256。真实吞吐、功耗和驱动兼容仍需在对应 RTX 20/30/40/50 Windows 硬件上验证，RTX 50 仍优先验证 CUDA 主包。
 
 ## 我们重点关心什么
 

--- a/scripts/package_windows_exe.sh
+++ b/scripts/package_windows_exe.sh
@@ -960,7 +960,7 @@ EOF
   if [[ "$has_tensorrt_split" == "true" ]]; then
     cat >>"$note_file" <<'EOF'
 - The advanced optional TensorRT split package is for users who already know how to extract multi-volume 7z archives.
-- It is not the default recommended package. Download all .7z.00N volumes before extracting; downloading only .7z.001 is not enough.
+- It is not the default recommended package. Download both .7z.001 and .7z.002 before extracting.
 EOF
   fi
 
@@ -1007,8 +1007,8 @@ write_tensorrt_split_readme() {
 不确定怎么选的普通用户，请下载普通 NVIDIA/CUDA 包，然后在软件内「KataGo 一键设置」安装 TensorRT；软件内安装支持断点续传。
 
 解压方法：
-1. 下载本次 release 里的全部 ${DATE_TAG}-${NVIDIA_TRT_ARCH_TAG}.portable.7z.00N 文件。
-2. 只下载 .7z.001 没有用，必须把 .001、.002、.003 等所有分卷放在同一个文件夹。
+1. 下载本次 release 里的 ${DATE_TAG}-${NVIDIA_TRT_ARCH_TAG}.portable.7z.001 和 .002。
+2. 只下载 .7z.001 没有用，必须把 .001、.002 两个分卷放在同一个文件夹。
 3. 安装 7-Zip。
 4. 右键 ${DATE_TAG}-${NVIDIA_TRT_ARCH_TAG}.portable.7z.001，选择 7-Zip 解压。
 5. 解压后打开 ${NVIDIA_TRT_APP_NAME}.exe。
@@ -1025,8 +1025,8 @@ This package is only for RTX 20/30/40/50 users who are comfortable with 7-Zip an
 Most users should download the regular NVIDIA/CUDA package and install TensorRT from KataGo Auto Setup inside the app; the in-app installer supports resume.
 
 How to extract:
-1. Download every ${DATE_TAG}-${NVIDIA_TRT_ARCH_TAG}.portable.7z.00N file from this release.
-2. Downloading only .7z.001 is not enough. Put all .001, .002, .003, ... volumes in the same folder.
+1. Download ${DATE_TAG}-${NVIDIA_TRT_ARCH_TAG}.portable.7z.001 and .002 from this release.
+2. Downloading only .7z.001 is not enough. Put both .001 and .002 volumes in the same folder.
 3. Install 7-Zip.
 4. Right-click ${DATE_TAG}-${NVIDIA_TRT_ARCH_TAG}.portable.7z.001 and extract with 7-Zip.
 5. Launch ${NVIDIA_TRT_APP_NAME}.exe.
@@ -1095,7 +1095,7 @@ payload = {
     "katagoSha256": katago_sha256,
     "parts": parts,
     "userGuidance": [
-        "Download all .7z.00N parts before extracting.",
+        "Download both .7z.001 and .7z.002 before extracting.",
         "Most users should use the in-app TensorRT installer with resume support instead.",
         "GTX 10 series and older NVIDIA GPUs should prefer CUDA/OpenCL.",
     ],
@@ -1134,8 +1134,11 @@ create_tensorrt_split_package() {
   shopt -s nullglob
   split_parts=("$archive_base.7z".[0-9][0-9][0-9])
   shopt -u nullglob
-  if (( ${#split_parts[@]} == 0 )) || [[ "$(basename "${split_parts[0]}")" != "$(basename "$archive_base").7z.001" ]]; then
-    echo "TensorRT split package was not produced correctly: $archive_base.7z.001" >&2
+  if (( ${#split_parts[@]} != 2 )) \
+    || [[ "$(basename "${split_parts[0]}")" != "$(basename "$archive_base").7z.001" ]] \
+    || [[ "$(basename "${split_parts[1]}")" != "$(basename "$archive_base").7z.002" ]]; then
+    echo "TensorRT split package must contain exactly .001 and .002 volumes" >&2
+    printf 'Produced: %s\n' "${split_parts[@]:-<none>}" >&2
     return 1
   fi
 

--- a/scripts/publish_release_request.py
+++ b/scripts/publish_release_request.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 
 import argparse
 from dataclasses import dataclass
+import hashlib
+import io
 import json
 import os
 from pathlib import Path
@@ -19,6 +21,12 @@ from typing import Callable, Iterable
 from urllib.error import HTTPError
 from urllib.parse import quote, urlencode
 from urllib.request import Request, urlopen
+import zipfile
+
+try:
+    from scripts import release_asset_provenance as provenance
+except ModuleNotFoundError:  # Direct execution: python scripts/publish_release_request.py
+    import release_asset_provenance as provenance  # type: ignore[no-redef]
 
 
 API_VERSION = "2026-03-10"
@@ -52,6 +60,16 @@ DIRECT_DOWNLOAD_SUFFIXES = (
     "linux64.nvidia.zip",
 )
 ACTIVE_RUN_STATUSES = {"queued", "in_progress", "waiting", "requested", "pending"}
+CI_WORKFLOW_FILE = "ci.yml"
+UNRESOLVED_NOTE_MARKERS = (
+    re.compile(r"\bFULL_TEST_COUNT\b"),
+    re.compile(r"\bREAL_GUI_VALIDATION_[A-Z0-9_]*\b"),
+    re.compile(
+        r"\b(?:TODO|TBD|FIXME|PLACEHOLDER|REPLACE_ME|CHANGEME)\b",
+        re.IGNORECASE,
+    ),
+    re.compile(r"\{\{|\}\}"),
+)
 
 
 class PublishError(RuntimeError):
@@ -121,6 +139,18 @@ def validate_direct_download_tables(
                     )
 
 
+def validate_no_unresolved_note_markers(body: str) -> None:
+    """Reject release notes that still contain authoring placeholders."""
+
+    for marker in UNRESOLVED_NOTE_MARKERS:
+        match = marker.search(body)
+        if match is not None:
+            raise PublishError(
+                "Reviewed release notes contain an unresolved marker: "
+                f"{match.group(0)}"
+            )
+
+
 @dataclass(frozen=True)
 class ReleaseRequest:
     date_tag: str
@@ -175,8 +205,19 @@ class WorkflowSpec:
     platform: str
     workflow_file: str
     exact_suffixes: tuple[str, ...]
+    run_name_template: str
+    provenance_platform: str
     required_patterns: tuple[re.Pattern[str], ...] = ()
     dispatch_inputs: tuple[tuple[str, str], ...] = ()
+
+    def expected_run_name(
+        self, date_tag: str, release_tag: str, prerelease: str = "true"
+    ) -> str:
+        return self.run_name_template.format(
+            date_tag=date_tag,
+            release_tag=release_tag,
+            prerelease=prerelease,
+        )
 
     def missing_assets(self, asset_names: Iterable[str], date_tag: str) -> list[str]:
         names = set(asset_names)
@@ -211,37 +252,173 @@ WORKFLOWS = (
             "windows64.nvidia.tensorrt.portable.README.txt",
             "windows64.nvidia.tensorrt.portable.manifest.json",
             "windows64.nvidia.tensorrt.portable.sha256.txt",
+            "windows64.nvidia.tensorrt.portable.7z.001",
+            "windows64.nvidia.tensorrt.portable.7z.002",
         ),
-        (re.compile(r"^{date}-windows64\.nvidia\.tensorrt\.portable\.7z\.\d{{3}}$"),),
-        (("release_prerelease", "true"),),
+        "Windows release {release_tag} | {date_tag} | prerelease={prerelease}",
+        "windows",
+        dispatch_inputs=(("release_prerelease", "true"),),
     ),
     WorkflowSpec(
         "Linux",
         "build-linux-release.yml",
         ("linux64.with-katago.zip", "linux64.opencl.zip", "linux64.nvidia.zip"),
+        "Linux release {release_tag} | {date_tag} | prerelease={prerelease}",
+        "linux",
+        dispatch_inputs=(("release_prerelease", "true"),),
     ),
     WorkflowSpec(
         "macOS Intel",
         "build-macos-amd64-release.yml",
         ("mac-intel.with-katago.dmg",),
+        "macOS Intel release {release_tag} | {date_tag} | prerelease={prerelease}",
+        "mac-amd64",
+        dispatch_inputs=(("release_prerelease", "true"),),
     ),
     WorkflowSpec(
         "macOS Apple Silicon",
         "build-macos-arm64-release.yml",
         ("mac-apple-silicon.with-katago.dmg",),
+        "macOS Apple Silicon release {release_tag} | {date_tag} | prerelease={prerelease}",
+        "mac-arm64",
+        dispatch_inputs=(("release_prerelease", "true"),),
     ),
 )
 
 
 class GitHubClient:
-    def __init__(self, repository: str, token: str, api_url: str | None = None) -> None:
+    def __init__(
+        self,
+        repository: str,
+        token: str,
+        api_url: str | None = None,
+        *,
+        sleep: Callable[[float], None] = time.sleep,
+        retry_attempts: int = 5,
+    ) -> None:
         if not token:
             raise PublishError("GITHUB_TOKEN is required")
         if not re.fullmatch(r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+", repository):
             raise PublishError("repository must use owner/name format")
+        if retry_attempts < 1:
+            raise PublishError("retry_attempts must be positive")
         self.repository = repository
         self.token = token
         self.api_url = (api_url or "https://api.github.com").rstrip("/")
+        self.sleep = sleep
+        self.retry_attempts = retry_attempts
+
+    @staticmethod
+    def _retry_delay(exc: HTTPError | None, attempt: int) -> float:
+        fallback = float(min(2**attempt, 30))
+        if exc is None:
+            return fallback
+        headers = exc.headers or {}
+        retry_after = headers.get("Retry-After")
+        if retry_after:
+            try:
+                return float(max(0, min(int(retry_after), 60)))
+            except ValueError:
+                pass
+        reset = headers.get("X-RateLimit-Reset")
+        if reset:
+            try:
+                return float(max(0, min(int(reset) - int(time.time()) + 1, 60)))
+            except ValueError:
+                pass
+        return fallback
+
+    @staticmethod
+    def _is_transient_http_error(exc: HTTPError) -> bool:
+        headers = exc.headers or {}
+        return (
+            exc.code == 429
+            or 500 <= exc.code <= 599
+            or (
+                exc.code == 403
+                and (
+                    headers.get("Retry-After") is not None
+                    or headers.get("X-RateLimit-Remaining") == "0"
+                )
+            )
+        )
+
+    def _request_raw(
+        self,
+        method: str,
+        path: str,
+        payload: dict[str, object] | None = None,
+        expected: tuple[int, ...] = (200,),
+        allow_not_found: bool = False,
+        *,
+        accept: str = "application/vnd.github+json",
+        max_bytes: int = 16 * 1024 * 1024,
+        retry_transient: bool = True,
+    ) -> tuple[int, bytes | None]:
+        body = json.dumps(payload).encode("utf-8") if payload is not None else None
+        attempts = self.retry_attempts if retry_transient else 1
+        for attempt in range(1, attempts + 1):
+            request = Request(
+                f"{self.api_url}{path}",
+                data=body,
+                method=method,
+                headers={
+                    "Accept": accept,
+                    "Content-Type": "application/json",
+                    "User-Agent": "lizzieyzy-next-release-publisher",
+                    "X-GitHub-Api-Version": API_VERSION,
+                },
+            )
+            # GitHub's artifact download endpoint redirects to a short-lived
+            # external storage URL. Keep the repository token on the first hop
+            # only: urllib copies ordinary headers to redirected requests.
+            request.add_unredirected_header(
+                "Authorization", f"Bearer {self.token}"
+            )
+            try:
+                with urlopen(request, timeout=60) as response:
+                    status = response.status
+                    raw = response.read(max_bytes + 1)
+            except HTTPError as exc:
+                if allow_not_found and exc.code == 404:
+                    return 404, None
+                detail = exc.read(2000).decode("utf-8", errors="replace")
+                if self._is_transient_http_error(exc) and attempt < attempts:
+                    delay = self._retry_delay(exc, attempt)
+                    print(
+                        f"GitHub API {method} {path} returned {exc.code}; "
+                        f"retrying in {delay:g}s ({attempt}/{attempts})",
+                        file=sys.stderr,
+                        flush=True,
+                    )
+                    self.sleep(delay)
+                    continue
+                raise PublishError(
+                    f"GitHub API {method} {path} failed ({exc.code}): {detail}"
+                ) from exc
+            except OSError as exc:
+                if attempt < attempts:
+                    delay = self._retry_delay(None, attempt)
+                    print(
+                        f"GitHub API {method} {path} failed transiently; "
+                        f"retrying in {delay:g}s ({attempt}/{attempts})",
+                        file=sys.stderr,
+                        flush=True,
+                    )
+                    self.sleep(delay)
+                    continue
+                raise PublishError(f"GitHub API {method} {path} failed: {exc}") from exc
+
+            if status not in expected:
+                raise PublishError(
+                    f"GitHub API {method} {path} returned {status}; expected {expected}"
+                )
+            if len(raw) > max_bytes:
+                raise PublishError(
+                    f"GitHub API {method} {path} response exceeds {max_bytes} bytes"
+                )
+            return status, raw
+        raise AssertionError("unreachable GitHub retry loop")
 
     def _request(
         self,
@@ -250,42 +427,34 @@ class GitHubClient:
         payload: dict[str, object] | None = None,
         expected: tuple[int, ...] = (200,),
         allow_not_found: bool = False,
+        *,
+        retry_transient: bool = True,
     ) -> tuple[int, dict[str, object] | list[object] | None]:
-        body = json.dumps(payload).encode("utf-8") if payload is not None else None
-        request = Request(
-            f"{self.api_url}{path}",
-            data=body,
-            method=method,
-            headers={
-                "Accept": "application/vnd.github+json",
-                "Authorization": f"Bearer {self.token}",
-                "Content-Type": "application/json",
-                "User-Agent": "lizzieyzy-next-release-publisher",
-                "X-GitHub-Api-Version": API_VERSION,
-            },
+        status, raw = self._request_raw(
+            method,
+            path,
+            payload,
+            expected,
+            allow_not_found,
+            retry_transient=retry_transient,
         )
-        try:
-            with urlopen(request, timeout=60) as response:
-                status = response.status
-                raw = response.read()
-        except HTTPError as exc:
-            if allow_not_found and exc.code == 404:
-                return 404, None
-            detail = exc.read().decode("utf-8", errors="replace")[:2000]
-            raise PublishError(f"GitHub API {method} {path} failed ({exc.code}): {detail}") from exc
-        except OSError as exc:
-            raise PublishError(f"GitHub API {method} {path} failed: {exc}") from exc
-
-        if status not in expected:
-            raise PublishError(
-                f"GitHub API {method} {path} returned {status}; expected {expected}"
-            )
         if not raw:
             return status, None
         try:
             return status, json.loads(raw.decode("utf-8"))
         except json.JSONDecodeError as exc:
             raise PublishError(f"GitHub API {method} {path} returned invalid JSON") from exc
+
+    def _request_bytes(self, path: str, *, max_bytes: int) -> bytes:
+        _status, raw = self._request_raw(
+            "GET",
+            path,
+            accept="application/octet-stream",
+            max_bytes=max_bytes,
+        )
+        if raw is None:
+            raise PublishError(f"GitHub API GET {path} returned an empty response")
+        return raw
 
     def get_tag_sha(self, tag: str) -> str | None:
         path = f"/repos/{self.repository}/git/ref/tags/{quote(tag, safe='')}"
@@ -304,6 +473,10 @@ class GitHubClient:
             f"/repos/{self.repository}/git/refs",
             {"ref": f"refs/tags/{tag}", "sha": target_sha},
             expected=(201,),
+            # Creating a ref has no idempotency key. If GitHub accepted the
+            # request but the response was lost, a retry produces a misleading
+            # 422. A publisher rerun discovers and verifies the existing tag.
+            retry_transient=False,
         )
 
     def get_release_by_tag(self, tag: str) -> dict[str, object] | None:
@@ -315,11 +488,22 @@ class GitHubClient:
         return None
 
     def list_releases(self) -> list[dict[str, object]]:
-        _status, payload = self._request(
-            "GET", f"/repos/{self.repository}/releases?per_page=100"
-        )
-        assert isinstance(payload, list)
-        return [release for release in payload if isinstance(release, dict)]
+        releases: list[dict[str, object]] = []
+        for page in range(1, 11):
+            _status, payload = self._request(
+                "GET",
+                f"/repos/{self.repository}/releases?per_page=100&page={page}",
+            )
+            if not isinstance(payload, list) or len(payload) > 100:
+                raise PublishError("Release listing returned invalid pagination")
+            if any(not isinstance(release, dict) for release in payload):
+                raise PublishError("Release listing contains invalid metadata")
+            releases.extend(
+                release for release in payload if isinstance(release, dict)
+            )
+            if len(payload) < 100:
+                return releases
+        raise PublishError("Repository has too many releases to validate safely")
 
     def get_release(self, tag: str) -> dict[str, object] | None:
         release = self.get_release_by_tag(tag)
@@ -375,6 +559,9 @@ class GitHubClient:
             "DELETE",
             f"/repos/{self.repository}/git/refs/tags/{quote(tag, safe='')}",
             expected=(204,),
+            # DELETE is idempotent. A retry after a lost successful response may
+            # see 404, which means the requested absent state was achieved.
+            allow_not_found=True,
         )
 
     def create_draft_release(
@@ -394,6 +581,9 @@ class GitHubClient:
                 "make_latest": "false",
             },
             expected=(201,),
+            # Release creation has no idempotency key. Recovery is performed by
+            # discovering the existing tagged draft or its untagged orphan.
+            retry_transient=False,
         )
         assert isinstance(payload, dict)
         return payload
@@ -407,17 +597,79 @@ class GitHubClient:
         assert isinstance(response, dict)
         return response
 
-    def list_release_assets(self, release_id: int) -> list[str]:
-        _status, payload = self._request(
-            "GET",
-            f"/repos/{self.repository}/releases/{release_id}/assets?per_page=100",
-        )
-        assert isinstance(payload, list)
-        return [str(asset["name"]) for asset in payload if isinstance(asset, dict)]
+    def list_release_assets(self, release_id: int) -> list[dict[str, object]]:
+        assets: list[dict[str, object]] = []
+        for page in range(1, 11):
+            _status, payload = self._request(
+                "GET",
+                f"/repos/{self.repository}/releases/{release_id}/assets"
+                f"?per_page=100&page={page}",
+            )
+            if not isinstance(payload, list) or len(payload) > 100:
+                raise PublishError("Release asset listing returned invalid pagination")
+            if any(not isinstance(asset, dict) for asset in payload):
+                raise PublishError("Release asset listing contains invalid metadata")
+            assets.extend(asset for asset in payload if isinstance(asset, dict))
+            if len(payload) < 100:
+                return assets
+        raise PublishError("Release has too many assets to validate safely")
 
-    def list_workflow_runs(self, workflow_file: str, tag: str) -> list[dict[str, object]]:
+    def list_workflow_runs(
+        self, workflow_file: str, target_sha: str
+    ) -> list[dict[str, object]]:
         workflow = quote(workflow_file, safe="")
-        query = urlencode({"event": "workflow_dispatch", "branch": tag, "per_page": 50})
+        runs: list[dict[str, object]] = []
+        seen_ids: set[int] = set()
+        expected_total: int | None = None
+        for page in range(1, 11):
+            query = urlencode(
+                {
+                    "event": "workflow_dispatch",
+                    "head_sha": target_sha,
+                    "per_page": 100,
+                    "page": page,
+                }
+            )
+            _status, payload = self._request(
+                "GET",
+                f"/repos/{self.repository}/actions/workflows/{workflow}/runs?{query}",
+            )
+            if not isinstance(payload, dict):
+                raise PublishError("Workflow run listing returned invalid metadata")
+            page_runs = payload.get("workflow_runs")
+            total_count = payload.get("total_count")
+            if (
+                not isinstance(page_runs, list)
+                or len(page_runs) > 100
+                or type(total_count) is not int
+                or total_count < 0
+                or any(not isinstance(run, dict) for run in page_runs)
+            ):
+                raise PublishError("Workflow run listing returned invalid pagination")
+            if expected_total is None:
+                expected_total = total_count
+            elif total_count != expected_total:
+                raise PublishError("Workflow run listing changed during pagination")
+            for run in page_runs:
+                assert isinstance(run, dict)
+                run_id = run.get("id")
+                if type(run_id) is not int or run_id in seen_ids:
+                    raise PublishError(
+                        "Workflow run listing contains invalid or duplicate run IDs"
+                    )
+                seen_ids.add(run_id)
+                runs.append(run)
+            if len(runs) == expected_total:
+                return runs
+            if len(runs) > expected_total or len(page_runs) < 100:
+                raise PublishError("Workflow run listing is truncated or inconsistent")
+        raise PublishError("Workflow run listing exceeds the 1,000-run audit limit")
+
+    def list_ci_runs(self, target_sha: str) -> list[dict[str, object]]:
+        workflow = quote(CI_WORKFLOW_FILE, safe="")
+        query = urlencode(
+            {"event": "push", "head_sha": target_sha, "per_page": 20}
+        )
         _status, payload = self._request(
             "GET",
             f"/repos/{self.repository}/actions/workflows/{workflow}/runs?{query}",
@@ -435,6 +687,9 @@ class GitHubClient:
             f"/repos/{self.repository}/actions/workflows/{workflow}/dispatches",
             {"ref": tag, "inputs": inputs},
             expected=(200, 204),
+            # workflow_dispatch has no idempotency key. An ambiguous retry can
+            # create two runs that race to clobber the same draft assets.
+            retry_transient=False,
         )
         if isinstance(payload, dict) and payload.get("workflow_run_id") is not None:
             return int(payload["workflow_run_id"])
@@ -447,6 +702,28 @@ class GitHubClient:
         assert isinstance(payload, dict)
         return payload
 
+    def list_run_artifacts(self, run_id: int) -> list[dict[str, object]]:
+        _status, payload = self._request(
+            "GET",
+            f"/repos/{self.repository}/actions/runs/{run_id}/artifacts?per_page=100",
+        )
+        assert isinstance(payload, dict)
+        artifacts = payload.get("artifacts")
+        total_count = payload.get("total_count")
+        if not isinstance(artifacts, list) or type(total_count) is not int:
+            raise PublishError(f"Workflow run {run_id} returned invalid artifact metadata")
+        if total_count != len(artifacts):
+            raise PublishError(
+                f"Workflow run {run_id} artifact listing is truncated or inconsistent"
+            )
+        return [artifact for artifact in artifacts if isinstance(artifact, dict)]
+
+    def download_artifact_zip(self, artifact_id: int) -> bytes:
+        return self._request_bytes(
+            f"/repos/{self.repository}/actions/artifacts/{artifact_id}/zip",
+            max_bytes=2 * 1024 * 1024,
+        )
+
 
 class ReleasePublisher:
     def __init__(
@@ -457,7 +734,8 @@ class ReleasePublisher:
         release_notes: str,
         sleep: Callable[[float], None] = time.sleep,
         poll_seconds: float = 30,
-        run_timeout_seconds: float = 5 * 60 * 60 + 30 * 60,
+        run_timeout_seconds: float = 4 * 60 * 60 + 45 * 60,
+        ci_timeout_seconds: float = 20 * 60,
     ) -> None:
         if not re.fullmatch(r"[0-9a-f]{40}", target_sha):
             raise PublishError("target_sha must be a full 40-character commit SHA")
@@ -468,11 +746,11 @@ class ReleasePublisher:
         self.sleep = sleep
         self.poll_seconds = poll_seconds
         self.run_timeout_seconds = run_timeout_seconds
+        self.ci_timeout_seconds = ci_timeout_seconds
         self.run_urls: dict[str, str] = {}
         if not self._notes_text_complete(release_notes):
             raise PublishError("Reviewed release notes are missing the tag or a language section")
-        if "{{" in release_notes or "}}" in release_notes:
-            raise PublishError("Reviewed release notes contain an unresolved template token")
+        validate_no_unresolved_note_markers(release_notes)
         validate_direct_download_tables(
             release_notes,
             request.date_tag,
@@ -492,6 +770,14 @@ class ReleasePublisher:
             )
         print(f"Reusing tag {self.request.release_tag} at {existing}", flush=True)
 
+    def _assert_live_tag_identity(self) -> None:
+        actual = self.client.get_tag_sha(self.request.release_tag)
+        if actual != self.target_sha:
+            raise PublishError(
+                f"Live tag {self.request.release_tag} changed: "
+                f"expected {self.target_sha}, got {actual or '<missing>'}"
+            )
+
     def _assert_release_identity(self, release: dict[str, object]) -> None:
         actual_tag = str(release.get("tag_name") or "")
         if actual_tag != self.request.release_tag:
@@ -505,10 +791,21 @@ class ReleasePublisher:
                 "Release target changed: "
                 f"expected {self.target_sha}, got {actual_target or '<missing>'}"
             )
+        actual_title = str(release.get("name") or "")
+        if actual_title != self.request.title:
+            raise PublishError(
+                "Release title changed: "
+                f"expected {self.request.title}, got {actual_title or '<missing>'}"
+            )
 
     def _restore_orphaned_release(
         self, release: dict[str, object]
     ) -> dict[str, object]:
+        if release.get("draft") is not True:
+            raise PublishError(
+                "Refusing to bind a public orphaned release to the requested tag; "
+                "make it a draft or delete it before recovery"
+            )
         release_id = int(release["id"])
         restored = self.client.update_release(
             release_id,
@@ -516,7 +813,7 @@ class ReleasePublisher:
                 "tag_name": self.request.release_tag,
                 "target_commitish": self.target_sha,
                 "name": self.request.title,
-                "draft": release.get("draft") is True,
+                "draft": True,
                 "prerelease": True,
                 "make_latest": "false",
             },
@@ -543,6 +840,8 @@ class ReleasePublisher:
         self._assert_release_identity(release)
         if release.get("draft") is not False or release.get("prerelease") is not True:
             raise PublishError("Release is not publicly visible as a pre-release")
+        self._assert_canonical_notes(release)
+        self._assert_live_tag_identity()
         return release
 
     def _cleanup_detached_tag_aliases(self) -> None:
@@ -573,29 +872,108 @@ class ReleasePublisher:
         print(f"Reusing draft pre-release {self.request.release_tag}", flush=True)
         return release, False
 
-    def _matching_active_run(self, workflow_file: str) -> dict[str, object] | None:
-        for run in self.client.list_workflow_runs(workflow_file, self.request.release_tag):
-            if run.get("head_sha") != self.target_sha:
-                continue
-            if str(run.get("status")) in ACTIVE_RUN_STATUSES:
-                return run
-        return None
+    def _wait_for_target_ci(self) -> None:
+        deadline = time.monotonic() + self.ci_timeout_seconds
+        last_state: tuple[str, object] | None = None
+        while True:
+            matching = [
+                run
+                for run in self.client.list_ci_runs(self.target_sha)
+                if run.get("head_sha") == self.target_sha and run.get("id") is not None
+            ]
+            run = max(matching, key=lambda item: int(item["id"]), default=None)
+            if run is not None:
+                run_id = int(run["id"])
+                status = str(run.get("status", "unknown"))
+                conclusion = run.get("conclusion")
+                state = (status, conclusion)
+                if state != last_state:
+                    print(
+                        f"CI: {status} ({conclusion or 'pending'}) on {self.target_sha}",
+                        flush=True,
+                    )
+                    last_state = state
+                if run.get("html_url"):
+                    self.run_urls["CI"] = str(run["html_url"])
+                if status == "completed":
+                    if conclusion != "success":
+                        raise PublishError(
+                            f"CI workflow run {run_id} completed with {conclusion}"
+                        )
+                    return
+            if time.monotonic() >= deadline:
+                raise PublishError(
+                    f"Timed out waiting for successful CI on target {self.target_sha}"
+                )
+            self.sleep(self.poll_seconds)
+
+    def _expected_run_name(self, spec: WorkflowSpec) -> str:
+        inputs = dict(spec.dispatch_inputs)
+        return spec.expected_run_name(
+            self.request.date_tag,
+            self.request.release_tag,
+            inputs.get("release_prerelease", "true"),
+        )
+
+    def _run_has_expected_identity(
+        self, spec: WorkflowSpec, run: dict[str, object]
+    ) -> bool:
+        return (
+            run.get("head_sha") == self.target_sha
+            and run.get("display_title") == self._expected_run_name(spec)
+            and run.get("id") is not None
+        )
+
+    def _latest_target_run(self, spec: WorkflowSpec) -> dict[str, object] | None:
+        matching = [
+            run
+            for run in self.client.list_workflow_runs(
+                spec.workflow_file, self.target_sha
+            )
+            if self._run_has_expected_identity(spec, run)
+        ]
+        return max(matching, key=lambda run: int(run["id"]), default=None)
+
+    def _assert_successful_target_run(
+        self, spec: WorkflowSpec, run_id: int, run: dict[str, object]
+    ) -> None:
+        if not self._run_has_expected_identity(spec, run):
+            raise PublishError(
+                f"{spec.platform} workflow run {run_id} does not match target SHA "
+                "and exact release inputs"
+            )
+        status = str(run.get("status", "unknown"))
+        conclusion = run.get("conclusion")
+        if status != "completed" or conclusion != "success":
+            raise PublishError(
+                f"{spec.platform} workflow run {run_id} is not a successful completed run"
+            )
+        if type(run.get("run_attempt")) is not int or int(run["run_attempt"]) < 1:
+            raise PublishError(
+                f"{spec.platform} workflow run {run_id} has no valid run attempt"
+            )
 
     def _discover_new_run(
-        self, workflow_file: str, previous_ids: set[int], timeout_seconds: float = 180
+        self, spec: WorkflowSpec, previous_ids: set[int], timeout_seconds: float = 90
     ) -> int:
         deadline = time.monotonic() + timeout_seconds
         while time.monotonic() < deadline:
-            for run in self.client.list_workflow_runs(workflow_file, self.request.release_tag):
+            for run in self.client.list_workflow_runs(
+                spec.workflow_file, self.target_sha
+            ):
                 run_id = int(run["id"])
-                if run_id not in previous_ids and run.get("head_sha") == self.target_sha:
+                if run_id not in previous_ids and self._run_has_expected_identity(
+                    spec, run
+                ):
                     return run_id
             self.sleep(min(self.poll_seconds, 10))
-        raise PublishError(f"Timed out locating dispatched workflow run for {workflow_file}")
+        raise PublishError(
+            f"Timed out locating dispatched workflow run for {spec.workflow_file}"
+        )
 
     def _dispatch(self, spec: WorkflowSpec) -> int:
         workflow_file = spec.workflow_file
-        existing = self.client.list_workflow_runs(workflow_file, self.request.release_tag)
+        existing = self.client.list_workflow_runs(workflow_file, self.target_sha)
         previous_ids = {int(run["id"]) for run in existing if run.get("id") is not None}
         inputs = {
             "date_tag": self.request.date_tag,
@@ -608,7 +986,7 @@ class ReleasePublisher:
             inputs,
         )
         if run_id is None:
-            run_id = self._discover_new_run(workflow_file, previous_ids)
+            run_id = self._discover_new_run(spec, previous_ids)
         print(f"Dispatched {workflow_file}: run {run_id}", flush=True)
         return run_id
 
@@ -623,7 +1001,13 @@ class ReleasePublisher:
                 names = ", ".join(sorted(pending))
                 raise PublishError(f"Timed out waiting for workflows: {names}")
             for name, run_id in list(pending.items()):
+                spec = next(item for item in WORKFLOWS if item.platform == name)
                 run = self.client.get_workflow_run(run_id)
+                if not self._run_has_expected_identity(spec, run):
+                    raise PublishError(
+                        f"{name} workflow run {run_id} does not match target SHA "
+                        "and exact release inputs"
+                    )
                 status = str(run.get("status", "unknown"))
                 conclusion = run.get("conclusion")
                 state = (status, conclusion)
@@ -641,23 +1025,257 @@ class ReleasePublisher:
             if pending:
                 self.sleep(self.poll_seconds)
 
-    def _verify_platform_assets(self, release_id: int) -> list[str]:
-        missing: list[str] = []
+    def _require_successful_target_runs(
+        self, selected_runs: dict[str, int] | None = None
+    ) -> dict[str, dict[str, object]]:
+        verified: dict[str, dict[str, object]] = {}
+        for spec in WORKFLOWS:
+            if selected_runs is not None:
+                run_id = selected_runs[spec.platform]
+                run = self.client.get_workflow_run(run_id)
+            else:
+                run = self._latest_target_run(spec)
+                if run is None:
+                    raise PublishError(
+                        f"{spec.platform} has no workflow run for target {self.target_sha}"
+                    )
+                run_id = int(run["id"])
+            self._assert_successful_target_run(spec, run_id, run)
+            verified[spec.platform] = run
+            if run.get("html_url"):
+                self.run_urls[spec.platform] = str(run["html_url"])
+        return verified
+
+    def _require_no_active_target_runs(self, selected_runs: dict[str, int]) -> None:
+        selected_ids = set(selected_runs.values())
+        active: list[str] = []
+        for spec in WORKFLOWS:
+            for listed_run in self.client.list_workflow_runs(
+                spec.workflow_file, self.target_sha
+            ):
+                if not self._run_has_expected_identity(spec, listed_run):
+                    continue
+                run_id = int(listed_run["id"])
+                if run_id in selected_ids:
+                    # The selected runs were just re-read and required to be completed
+                    # successfully. Ignore a stale active status in the list endpoint.
+                    continue
+                listed_status = str(listed_run.get("status", "unknown"))
+                if listed_status not in ACTIVE_RUN_STATUSES:
+                    continue
+                run = self.client.get_workflow_run(run_id)
+                if not self._run_has_expected_identity(spec, run):
+                    raise PublishError(
+                        f"{spec.platform} workflow run {run_id} changed identity "
+                        "during the final active-run check"
+                    )
+                status = str(run.get("status", "unknown"))
+                if status in ACTIVE_RUN_STATUSES:
+                    active.append(f"{spec.platform} run {run_id} ({status})")
+        if active:
+            raise PublishError(
+                "Refusing to publish while duplicate target workflow runs are active: "
+                + ", ".join(active)
+            )
+
+    def _load_run_provenance(
+        self, spec: WorkflowSpec, run: dict[str, object]
+    ) -> dict[str, dict[str, object]]:
+        run_id = int(run["id"])
+        run_attempt = int(run["run_attempt"])
+        expected_artifact_name = provenance.artifact_name(
+            spec.provenance_platform, run_attempt
+        )
+        artifacts = self.client.list_run_artifacts(run_id)
+        matches = [
+            artifact
+            for artifact in artifacts
+            if artifact.get("name") == expected_artifact_name
+        ]
+        if len(matches) != 1:
+            raise PublishError(
+                f"{spec.platform} run {run_id} must have exactly one "
+                f"{expected_artifact_name} artifact"
+            )
+        artifact = matches[0]
+        if artifact.get("expired") is not False:
+            raise PublishError(
+                f"{spec.platform} run {run_id} provenance artifact is expired"
+            )
+        artifact_id = artifact.get("id")
+        artifact_size = artifact.get("size_in_bytes")
+        if type(artifact_id) is not int or int(artifact_id) < 1:
+            raise PublishError(f"{spec.platform} provenance artifact id is invalid")
+        if (
+            type(artifact_size) is not int
+            or int(artifact_size) < 1
+            or int(artifact_size) > 2 * 1024 * 1024
+        ):
+            raise PublishError(f"{spec.platform} provenance artifact size is invalid")
+        workflow_run = artifact.get("workflow_run")
+        if not isinstance(workflow_run, dict) or (
+            workflow_run.get("id") != run_id
+            or workflow_run.get("head_sha") != self.target_sha
+        ):
+            raise PublishError(
+                f"{spec.platform} provenance artifact is not bound to run {run_id}"
+            )
+        artifact_digest = artifact.get("digest")
+        if not isinstance(artifact_digest, str) or re.fullmatch(
+            r"sha256:[0-9a-f]{64}", artifact_digest
+        ) is None:
+            raise PublishError(
+                f"{spec.platform} provenance artifact has no valid SHA-256 digest"
+            )
+
+        archive = self.client.download_artifact_zip(int(artifact_id))
+        if len(archive) != artifact_size:
+            raise PublishError(
+                f"{spec.platform} provenance artifact download size does not match metadata"
+            )
+        archive_digest = "sha256:" + hashlib.sha256(archive).hexdigest()
+        if archive_digest != artifact_digest:
+            raise PublishError(
+                f"{spec.platform} provenance artifact digest does not match its download"
+            )
+        try:
+            with zipfile.ZipFile(io.BytesIO(archive)) as bundle:
+                files = [info for info in bundle.infolist() if not info.is_dir()]
+                if len(files) != 1 or files[0].filename != provenance.PROVENANCE_FILENAME:
+                    raise PublishError(
+                        f"{spec.platform} provenance artifact must contain only "
+                        f"{provenance.PROVENANCE_FILENAME}"
+                    )
+                info = files[0]
+                if info.flag_bits & 0x1 or info.file_size > 512 * 1024:
+                    raise PublishError(
+                        f"{spec.platform} provenance manifest is encrypted or oversized"
+                    )
+                raw_manifest = bundle.read(info)
+        except (OSError, zipfile.BadZipFile, RuntimeError) as exc:
+            raise PublishError(
+                f"{spec.platform} provenance artifact is not a valid ZIP: {exc}"
+            ) from exc
+        try:
+            payload = json.loads(raw_manifest.decode("utf-8"))
+            records = provenance.validate_provenance(
+                payload,
+                platform=spec.provenance_platform,
+                date_tag=self.request.date_tag,
+                release_tag=self.request.release_tag,
+                target_sha=self.target_sha,
+                run_id=run_id,
+                run_attempt=run_attempt,
+            )
+        except (UnicodeDecodeError, json.JSONDecodeError, provenance.ProvenanceError) as exc:
+            raise PublishError(
+                f"{spec.platform} provenance manifest is invalid: {exc}"
+            ) from exc
+
+        publisher_names = {
+            f"{self.request.date_tag}-{suffix}" for suffix in spec.exact_suffixes
+        }
+        if spec.provenance_platform == "windows":
+            publisher_names.add("lizzieyzy-next-update-manifest.json")
+        if set(records) != publisher_names:
+            raise PublishError(
+                f"{spec.platform} publisher and provenance asset inventories disagree"
+            )
+        return records
+
+    def _verify_platform_assets(
+        self, release_id: int, selected_runs: dict[str, dict[str, object]]
+    ) -> list[str]:
+        expected_records: dict[str, dict[str, object]] = {}
+        for spec in WORKFLOWS:
+            records = self._load_run_provenance(spec, selected_runs[spec.platform])
+            overlap = set(expected_records).intersection(records)
+            if overlap:
+                raise PublishError(
+                    "Duplicate asset provenance across workflows: "
+                    + ", ".join(sorted(overlap))
+                )
+            expected_records.update(records)
+
+        expected = set(expected_records)
+        failure_details: list[str] = []
         for attempt in range(7):
             assets = self.client.list_release_assets(release_id)
-            missing = []
-            for spec in WORKFLOWS:
-                missing.extend(spec.missing_assets(assets, self.request.date_tag))
-            if "lizzieyzy-next-update-manifest.json" not in assets:
-                missing.append("lizzieyzy-next-update-manifest.json")
-            if not missing:
-                return assets
+            by_name: dict[str, dict[str, object]] = {}
+            duplicate_names: list[str] = []
+            invalid_metadata: list[str] = []
+            for asset in assets:
+                name = asset.get("name")
+                if not isinstance(name, str) or not name:
+                    invalid_metadata.append("<invalid-name>")
+                    continue
+                if name in by_name:
+                    duplicate_names.append(name)
+                    continue
+                by_name[name] = asset
+            actual = set(by_name)
+            missing = sorted(expected - actual)
+            unexpected = sorted(actual - expected)
+            mismatches: list[str] = []
+            for name in sorted(expected.intersection(actual)):
+                remote = by_name[name]
+                trusted = expected_records[name]
+                if remote.get("state") != "uploaded":
+                    mismatches.append(f"{name}: state is not uploaded")
+                size = remote.get("size")
+                if type(size) is not int or int(size) <= 0:
+                    mismatches.append(f"{name}: size is not positive")
+                elif size != trusted["sizeBytes"]:
+                    mismatches.append(f"{name}: size differs from run provenance")
+                digest = remote.get("digest")
+                if not isinstance(digest, str) or re.fullmatch(
+                    r"sha256:[0-9a-f]{64}", digest
+                ) is None:
+                    mismatches.append(f"{name}: SHA-256 digest is missing or invalid")
+                elif digest.removeprefix("sha256:") != trusted["sha256"]:
+                    mismatches.append(f"{name}: digest differs from run provenance")
+            failure_details = []
+            if missing:
+                failure_details.append("missing assets: " + ", ".join(missing))
+            if unexpected:
+                failure_details.append("unexpected assets: " + ", ".join(unexpected))
+            if duplicate_names:
+                failure_details.append(
+                    "duplicate assets: " + ", ".join(sorted(set(duplicate_names)))
+                )
+            if invalid_metadata:
+                failure_details.append("release asset metadata contains invalid names")
+            if mismatches:
+                failure_details.append("metadata/provenance mismatch: " + "; ".join(mismatches))
+            if not failure_details:
+                return sorted(actual)
             if attempt < 6:
                 self.sleep(min(self.poll_seconds, 10))
-        raise PublishError("Release is missing assets: " + ", ".join(missing))
+        raise PublishError("Release has invalid assets: " + "; ".join(failure_details))
 
     def _notes_complete(self, release: dict[str, object]) -> bool:
-        return self._notes_text_complete(str(release.get("body") or ""))
+        body = str(release.get("body") or "")
+        if not self._notes_text_complete(body):
+            return False
+        try:
+            validate_no_unresolved_note_markers(body)
+            validate_direct_download_tables(
+                body,
+                self.request.date_tag,
+                self.request.release_tag,
+                self.client.repository,
+            )
+        except PublishError:
+            return False
+        return True
+
+    def _assert_canonical_notes(self, release: dict[str, object]) -> None:
+        if release.get("body") != self.release_notes:
+            raise PublishError(
+                "Release notes differ from the canonical reviewed release notes"
+            )
+        if not self._notes_complete(release):
+            raise PublishError("Release notes failed canonical content validation")
 
     def _notes_text_complete(self, body: str) -> bool:
         return self.request.release_tag in body and all(
@@ -683,38 +1301,39 @@ class ReleasePublisher:
             handle.write("\n".join(lines) + "\n")
 
     def publish(self) -> dict[str, object]:
+        self._wait_for_target_ci()
         self._ensure_tag()
         release, already_published = self._ensure_draft_release()
         release_id = int(release["id"])
         if already_published:
-            assets = self._verify_platform_assets(release_id)
-            if not self._notes_complete(release):
-                raise PublishError("Published pre-release does not contain all six language sections")
+            verified_runs = self._require_successful_target_runs()
+            assets = self._verify_platform_assets(release_id, verified_runs)
+            self._assert_canonical_notes(release)
             release = self._verify_public_release_identity(release_id)
             self._cleanup_detached_tag_aliases()
             print(f"{self.request.release_tag} is already complete", flush=True)
             self._publish_summary(release, assets)
             return release
 
-        current_assets = self.client.list_release_assets(release_id)
         runs: dict[str, int] = {}
         for spec in WORKFLOWS:
-            missing = spec.missing_assets(current_assets, self.request.date_tag)
-            if not missing and (
-                spec.platform != "Windows" or "lizzieyzy-next-update-manifest.json" in current_assets
+            existing = self._latest_target_run(spec)
+            if existing is not None and (
+                str(existing.get("status")) in ACTIVE_RUN_STATUSES
+                or (
+                    existing.get("status") == "completed"
+                    and existing.get("conclusion") == "success"
+                )
             ):
-                print(f"{spec.platform}: required assets already present", flush=True)
-                continue
-            active = self._matching_active_run(spec.workflow_file)
-            if active is not None:
-                run_id = int(active["id"])
-                print(f"{spec.platform}: waiting for existing run {run_id}", flush=True)
+                run_id = int(existing["id"])
+                print(f"{spec.platform}: verifying existing run {run_id}", flush=True)
             else:
                 run_id = self._dispatch(spec)
             runs[spec.platform] = run_id
 
         self._wait_for_runs(runs)
-        assets = self._verify_platform_assets(release_id)
+        verified_runs = self._require_successful_target_runs(runs)
+        assets = self._verify_platform_assets(release_id, verified_runs)
 
         release = self.client.update_release(
             release_id,
@@ -729,8 +1348,24 @@ class ReleasePublisher:
             },
         )
         self._assert_release_identity(release)
-        if not self._notes_complete(release):
-            raise PublishError("GitHub did not retain the reviewed six-language release notes")
+        self._assert_canonical_notes(release)
+
+        # Re-read every mutable gate immediately before public visibility. GitHub
+        # does not offer an atomic "verify-and-publish" operation, so this second
+        # fail-closed pass minimizes the mutation window and prevents a stale first
+        # check from authorizing publication.
+        self._wait_for_target_ci()
+        verified_runs = self._require_successful_target_runs(runs)
+        assets = self._verify_platform_assets(release_id, verified_runs)
+        self._require_no_active_target_runs(runs)
+        current = self.client.get_release(self.request.release_tag)
+        if current is None or int(current.get("id", -1)) != release_id:
+            raise PublishError("Draft release identity changed before publication")
+        self._assert_release_identity(current)
+        if current.get("draft") is not True or current.get("prerelease") is not True:
+            raise PublishError("Release is no longer the expected draft pre-release")
+        self._assert_canonical_notes(current)
+        self._assert_live_tag_identity()
 
         release = self.client.update_release(
             release_id,
@@ -738,6 +1373,7 @@ class ReleasePublisher:
                 "tag_name": self.request.release_tag,
                 "target_commitish": self.target_sha,
                 "name": self.request.title,
+                "body": self.release_notes,
                 "draft": False,
                 "prerelease": True,
                 "make_latest": "false",
@@ -746,9 +1382,10 @@ class ReleasePublisher:
         self._assert_release_identity(release)
         if release.get("draft") is not False or release.get("prerelease") is not True:
             raise PublishError("GitHub did not publish the release as a pre-release")
+        self._assert_canonical_notes(release)
         release = self._verify_public_release_identity(release_id)
         self._cleanup_detached_tag_aliases()
-        assets = self._verify_platform_assets(release_id)
+        assets = self._verify_platform_assets(release_id, verified_runs)
         self._publish_summary(release, assets)
         print(f"Published pre-release: {release.get('html_url', '')}", flush=True)
         return release

--- a/scripts/release_asset_provenance.py
+++ b/scripts/release_asset_provenance.py
@@ -1,0 +1,251 @@
+#!/usr/bin/env python3
+"""Create and validate run-bound SHA-256 provenance for release assets."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+import re
+import sys
+
+
+SCHEMA_VERSION = 1
+PROVENANCE_FILENAME = "release-asset-provenance.json"
+PLATFORM_ASSET_SUFFIXES: dict[str, tuple[str, ...]] = {
+    "windows": (
+        "windows64.opencl.installer.exe",
+        "windows64.opencl.portable.zip",
+        "windows64.nvidia.installer.exe",
+        "windows64.nvidia.portable.zip",
+        "windows64.nvidia50.cuda.installer.exe",
+        "windows64.nvidia50.cuda.portable.zip",
+        "windows64.with-katago.installer.exe",
+        "windows64.with-katago.portable.zip",
+        "windows64.without.engine.installer.exe",
+        "windows64.without.engine.portable.zip",
+        "windows64.core-update.zip",
+        "windows64.nvidia.tensorrt.portable.README.txt",
+        "windows64.nvidia.tensorrt.portable.manifest.json",
+        "windows64.nvidia.tensorrt.portable.sha256.txt",
+        "windows64.nvidia.tensorrt.portable.7z.001",
+        "windows64.nvidia.tensorrt.portable.7z.002",
+    ),
+    "linux": (
+        "linux64.with-katago.zip",
+        "linux64.opencl.zip",
+        "linux64.nvidia.zip",
+    ),
+    "mac-amd64": ("mac-intel.with-katago.dmg",),
+    "mac-arm64": ("mac-apple-silicon.with-katago.dmg",),
+}
+
+
+class ProvenanceError(RuntimeError):
+    """Release asset provenance is missing, ambiguous, or inconsistent."""
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise ProvenanceError(message)
+
+
+def _positive_integer(value: object, field: str) -> int:
+    require(type(value) is int and int(value) > 0, f"{field} must be a positive integer")
+    return int(value)
+
+
+def validate_identity(
+    platform: str,
+    date_tag: str,
+    release_tag: str,
+    target_sha: str,
+    run_id: int,
+    run_attempt: int,
+) -> None:
+    require(platform in PLATFORM_ASSET_SUFFIXES, f"Unsupported release platform: {platform}")
+    require(
+        re.fullmatch(r"\d{4}-\d{2}-\d{2}", date_tag) is not None,
+        "dateTag must use YYYY-MM-DD",
+    )
+    require(
+        re.fullmatch(rf"next-{re.escape(date_tag)}\.[1-9][0-9]*", release_tag)
+        is not None,
+        "releaseTag must exactly match dateTag and use a positive serial",
+    )
+    require(
+        re.fullmatch(r"[0-9a-f]{40}", target_sha) is not None,
+        "targetSha must be a full lowercase commit SHA",
+    )
+    _positive_integer(run_id, "workflowRunId")
+    _positive_integer(run_attempt, "workflowRunAttempt")
+
+
+def expected_asset_names(platform: str, date_tag: str) -> tuple[str, ...]:
+    require(platform in PLATFORM_ASSET_SUFFIXES, f"Unsupported release platform: {platform}")
+    names = [f"{date_tag}-{suffix}" for suffix in PLATFORM_ASSET_SUFFIXES[platform]]
+    if platform == "windows":
+        names.append("lizzieyzy-next-update-manifest.json")
+    return tuple(sorted(names))
+
+
+def artifact_name(platform: str, run_attempt: int) -> str:
+    require(platform in PLATFORM_ASSET_SUFFIXES, f"Unsupported release platform: {platform}")
+    _positive_integer(run_attempt, "workflowRunAttempt")
+    return f"release-asset-provenance-{platform}-attempt-{run_attempt}"
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    try:
+        with path.open("rb") as handle:
+            for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+                digest.update(chunk)
+    except OSError as exc:
+        raise ProvenanceError(f"Unable to hash release asset {path.name}: {exc}") from exc
+    return digest.hexdigest()
+
+
+def build_provenance(
+    release_dir: Path,
+    platform: str,
+    date_tag: str,
+    release_tag: str,
+    target_sha: str,
+    run_id: int,
+    run_attempt: int,
+) -> dict[str, object]:
+    validate_identity(platform, date_tag, release_tag, target_sha, run_id, run_attempt)
+    assets: list[dict[str, object]] = []
+    for name in expected_asset_names(platform, date_tag):
+        path = release_dir / name
+        require(path.is_file(), f"Missing release asset for provenance: {name}")
+        size = path.stat().st_size
+        require(size > 0, f"Release asset is empty: {name}")
+        assets.append(
+            {
+                "name": name,
+                "sizeBytes": size,
+                "sha256": sha256_file(path),
+            }
+        )
+    return {
+        "schemaVersion": SCHEMA_VERSION,
+        "platform": platform,
+        "dateTag": date_tag,
+        "releaseTag": release_tag,
+        "targetSha": target_sha,
+        "workflowRunId": run_id,
+        "workflowRunAttempt": run_attempt,
+        "assets": assets,
+    }
+
+
+def validate_provenance(
+    payload: object,
+    *,
+    platform: str,
+    date_tag: str,
+    release_tag: str,
+    target_sha: str,
+    run_id: int,
+    run_attempt: int,
+) -> dict[str, dict[str, object]]:
+    validate_identity(platform, date_tag, release_tag, target_sha, run_id, run_attempt)
+    require(isinstance(payload, dict), "Provenance manifest must contain a JSON object")
+    assert isinstance(payload, dict)
+    expected_fields = {
+        "schemaVersion",
+        "platform",
+        "dateTag",
+        "releaseTag",
+        "targetSha",
+        "workflowRunId",
+        "workflowRunAttempt",
+        "assets",
+    }
+    require(
+        set(payload) == expected_fields,
+        "Provenance manifest fields do not exactly match the schema",
+    )
+    require(payload.get("schemaVersion") == SCHEMA_VERSION, "Unsupported provenance schema")
+    require(payload.get("platform") == platform, "Provenance platform does not match the run")
+    require(payload.get("dateTag") == date_tag, "Provenance dateTag does not match")
+    require(payload.get("releaseTag") == release_tag, "Provenance releaseTag does not match")
+    require(payload.get("targetSha") == target_sha, "Provenance targetSha does not match")
+    require(payload.get("workflowRunId") == run_id, "Provenance workflowRunId does not match")
+    require(
+        payload.get("workflowRunAttempt") == run_attempt,
+        "Provenance workflowRunAttempt does not match",
+    )
+
+    assets = payload.get("assets")
+    require(isinstance(assets, list), "Provenance assets must be a list")
+    assert isinstance(assets, list)
+    records: dict[str, dict[str, object]] = {}
+    ordered_names: list[str] = []
+    for item in assets:
+        require(isinstance(item, dict), "Every provenance asset must be an object")
+        assert isinstance(item, dict)
+        require(
+            set(item) == {"name", "sizeBytes", "sha256"},
+            "Provenance asset fields do not exactly match the schema",
+        )
+        name = item.get("name")
+        require(isinstance(name, str) and bool(name), "Provenance asset name is invalid")
+        assert isinstance(name, str)
+        require(name not in records, f"Duplicate provenance asset: {name}")
+        size = _positive_integer(item.get("sizeBytes"), f"sizeBytes for {name}")
+        digest = item.get("sha256")
+        require(
+            isinstance(digest, str) and re.fullmatch(r"[0-9a-f]{64}", digest) is not None,
+            f"sha256 for {name} is invalid",
+        )
+        records[name] = {"name": name, "sizeBytes": size, "sha256": digest}
+        ordered_names.append(name)
+
+    expected_names = list(expected_asset_names(platform, date_tag))
+    require(ordered_names == expected_names, "Provenance asset inventory is not exact and sorted")
+    return records
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--release-dir", required=True, type=Path)
+    parser.add_argument("--platform", required=True, choices=tuple(PLATFORM_ASSET_SUFFIXES))
+    parser.add_argument("--date-tag", required=True)
+    parser.add_argument("--release-tag", required=True)
+    parser.add_argument("--target-sha", required=True)
+    parser.add_argument("--run-id", required=True, type=int)
+    parser.add_argument("--run-attempt", required=True, type=int)
+    parser.add_argument("--output", required=True, type=Path)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        payload = build_provenance(
+            args.release_dir,
+            args.platform,
+            args.date_tag,
+            args.release_tag,
+            args.target_sha,
+            args.run_id,
+            args.run_attempt,
+        )
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(
+            json.dumps(payload, ensure_ascii=False, indent=2) + "\n",
+            encoding="utf-8",
+        )
+    except (OSError, ProvenanceError) as exc:
+        print(f"Release asset provenance failed: {exc}", file=sys.stderr)
+        return 1
+    print(f"Wrote run-bound release asset provenance: {args.output}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/sign_macos_release.sh
+++ b/scripts/sign_macos_release.sh
@@ -2,8 +2,8 @@
 # Sign and notarize macOS DMG release assets.
 #
 # Requires the following environment variables (typically provided via GitHub
-# Actions secrets). If any of them are empty, the script exits 0 and leaves the
-# unsigned asset untouched so local builds are unaffected.
+# Actions secrets). A fully absent credential set is an explicit local-build
+# skip. A partially configured credential set fails closed.
 #
 #   APPLE_CERT_P12         Base64-encoded Developer ID Application .p12
 #   APPLE_CERT_PASSWORD    Password for the .p12 (may be empty)
@@ -24,10 +24,39 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 entitlements_path="$ROOT_DIR/packaging/macos-entitlements.plist"
 drag_dmg_script="$ROOT_DIR/scripts/create_macos_drag_dmg.sh"
 validate_dmg_script="$ROOT_DIR/scripts/validate_macos_dmg_layout.sh"
+temp_root="${TMPDIR:-/tmp}"
 
-if [[ -z "${APPLE_CERT_P12:-}" || -z "${APPLE_TEAM_ID:-}" ]]; then
-  echo "Apple Developer credentials not configured; skipping sign/notarize."
+required_secret_names=(
+  APPLE_CERT_P12
+  APPLE_ID
+  APPLE_APP_PASSWORD
+  APPLE_TEAM_ID
+)
+configured_secret_count=0
+missing_secret_names=()
+for secret_name in "${required_secret_names[@]}"; do
+  case "$secret_name" in
+    APPLE_CERT_P12) secret_value="${APPLE_CERT_P12:-}" ;;
+    APPLE_ID) secret_value="${APPLE_ID:-}" ;;
+    APPLE_APP_PASSWORD) secret_value="${APPLE_APP_PASSWORD:-}" ;;
+    APPLE_TEAM_ID) secret_value="${APPLE_TEAM_ID:-}" ;;
+    *) echo "Internal error: unknown required secret $secret_name" >&2; exit 2 ;;
+  esac
+  if [[ -n "$secret_value" ]]; then
+    configured_secret_count=$((configured_secret_count + 1))
+  else
+    missing_secret_names+=("$secret_name")
+  fi
+done
+secret_value=""
+
+if [[ "$configured_secret_count" -eq 0 ]]; then
+  echo "Apple Developer credentials are fully absent; skipping sign/notarize."
   exit 0
+fi
+if [[ "$configured_secret_count" -ne "${#required_secret_names[@]}" ]]; then
+  echo "Apple Developer credentials are only partially configured; missing: ${missing_secret_names[*]}" >&2
+  exit 1
 fi
 
 if ! command -v codesign >/dev/null 2>&1 || ! command -v xcrun >/dev/null 2>&1; then
@@ -49,34 +78,61 @@ if [[ ! -x "$validate_dmg_script" ]]; then
   exit 1
 fi
 
-keychain="lizzieyzy-sign.keychain-db"
-keychain_password="$(openssl rand -hex 16)"
-security create-keychain -p "$keychain_password" "$keychain" >/dev/null
-security set-keychain-settings -lut 21600 "$keychain" >/dev/null
-security unlock-keychain -p "$keychain_password" "$keychain" >/dev/null
-
-cert_path="$(mktemp -t lizzieyzy-cert.XXXXXX).p12"
-printf '%s' "$APPLE_CERT_P12" | base64 --decode > "$cert_path"
-security import "$cert_path" -k "$keychain" -P "${APPLE_CERT_PASSWORD:-}" -T /usr/bin/codesign >/dev/null
-security list-keychains -d user -s "$keychain" "$(security list-keychains -d user | tr -d '"')"
-security set-key-partition-list -S apple-tool:,apple: -s -k "$keychain_password" "$keychain" >/dev/null
-rm -f "$cert_path"
-
-sign_identity="${APPLE_SIGN_IDENTITY:-}"
-if [[ -z "$sign_identity" ]]; then
-  sign_identity="$(security find-identity -v -p codesigning "$keychain" | awk -F '"' '/Developer ID Application/ {print $2; exit}')"
-fi
-if [[ -z "$sign_identity" ]]; then
-  echo "Could not locate a Developer ID Application identity in keychain." >&2
-  security delete-keychain "$keychain" >/dev/null 2>&1 || true
-  exit 1
-fi
-echo "Using signing identity: $sign_identity"
+keychain=""
+keychain_dir=""
+keychain_password=""
+cert_path=""
+sign_identity=""
+work_dir=""
+mount_point=""
+mounted_target=""
+original_keychains=()
+temporary_paths=()
 
 cleanup() {
-  security delete-keychain "$keychain" >/dev/null 2>&1 || true
+  local exit_code=$?
+  local path
+  trap - EXIT HUP INT TERM
+  set +e
+
+  if [[ -n "$mounted_target" ]] && command -v hdiutil >/dev/null 2>&1; then
+    hdiutil detach "$mounted_target" -force -quiet >/dev/null 2>&1 || true
+    mounted_target=""
+  elif [[ -n "$mount_point" ]] && command -v mount >/dev/null 2>&1 && \
+       mount | grep -Fq " on $mount_point "; then
+    hdiutil detach "$mount_point" -force -quiet >/dev/null 2>&1 || true
+  fi
+
+  if [[ -n "$cert_path" ]]; then
+    rm -f -- "$cert_path"
+    cert_path=""
+  fi
+  for path in "${temporary_paths[@]}"; do
+    [[ -z "$path" ]] || rm -rf -- "$path"
+  done
+  if [[ -n "$work_dir" ]]; then
+    rm -rf -- "$work_dir"
+    work_dir=""
+  fi
+
+  if [[ -n "$keychain" ]] && command -v security >/dev/null 2>&1; then
+    if [[ "${#original_keychains[@]}" -gt 0 ]]; then
+      security list-keychains -d user -s "${original_keychains[@]}" >/dev/null 2>&1 || true
+    fi
+    security delete-keychain "$keychain" >/dev/null 2>&1 || true
+    keychain=""
+  fi
+  if [[ -n "$keychain_dir" ]]; then
+    rm -rf -- "$keychain_dir"
+    keychain_dir=""
+  fi
+  keychain_password=""
+  exit "$exit_code"
 }
 trap cleanup EXIT
+trap 'exit 129' HUP
+trap 'exit 130' INT
+trap 'exit 143' TERM
 
 detach_image() {
   local target="$1"
@@ -147,10 +203,13 @@ sign_embedded_jar_natives() {
       continue
     fi
 
-    local jar_work rebuilt_jar native_count
-    jar_work="$(mktemp -d -t lizzieyzy-jar-sign.XXXXXX)"
-    rebuilt_jar="$(mktemp -t lizzieyzy-signed-jar.XXXXXX).jar"
-    rm -f "$rebuilt_jar"
+    local jar_work jar_output_dir rebuilt_jar native_count
+    jar_work="$(mktemp -d "$temp_root/lizzieyzy-jar-sign.XXXXXXXX")"
+    jar_output_dir="$(mktemp -d "$temp_root/lizzieyzy-signed-jar.XXXXXXXX")"
+    rebuilt_jar="$jar_output_dir/rebuilt.jar"
+    chmod 700 "$jar_work"
+    chmod 700 "$jar_output_dir"
+    temporary_paths+=("$jar_work" "$jar_output_dir")
 
     (
       cd "$jar_work"
@@ -174,6 +233,7 @@ sign_embedded_jar_natives() {
       cd "$jar_work"
       zip -qry "$rebuilt_jar" .
     )
+    chmod 600 "$rebuilt_jar"
     mv "$rebuilt_jar" "$jar_file"
     rm -rf "$jar_work"
     signed_any=1
@@ -311,22 +371,60 @@ if [[ ${#dmg_files[@]} -eq 0 ]]; then
   exit 1
 fi
 
+# The cleanup trap is deliberately installed before any credential material or
+# keychain is created. Every failure from this point removes both.
+while IFS= read -r existing_keychain; do
+  [[ -z "$existing_keychain" ]] || original_keychains+=("$existing_keychain")
+done < <(
+  security list-keychains -d user |
+    sed -E 's/^[[:space:]]*"//; s/"[[:space:]]*$//'
+)
+
+keychain_dir="$(mktemp -d "$temp_root/lizzieyzy-keychain.XXXXXXXX")"
+chmod 700 "$keychain_dir"
+keychain="$keychain_dir/signing.keychain-db"
+keychain_password="$(openssl rand -hex 16)"
+security create-keychain -p "$keychain_password" "$keychain" >/dev/null
+security set-keychain-settings -lut 21600 "$keychain" >/dev/null
+security unlock-keychain -p "$keychain_password" "$keychain" >/dev/null
+
+cert_path="$(mktemp "$temp_root/lizzieyzy-cert.XXXXXXXX")"
+chmod 600 "$cert_path"
+if ! printf '%s' "$APPLE_CERT_P12" | base64 -D > "$cert_path"; then
+  : > "$cert_path"
+  if ! printf '%s' "$APPLE_CERT_P12" | base64 --decode > "$cert_path"; then
+    echo "APPLE_CERT_P12 is not valid base64." >&2
+    exit 1
+  fi
+fi
+if [[ ! -s "$cert_path" ]]; then
+  echo "APPLE_CERT_P12 decoded to an empty certificate." >&2
+  exit 1
+fi
+security import "$cert_path" -k "$keychain" -P "${APPLE_CERT_PASSWORD:-}" -T /usr/bin/codesign >/dev/null
+security list-keychains -d user -s "$keychain" "${original_keychains[@]}" >/dev/null
+security set-key-partition-list -S apple-tool:,apple: -s -k "$keychain_password" "$keychain" >/dev/null
+rm -f -- "$cert_path"
+cert_path=""
+
+sign_identity="${APPLE_SIGN_IDENTITY:-}"
+if [[ -z "$sign_identity" ]]; then
+  sign_identity="$(security find-identity -v -p codesigning "$keychain" | awk -F '"' '/Developer ID Application/ {print $2; exit}')"
+fi
+if [[ -z "$sign_identity" ]]; then
+  echo "Could not locate a Developer ID Application identity in the temporary keychain." >&2
+  exit 1
+fi
+echo "Using signing identity: $sign_identity"
+
 for dmg in "${dmg_files[@]}"; do
   echo "Processing $dmg"
 
-  work_dir="$(mktemp -d -t lizzieyzy-sign.XXXXXX)"
+  work_dir="$(mktemp -d "$temp_root/lizzieyzy-sign.XXXXXXXX")"
+  chmod 700 "$work_dir"
   mount_point="$work_dir/mount"
   mounted_target=""
   mkdir -p "$mount_point"
-  cleanup_work_dir() {
-    if [[ -n "$mounted_target" ]]; then
-      detach_image "$mounted_target" || true
-    elif mount | grep -q " on $mount_point "; then
-      detach_image "$mount_point" || true
-    fi
-    rm -rf "$work_dir"
-  }
-  trap 'cleanup_work_dir; cleanup' EXIT
 
   attach_plist="$work_dir/attach.plist"
   hdiutil attach "$dmg" -mountpoint "$mount_point" -nobrowse -noautoopen -readonly -plist >"$attach_plist"
@@ -426,10 +524,15 @@ PY
 
   xcrun stapler staple "$signed_dmg"
   "$validate_dmg_script" "$signed_dmg" "$dmg_arch_label" "$release_tag"
-  spctl --assess --type open --context context:primary-signature -vvv "$signed_dmg" || true
+  if ! spctl --assess --type open --context context:primary-signature -vvv "$signed_dmg"; then
+    echo "Gatekeeper assessment failed; refusing to replace the original DMG: $dmg" >&2
+    exit 1
+  fi
 
   mv "$signed_dmg" "$dmg"
-  rm -rf "$work_dir"
-  trap cleanup EXIT
+  rm -rf -- "$work_dir"
+  work_dir=""
+  mount_point=""
+  mounted_target=""
   echo "Signed and notarized: $dmg"
 done

--- a/scripts/test_macos_signing_security.py
+++ b/scripts/test_macos_signing_security.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Windows-runnable static security tests for the macOS signing transaction."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SIGN_SCRIPT = ROOT / "scripts" / "sign_macos_release.sh"
+
+
+class MacOSSigningSecurityTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.script = SIGN_SCRIPT.read_text(encoding="utf-8")
+
+    def test_cleanup_trap_precedes_all_keychain_and_certificate_creation(self) -> None:
+        trap = self.script.index("trap cleanup EXIT")
+        self.assertLess(trap, self.script.index("security create-keychain"))
+        self.assertLess(trap, self.script.index('cert_path="$(mktemp'))
+        self.assertIn("trap 'exit 129' HUP", self.script)
+        self.assertIn("trap 'exit 130' INT", self.script)
+        self.assertIn("trap 'exit 143' TERM", self.script)
+
+    def test_keychain_and_sensitive_files_are_unique_and_restrictive(self) -> None:
+        self.assertNotIn('keychain="lizzieyzy-sign.keychain-db"', self.script)
+        self.assertNotIn("mktemp -t", self.script)
+        self.assertNotIn(").p12", self.script)
+        self.assertIn("lizzieyzy-keychain.XXXXXXXX", self.script)
+        self.assertIn('keychain="$keychain_dir/signing.keychain-db"', self.script)
+        self.assertIn('chmod 700 "$keychain_dir"', self.script)
+        self.assertIn("lizzieyzy-cert.XXXXXXXX", self.script)
+        self.assertIn('chmod 600 "$cert_path"', self.script)
+
+    def test_partial_secrets_fail_closed_and_all_absent_explicitly_skip(self) -> None:
+        for name in (
+            "APPLE_CERT_P12",
+            "APPLE_ID",
+            "APPLE_APP_PASSWORD",
+            "APPLE_TEAM_ID",
+        ):
+            self.assertIn(name, self.script)
+        self.assertIn('if [[ "$configured_secret_count" -eq 0 ]]', self.script)
+        self.assertIn("credentials are fully absent; skipping", self.script)
+        self.assertIn('if [[ "$configured_secret_count" -ne', self.script)
+        self.assertIn("credentials are only partially configured", self.script)
+
+    def test_cleanup_removes_every_sensitive_resource_on_early_failure(self) -> None:
+        cleanup_start = self.script.index("cleanup() {")
+        cleanup_end = self.script.index("trap cleanup EXIT", cleanup_start)
+        cleanup = self.script[cleanup_start:cleanup_end]
+        self.assertIn('rm -f -- "$cert_path"', cleanup)
+        self.assertIn('security delete-keychain "$keychain"', cleanup)
+        self.assertIn('rm -rf -- "$keychain_dir"', cleanup)
+        self.assertIn('rm -rf -- "$work_dir"', cleanup)
+        self.assertIn('hdiutil detach "$mounted_target" -force', cleanup)
+
+    def test_gatekeeper_failure_keeps_original_dmg_and_runs_cleanup(self) -> None:
+        assessment = self.script.index("if ! spctl --assess")
+        replacement = self.script.index('mv "$signed_dmg" "$dmg"', assessment)
+        guarded_tail = self.script[assessment:replacement]
+        self.assertNotIn("|| true", guarded_tail)
+        self.assertIn("refusing to replace the original DMG", guarded_tail)
+        self.assertIn("exit 1", guarded_tail)
+        self.assertLess(assessment, replacement)
+
+        cleanup_start = self.script.index("cleanup() {")
+        cleanup_end = self.script.index("trap cleanup EXIT", cleanup_start)
+        cleanup = self.script[cleanup_start:cleanup_end]
+        self.assertIn('rm -rf -- "$work_dir"', cleanup)
+        self.assertIn('rm -f -- "$cert_path"', cleanup)
+        self.assertIn('security delete-keychain "$keychain"', cleanup)
+
+    def test_signing_failure_blocks_both_macos_release_uploads(self) -> None:
+        for workflow_name in (
+            "build-macos-amd64-release.yml",
+            "build-macos-arm64-release.yml",
+        ):
+            with self.subTest(workflow=workflow_name):
+                workflow = (ROOT / ".github" / "workflows" / workflow_name).read_text(
+                    encoding="utf-8"
+                )
+                sign_step = workflow.index("sign_macos_release_with_retry.sh")
+                release_upload = workflow.index("gh release upload")
+                self.assertLess(sign_step, release_upload)
+                nearby = workflow[max(0, sign_step - 250): sign_step + 250]
+                self.assertNotIn("continue-on-error", nearby)
+
+    def test_documentation_matches_fail_closed_secret_and_upload_behavior(self) -> None:
+        documentation = (ROOT / "docs" / "MACOS_SIGNING.md").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn("四个必需 secret 全部未配置", documentation)
+        self.assertIn("部分配置会 fail closed", documentation)
+        self.assertIn("上传 Release asset 之前终止", documentation)
+        self.assertNotIn("这步失败不会阻断 artifact 上传", documentation)
+        self.assertIn("逐层执行", documentation)
+        self.assertIn("`--deep` 只用于签名后的递归验证", documentation)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_prepare_bundled_jcef.py
+++ b/scripts/test_prepare_bundled_jcef.py
@@ -45,10 +45,17 @@ class PrepareBundledJcefTest(unittest.TestCase):
     def test_validate_bundle_rejects_wrong_platform(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:
             root = Path(temporary_directory)
-            self.create_bundle(root, metadata_platform="linux-amd64")
+            # Use the non-executable fixture layout here. Some hardened Windows hosts quarantine a
+            # directory that imitates the complete Chromium DLL/EXE layout, before the metadata
+            # assertion under test can run.
+            self.create_bundle(
+                root,
+                package_platform="macosx-arm64",
+                metadata_platform="macosx-amd64",
+            )
 
             with self.assertRaisesRegex(SystemExit, "JCEF platform mismatch"):
-                JCEF.validate_bundle(root, "windows-amd64")
+                JCEF.validate_bundle(root, "macosx-arm64")
 
     def test_windows_locale_trim_keeps_supported_languages_only(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:

--- a/scripts/test_publish_release_request.py
+++ b/scripts/test_publish_release_request.py
@@ -4,6 +4,9 @@
 from __future__ import annotations
 
 import importlib.util
+import hashlib
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+import io
 import json
 import os
 from pathlib import Path
@@ -11,7 +14,12 @@ import shutil
 import subprocess
 import sys
 import tempfile
+import threading
 import unittest
+from unittest import mock
+import zipfile
+
+from scripts import release_asset_provenance as provenance
 
 
 SCRIPT_PATH = Path(__file__).with_name("publish_release_request.py")
@@ -44,13 +52,23 @@ def all_asset_names() -> list[str]:
     names: list[str] = []
     for spec in PUBLISH.WORKFLOWS:
         names.extend(f"{DATE_TAG}-{suffix}" for suffix in spec.exact_suffixes)
-    names.extend(
-        [
-            f"{DATE_TAG}-windows64.nvidia.tensorrt.portable.7z.001",
-            "lizzieyzy-next-update-manifest.json",
-        ]
-    )
+    names.append("lizzieyzy-next-update-manifest.json")
     return names
+
+
+def fake_asset_bytes(name: str) -> bytes:
+    return f"verified-release-asset:{name}".encode("utf-8")
+
+
+def fake_asset_metadata(name: str) -> dict[str, object]:
+    content = fake_asset_bytes(name)
+    return {
+        "id": abs(hash(name)) + 1,
+        "name": name,
+        "state": "uploaded",
+        "size": len(content),
+        "digest": "sha256:" + hashlib.sha256(content).hexdigest(),
+    }
 
 
 class FakeClient:
@@ -64,7 +82,7 @@ class FakeClient:
     ) -> None:
         self.tag_sha: str | None = None
         self.release: dict[str, object] | None = None
-        self.assets: list[str] = []
+        self.assets: list[str | dict[str, object]] = []
         self.runs: dict[int, dict[str, object]] = {}
         self.workflow_runs: dict[str, list[dict[str, object]]] = {}
         self.next_run_id = 100
@@ -74,14 +92,33 @@ class FakeClient:
         self.dispatched: list[str] = []
         self.dispatched_inputs: dict[str, dict[str, str]] = {}
         self.update_payloads: list[dict[str, object]] = []
+        self.create_tag_calls = 0
+        self.create_draft_release_calls = 0
         self.detached_tag_aliases: dict[str, str] = {}
         self.deleted_tags: list[str] = []
         self.protected_release_tags: set[str] = set()
+        self.run_workflows: dict[int, str] = {}
+        self.artifact_archives: dict[int, bytes] = {}
+        self.artifact_metadata_overrides: dict[int, dict[str, object]] = {}
+        self.provenance_payload_overrides: dict[int, dict[str, object]] = {}
+        self.ci_run_snapshots: list[list[dict[str, object]]] = [
+            [
+                {
+                    "id": 50,
+                    "head_sha": TARGET_SHA,
+                    "status": "completed",
+                    "conclusion": "success",
+                    "html_url": "https://example.invalid/runs/50",
+                }
+            ]
+        ]
+        self.ci_list_calls = 0
 
     def get_tag_sha(self, _tag: str) -> str | None:
         return self.tag_sha
 
     def create_tag(self, _tag: str, target_sha: str) -> None:
+        self.create_tag_calls += 1
         self.tag_sha = target_sha
 
     def get_release_by_tag(self, tag: str) -> dict[str, object] | None:
@@ -128,6 +165,7 @@ class FakeClient:
     def create_draft_release(
         self, request: PUBLISH.ReleaseRequest, _target_sha: str
     ) -> dict[str, object]:
+        self.create_draft_release_calls += 1
         self.release = {
             "id": 7,
             "tag_name": request.release_tag,
@@ -151,47 +189,157 @@ class FakeClient:
         self.release["html_url"] = "https://example.invalid/release"
         return dict(self.release)
 
-    def list_release_assets(self, _release_id: int) -> list[str]:
-        return list(self.assets)
+    def list_release_assets(self, _release_id: int) -> list[dict[str, object]]:
+        return [
+            dict(item) if isinstance(item, dict) else fake_asset_metadata(item)
+            for item in self.assets
+        ]
 
-    def list_workflow_runs(self, workflow_file: str, _tag: str) -> list[dict[str, object]]:
+    def list_workflow_runs(
+        self, workflow_file: str, _target_sha: str
+    ) -> list[dict[str, object]]:
         return list(self.workflow_runs.get(workflow_file, []))
+
+    def list_ci_runs(self, _target_sha: str) -> list[dict[str, object]]:
+        self.ci_list_calls += 1
+        if len(self.ci_run_snapshots) > 1:
+            return [dict(run) for run in self.ci_run_snapshots.pop(0)]
+        return [dict(run) for run in self.ci_run_snapshots[0]]
 
     def dispatch_workflow(
         self, workflow_file: str, _tag: str, inputs: dict[str, str]
     ) -> int:
-        self.next_run_id += 1
-        run_id = self.next_run_id
         conclusion = "failure" if workflow_file == self.failed_workflow else "success"
-        run = {
-            "id": run_id,
-            "head_sha": TARGET_SHA,
-            "status": "completed",
-            "conclusion": conclusion,
-            "html_url": f"https://example.invalid/runs/{run_id}",
-        }
-        self.runs[run_id] = run
-        self.workflow_runs.setdefault(workflow_file, []).insert(0, run)
+        run_id = self.seed_workflow_run(
+            workflow_file,
+            conclusion=conclusion,
+            display_title=self.expected_run_name(workflow_file, inputs),
+        )
         self.dispatched.append(workflow_file)
         self.dispatched_inputs[workflow_file] = dict(inputs)
 
         if conclusion == "success":
             for spec in PUBLISH.WORKFLOWS:
                 if spec.workflow_file == workflow_file:
-                    self.assets.extend(
-                        f"{DATE_TAG}-{suffix}" for suffix in spec.exact_suffixes
-                    )
+                    names = [f"{DATE_TAG}-{suffix}" for suffix in spec.exact_suffixes]
                     if spec.platform == "Windows":
-                        self.assets.extend(
-                            [
-                                f"{DATE_TAG}-windows64.nvidia.tensorrt.portable.7z.001",
-                                "lizzieyzy-next-update-manifest.json",
-                            ]
+                        names.append("lizzieyzy-next-update-manifest.json")
+                    replace_names = set(names)
+                    self.assets = [
+                        item
+                        for item in self.assets
+                        if (
+                            item.get("name") if isinstance(item, dict) else item
                         )
+                        not in replace_names
+                    ]
+                    self.assets.extend(names)
+        return run_id
+
+    def expected_run_name(
+        self, workflow_file: str, inputs: dict[str, str] | None = None
+    ) -> str:
+        spec = next(
+            item for item in PUBLISH.WORKFLOWS if item.workflow_file == workflow_file
+        )
+        values = dict(spec.dispatch_inputs)
+        if inputs is not None:
+            values.update(inputs)
+        return spec.expected_run_name(
+            values.get("date_tag", DATE_TAG),
+            values.get("release_tag", RELEASE_TAG),
+            values.get("release_prerelease", "true"),
+        )
+
+    def seed_workflow_run(
+        self,
+        workflow_file: str,
+        *,
+        conclusion: str = "success",
+        head_sha: str = TARGET_SHA,
+        status: str = "completed",
+        display_title: str | None = None,
+    ) -> int:
+        self.next_run_id += 1
+        run_id = self.next_run_id
+        run = {
+            "id": run_id,
+            "head_sha": head_sha,
+            "status": status,
+            "conclusion": conclusion if status == "completed" else None,
+            "run_attempt": 1,
+            "display_title": display_title or self.expected_run_name(workflow_file),
+            "html_url": f"https://example.invalid/runs/{run_id}",
+        }
+        self.runs[run_id] = run
+        self.run_workflows[run_id] = workflow_file
+        self.workflow_runs.setdefault(workflow_file, []).insert(0, run)
         return run_id
 
     def get_workflow_run(self, run_id: int) -> dict[str, object]:
         return dict(self.runs[run_id])
+
+    def provenance_payload(self, run_id: int) -> dict[str, object]:
+        if run_id in self.provenance_payload_overrides:
+            return json.loads(json.dumps(self.provenance_payload_overrides[run_id]))
+        workflow_file = self.run_workflows[run_id]
+        spec = next(
+            item for item in PUBLISH.WORKFLOWS if item.workflow_file == workflow_file
+        )
+        run = self.runs[run_id]
+        names = provenance.expected_asset_names(spec.provenance_platform, DATE_TAG)
+        return {
+            "schemaVersion": provenance.SCHEMA_VERSION,
+            "platform": spec.provenance_platform,
+            "dateTag": DATE_TAG,
+            "releaseTag": RELEASE_TAG,
+            "targetSha": TARGET_SHA,
+            "workflowRunId": run_id,
+            "workflowRunAttempt": run["run_attempt"],
+            "assets": [
+                {
+                    "name": name,
+                    "sizeBytes": len(fake_asset_bytes(name)),
+                    "sha256": hashlib.sha256(fake_asset_bytes(name)).hexdigest(),
+                }
+                for name in names
+            ],
+        }
+
+    def provenance_archive(self, run_id: int) -> bytes:
+        if run_id not in self.artifact_archives:
+            buffer = io.BytesIO()
+            with zipfile.ZipFile(buffer, "w", zipfile.ZIP_DEFLATED) as bundle:
+                bundle.writestr(
+                    provenance.PROVENANCE_FILENAME,
+                    json.dumps(self.provenance_payload(run_id), sort_keys=True),
+                )
+            self.artifact_archives[run_id] = buffer.getvalue()
+        return self.artifact_archives[run_id]
+
+    def list_run_artifacts(self, run_id: int) -> list[dict[str, object]]:
+        run = self.runs[run_id]
+        spec = next(
+            item
+            for item in PUBLISH.WORKFLOWS
+            if item.workflow_file == self.run_workflows[run_id]
+        )
+        archive = self.provenance_archive(run_id)
+        artifact: dict[str, object] = {
+            "id": 1000 + run_id,
+            "name": provenance.artifact_name(
+                spec.provenance_platform, int(run["run_attempt"])
+            ),
+            "size_in_bytes": len(archive),
+            "expired": False,
+            "digest": "sha256:" + hashlib.sha256(archive).hexdigest(),
+            "workflow_run": {"id": run_id, "head_sha": run["head_sha"]},
+        }
+        artifact.update(self.artifact_metadata_overrides.get(run_id, {}))
+        return [artifact]
+
+    def download_artifact_zip(self, artifact_id: int) -> bytes:
+        return self.provenance_archive(artifact_id - 1000)
 
 
 class ReleaseRequestTest(unittest.TestCase):
@@ -222,6 +370,21 @@ class ReleaseRequestTest(unittest.TestCase):
 
 
 class GitHubClientTagAliasTest(unittest.TestCase):
+    class Response:
+        status = 200
+
+        def __init__(self, payload: bytes) -> None:
+            self.payload = payload
+
+        def __enter__(self) -> "GitHubClientTagAliasTest.Response":
+            return self
+
+        def __exit__(self, *_args: object) -> None:
+            return None
+
+        def read(self, _limit: int | None = None) -> bytes:
+            return self.payload
+
     def test_only_returns_synthetic_lightweight_aliases_for_the_release_target(self) -> None:
         client = PUBLISH.GitHubClient("owner/repository", "test-token")
         client._request = lambda *_args, **_kwargs: (  # type: ignore[method-assign]
@@ -251,6 +414,359 @@ class GitHubClientTagAliasTest(unittest.TestCase):
             client.list_detached_tag_aliases(TARGET_SHA),
         )
 
+    def test_ci_lookup_is_scoped_to_push_event_and_exact_head_sha(self) -> None:
+        client = PUBLISH.GitHubClient("owner/repository", "test-token")
+        requested_paths: list[str] = []
+
+        def request(method: str, path: str, **_kwargs: object) -> tuple[int, object]:
+            self.assertEqual("GET", method)
+            requested_paths.append(path)
+            return 200, {"total_count": 0, "workflow_runs": []}
+
+        client._request = request  # type: ignore[method-assign]
+
+        self.assertEqual([], client.list_ci_runs(TARGET_SHA))
+        self.assertEqual(1, len(requested_paths))
+        self.assertIn("/actions/workflows/ci.yml/runs?", requested_paths[0])
+        self.assertIn("event=push", requested_paths[0])
+        self.assertIn(f"head_sha={TARGET_SHA}", requested_paths[0])
+
+    def test_platform_lookup_uses_exact_sha_not_branch_filter(self) -> None:
+        client = PUBLISH.GitHubClient("owner/repository", "test-token")
+        requested_paths: list[str] = []
+
+        def request(method: str, path: str, **_kwargs: object) -> tuple[int, object]:
+            self.assertEqual("GET", method)
+            requested_paths.append(path)
+            return 200, {"total_count": 0, "workflow_runs": []}
+
+        client._request = request  # type: ignore[method-assign]
+
+        self.assertEqual(
+            [], client.list_workflow_runs("build-windows-release.yml", TARGET_SHA)
+        )
+        self.assertEqual(1, len(requested_paths))
+        self.assertIn("event=workflow_dispatch", requested_paths[0])
+        self.assertIn(f"head_sha={TARGET_SHA}", requested_paths[0])
+        self.assertNotIn("branch=", requested_paths[0])
+
+    def test_platform_lookup_reads_every_page(self) -> None:
+        client = PUBLISH.GitHubClient("owner/repository", "test-token")
+        requested_paths: list[str] = []
+        pages: list[dict[str, object]] = [
+            {
+                "total_count": 101,
+                "workflow_runs": [{"id": index} for index in range(1, 101)],
+            },
+            {"total_count": 101, "workflow_runs": [{"id": 101}]},
+        ]
+
+        def request(method: str, path: str, **_kwargs: object) -> tuple[int, object]:
+            self.assertEqual("GET", method)
+            requested_paths.append(path)
+            return 200, pages.pop(0)
+
+        client._request = request  # type: ignore[method-assign]
+
+        runs = client.list_workflow_runs(
+            "build-windows-release.yml", TARGET_SHA
+        )
+
+        self.assertEqual(101, len(runs))
+        self.assertEqual(2, len(requested_paths))
+        self.assertIn("per_page=100", requested_paths[0])
+        self.assertIn("page=1", requested_paths[0])
+        self.assertIn("page=2", requested_paths[1])
+
+    def test_platform_lookup_fails_closed_if_pagination_changes(self) -> None:
+        client = PUBLISH.GitHubClient("owner/repository", "test-token")
+        pages: list[dict[str, object]] = [
+            {
+                "total_count": 101,
+                "workflow_runs": [{"id": index} for index in range(1, 101)],
+            },
+            {"total_count": 102, "workflow_runs": [{"id": 101}, {"id": 102}]},
+        ]
+        client._request = (  # type: ignore[method-assign]
+            lambda *_args, **_kwargs: (200, pages.pop(0))
+        )
+
+        with self.assertRaisesRegex(PUBLISH.PublishError, "changed during pagination"):
+            client.list_workflow_runs("build-windows-release.yml", TARGET_SHA)
+
+    def test_transient_api_failures_retry_for_429_5xx_and_rate_limit(self) -> None:
+        for status, headers in (
+            (429, {"Retry-After": "0"}),
+            (503, {}),
+            (403, {"X-RateLimit-Remaining": "0", "Retry-After": "0"}),
+        ):
+            with self.subTest(status=status):
+                delays: list[float] = []
+                client = PUBLISH.GitHubClient(
+                    "owner/repository",
+                    "test-token",
+                    sleep=delays.append,
+                    retry_attempts=2,
+                )
+                failure = PUBLISH.HTTPError(
+                    "https://api.github.test/example",
+                    status,
+                    "transient",
+                    headers,
+                    io.BytesIO(b"try again"),
+                )
+                response = self.Response(b'{"ok": true}')
+                with mock.patch.object(
+                    PUBLISH, "urlopen", side_effect=[failure, response]
+                ) as request:
+                    _status, payload = client._request("GET", "/example")
+                self.assertEqual({"ok": True}, payload)
+                self.assertEqual(2, request.call_count)
+                self.assertEqual(1, len(delays))
+
+    def test_cross_host_artifact_redirect_does_not_forward_token(self) -> None:
+        token = "dummy-artifact-token"
+        first_hop_authorization: list[str | None] = []
+        second_hop_authorization: list[str | None] = []
+
+        class ArchiveHandler(BaseHTTPRequestHandler):
+            def do_GET(self) -> None:  # noqa: N802 - stdlib callback name
+                second_hop_authorization.append(self.headers.get("Authorization"))
+                payload = b"provenance archive"
+                self.send_response(200)
+                self.send_header("Content-Length", str(len(payload)))
+                self.end_headers()
+                self.wfile.write(payload)
+
+            def log_message(self, *_args: object) -> None:
+                return
+
+        archive_server = ThreadingHTTPServer(("127.0.0.1", 0), ArchiveHandler)
+        redirect_server: ThreadingHTTPServer | None = None
+        archive_thread: threading.Thread | None = None
+        redirect_thread: threading.Thread | None = None
+
+        def stop_server(
+            server: ThreadingHTTPServer | None,
+            thread: threading.Thread | None,
+            label: str,
+        ) -> None:
+            if server is None:
+                return
+            try:
+                if thread is not None and thread.is_alive():
+                    server.shutdown()
+            finally:
+                server.server_close()
+            if thread is not None:
+                thread.join(timeout=5)
+                self.assertFalse(
+                    thread.is_alive(), f"{label} test server thread did not stop"
+                )
+
+        try:
+            class RedirectHandler(BaseHTTPRequestHandler):
+                def do_GET(self) -> None:  # noqa: N802 - stdlib callback name
+                    first_hop_authorization.append(
+                        self.headers.get("Authorization")
+                    )
+                    self.send_response(302)
+                    self.send_header(
+                        "Location",
+                        f"http://127.0.0.1:{archive_server.server_port}/archive.zip",
+                    )
+                    self.end_headers()
+
+                def log_message(self, *_args: object) -> None:
+                    return
+
+            redirect_server = ThreadingHTTPServer(
+                ("127.0.0.1", 0), RedirectHandler
+            )
+            archive_thread = threading.Thread(
+                target=archive_server.serve_forever, daemon=True
+            )
+            redirect_thread = threading.Thread(
+                target=redirect_server.serve_forever, daemon=True
+            )
+            archive_thread.start()
+            redirect_thread.start()
+            client = PUBLISH.GitHubClient(
+                "owner/repository",
+                token,
+                api_url=f"http://127.0.0.1:{redirect_server.server_port}",
+            )
+
+            diagnostics = io.StringIO()
+            with mock.patch.object(PUBLISH.sys, "stderr", diagnostics):
+                payload = client._request_bytes("/artifact.zip", max_bytes=1024)
+
+            self.assertEqual(b"provenance archive", payload)
+            self.assertTrue(
+                len(first_hop_authorization) == 1
+                and first_hop_authorization[0] == f"Bearer {token}",
+                "The API first hop did not receive the expected bearer authorization",
+            )
+            self.assertTrue(
+                second_hop_authorization == [None],
+                "The redirected artifact hop received repository authorization",
+            )
+            self.assertFalse(
+                token in diagnostics.getvalue(),
+                "GitHub API diagnostics exposed the bearer token",
+            )
+        finally:
+            try:
+                stop_server(redirect_server, redirect_thread, "Redirect")
+            finally:
+                stop_server(archive_server, archive_thread, "Artifact")
+
+    def test_workflow_dispatch_does_not_retry_an_ambiguous_failure(self) -> None:
+        delays: list[float] = []
+        client = PUBLISH.GitHubClient(
+            "owner/repository",
+            "test-token",
+            sleep=delays.append,
+            retry_attempts=3,
+        )
+        with mock.patch.object(
+            PUBLISH,
+            "urlopen",
+            side_effect=[OSError("connection reset"), self.Response(b"")],
+        ) as request:
+            with self.assertRaisesRegex(PUBLISH.PublishError, "connection reset"):
+                client.dispatch_workflow("build-windows-release.yml", RELEASE_TAG, {})
+
+        self.assertEqual(1, request.call_count)
+        self.assertEqual([], delays)
+
+    def test_non_idempotent_creation_posts_do_not_retry_ambiguous_failures(self) -> None:
+        release_request = PUBLISH.ReleaseRequest(
+            DATE_TAG,
+            RELEASE_TAG,
+            f"LizzieYzy Next {RELEASE_TAG}",
+            True,
+            f".github/release-notes/{RELEASE_TAG}.md",
+        )
+        for operation_name in ("tag", "draft release"):
+            with self.subTest(operation=operation_name):
+                delays: list[float] = []
+                client = PUBLISH.GitHubClient(
+                    "owner/repository",
+                    "test-token",
+                    sleep=delays.append,
+                    retry_attempts=3,
+                )
+                with mock.patch.object(
+                    PUBLISH,
+                    "urlopen",
+                    side_effect=[
+                        OSError("response lost"),
+                        self.Response(b'{"id": 7}'),
+                    ],
+                ) as request:
+                    with self.assertRaisesRegex(PUBLISH.PublishError, "response lost"):
+                        if operation_name == "tag":
+                            client.create_tag(RELEASE_TAG, TARGET_SHA)
+                        else:
+                            client.create_draft_release(release_request, TARGET_SHA)
+
+                self.assertEqual(1, request.call_count)
+                self.assertEqual([], delays)
+
+    def test_release_patch_keeps_transient_retry(self) -> None:
+        delays: list[float] = []
+        client = PUBLISH.GitHubClient(
+            "owner/repository",
+            "test-token",
+            sleep=delays.append,
+            retry_attempts=2,
+        )
+        with mock.patch.object(
+            PUBLISH,
+            "urlopen",
+            side_effect=[OSError("response lost"), self.Response(b'{"id": 7}')],
+        ) as request:
+            release = client.update_release(7, {"draft": False})
+
+        self.assertEqual({"id": 7}, release)
+        self.assertEqual(2, request.call_count)
+        self.assertEqual(1, len(delays))
+
+    def test_delete_tag_retries_lost_response_and_accepts_missing_alias(self) -> None:
+        delays: list[float] = []
+        alias_present = True
+        calls = 0
+
+        def delete_then_report_missing(
+            _request: object, *, timeout: int
+        ) -> object:
+            nonlocal alias_present, calls
+            self.assertEqual(60, timeout)
+            calls += 1
+            if calls == 1:
+                alias_present = False
+                raise OSError("delete response lost")
+            raise PUBLISH.HTTPError(
+                "https://api.github.test/tag",
+                404,
+                "not found",
+                {},
+                io.BytesIO(b'{"message":"Not Found"}'),
+            )
+
+        client = PUBLISH.GitHubClient(
+            "owner/repository",
+            "test-token",
+            sleep=delays.append,
+            retry_attempts=2,
+        )
+        diagnostics = io.StringIO()
+        with mock.patch.object(PUBLISH, "urlopen", side_effect=delete_then_report_missing):
+            with mock.patch.object(PUBLISH.sys, "stderr", diagnostics):
+                client.delete_tag("untagged-0123456789abcdefabcd")
+
+        self.assertFalse(alias_present)
+        self.assertEqual(2, calls)
+        self.assertEqual(1, len(delays))
+
+    def test_delete_tag_still_rejects_non_not_found_errors(self) -> None:
+        client = PUBLISH.GitHubClient(
+            "owner/repository", "test-token", retry_attempts=3
+        )
+        failure = PUBLISH.HTTPError(
+            "https://api.github.test/tag",
+            422,
+            "unprocessable",
+            {},
+            io.BytesIO(b'{"message":"cannot delete"}'),
+        )
+        with mock.patch.object(PUBLISH, "urlopen", side_effect=failure) as request:
+            with self.assertRaisesRegex(PUBLISH.PublishError, "422"):
+                client.delete_tag("untagged-0123456789abcdefabcd")
+
+        self.assertEqual(1, request.call_count)
+
+    def test_release_asset_listing_reads_every_page(self) -> None:
+        client = PUBLISH.GitHubClient("owner/repository", "test-token")
+        requested_paths: list[str] = []
+        pages: list[list[dict[str, object]]] = [
+            [{"name": f"asset-{index}"} for index in range(100)],
+            [{"name": "asset-100"}],
+        ]
+
+        def request(method: str, path: str, **_kwargs: object) -> tuple[int, object]:
+            self.assertEqual("GET", method)
+            requested_paths.append(path)
+            return 200, pages.pop(0)
+
+        client._request = request  # type: ignore[method-assign]
+
+        self.assertEqual(101, len(client.list_release_assets(7)))
+        self.assertEqual(2, len(requested_paths))
+        self.assertIn("page=1", requested_paths[0])
+        self.assertIn("page=2", requested_paths[1])
+
 
 class WorkflowSpecTest(unittest.TestCase):
     def test_complete_asset_set_satisfies_every_platform(self) -> None:
@@ -259,18 +775,19 @@ class WorkflowSpecTest(unittest.TestCase):
         for spec in PUBLISH.WORKFLOWS:
             self.assertEqual([], spec.missing_assets(assets, DATE_TAG), spec.platform)
 
-    def test_windows_requires_a_tensorrt_volume(self) -> None:
-        assets = [
-            name
-            for name in all_asset_names()
-            if "nvidia.tensorrt.portable.7z.001" not in name
-        ]
+    def test_windows_requires_both_fixed_tensorrt_volumes(self) -> None:
+        for suffix in (".001", ".002"):
+            with self.subTest(suffix=suffix):
+                assets = [
+                    name
+                    for name in all_asset_names()
+                    if not name.endswith(f"portable.7z{suffix}")
+                ]
 
-        missing = PUBLISH.WORKFLOWS[0].missing_assets(assets, DATE_TAG)
+                missing = PUBLISH.WORKFLOWS[0].missing_assets(assets, DATE_TAG)
 
-        self.assertEqual(1, len(missing))
-        self.assertIn("nvidia", missing[0])
-        self.assertIn("7z", missing[0])
+                self.assertEqual(1, len(missing))
+                self.assertTrue(missing[0].endswith(suffix))
 
 
 class ReviewedReleaseNotesTest(unittest.TestCase):
@@ -315,20 +832,90 @@ class ReleaseWorkflowResilienceTest(unittest.TestCase):
         self.assertIn('target_sha="$TARGET_SHA"', workflow)
         self.assertIn("Manual recovery requires an existing release tag", workflow)
         self.assertIn('echo "target_sha=$target_sha" >> "$GITHUB_OUTPUT"', workflow)
+        self.assertIn('echo "request_sha256=$request_sha256" >> "$GITHUB_OUTPUT"', workflow)
+        self.assertIn('echo "release_tag=$release_tag" >> "$GITHUB_OUTPUT"', workflow)
+        self.assertIn("- name: Checkout exact target SHA", workflow)
+        self.assertIn("ref: ${{ steps.request.outputs.target_sha }}", workflow)
+        self.assertIn('test "$(git rev-parse HEAD)" = "$RELEASE_TARGET_SHA"', workflow)
         self.assertIn(
-            '--target-sha "${{ steps.request.outputs.target_sha }}"', workflow
+            'if [[ "$actual_request_sha256" != "$EXPECTED_REQUEST_SHA256" ]]',
+            workflow,
         )
+        self.assertIn(
+            'if [[ "$actual_release_tag" != "$EXPECTED_RELEASE_TAG" ]]',
+            workflow,
+        )
+        self.assertIn(
+            "RELEASE_TARGET_SHA: ${{ steps.request.outputs.target_sha }}", workflow
+        )
+        self.assertIn('--target-sha "$RELEASE_TARGET_SHA"', workflow)
         self.assertNotIn('--target-sha "${{ github.sha }}"', workflow)
 
-    def test_windows_draft_release_metadata_has_an_explicit_input_and_safe_fallback(self) -> None:
+    def test_publisher_step_env_isolates_untrusted_step_outputs(self) -> None:
+        workflow = (
+            SCRIPT_PATH.parents[1]
+            / ".github"
+            / "workflows"
+            / "publish-requested-pre-release.yml"
+        ).read_text(encoding="utf-8")
+        publish_step = workflow[workflow.index("Build, verify, and publish the pre-release"):]
+        self.assertIn(
+            "RELEASE_REQUEST_FILE: ${{ steps.request.outputs.request_file }}",
+            publish_step,
+        )
+        self.assertIn(
+            "RELEASE_TARGET_SHA: ${{ steps.request.outputs.target_sha }}",
+            publish_step,
+        )
+        self.assertIn('RELEASE_REPOSITORY: ${{ github.repository }}', publish_step)
+        run_body = publish_step[publish_step.index("run: |") :]
+        self.assertNotIn("${{ steps.", run_body)
+        self.assertNotIn("${{ github.repository }}", run_body)
+        self.assertIn('--request "$RELEASE_REQUEST_FILE"', run_body)
+        self.assertIn('--target-sha "$RELEASE_TARGET_SHA"', run_body)
+        self.assertIn(
+            r'^\.github/release-requests/[A-Za-z0-9._-]+\.json$', workflow
+        )
+
+    def test_windows_draft_release_metadata_is_explicit_and_fail_closed(self) -> None:
         workflow = (
             SCRIPT_PATH.parents[1] / ".github" / "workflows" / "build-windows-release.yml"
         ).read_text(encoding="utf-8")
 
         self.assertIn("release_prerelease:", workflow)
-        self.assertIn("releases?per_page=100", workflow)
-        self.assertNotIn("releases/tags/", workflow)
+        self.assertIn("required: true", workflow)
+        self.assertIn("validate_release_workflow_identity.py", workflow)
+        self.assertNotIn("default: 2026-", workflow)
+        self.assertNotIn("gh api --paginate", workflow)
         self.assertIn('LIZZIE_RELEASE_PRERELEASE="$release_prerelease"', workflow)
+
+    def test_every_platform_serializes_by_workflow_and_release_tag(self) -> None:
+        for workflow_name in (
+            "build-windows-release.yml",
+            "build-linux-release.yml",
+            "build-macos-amd64-release.yml",
+            "build-macos-arm64-release.yml",
+        ):
+            with self.subTest(workflow=workflow_name):
+                workflow = (
+                    SCRIPT_PATH.parents[1] / ".github" / "workflows" / workflow_name
+                ).read_text(encoding="utf-8")
+                self.assertIn("concurrency:", workflow)
+                self.assertIn(
+                    "group: release-${{ github.workflow }}-${{ inputs.release_tag }}",
+                    workflow,
+                )
+                self.assertIn("cancel-in-progress: true", workflow)
+
+    def test_ci_runs_publisher_tests_as_an_importable_module(self) -> None:
+        workflow = (
+            SCRIPT_PATH.parents[1] / ".github" / "workflows" / "ci.yml"
+        ).read_text(encoding="utf-8")
+
+        self.assertIn(
+            "python3 -m unittest scripts.test_publish_release_request", workflow
+        )
+        self.assertNotIn("python3 scripts/test_publish_release_request.py", workflow)
 
     @unittest.skipIf(os.name == "nt", "behavior test runs with native bash in CI")
     def test_macos_signing_retries_transient_failures(self) -> None:
@@ -437,6 +1024,16 @@ class ReleasePublisherTest(unittest.TestCase):
             run_timeout_seconds=30,
         )
 
+    def seed_successful_workflows(self, client: FakeClient) -> None:
+        for spec in PUBLISH.WORKFLOWS:
+            client.seed_workflow_run(spec.workflow_file)
+
+    def prepared_successful_client(self) -> FakeClient:
+        client = FakeClient()
+        client.assets = [fake_asset_metadata(name) for name in all_asset_names()]
+        self.seed_successful_workflows(client)
+        return client
+
     def test_publishes_only_after_platforms_assets_and_notes_succeed(self) -> None:
         client = FakeClient()
 
@@ -456,13 +1053,97 @@ class ReleasePublisherTest(unittest.TestCase):
             client.dispatched_inputs["build-windows-release.yml"]["release_prerelease"],
         )
         for workflow_file, inputs in client.dispatched_inputs.items():
-            if workflow_file != "build-windows-release.yml":
-                self.assertNotIn("release_prerelease", inputs)
+            self.assertEqual("true", inputs["release_prerelease"], workflow_file)
         self.assertCountEqual(all_asset_names(), client.assets)
         self.assertTrue(client.update_payloads)
         for payload in client.update_payloads:
             self.assertEqual(RELEASE_TAG, payload["tag_name"])
             self.assertEqual(TARGET_SHA, payload["target_commitish"])
+        self.assertEqual(self.release_notes(), client.update_payloads[-1]["body"])
+
+    def test_rerun_reuses_tag_created_before_a_lost_response(self) -> None:
+        client = self.prepared_successful_client()
+        create_tag = client.create_tag
+
+        def create_tag_then_lose_response(tag: str, target_sha: str) -> None:
+            create_tag(tag, target_sha)
+            raise PUBLISH.PublishError("simulated lost create-tag response")
+
+        client.create_tag = create_tag_then_lose_response  # type: ignore[method-assign]
+        with self.assertRaisesRegex(PUBLISH.PublishError, "lost create-tag"):
+            self.publisher(client).publish()
+
+        self.assertEqual(TARGET_SHA, client.tag_sha)
+        self.assertEqual(1, client.create_tag_calls)
+        self.assertIsNone(client.release)
+
+        client.create_tag = create_tag  # type: ignore[method-assign]
+        release = self.publisher(client).publish()
+
+        self.assertFalse(release["draft"])
+        self.assertEqual(1, client.create_tag_calls)
+        self.assertEqual(1, client.create_draft_release_calls)
+
+    def test_rerun_reuses_draft_created_before_a_lost_response(self) -> None:
+        client = self.prepared_successful_client()
+        create_draft_release = client.create_draft_release
+
+        def create_draft_then_lose_response(
+            request: PUBLISH.ReleaseRequest, target_sha: str
+        ) -> dict[str, object]:
+            create_draft_release(request, target_sha)
+            raise PUBLISH.PublishError("simulated lost create-release response")
+
+        client.create_draft_release = (  # type: ignore[method-assign]
+            create_draft_then_lose_response
+        )
+        with self.assertRaisesRegex(PUBLISH.PublishError, "lost create-release"):
+            self.publisher(client).publish()
+
+        assert client.release is not None
+        self.assertTrue(client.release["draft"])
+        self.assertEqual(RELEASE_TAG, client.release["tag_name"])
+        self.assertEqual(1, client.create_tag_calls)
+        self.assertEqual(1, client.create_draft_release_calls)
+
+        client.create_draft_release = create_draft_release  # type: ignore[method-assign]
+        release = self.publisher(client).publish()
+
+        self.assertFalse(release["draft"])
+        self.assertEqual(1, client.create_tag_calls)
+        self.assertEqual(1, client.create_draft_release_calls)
+
+    def test_rerun_restores_untagged_draft_created_before_lost_response(self) -> None:
+        client = self.prepared_successful_client()
+        create_draft_release = client.create_draft_release
+
+        def create_orphan_then_lose_response(
+            request: PUBLISH.ReleaseRequest, target_sha: str
+        ) -> dict[str, object]:
+            create_draft_release(request, target_sha)
+            assert client.release is not None
+            client.release["tag_name"] = "untagged-0123456789abcdefabcd"
+            raise PUBLISH.PublishError("simulated lost orphan response")
+
+        client.create_draft_release = (  # type: ignore[method-assign]
+            create_orphan_then_lose_response
+        )
+        with self.assertRaisesRegex(PUBLISH.PublishError, "lost orphan"):
+            self.publisher(client).publish()
+
+        assert client.release is not None
+        self.assertTrue(client.release["draft"])
+        self.assertTrue(str(client.release["tag_name"]).startswith("untagged-"))
+        self.assertEqual(1, client.create_tag_calls)
+        self.assertEqual(1, client.create_draft_release_calls)
+
+        client.create_draft_release = create_draft_release  # type: ignore[method-assign]
+        release = self.publisher(client).publish()
+
+        self.assertFalse(release["draft"])
+        self.assertEqual(RELEASE_TAG, release["tag_name"])
+        self.assertEqual(1, client.create_tag_calls)
+        self.assertEqual(1, client.create_draft_release_calls)
 
     def test_failed_platform_keeps_release_as_draft(self) -> None:
         client = FakeClient(failed_workflow="build-linux-release.yml")
@@ -474,8 +1155,258 @@ class ReleasePublisherTest(unittest.TestCase):
         self.assertTrue(client.release["draft"])
         self.assertTrue(client.release["prerelease"])
 
+    def test_waits_for_target_ci_before_creating_release(self) -> None:
+        client = FakeClient()
+        client.ci_run_snapshots = [
+            [
+                {
+                    "id": 50,
+                    "head_sha": TARGET_SHA,
+                    "status": "in_progress",
+                    "conclusion": None,
+                }
+            ],
+            [
+                {
+                    "id": 50,
+                    "head_sha": TARGET_SHA,
+                    "status": "completed",
+                    "conclusion": "success",
+                }
+            ],
+        ]
+
+        release = self.publisher(client).publish()
+
+        self.assertFalse(release["draft"])
+        self.assertGreaterEqual(client.ci_list_calls, 2)
+
+    def test_failed_target_ci_prevents_tag_release_and_dispatch(self) -> None:
+        client = FakeClient()
+        client.ci_run_snapshots[0][0]["conclusion"] = "failure"
+
+        with self.assertRaisesRegex(PUBLISH.PublishError, "CI workflow.*failure"):
+            self.publisher(client).publish()
+
+        self.assertIsNone(client.tag_sha)
+        self.assertIsNone(client.release)
+        self.assertEqual([], client.dispatched)
+
+    def test_ci_is_rechecked_immediately_before_publication(self) -> None:
+        client = FakeClient()
+        client.ci_run_snapshots = [
+            [
+                {
+                    "id": 50,
+                    "head_sha": TARGET_SHA,
+                    "status": "completed",
+                    "conclusion": "success",
+                }
+            ],
+            [
+                {
+                    "id": 51,
+                    "head_sha": TARGET_SHA,
+                    "status": "completed",
+                    "conclusion": "failure",
+                }
+            ],
+        ]
+
+        with self.assertRaisesRegex(PUBLISH.PublishError, "CI workflow.*failure"):
+            self.publisher(client).publish()
+
+        assert client.release is not None
+        self.assertTrue(client.release["draft"])
+
+    def test_existing_assets_do_not_hide_latest_failed_platform_run(self) -> None:
+        client = FakeClient()
+        client.assets = all_asset_names()
+        self.seed_successful_workflows(client)
+        client.seed_workflow_run("build-windows-release.yml", conclusion="failure")
+
+        release = self.publisher(client).publish()
+
+        self.assertFalse(release["draft"])
+        self.assertEqual(["build-windows-release.yml"], client.dispatched)
+
+    def test_existing_assets_and_current_successful_runs_are_reused(self) -> None:
+        client = FakeClient()
+        client.assets = all_asset_names()
+        self.seed_successful_workflows(client)
+
+        release = self.publisher(client).publish()
+
+        self.assertFalse(release["draft"])
+        self.assertEqual([], client.dispatched)
+
+    def test_duplicate_active_target_run_blocks_publication(self) -> None:
+        client = FakeClient()
+        client.assets = [fake_asset_metadata(name) for name in all_asset_names()]
+        client.seed_workflow_run(
+            "build-windows-release.yml", status="in_progress"
+        )
+        self.seed_successful_workflows(client)
+
+        with self.assertRaisesRegex(
+            PUBLISH.PublishError, "duplicate target workflow runs are active"
+        ):
+            self.publisher(client).publish()
+
+        assert client.release is not None
+        self.assertTrue(client.release["draft"])
+
+    def test_stale_active_list_state_for_selected_run_does_not_block(self) -> None:
+        client = FakeClient()
+        client.assets = [fake_asset_metadata(name) for name in all_asset_names()]
+        self.seed_successful_workflows(client)
+        original_list_workflow_runs = client.list_workflow_runs
+
+        def list_with_stale_selected_status(
+            workflow_file: str, target_sha: str
+        ) -> list[dict[str, object]]:
+            runs = [
+                dict(run)
+                for run in original_list_workflow_runs(workflow_file, target_sha)
+            ]
+            if workflow_file == "build-windows-release.yml" and runs:
+                runs[0]["status"] = "in_progress"
+                runs[0]["conclusion"] = None
+            return runs
+
+        client.list_workflow_runs = (  # type: ignore[method-assign]
+            list_with_stale_selected_status
+        )
+
+        release = self.publisher(client).publish()
+
+        self.assertFalse(release["draft"])
+
+    def test_successful_runs_for_another_sha_do_not_satisfy_platform_gate(self) -> None:
+        client = FakeClient()
+        client.assets = all_asset_names()
+        for spec in PUBLISH.WORKFLOWS:
+            client.seed_workflow_run(spec.workflow_file, head_sha="b" * 40)
+
+        release = self.publisher(client).publish()
+
+        self.assertFalse(release["draft"])
+        self.assertEqual(
+            [spec.workflow_file for spec in PUBLISH.WORKFLOWS],
+            client.dispatched,
+        )
+
+    def test_successful_run_with_wrong_input_attestation_is_not_reused(self) -> None:
+        client = FakeClient()
+        client.assets = all_asset_names()
+        for spec in PUBLISH.WORKFLOWS:
+            if spec.platform != "Windows":
+                client.seed_workflow_run(spec.workflow_file)
+        client.seed_workflow_run(
+            "build-windows-release.yml",
+            display_title=(
+                f"Windows release {RELEASE_TAG} | 2026-07-21 | prerelease=true"
+            ),
+        )
+
+        release = self.publisher(client).publish()
+
+        self.assertFalse(release["draft"])
+        self.assertEqual(["build-windows-release.yml"], client.dispatched)
+
+    def test_any_unexpected_release_asset_fails_closed(self) -> None:
+        client = FakeClient()
+        client.assets = all_asset_names() + [f"{DATE_TAG}-windows64-install.txt"]
+        self.seed_successful_workflows(client)
+
+        with self.assertRaisesRegex(PUBLISH.PublishError, "unexpected assets"):
+            self.publisher(client).publish()
+
+        assert client.release is not None
+        self.assertTrue(client.release["draft"])
+
+    def test_missing_expected_release_asset_fails_closed(self) -> None:
+        client = FakeClient()
+        client.assets = [
+            name
+            for name in all_asset_names()
+            if name != "lizzieyzy-next-update-manifest.json"
+        ]
+        self.seed_successful_workflows(client)
+
+        with self.assertRaisesRegex(PUBLISH.PublishError, "missing assets"):
+            self.publisher(client).publish()
+
+        assert client.release is not None
+        self.assertTrue(client.release["draft"])
+
+    def test_same_named_incomplete_release_asset_fails_closed(self) -> None:
+        for field, value, message in (
+            ("state", "starter", "state is not uploaded"),
+            ("size", 0, "size is not positive"),
+            ("digest", None, "digest is missing or invalid"),
+        ):
+            with self.subTest(field=field):
+                client = self.prepared_successful_client()
+                asset = client.assets[0]
+                assert isinstance(asset, dict)
+                asset[field] = value
+                with self.assertRaisesRegex(PUBLISH.PublishError, message):
+                    self.publisher(client).publish()
+                assert client.release is not None
+                self.assertTrue(client.release["draft"])
+
+    def test_same_named_replacement_asset_must_match_run_provenance(self) -> None:
+        for field, value, message in (
+            ("size", 999, "size differs from run provenance"),
+            (
+                "digest",
+                "sha256:" + hashlib.sha256(b"replacement payload").hexdigest(),
+                "digest differs from run provenance",
+            ),
+        ):
+            with self.subTest(field=field):
+                client = self.prepared_successful_client()
+                asset = client.assets[0]
+                assert isinstance(asset, dict)
+                asset[field] = value
+                with self.assertRaisesRegex(PUBLISH.PublishError, message):
+                    self.publisher(client).publish()
+
+    def test_selected_run_rejects_provenance_from_an_older_successful_run(self) -> None:
+        client = FakeClient()
+        client.assets = [fake_asset_metadata(name) for name in all_asset_names()]
+        old_windows_run = client.seed_workflow_run("build-windows-release.yml")
+        old_payload = client.provenance_payload(old_windows_run)
+        selected_windows_run = client.seed_workflow_run("build-windows-release.yml")
+        client.provenance_payload_overrides[selected_windows_run] = old_payload
+        for spec in PUBLISH.WORKFLOWS:
+            if spec.platform != "Windows":
+                client.seed_workflow_run(spec.workflow_file)
+
+        with self.assertRaisesRegex(PUBLISH.PublishError, "workflowRunId"):
+            self.publisher(client).publish()
+
+    def test_provenance_artifact_metadata_and_download_are_fail_closed(self) -> None:
+        mutations = (
+            ({"expired": True}, "expired"),
+            ({"workflow_run": {"id": 999, "head_sha": TARGET_SHA}}, "not bound"),
+            ({"digest": "sha256:" + "0" * 64}, "digest does not match"),
+            ({"size_in_bytes": 1}, "download size does not match"),
+        )
+        for override, message in mutations:
+            with self.subTest(override=override):
+                client = self.prepared_successful_client()
+                windows_run = int(
+                    client.workflow_runs["build-windows-release.yml"][0]["id"]
+                )
+                client.artifact_metadata_overrides[windows_run] = override
+                with self.assertRaisesRegex(PUBLISH.PublishError, message):
+                    self.publisher(client).publish()
+
     def test_already_published_complete_release_is_idempotent(self) -> None:
         client = FakeClient()
+        self.seed_successful_workflows(client)
         client.tag_sha = TARGET_SHA
         client.assets = all_asset_names()
         client.release = {
@@ -494,8 +1425,138 @@ class ReleasePublisherTest(unittest.TestCase):
         self.assertFalse(release["draft"])
         self.assertEqual([], client.dispatched)
 
+    def test_idempotent_release_requires_exact_canonical_notes(self) -> None:
+        client = FakeClient()
+        self.seed_successful_workflows(client)
+        client.tag_sha = TARGET_SHA
+        client.assets = all_asset_names()
+        client.release = {
+            "id": 7,
+            "tag_name": RELEASE_TAG,
+            "target_commitish": TARGET_SHA,
+            "name": self.request().title,
+            "body": self.release_notes().replace("- Stable", "- Edited", 1),
+            "draft": False,
+            "prerelease": True,
+            "html_url": "https://example.invalid/release",
+        }
+
+        with self.assertRaisesRegex(PUBLISH.PublishError, "canonical reviewed"):
+            self.publisher(client).publish()
+
+    def test_canonical_notes_are_reread_immediately_before_publication(self) -> None:
+        client = self.prepared_successful_client()
+        original_get_release = client.get_release
+
+        def get_release_with_tamper(tag: str) -> dict[str, object] | None:
+            release = original_get_release(tag)
+            if (
+                release is not None
+                and release.get("draft") is True
+                and release.get("body") == self.release_notes()
+            ):
+                assert client.release is not None
+                client.release["body"] = self.release_notes() + "\nexternal edit\n"
+                return dict(client.release)
+            return release
+
+        client.get_release = get_release_with_tamper  # type: ignore[method-assign]
+
+        with self.assertRaisesRegex(PUBLISH.PublishError, "canonical reviewed"):
+            self.publisher(client).publish()
+
+        assert client.release is not None
+        self.assertTrue(client.release["draft"])
+
+    def test_canonical_notes_are_reread_after_publication(self) -> None:
+        client = self.prepared_successful_client()
+        original_get_release_by_tag = client.get_release_by_tag
+
+        def get_release_by_tag_with_tamper(tag: str) -> dict[str, object] | None:
+            release = original_get_release_by_tag(tag)
+            if release is not None and release.get("draft") is False:
+                assert client.release is not None
+                client.release["body"] = self.release_notes() + "\nexternal edit\n"
+                return dict(client.release)
+            return release
+
+        client.get_release_by_tag = (  # type: ignore[method-assign]
+            get_release_by_tag_with_tamper
+        )
+
+        with self.assertRaisesRegex(PUBLISH.PublishError, "canonical reviewed"):
+            self.publisher(client).publish()
+
+        assert client.release is not None
+        self.assertFalse(client.release["draft"])
+
+    def test_live_tag_is_reread_immediately_before_publication(self) -> None:
+        client = self.prepared_successful_client()
+        calls = 0
+
+        def moving_tag(_tag: str) -> str:
+            nonlocal calls
+            calls += 1
+            return TARGET_SHA if calls == 1 else "b" * 40
+
+        client.get_tag_sha = moving_tag  # type: ignore[method-assign]
+
+        with self.assertRaisesRegex(PUBLISH.PublishError, "Live tag.*changed"):
+            self.publisher(client).publish()
+
+        assert client.release is not None
+        self.assertTrue(client.release["draft"])
+
+    def test_live_tag_is_reread_after_publication(self) -> None:
+        client = self.prepared_successful_client()
+        client.tag_sha = TARGET_SHA
+        original_update_release = client.update_release
+
+        def update_and_move_tag(
+            release_id: int, payload: dict[str, object]
+        ) -> dict[str, object]:
+            release = original_update_release(release_id, payload)
+            if payload.get("draft") is False:
+                client.tag_sha = "b" * 40
+            return release
+
+        client.update_release = update_and_move_tag  # type: ignore[method-assign]
+
+        with self.assertRaisesRegex(PUBLISH.PublishError, "Live tag.*changed"):
+            self.publisher(client).publish()
+
+        assert client.release is not None
+        self.assertFalse(client.release["draft"])
+
+    def test_idempotent_path_rereads_live_tag(self) -> None:
+        client = FakeClient()
+        self.seed_successful_workflows(client)
+        client.assets = all_asset_names()
+        client.release = {
+            "id": 7,
+            "tag_name": RELEASE_TAG,
+            "target_commitish": TARGET_SHA,
+            "name": self.request().title,
+            "body": self.release_notes(),
+            "draft": False,
+            "prerelease": True,
+            "html_url": "https://example.invalid/release",
+        }
+        calls = 0
+
+        def moving_tag(_tag: str) -> str:
+            nonlocal calls
+            calls += 1
+            return TARGET_SHA if calls == 1 else "b" * 40
+
+        client.get_tag_sha = moving_tag  # type: ignore[method-assign]
+
+        with self.assertRaisesRegex(PUBLISH.PublishError, "Live tag.*changed"):
+            self.publisher(client).publish()
+
     def test_cleans_unbound_synthetic_tag_alias_for_published_release(self) -> None:
         client = FakeClient()
+        self.seed_successful_workflows(client)
         client.tag_sha = TARGET_SHA
         client.assets = all_asset_names()
         client.detached_tag_aliases = {
@@ -520,6 +1581,7 @@ class ReleasePublisherTest(unittest.TestCase):
     def test_preserves_synthetic_tag_alias_when_a_release_still_uses_it(self) -> None:
         alias = "untagged-0123456789abcdefabcd"
         client = FakeClient()
+        self.seed_successful_workflows(client)
         client.tag_sha = TARGET_SHA
         client.assets = all_asset_names()
         client.detached_tag_aliases = {alias: TARGET_SHA}
@@ -540,8 +1602,9 @@ class ReleasePublisherTest(unittest.TestCase):
         self.assertEqual([], client.deleted_tags)
         self.assertEqual({alias: TARGET_SHA}, client.detached_tag_aliases)
 
-    def test_recovers_orphaned_published_release_without_rebuilding(self) -> None:
+    def test_refuses_to_rebind_public_orphan_before_release_gates(self) -> None:
         client = FakeClient()
+        self.seed_successful_workflows(client)
         client.tag_sha = TARGET_SHA
         client.assets = all_asset_names()
         client.release = {
@@ -555,12 +1618,56 @@ class ReleasePublisherTest(unittest.TestCase):
             "html_url": "https://example.invalid/orphaned",
         }
 
+        with self.assertRaisesRegex(PUBLISH.PublishError, "public orphaned release"):
+            self.publisher(client).publish()
+
+        assert client.release is not None
+        self.assertEqual("untagged-detached-release", client.release["tag_name"])
+        self.assertFalse(client.release["draft"])
+        self.assertEqual([], client.dispatched)
+        self.assertEqual([], client.update_payloads)
+
+    def test_restores_only_draft_orphan_then_publishes_after_all_gates(self) -> None:
+        client = FakeClient()
+        self.seed_successful_workflows(client)
+        client.tag_sha = TARGET_SHA
+        client.assets = all_asset_names()
+        client.release = {
+            "id": 7,
+            "tag_name": "untagged-detached-release",
+            "target_commitish": TARGET_SHA,
+            "name": self.request().title,
+            "body": self.release_notes(),
+            "draft": True,
+            "prerelease": True,
+            "html_url": "https://example.invalid/orphaned",
+        }
+
         release = self.publisher(client).publish()
 
         self.assertEqual(RELEASE_TAG, release["tag_name"])
-        self.assertEqual(TARGET_SHA, release["target_commitish"])
-        self.assertEqual([], client.dispatched)
-        self.assertEqual(1, len(client.update_payloads))
+        self.assertFalse(release["draft"])
+        self.assertTrue(client.update_payloads[0]["draft"])
+        self.assertFalse(client.update_payloads[-1]["draft"])
+
+    def test_already_published_release_requires_exact_title(self) -> None:
+        client = FakeClient()
+        self.seed_successful_workflows(client)
+        client.tag_sha = TARGET_SHA
+        client.assets = all_asset_names()
+        client.release = {
+            "id": 7,
+            "tag_name": RELEASE_TAG,
+            "target_commitish": TARGET_SHA,
+            "name": "Stale release title",
+            "body": self.release_notes(),
+            "draft": False,
+            "prerelease": True,
+            "html_url": "https://example.invalid/release",
+        }
+
+        with self.assertRaisesRegex(PUBLISH.PublishError, "Release title changed"):
+            self.publisher(client).publish()
 
     def test_fails_closed_when_github_detaches_the_release_tag(self) -> None:
         client = FakeClient(detach_on_publish=True)
@@ -634,6 +1741,26 @@ class ReleasePublisherTest(unittest.TestCase):
                 TARGET_SHA,
                 notes,
             )
+
+    def test_rejects_unresolved_release_note_markers(self) -> None:
+        for marker in (
+            "FULL_TEST_COUNT",
+            "REAL_GUI_VALIDATION_",
+            "REAL_GUI_VALIDATION_EN",
+            "TODO",
+            "TBD",
+            "FIXME",
+            "PLACEHOLDER",
+            "{{ test_count }}",
+        ):
+            with self.subTest(marker=marker):
+                with self.assertRaisesRegex(PUBLISH.PublishError, "unresolved marker"):
+                    PUBLISH.ReleasePublisher(
+                        FakeClient(),
+                        self.request(),
+                        TARGET_SHA,
+                        self.release_notes() + f"\n{marker}\n",
+                    )
 
 
 if __name__ == "__main__":

--- a/scripts/test_release_asset_provenance.py
+++ b/scripts/test_release_asset_provenance.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""Tests for run-bound release asset checksum provenance."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import tempfile
+import unittest
+
+from scripts import release_asset_provenance as provenance
+
+
+DATE_TAG = "2026-08-19"
+RELEASE_TAG = f"next-{DATE_TAG}.1"
+TARGET_SHA = "a" * 40
+
+
+class ReleaseAssetProvenanceTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary_directory = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temporary_directory.cleanup)
+        self.release_dir = Path(self.temporary_directory.name)
+        for index, name in enumerate(
+            provenance.expected_asset_names("linux", DATE_TAG), 1
+        ):
+            (self.release_dir / name).write_bytes(f"asset-{index}".encode("ascii"))
+
+    def payload(self) -> dict[str, object]:
+        return provenance.build_provenance(
+            self.release_dir,
+            "linux",
+            DATE_TAG,
+            RELEASE_TAG,
+            TARGET_SHA,
+            123,
+            2,
+        )
+
+    def validate(self, payload: object) -> dict[str, dict[str, object]]:
+        return provenance.validate_provenance(
+            payload,
+            platform="linux",
+            date_tag=DATE_TAG,
+            release_tag=RELEASE_TAG,
+            target_sha=TARGET_SHA,
+            run_id=123,
+            run_attempt=2,
+        )
+
+    def test_builds_and_validates_exact_sorted_inventory(self) -> None:
+        payload = self.payload()
+        records = self.validate(json.loads(json.dumps(payload)))
+
+        self.assertEqual(
+            list(provenance.expected_asset_names("linux", DATE_TAG)),
+            list(records),
+        )
+        self.assertTrue(all(record["sizeBytes"] > 0 for record in records.values()))
+
+    def test_rejects_missing_empty_or_changed_local_asset(self) -> None:
+        name = provenance.expected_asset_names("linux", DATE_TAG)[0]
+        (self.release_dir / name).unlink()
+        with self.assertRaisesRegex(provenance.ProvenanceError, "Missing"):
+            self.payload()
+
+        (self.release_dir / name).write_bytes(b"")
+        with self.assertRaisesRegex(provenance.ProvenanceError, "empty"):
+            self.payload()
+
+    def test_rejects_wrong_run_sha_tag_or_attempt(self) -> None:
+        for field, value, message in (
+            ("targetSha", "b" * 40, "targetSha"),
+            ("releaseTag", "next-2026-08-19.2", "releaseTag"),
+            ("workflowRunId", 124, "workflowRunId"),
+            ("workflowRunAttempt", 1, "workflowRunAttempt"),
+        ):
+            with self.subTest(field=field):
+                payload = self.payload()
+                payload[field] = value
+                with self.assertRaisesRegex(provenance.ProvenanceError, message):
+                    self.validate(payload)
+
+    def test_rejects_missing_extra_duplicate_or_reordered_assets(self) -> None:
+        mutations = []
+        missing = self.payload()
+        assert isinstance(missing["assets"], list)
+        missing["assets"].pop()
+        mutations.append(missing)
+
+        extra = self.payload()
+        assert isinstance(extra["assets"], list)
+        extra["assets"].append(
+            {"name": "unexpected.zip", "sizeBytes": 1, "sha256": "0" * 64}
+        )
+        mutations.append(extra)
+
+        duplicate = self.payload()
+        assert isinstance(duplicate["assets"], list)
+        duplicate["assets"].append(dict(duplicate["assets"][0]))
+        mutations.append(duplicate)
+
+        reordered = self.payload()
+        assert isinstance(reordered["assets"], list)
+        reordered["assets"].reverse()
+        mutations.append(reordered)
+
+        for payload in mutations:
+            with self.subTest(assets=payload["assets"]):
+                with self.assertRaises(provenance.ProvenanceError):
+                    self.validate(payload)
+
+    def test_rejects_non_positive_size_or_malformed_digest(self) -> None:
+        for field, value, message in (
+            ("sizeBytes", 0, "positive integer"),
+            ("sha256", "0" * 63, "sha256"),
+        ):
+            with self.subTest(field=field):
+                payload = self.payload()
+                assets = payload["assets"]
+                assert isinstance(assets, list) and isinstance(assets[0], dict)
+                assets[0][field] = value
+                with self.assertRaisesRegex(provenance.ProvenanceError, message):
+                    self.validate(payload)
+
+    def test_artifact_name_is_bound_to_platform_and_attempt(self) -> None:
+        self.assertEqual(
+            "release-asset-provenance-linux-attempt-3",
+            provenance.artifact_name("linux", 3),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_validate_release_notes.py
+++ b/scripts/test_validate_release_notes.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""Tests for the fail-closed generated release-notes gate."""
+
+from __future__ import annotations
+
+import unittest
+
+from scripts import publish_release_request as publisher
+from scripts import validate_release_notes as validator
+
+
+DATE_TAG = "2026-08-20"
+RELEASE_TAG = f"next-{DATE_TAG}.1"
+REPOSITORY = "wimi321/lizzieyzy-next"
+
+
+def complete_notes() -> str:
+    blocks: list[str] = []
+    for heading in publisher.LOCALIZED_NOTE_HEADINGS:
+        links = []
+        for suffix in publisher.DIRECT_DOWNLOAD_SUFFIXES:
+            name = f"{DATE_TAG}-{suffix}"
+            url = (
+                f"https://github.com/{REPOSITORY}/releases/download/"
+                f"{RELEASE_TAG}/{name}"
+            )
+            links.append(f"- [`{name}`]({url})")
+        blocks.append(
+            "\n".join(
+                (
+                    heading,
+                    RELEASE_TAG,
+                    "### Updates",
+                    "Reviewed changes.",
+                    "### Before upgrading",
+                    "Back up your settings.",
+                    "### Downloads",
+                    *links,
+                    "### Contact",
+                    "Community support.",
+                )
+            )
+        )
+    return "\n\n---\n\n".join(blocks)
+
+
+class GeneratedReleaseNotesValidationTest(unittest.TestCase):
+    def validate(self, body: str | None = None, **overrides: str) -> None:
+        arguments = {
+            "date_tag": DATE_TAG,
+            "release_tag": RELEASE_TAG,
+            "repository": REPOSITORY,
+        }
+        arguments.update(overrides)
+        validator.validate_generated_release_notes(
+            complete_notes() if body is None else body,
+            **arguments,
+        )
+
+    def test_accepts_complete_notes_for_a_new_release_identity(self) -> None:
+        self.validate()
+
+    def test_refuses_to_overwrite_the_manually_audited_current_release(self) -> None:
+        protected = "next-2026-08-19.1"
+        body = complete_notes().replace(RELEASE_TAG, protected).replace(DATE_TAG, "2026-08-19")
+        with self.assertRaisesRegex(validator.NotesValidationError, "manually audited"):
+            self.validate(body, date_tag="2026-08-19", release_tag=protected)
+
+    def test_rejects_unresolved_markers(self) -> None:
+        with self.assertRaisesRegex(validator.NotesValidationError, "FULL_TEST_COUNT"):
+            self.validate(complete_notes() + "\nFULL_TEST_COUNT\n")
+
+    def test_rejects_stale_date_or_invalid_repository(self) -> None:
+        with self.assertRaisesRegex(validator.NotesValidationError, "match date_tag"):
+            self.validate(release_tag="next-2026-08-21.1")
+        with self.assertRaisesRegex(validator.NotesValidationError, "owner/name"):
+            self.validate(repository="https://github.com/wimi321/lizzieyzy-next")
+
+    def test_rejects_missing_direct_download_link(self) -> None:
+        suffix = publisher.DIRECT_DOWNLOAD_SUFFIXES[0]
+        name = f"{DATE_TAG}-{suffix}"
+        url = (
+            f"https://github.com/{REPOSITORY}/releases/download/"
+            f"{RELEASE_TAG}/{name}"
+        )
+        with self.assertRaisesRegex(validator.NotesValidationError, "directly link"):
+            self.validate(complete_notes().replace(f"- [`{name}`]({url})\n", "", 1))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_validate_release_workflow_identity.py
+++ b/scripts/test_validate_release_workflow_identity.py
@@ -1,0 +1,370 @@
+#!/usr/bin/env python3
+"""Regression tests for release-mutating workflow identity guards."""
+
+from __future__ import annotations
+
+import inspect
+import io
+from pathlib import Path
+import re
+import unittest
+from unittest import mock
+
+from scripts import publish_release_request as publisher
+from scripts import validate_release_workflow_identity as identity
+
+
+DATE_TAG = "2026-08-19"
+RELEASE_TAG = f"next-{DATE_TAG}.1"
+TARGET_SHA = "a" * 40
+REPOSITORY = "wimi321/lizzieyzy-next"
+
+
+def release(**overrides: object) -> dict[str, object]:
+    value: dict[str, object] = {
+        "tag_name": RELEASE_TAG,
+        "target_commitish": TARGET_SHA,
+        "draft": True,
+        "prerelease": True,
+    }
+    value.update(overrides)
+    return value
+
+
+class ReleaseWorkflowIdentityTest(unittest.TestCase):
+    def validate(self, **overrides: object) -> dict[str, object]:
+        arguments: dict[str, object] = {
+            "date_tag": DATE_TAG,
+            "release_tag": RELEASE_TAG,
+            "prerelease": True,
+            "repository": REPOSITORY,
+            "tag_sha": TARGET_SHA,
+            "releases": [release()],
+            "require_draft": True,
+            "target_sha": TARGET_SHA,
+            "github_ref": f"refs/tags/{RELEASE_TAG}",
+        }
+        arguments.update(overrides)
+        return identity.validate_requested_identity(**arguments)
+
+    def test_accepts_exact_draft_tag_date_prerelease_and_target(self) -> None:
+        self.assertEqual(RELEASE_TAG, self.validate()["tag_name"])
+
+    def test_rejects_stale_or_invalid_date_tag_pair(self) -> None:
+        for date_tag, release_tag in (
+            ("2026-08-18", RELEASE_TAG),
+            ("2026-02-30", "next-2026-02-30.1"),
+            (DATE_TAG, f"next-{DATE_TAG}.0"),
+        ):
+            with self.subTest(date_tag=date_tag, release_tag=release_tag):
+                with self.assertRaises(identity.IdentityError):
+                    self.validate(date_tag=date_tag, release_tag=release_tag)
+
+    def test_rejects_ambiguous_or_missing_release(self) -> None:
+        for releases in ([], [release(), release()]):
+            with self.subTest(count=len(releases)):
+                with self.assertRaisesRegex(identity.IdentityError, "exactly one"):
+                    self.validate(releases=releases)
+
+    def test_rejects_release_target_or_tag_commit_mismatch(self) -> None:
+        with self.assertRaisesRegex(identity.IdentityError, "target_commitish"):
+            self.validate(releases=[release(target_commitish="b" * 40)])
+        with self.assertRaisesRegex(identity.IdentityError, "target SHA"):
+            self.validate(target_sha="b" * 40)
+
+    def test_rejects_prerelease_mismatch(self) -> None:
+        with self.assertRaisesRegex(identity.IdentityError, "prerelease"):
+            self.validate(releases=[release(prerelease=False)])
+
+    def test_rejects_non_draft_upload_target(self) -> None:
+        with self.assertRaisesRegex(identity.IdentityError, "existing draft"):
+            self.validate(releases=[release(draft=False)])
+
+    def test_rejects_dispatch_from_non_tag_ref(self) -> None:
+        with self.assertRaisesRegex(identity.IdentityError, "exact release tag ref"):
+            self.validate(github_ref="refs/heads/main")
+
+    def test_notes_update_can_validate_published_release_without_build_ref(self) -> None:
+        validated = self.validate(
+            releases=[release(draft=False)],
+            require_draft=False,
+            target_sha=None,
+            github_ref=None,
+        )
+        self.assertFalse(validated["draft"])
+
+
+class GitHubIdentityRetryTest(unittest.TestCase):
+    class Response:
+        def __enter__(self) -> "GitHubIdentityRetryTest.Response":
+            return self
+
+        def __exit__(self, *_args: object) -> None:
+            return None
+
+        def read(self, _limit: int | None = None) -> bytes:
+            return b'{"ok": true}'
+
+    def test_retries_429_5xx_and_rate_limited_403(self) -> None:
+        for status, headers in (
+            (429, {"Retry-After": "0"}),
+            (502, {}),
+            (403, {"X-RateLimit-Remaining": "0", "Retry-After": "0"}),
+        ):
+            with self.subTest(status=status):
+                delays: list[float] = []
+                client = identity.GitHubIdentityClient(
+                    REPOSITORY,
+                    "token",
+                    "https://api.github.test",
+                    sleep=delays.append,
+                    retry_attempts=2,
+                )
+                failure = identity.HTTPError(
+                    "https://api.github.test/example",
+                    status,
+                    "transient",
+                    headers,
+                    io.BytesIO(b"try again"),
+                )
+                with mock.patch.object(
+                    identity,
+                    "urlopen",
+                    side_effect=[failure, self.Response()],
+                ) as request:
+                    self.assertEqual({"ok": True}, client.get_json("/example"))
+                self.assertEqual(2, request.call_count)
+                self.assertEqual(1, len(delays))
+
+
+class ReleaseWorkflowIdentityWiringTest(unittest.TestCase):
+    root = Path(__file__).resolve().parents[1]
+    build_workflows = (
+        "build-windows-release.yml",
+        "build-linux-release.yml",
+        "build-macos-amd64-release.yml",
+        "build-macos-arm64-release.yml",
+    )
+
+    def workflow(self, name: str) -> str:
+        return (self.root / ".github/workflows" / name).read_text(encoding="utf-8")
+
+    @staticmethod
+    def shell_bodies(workflow: str) -> tuple[str, ...]:
+        """Extract run values well enough to audit expressions without a YAML dependency."""
+        lines = workflow.splitlines()
+        bodies: list[str] = []
+        for index, line in enumerate(lines):
+            match = re.match(r"^(\s*)run:\s*(.*)$", line)
+            if match is None:
+                continue
+            indent = len(match.group(1))
+            value = match.group(2)
+            if value not in {"|", "|-", "|+", ">", ">-", ">+"}:
+                bodies.append(value)
+                continue
+            block: list[str] = []
+            for nested in lines[index + 1 :]:
+                if nested.strip() and len(nested) - len(nested.lstrip()) <= indent:
+                    break
+                block.append(nested)
+            bodies.append("\n".join(block))
+        return tuple(bodies)
+
+    def test_release_mutating_workflows_have_no_stale_date_or_tag_defaults(self) -> None:
+        for name in (*self.build_workflows, "update-release-notes.yml"):
+            with self.subTest(workflow=name):
+                workflow = self.workflow(name)
+                self.assertNotIn("default: 2026-", workflow)
+                self.assertNotRegex(workflow, r"default:\s+next-")
+                self.assertIn("release_prerelease:", workflow)
+                self.assertIn("validate_release_workflow_identity.py", workflow)
+
+    def test_build_run_names_attest_exact_dispatch_inputs(self) -> None:
+        expected_names = {
+            spec.workflow_file: spec.expected_run_name(
+                "${{ inputs.date_tag }}",
+                "${{ inputs.release_tag }}",
+                "${{ inputs.release_prerelease }}",
+            )
+            for spec in publisher.WORKFLOWS
+        }
+        for name in self.build_workflows:
+            with self.subTest(workflow=name):
+                workflow = self.workflow(name)
+                self.assertIn(f'run-name: "{expected_names[name]}"', workflow)
+                self.assertIn("--target-sha \"$RELEASE_TARGET_SHA\"", workflow)
+                self.assertIn("--github-ref \"$RELEASE_GITHUB_REF\"", workflow)
+                self.assertIn("--require-draft", workflow)
+
+    def test_dispatch_inputs_are_env_isolated_from_every_shell(self) -> None:
+        # A payload such as `next-$(touch owned).1` must only become inert env data;
+        # GitHub must never splice it into generated Bash or PowerShell source.
+        for name in (*self.build_workflows, "update-release-notes.yml"):
+            with self.subTest(workflow=name):
+                workflow = self.workflow(name)
+                self.assertIn("RELEASE_DATE_TAG: ${{ inputs.date_tag }}", workflow)
+                self.assertIn("RELEASE_TAG: ${{ inputs.release_tag }}", workflow)
+                self.assertIn(
+                    "RELEASE_PRERELEASE: ${{ inputs.release_prerelease }}", workflow
+                )
+                for line in workflow.splitlines():
+                    if "${{ inputs." not in line:
+                        continue
+                    self.assertTrue(
+                        line.startswith("run-name:")
+                        or re.match(r"^\s+RELEASE_[A-Z_]+:", line) is not None
+                        or line.strip()
+                        == "group: release-${{ github.workflow }}-${{ inputs.release_tag }}",
+                        f"dispatch input escapes env isolation in {name}: {line}",
+                    )
+                for body in self.shell_bodies(workflow):
+                    self.assertNotIn("${{ inputs.", body)
+                    self.assertNotIn("eval ", body)
+                    self.assertNotIn("bash -c", body)
+                    self.assertNotIn("sh -c", body)
+
+    def test_token_bearing_shells_use_quoted_env_identity(self) -> None:
+        for name in (*self.build_workflows, "update-release-notes.yml"):
+            with self.subTest(workflow=name):
+                workflow = self.workflow(name)
+                self.assertIn('--date-tag "$RELEASE_DATE_TAG"', workflow)
+                self.assertIn('--release-tag "$RELEASE_TAG"', workflow)
+                self.assertIn('--prerelease "$RELEASE_PRERELEASE"', workflow)
+                self.assertIn('--repository "$RELEASE_REPOSITORY"', workflow)
+
+    def test_builds_publish_run_bound_provenance_after_platform_gates(self) -> None:
+        platforms = {
+            "build-windows-release.yml": "windows",
+            "build-linux-release.yml": "linux",
+            "build-macos-amd64-release.yml": "mac-amd64",
+            "build-macos-arm64-release.yml": "mac-arm64",
+        }
+        validation_steps = {
+            "build-windows-release.yml": "Validate public Windows assets",
+            "build-linux-release.yml": "Validate public Linux assets",
+            "build-macos-amd64-release.yml": "Validate public macOS amd64 assets",
+            "build-macos-arm64-release.yml": "Validate public macOS arm64 assets",
+        }
+        for name, platform in platforms.items():
+            with self.subTest(workflow=name):
+                workflow = self.workflow(name)
+                create = workflow.index("Create run-bound release asset provenance")
+                provenance_upload = workflow.index(
+                    "Upload run-bound release asset provenance"
+                )
+                release_upload = workflow.index(
+                    "Upload verified assets to draft release"
+                )
+                self.assertLess(workflow.index(validation_steps[name]), create)
+                self.assertLess(create, provenance_upload)
+                self.assertLess(provenance_upload, release_upload)
+                self.assertIn(f"--platform {platform}", workflow)
+                self.assertIn('--target-sha "$RELEASE_TARGET_SHA"', workflow)
+                self.assertIn('--run-id "$RELEASE_RUN_ID"', workflow)
+                self.assertIn('--run-attempt "$RELEASE_RUN_ATTEMPT"', workflow)
+                self.assertIn(
+                    f"name: release-asset-provenance-{platform}-attempt-"
+                    "${{ github.run_attempt }}",
+                    workflow,
+                )
+                self.assertIn("if-no-files-found: error", workflow[create:release_upload])
+
+    def test_every_clobber_is_guarded_and_windows_upload_is_last(self) -> None:
+        for name in self.build_workflows:
+            with self.subTest(workflow=name):
+                workflow = self.workflow(name)
+                self.assertEqual(1, workflow.count("--clobber"))
+                self.assertEqual(2, workflow.count("validate_release_workflow_identity.py"))
+                upload = workflow.index("Upload verified assets to draft release")
+                final_guard = workflow.index(
+                    "validate_release_workflow_identity.py", upload
+                )
+                self.assertLess(
+                    final_guard,
+                    workflow.index("--clobber"),
+                )
+
+        windows = self.workflow("build-windows-release.yml")
+        upload = windows.index("Upload verified assets to draft release")
+        self.assertLess(windows.index("Smoke test bundled Windows app images"), upload)
+        self.assertLess(windows.index("Smoke test Windows upgrade install path"), upload)
+        self.assertLess(windows.index("Upload Windows smoke logs"), upload)
+        provenance = windows.index("Create run-bound release asset provenance")
+        self.assertLess(windows.index("Smoke test bundled Windows app images"), provenance)
+        self.assertLess(windows.index("Smoke test Windows upgrade install path"), provenance)
+        self.assertLess(windows.index("Upload Windows smoke logs"), provenance)
+
+    def test_windows_build_timeout_fits_publisher_wait_budget(self) -> None:
+        workflow = self.workflow("build-windows-release.yml")
+        self.assertRegex(
+            workflow,
+            r"runs-on: windows-latest\s+timeout-minutes: 280",
+        )
+        self.assertNotIn("timeout-minutes: 300", workflow)
+        publisher_wait = inspect.signature(publisher.ReleasePublisher).parameters[
+            "run_timeout_seconds"
+        ].default
+        self.assertGreater(publisher_wait, 280 * 60)
+
+    def test_publisher_explicit_waits_leave_job_timeout_margin(self) -> None:
+        workflow = (
+            self.root / ".github/workflows/publish-requested-pre-release.yml"
+        ).read_text(encoding="utf-8")
+        job_timeout_match = re.search(r"timeout-minutes:\s*(\d+)", workflow)
+        self.assertIsNotNone(job_timeout_match)
+        assert job_timeout_match is not None
+        job_timeout_seconds = int(job_timeout_match.group(1)) * 60
+        parameters = inspect.signature(publisher.ReleasePublisher).parameters
+        run_wait = parameters["run_timeout_seconds"].default
+        ci_wait = parameters["ci_timeout_seconds"].default
+        discovery_wait = inspect.signature(
+            publisher.ReleasePublisher._discover_new_run
+        ).parameters["timeout_seconds"].default
+        explicit_worst_case = run_wait + (2 * ci_wait) + (
+            len(publisher.WORKFLOWS) * discovery_wait
+        )
+        self.assertLessEqual(explicit_worst_case, job_timeout_seconds - 25 * 60)
+
+    def test_notes_edit_is_identity_guarded(self) -> None:
+        workflow = self.workflow("update-release-notes.yml")
+        update_step = workflow.index("Update GitHub release body")
+        identity_guard = workflow.index(
+            "validate_release_workflow_identity.py", update_step
+        )
+        notes_guard = workflow.index("validate_release_notes.py", update_step)
+        edit = workflow.index("gh release edit", update_step)
+        self.assertLess(identity_guard, notes_guard)
+        self.assertLess(notes_guard, edit)
+        self.assertIn('--notes-file "$RELEASE_NOTES_PATH"', workflow[notes_guard:])
+
+    def test_notes_update_shares_publish_lock_and_protects_audited_tag(self) -> None:
+        workflow = self.workflow("update-release-notes.yml")
+        self.assertIn(
+            "concurrency:\n  group: publish-requested-pre-release\n"
+            "  cancel-in-progress: false",
+            workflow,
+        )
+        audited_tag = "next-2026-08-19.1"
+        self.assertGreaterEqual(workflow.count(audited_tag), 2)
+        self.assertLess(
+            workflow.index(audited_tag),
+            workflow.index("Generate release notes"),
+        )
+        update_step = workflow.index("Update GitHub release body")
+        self.assertLess(
+            workflow.index(audited_tag, update_step),
+            workflow.index("gh release edit", update_step),
+        )
+
+    def test_release_checklist_requires_explicit_notes_prerelease_identity(self) -> None:
+        checklist = (self.root / "docs/RELEASE_CHECKLIST.md").read_text(
+            encoding="utf-8"
+        )
+        command = checklist[checklist.index("gh workflow run update-release-notes.yml") :]
+        command = command[: command.index("```")]
+        self.assertIn("-f release_prerelease=true", command)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_validate_windows_release_assets.py
+++ b/scripts/test_validate_windows_release_assets.py
@@ -1,0 +1,312 @@
+#!/usr/bin/env python3
+"""Regression tests for exact Windows release asset validation."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import tempfile
+import unittest
+import zipfile
+
+from scripts import validate_windows_release_assets as validator
+
+
+DATE_TAG = "2026-08-19"
+RELEASE_TAG = f"next-{DATE_TAG}.1"
+
+
+class WindowsReleaseAssetValidationTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary_directory = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temporary_directory.cleanup)
+        self.release_dir = Path(self.temporary_directory.name)
+        self.core_name = f"{DATE_TAG}-windows64.core-update.zip"
+        self.prefix = f"{DATE_TAG}-windows64.nvidia.tensorrt.portable.7z"
+        self.part_names = [f"{self.prefix}.001", f"{self.prefix}.002"]
+        self.readme_name = f"{DATE_TAG}-windows64.nvidia.tensorrt.portable.README.txt"
+        self.manifest_name = f"{DATE_TAG}-windows64.nvidia.tensorrt.portable.manifest.json"
+        self.checksum_name = f"{DATE_TAG}-windows64.nvidia.tensorrt.portable.sha256.txt"
+        self.create_valid_fixture()
+
+    def write_json(self, name: str, value: dict[str, object]) -> None:
+        (self.release_dir / name).write_text(
+            json.dumps(value, ensure_ascii=False, indent=2) + "\n",
+            encoding="utf-8",
+        )
+
+    def read_json(self, name: str) -> dict[str, object]:
+        return json.loads((self.release_dir / name).read_text(encoding="utf-8"))
+
+    def write_checksums(self, names: list[str] | None = None) -> None:
+        if names is None:
+            names = [*self.part_names, self.readme_name, self.manifest_name]
+        lines = [
+            f"{validator.sha256(self.release_dir / name)}  {name}"
+            for name in names
+        ]
+        (self.release_dir / self.checksum_name).write_text(
+            "\n".join(lines) + "\n",
+            encoding="utf-8",
+        )
+
+    def create_valid_fixture(self) -> None:
+        core_path = self.release_dir / self.core_name
+        with zipfile.ZipFile(core_path, "w") as archive:
+            archive.writestr("app/lizzie-yzy2.5.3-shaded.jar", b"jar")
+            archive.writestr("app/LizzieYzy Next.cfg", b"cfg")
+            archive.writestr("lizzieyzy-next-core.jar", b"alias")
+            archive.writestr("README.txt", b"readme")
+            archive.writestr("lizzieyzy-next-core-update-manifest.json", b"{}")
+        core_hash = validator.sha256(core_path)
+        self.write_json(
+            "lizzieyzy-next-update-manifest.json",
+            {
+                "schemaVersion": 1,
+                "releaseTag": RELEASE_TAG,
+                "publishedAt": f"{DATE_TAG}T00:00:00Z",
+                "notesUrl": (
+                    "https://github.com/wimi321/lizzieyzy-next/releases/tag/"
+                    f"{RELEASE_TAG}"
+                ),
+                "prerelease": True,
+                "components": [
+                    {
+                        "id": "core",
+                        "platform": "windows",
+                        "flavor": "all",
+                        "version": RELEASE_TAG,
+                        "assetName": self.core_name,
+                        "downloadUrl": (
+                            "https://github.com/wimi321/lizzieyzy-next/releases/download/"
+                            f"{RELEASE_TAG}/{self.core_name}"
+                        ),
+                        "sizeBytes": core_path.stat().st_size,
+                        "sha256": core_hash,
+                        "installAction": "replace-core",
+                        "defaultSelectedIfChanged": True,
+                    }
+                ],
+            },
+        )
+
+        for index, name in enumerate(self.part_names, 1):
+            (self.release_dir / name).write_bytes(f"part-{index}".encode("ascii"))
+        (self.release_dir / self.readme_name).write_text(
+            "both parts required\n",
+            encoding="utf-8",
+        )
+        self.write_json(
+            self.manifest_name,
+            {
+                "dateTag": DATE_TAG,
+                "releaseDisplayVersion": RELEASE_TAG,
+                "assetKind": "advanced-optional-tensorrt-split-package",
+                "archivePrefix": self.prefix,
+                "engineBackend": "nvidia-tensorrt",
+                "parts": [
+                    {
+                        "name": name,
+                        "sizeBytes": (self.release_dir / name).stat().st_size,
+                        "sha256": validator.sha256(self.release_dir / name),
+                    }
+                    for name in self.part_names
+                ],
+            },
+        )
+        self.write_checksums()
+
+    def validate(self, prerelease: bool = True) -> None:
+        validator.validate_windows_release_assets(
+            self.release_dir,
+            DATE_TAG,
+            RELEASE_TAG,
+            prerelease,
+        )
+
+    def test_accepts_exact_release_identity_and_integrity(self) -> None:
+        self.validate()
+
+    def test_rejects_missing_or_extra_tensorrt_volume(self) -> None:
+        (self.release_dir / self.part_names[1]).unlink()
+        with self.assertRaisesRegex(validator.ValidationError, "exactly contiguous"):
+            self.validate()
+
+        (self.release_dir / self.part_names[1]).write_bytes(b"part-2")
+        (self.release_dir / f"{self.prefix}.003").write_bytes(b"stale-part")
+        with self.assertRaisesRegex(validator.ValidationError, "exactly contiguous"):
+            self.validate()
+
+    def test_rejects_manifest_part_order_size_or_hash_mismatch(self) -> None:
+        for field, value, message in (
+            ("name", self.part_names[1], "not contiguous/in order"),
+            ("sizeBytes", 999, "size mismatch"),
+            ("sha256", "0" * 64, "SHA mismatch"),
+        ):
+            with self.subTest(field=field):
+                self.create_valid_fixture()
+                manifest = self.read_json(self.manifest_name)
+                parts = manifest["parts"]
+                assert isinstance(parts, list) and isinstance(parts[0], dict)
+                parts[0][field] = value
+                self.write_json(self.manifest_name, manifest)
+                self.write_checksums()
+                with self.assertRaisesRegex(validator.ValidationError, message):
+                    self.validate()
+
+    def test_rejects_incomplete_or_incorrect_checksum_inventory(self) -> None:
+        self.write_checksums([*self.part_names, self.readme_name])
+        with self.assertRaisesRegex(validator.ValidationError, "checksum inventory"):
+            self.validate()
+
+        self.write_checksums()
+        checksum_path = self.release_dir / self.checksum_name
+        checksum_path.write_text(
+            checksum_path.read_text(encoding="utf-8").replace(
+                validator.sha256(self.release_dir / self.part_names[0]),
+                "0" * 64,
+                1,
+            ),
+            encoding="utf-8",
+        )
+        with self.assertRaisesRegex(validator.ValidationError, "checksum mismatch"):
+            self.validate()
+
+    def test_rejects_update_manifest_release_identity_mismatch(self) -> None:
+        for field, value, message in (
+            ("releaseTag", "next-2026-08-18.1", "releaseTag"),
+            ("publishedAt", "2026-08-18T00:00:00Z", "publishedAt"),
+            (
+                "notesUrl",
+                "https://github.com/example/repo/releases/tag/next-old",
+                "notesUrl",
+            ),
+        ):
+            with self.subTest(field=field):
+                self.create_valid_fixture()
+                manifest = self.read_json("lizzieyzy-next-update-manifest.json")
+                manifest[field] = value
+                self.write_json("lizzieyzy-next-update-manifest.json", manifest)
+                with self.assertRaisesRegex(validator.ValidationError, message):
+                    self.validate()
+
+    def test_rejects_manifest_urls_that_only_share_a_matching_suffix(self) -> None:
+        manifest = self.read_json("lizzieyzy-next-update-manifest.json")
+        expected_notes = str(manifest["notesUrl"])
+        components = manifest["components"]
+        assert isinstance(components, list) and isinstance(components[0], dict)
+        expected_download = str(components[0]["downloadUrl"])
+
+        for field, malicious, message in (
+            (
+                "notesUrl",
+                f"https://evil.invalid/proxy/{expected_notes}",
+                "notesUrl",
+            ),
+            (
+                "notesUrl",
+                f"{expected_notes}?redirect=https://evil.invalid",
+                "notesUrl",
+            ),
+            (
+                "downloadUrl",
+                f"https://evil.invalid/proxy/{expected_download}",
+                "downloadUrl",
+            ),
+            (
+                "downloadUrl",
+                f"{expected_download}#stale-replacement",
+                "downloadUrl",
+            ),
+        ):
+            with self.subTest(field=field):
+                self.create_valid_fixture()
+                manifest = self.read_json("lizzieyzy-next-update-manifest.json")
+                if field == "notesUrl":
+                    manifest[field] = malicious
+                else:
+                    items = manifest["components"]
+                    assert isinstance(items, list) and isinstance(items[0], dict)
+                    items[0][field] = malicious
+                self.write_json("lizzieyzy-next-update-manifest.json", manifest)
+                with self.assertRaisesRegex(validator.ValidationError, message):
+                    self.validate()
+
+    def test_rejects_update_manifest_prerelease_mismatch(self) -> None:
+        with self.assertRaisesRegex(validator.ValidationError, "prerelease"):
+            self.validate(prerelease=False)
+
+    def test_rejects_core_component_version_or_download_tag_mismatch(self) -> None:
+        for field, value, message in (
+            ("version", "next-old", "version"),
+            ("downloadUrl", "https://example.invalid/wrong.zip", "downloadUrl"),
+        ):
+            with self.subTest(field=field):
+                self.create_valid_fixture()
+                manifest = self.read_json("lizzieyzy-next-update-manifest.json")
+                components = manifest["components"]
+                assert isinstance(components, list) and isinstance(components[0], dict)
+                components[0][field] = value
+                self.write_json("lizzieyzy-next-update-manifest.json", manifest)
+                with self.assertRaisesRegex(validator.ValidationError, message):
+                    self.validate()
+
+    def test_rejects_tensorrt_manifest_release_tag_mismatch(self) -> None:
+        manifest = self.read_json(self.manifest_name)
+        manifest["releaseDisplayVersion"] = "next-old"
+        self.write_json(self.manifest_name, manifest)
+        self.write_checksums()
+        with self.assertRaisesRegex(validator.ValidationError, "releaseDisplayVersion"):
+            self.validate()
+
+
+class WindowsReleaseValidationWiringTest(unittest.TestCase):
+    root = Path(__file__).resolve().parents[1]
+
+    def test_windows_workflow_passes_exact_release_identity_to_validator(self) -> None:
+        workflow = (self.root / ".github/workflows/build-windows-release.yml").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn('echo "release_prerelease=$release_prerelease"', workflow)
+        self.assertIn(
+            "RELEASE_METADATA_PRERELEASE: "
+            "${{ steps.release_metadata.outputs.release_prerelease }}",
+            workflow,
+        )
+        self.assertIn('"$RELEASE_METADATA_PRERELEASE"', workflow)
+        self.assertNotIn(
+            '"${{ steps.release_metadata.outputs.release_prerelease }}"', workflow
+        )
+        self.assertIn("scripts/validate_release_assets.sh", workflow)
+        validator_wrapper = (self.root / "scripts/validate_release_assets.sh").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn("validate_windows_release_assets.py", validator_wrapper)
+
+    def test_package_and_publisher_require_exact_two_tensorrt_volumes(self) -> None:
+        package_script = (self.root / "scripts/package_windows_exe.sh").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn("${#split_parts[@]} != 2", package_script)
+        self.assertIn(".7z.001", package_script)
+        self.assertIn(".7z.002", package_script)
+
+    def test_windows_ci_runs_jcef_tests_with_isolated_work_directories(self) -> None:
+        workflow = (self.root / ".github/workflows/ci.yml").read_text(encoding="utf-8")
+        self.assertIn("python scripts/test_prepare_bundled_jcef.py", workflow)
+        self.assertIn(
+            "python3 -m unittest scripts.test_validate_windows_release_assets",
+            workflow,
+        )
+        self.assertIn(
+            "-Dlizzie.work.dir=$env:RUNNER_TEMP\\lizzieyzy-next-credential-tests",
+            workflow,
+        )
+        self.assertIn(
+            "-Dlizzie.work.dir=$env:RUNNER_TEMP\\lizzieyzy-next-full-tests",
+            workflow,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_windows_launcher_packaging.py
+++ b/scripts/test_windows_launcher_packaging.py
@@ -126,14 +126,33 @@ def main() -> None:
         "RELEASE_PRERELEASE: ${{ inputs.release_prerelease }}",
         "build-windows-release.yml",
     )
-    require(workflow, "releases?per_page=100", "build-windows-release.yml")
+    require(
+        workflow,
+        "scripts/validate_release_workflow_identity.py",
+        "build-windows-release.yml",
+    )
+    require(workflow, "--require-draft", "build-windows-release.yml")
+    require(
+        workflow,
+        "RELEASE_TARGET_SHA: ${{ github.sha }}",
+        "build-windows-release.yml",
+    )
+    require(
+        workflow,
+        "RELEASE_GITHUB_REF: ${{ github.ref }}",
+        "build-windows-release.yml",
+    )
+    require(workflow, '--target-sha "$RELEASE_TARGET_SHA"', "build-windows-release.yml")
+    require(workflow, '--github-ref "$RELEASE_GITHUB_REF"', "build-windows-release.yml")
     require(
         workflow,
         'if [[ "$release_prerelease" != "true" && "$release_prerelease" != "false" ]]',
         "build-windows-release.yml",
     )
-    if "releases/tags/" in workflow:
-        raise AssertionError("draft release metadata must not use the tag endpoint")
+    if "releases?per_page=100" in workflow or "releases/tags/" in workflow:
+        raise AssertionError(
+            "release identity lookup belongs in validate_release_workflow_identity.py"
+        )
     if "scheduleAutomaticCheck" in lizzie_source or "auto-check" in update_controller:
         raise AssertionError("Windows updates must only run after an explicit user action")
 

--- a/scripts/validate_release_assets.sh
+++ b/scripts/validate_release_assets.sh
@@ -5,10 +5,11 @@ PLATFORM="${1:-}"
 RELEASE_DIR="${2:-dist/release}"
 DATE_TAG="${3:-}"
 RELEASE_TAG="${4:-}"
+RELEASE_PRERELEASE="${5:-}"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 if [[ -z "$PLATFORM" || -z "$DATE_TAG" ]]; then
-  echo "Usage: $0 <windows|mac-arm64|mac-amd64|linux> [release_dir] <date_tag> [release_tag]"
+  echo "Usage: $0 <windows|mac-arm64|mac-amd64|linux> [release_dir] <date_tag> [release_tag] [prerelease]"
   exit 1
 fi
 
@@ -33,28 +34,12 @@ case "$PLATFORM" in
       "${DATE_TAG}-windows64.without.engine.portable.zip"
       "${DATE_TAG}-windows64.core-update.zip"
       "lizzieyzy-next-update-manifest.json"
+      "${DATE_TAG}-windows64.nvidia.tensorrt.portable.7z.001"
+      "${DATE_TAG}-windows64.nvidia.tensorrt.portable.7z.002"
+      "${DATE_TAG}-windows64.nvidia.tensorrt.portable.README.txt"
+      "${DATE_TAG}-windows64.nvidia.tensorrt.portable.manifest.json"
+      "${DATE_TAG}-windows64.nvidia.tensorrt.portable.sha256.txt"
     )
-    trt_prefix="${DATE_TAG}-windows64.nvidia.tensorrt.portable.7z"
-    trt_readme="${DATE_TAG}-windows64.nvidia.tensorrt.portable.README.txt"
-    trt_manifest="${DATE_TAG}-windows64.nvidia.tensorrt.portable.manifest.json"
-    trt_checksum="${DATE_TAG}-windows64.nvidia.tensorrt.portable.sha256.txt"
-    shopt -s nullglob
-    trt_parts=("$RELEASE_DIR/${trt_prefix}".[0-9][0-9][0-9])
-    shopt -u nullglob
-    if [[ "${#trt_parts[@]}" -eq 0 ]]; then
-      echo "Missing advanced optional TensorRT split package: ${trt_prefix}.001"
-      exit 1
-    fi
-    for index in "${!trt_parts[@]}"; do
-      expected_part="$(printf '%s.%03d' "$trt_prefix" "$((index + 1))")"
-      if [[ "$(basename "${trt_parts[$index]}")" != "$expected_part" ]]; then
-        echo "TensorRT split volumes must be contiguous from .001"
-        printf 'Expected: %s\nActual:   %s\n' "$expected_part" "$(basename "${trt_parts[$index]}")"
-        exit 1
-      fi
-      expected+=("$(basename "${trt_parts[$index]}")")
-    done
-    expected+=("$trt_readme" "$trt_manifest" "$trt_checksum")
     ;;
   mac-arm64)
     expected=("${DATE_TAG}-mac-apple-silicon.with-katago.dmg")
@@ -131,71 +116,19 @@ done
 
 case "$PLATFORM" in
   windows)
+    if [[ -z "$RELEASE_TAG" || ( "$RELEASE_PRERELEASE" != "true" && "$RELEASE_PRERELEASE" != "false" ) ]]; then
+      echo "Windows validation requires the exact release tag and prerelease=true|false" >&2
+      exit 1
+    fi
     PYTHON_BIN="python3"
     if ! command -v "$PYTHON_BIN" >/dev/null 2>&1; then
       PYTHON_BIN="python"
     fi
-    "$PYTHON_BIN" - "$RELEASE_DIR" "$DATE_TAG" <<'PY'
-import hashlib
-import json
-import pathlib
-import re
-import sys
-import zipfile
-
-release_dir = pathlib.Path(sys.argv[1])
-date_tag = sys.argv[2]
-manifest = json.loads((release_dir / "lizzieyzy-next-update-manifest.json").read_text(encoding="utf-8"))
-assert manifest["schemaVersion"] == 1
-assert manifest["releaseTag"].startswith("next-")
-assert isinstance(manifest["prerelease"], bool)
-components = manifest["components"]
-assert components, "manifest must include components"
-core = next(item for item in components if item["id"] == "core")
-expected_asset = f"{date_tag}-windows64.core-update.zip"
-assert core["assetName"] == expected_asset
-assert core["platform"] == "windows"
-assert core["flavor"] == "all"
-assert core["installAction"] == "replace-core"
-assert core["defaultSelectedIfChanged"] is True
-core_path = release_dir / expected_asset
-assert core_path.is_file()
-assert core["sizeBytes"] == core_path.stat().st_size
-assert re.fullmatch(r"[0-9a-fA-F]{64}", core["sha256"])
-assert core["sha256"].lower() == hashlib.sha256(core_path.read_bytes()).hexdigest()
-with zipfile.ZipFile(core_path) as archive:
-    entries = {
-        name.replace("\\", "/")
-        for name in archive.namelist()
-        if name and not name.endswith("/")
-    }
-assert "app/lizzie-yzy2.5.3-shaded.jar" in entries
-assert "lizzieyzy-next-core.jar" in entries, "core update must retain the legacy updater source alias"
-assert any(entry.startswith("app/LizzieYzy Next") and entry.endswith(".cfg") for entry in entries), "core update must include launcher cfg files so title-bar version and JVM options are refreshed"
-assert "README.txt" in entries
-assert "lizzieyzy-next-core-update-manifest.json" in entries
-for entry in entries:
-    normalized = entry.strip("/")
-    first = normalized.split("/", 1)[0]
-    assert first not in {
-        "weights",
-        "engines",
-        "runtime",
-        "jcef-bundle",
-        "readboard",
-        "user-data",
-    }, f"core update must not bundle large/resource path: {entry}"
-    if normalized.startswith("app/"):
-        second = normalized.split("/", 2)[1] if "/" in normalized[4:] else ""
-        assert second not in {
-            "weights",
-            "engines",
-            "runtime",
-            "jcef-bundle",
-            "readboard",
-            "user-data",
-        }, f"core update must not bundle app resource path: {entry}"
-PY
+    "$PYTHON_BIN" "$SCRIPT_DIR/validate_windows_release_assets.py" \
+      "$RELEASE_DIR" \
+      "$DATE_TAG" \
+      "$RELEASE_TAG" \
+      "$RELEASE_PRERELEASE"
     ;;
   mac-arm64|mac-amd64)
     if command -v hdiutil >/dev/null 2>&1; then

--- a/scripts/validate_release_notes.py
+++ b/scripts/validate_release_notes.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""Validate generated release notes before any workflow may edit a release."""
+
+from __future__ import annotations
+
+import argparse
+from datetime import date
+from pathlib import Path
+import re
+import sys
+
+try:
+    from scripts import publish_release_request as publisher
+except ModuleNotFoundError:  # Direct execution: python scripts/validate_release_notes.py
+    import publish_release_request as publisher  # type: ignore[no-redef]
+
+
+MAX_NOTES_BYTES = 2 * 1024 * 1024
+PROTECTED_AUDITED_TAGS = frozenset({"next-2026-08-19.1"})
+
+
+class NotesValidationError(RuntimeError):
+    """Generated release notes are unsafe or do not match the release identity."""
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise NotesValidationError(message)
+
+
+def validate_generated_release_notes(
+    body: str,
+    *,
+    date_tag: str,
+    release_tag: str,
+    repository: str,
+) -> None:
+    try:
+        parsed_date = date.fromisoformat(date_tag)
+    except ValueError as exc:
+        raise NotesValidationError(f"Invalid release date: {date_tag}") from exc
+    require(parsed_date.isoformat() == date_tag, f"Invalid release date: {date_tag}")
+    match = publisher.TAG_PATTERN.fullmatch(release_tag)
+    require(match is not None, "release_tag must use next-YYYY-MM-DD.N")
+    assert match is not None
+    require(match.group(1) == date_tag, "release_tag must exactly match date_tag")
+    require(
+        not match.group(2).startswith("0"),
+        "release serial must be a positive integer without leading zeros",
+    )
+    require(
+        re.fullmatch(r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+", repository) is not None,
+        "repository must use owner/name format",
+    )
+    require(
+        release_tag not in PROTECTED_AUDITED_TAGS,
+        f"Refusing to regenerate manually audited release notes for {release_tag}",
+    )
+    require(release_tag in body, "Generated release notes do not contain release_tag")
+    try:
+        publisher.validate_no_unresolved_note_markers(body)
+        publisher.validate_direct_download_tables(
+            body,
+            date_tag,
+            release_tag,
+            repository,
+        )
+    except publisher.PublishError as exc:
+        raise NotesValidationError(str(exc)) from exc
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--notes-file", required=True, type=Path)
+    parser.add_argument("--date-tag", required=True)
+    parser.add_argument("--release-tag", required=True)
+    parser.add_argument("--repository", required=True)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        if not args.notes_file.is_file():
+            raise NotesValidationError(
+                f"Generated release notes file is missing: {args.notes_file}"
+            )
+        size = args.notes_file.stat().st_size
+        if size <= 0 or size > MAX_NOTES_BYTES:
+            raise NotesValidationError(
+                f"Generated release notes size must be between 1 and {MAX_NOTES_BYTES} bytes"
+            )
+        body = args.notes_file.read_text(encoding="utf-8")
+        validate_generated_release_notes(
+            body,
+            date_tag=args.date_tag,
+            release_tag=args.release_tag,
+            repository=args.repository,
+        )
+    except (OSError, UnicodeError, NotesValidationError) as exc:
+        print(f"Generated release notes validation failed: {exc}", file=sys.stderr)
+        return 1
+    print(f"Validated generated release notes for {args.release_tag}", flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validate_release_workflow_identity.py
+++ b/scripts/validate_release_workflow_identity.py
@@ -1,0 +1,250 @@
+#!/usr/bin/env python3
+"""Fail-closed identity guard for workflows that mutate a GitHub release."""
+
+from __future__ import annotations
+
+import argparse
+from datetime import date
+import json
+import os
+import re
+import sys
+import time
+from typing import Callable
+from urllib.error import HTTPError
+from urllib.parse import quote
+from urllib.request import Request, urlopen
+
+
+API_VERSION = "2026-03-10"
+
+
+class IdentityError(RuntimeError):
+    """The requested workflow target is ambiguous or does not match the release."""
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise IdentityError(message)
+
+
+def validate_requested_identity(
+    date_tag: str,
+    release_tag: str,
+    prerelease: bool,
+    repository: str,
+    tag_sha: str,
+    releases: list[object],
+    *,
+    require_draft: bool,
+    target_sha: str | None = None,
+    github_ref: str | None = None,
+) -> dict[str, object]:
+    try:
+        parsed_date = date.fromisoformat(date_tag)
+    except ValueError as exc:
+        raise IdentityError(f"Invalid release date: {date_tag}") from exc
+    require(parsed_date.isoformat() == date_tag, f"Invalid release date: {date_tag}")
+    require(
+        re.fullmatch(rf"next-{re.escape(date_tag)}\.[1-9][0-9]*", release_tag)
+        is not None,
+        "release_tag must exactly match date_tag and use a positive serial",
+    )
+    require(
+        re.fullmatch(r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+", repository) is not None,
+        "repository must use owner/name format",
+    )
+    require(
+        re.fullmatch(r"[0-9a-f]{40}", tag_sha) is not None,
+        "Release tag must resolve to a full commit SHA",
+    )
+
+    matches = [
+        item
+        for item in releases
+        if isinstance(item, dict) and item.get("tag_name") == release_tag
+    ]
+    require(len(matches) == 1, f"Expected exactly one release for {release_tag}")
+    release = matches[0]
+    require(
+        release.get("target_commitish") == tag_sha,
+        "Release target_commitish must exactly match the release tag commit",
+    )
+    require(
+        type(release.get("prerelease")) is bool
+        and release.get("prerelease") is prerelease,
+        f"Release prerelease must be {str(prerelease).lower()}",
+    )
+    if require_draft:
+        require(release.get("draft") is True, "Release uploads require an existing draft")
+
+    if target_sha is not None or github_ref is not None:
+        require(target_sha is not None and github_ref is not None, "Target SHA and ref are paired")
+        assert target_sha is not None and github_ref is not None
+        require(
+            re.fullmatch(r"[0-9a-f]{40}", target_sha) is not None,
+            "target_sha must be a full commit SHA",
+        )
+        require(target_sha == tag_sha, "Workflow target SHA must match release tag commit")
+        require(
+            github_ref == f"refs/tags/{release_tag}",
+            "Release build must be dispatched from the exact release tag ref",
+        )
+    return release
+
+
+class GitHubIdentityClient:
+    def __init__(
+        self,
+        repository: str,
+        token: str,
+        api_url: str,
+        *,
+        sleep: Callable[[float], None] = time.sleep,
+        retry_attempts: int = 5,
+    ) -> None:
+        require(bool(token), "GITHUB_TOKEN is required")
+        require(retry_attempts > 0, "retry_attempts must be positive")
+        self.repository = repository
+        self.token = token
+        self.api_url = api_url.rstrip("/")
+        self.sleep = sleep
+        self.retry_attempts = retry_attempts
+
+    @staticmethod
+    def _transient(exc: HTTPError) -> bool:
+        headers = exc.headers or {}
+        return (
+            exc.code == 429
+            or 500 <= exc.code <= 599
+            or (
+                exc.code == 403
+                and (
+                    headers.get("Retry-After") is not None
+                    or headers.get("X-RateLimit-Remaining") == "0"
+                )
+            )
+        )
+
+    @staticmethod
+    def _retry_delay(exc: HTTPError | None, attempt: int) -> float:
+        fallback = float(min(2**attempt, 30))
+        if exc is None:
+            return fallback
+        headers = exc.headers or {}
+        retry_after = headers.get("Retry-After")
+        if retry_after:
+            try:
+                return float(max(0, min(int(retry_after), 60)))
+            except ValueError:
+                pass
+        reset = headers.get("X-RateLimit-Reset")
+        if reset:
+            try:
+                return float(max(0, min(int(reset) - int(time.time()) + 1, 60)))
+            except ValueError:
+                pass
+        return fallback
+
+    def get_json(self, path: str) -> object:
+        for attempt in range(1, self.retry_attempts + 1):
+            request = Request(
+                f"{self.api_url}{path}",
+                headers={
+                    "Accept": "application/vnd.github+json",
+                    "Authorization": f"Bearer {self.token}",
+                    "User-Agent": "lizzieyzy-next-release-identity-guard",
+                    "X-GitHub-Api-Version": API_VERSION,
+                },
+            )
+            try:
+                with urlopen(request, timeout=60) as response:
+                    raw = response.read(16 * 1024 * 1024 + 1)
+            except HTTPError as exc:
+                detail = exc.read(2000).decode("utf-8", errors="replace")
+                if self._transient(exc) and attempt < self.retry_attempts:
+                    self.sleep(self._retry_delay(exc, attempt))
+                    continue
+                raise IdentityError(
+                    f"GitHub API request failed ({exc.code}): {detail}"
+                ) from exc
+            except OSError as exc:
+                if attempt < self.retry_attempts:
+                    self.sleep(self._retry_delay(None, attempt))
+                    continue
+                raise IdentityError(f"GitHub API request failed: {exc}") from exc
+            break
+        else:
+            raise AssertionError("unreachable GitHub retry loop")
+        require(len(raw) <= 16 * 1024 * 1024, "GitHub API response is too large")
+        try:
+            return json.loads(raw.decode("utf-8"))
+        except json.JSONDecodeError as exc:
+            raise IdentityError("GitHub API returned invalid JSON") from exc
+
+    def tag_sha(self, release_tag: str) -> str:
+        payload = self.get_json(
+            f"/repos/{self.repository}/git/ref/tags/{quote(release_tag, safe='')}"
+        )
+        require(isinstance(payload, dict), "Git tag response must be an object")
+        assert isinstance(payload, dict)
+        obj = payload.get("object")
+        require(
+            isinstance(obj, dict) and obj.get("type") == "commit" and obj.get("sha"),
+            "Release tag must be a lightweight commit tag",
+        )
+        assert isinstance(obj, dict)
+        return str(obj["sha"])
+
+    def releases(self) -> list[object]:
+        payload = self.get_json(f"/repos/{self.repository}/releases?per_page=100")
+        require(isinstance(payload, list), "GitHub releases response must be a list")
+        assert isinstance(payload, list)
+        return payload
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--date-tag", required=True)
+    parser.add_argument("--release-tag", required=True)
+    parser.add_argument("--prerelease", required=True, choices=("true", "false"))
+    parser.add_argument("--repository", required=True)
+    parser.add_argument("--target-sha")
+    parser.add_argument("--github-ref")
+    parser.add_argument("--require-draft", action="store_true")
+    parser.add_argument("--api-url", default=os.environ.get("GITHUB_API_URL", "https://api.github.com"))
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        client = GitHubIdentityClient(
+            args.repository,
+            os.environ.get("GITHUB_TOKEN", ""),
+            args.api_url,
+        )
+        tag_sha = client.tag_sha(args.release_tag)
+        validate_requested_identity(
+            args.date_tag,
+            args.release_tag,
+            args.prerelease == "true",
+            args.repository,
+            tag_sha,
+            client.releases(),
+            require_draft=args.require_draft,
+            target_sha=args.target_sha,
+            github_ref=args.github_ref,
+        )
+    except IdentityError as exc:
+        print(f"Release workflow identity validation failed: {exc}", file=sys.stderr)
+        return 1
+    print(
+        f"Validated release workflow identity: {args.release_tag} at {tag_sha}",
+        flush=True,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validate_windows_release_assets.py
+++ b/scripts/validate_windows_release_assets.py
@@ -1,0 +1,308 @@
+#!/usr/bin/env python3
+"""Validate identity and integrity of Windows release metadata and split assets."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+import re
+import sys
+import zipfile
+
+
+EXPECTED_RELEASE_REPOSITORY = "wimi321/lizzieyzy-next"
+
+
+class ValidationError(RuntimeError):
+    """A Windows release asset invariant failed."""
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise ValidationError(message)
+
+
+def sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def load_json(path: Path) -> dict[str, object]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ValidationError(f"Unable to read JSON metadata {path.name}: {exc}") from exc
+    require(isinstance(value, dict), f"{path.name} must contain a JSON object")
+    return value
+
+
+def parse_sha256_file(path: Path) -> dict[str, str]:
+    checksums: dict[str, str] = {}
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except OSError as exc:
+        raise ValidationError(f"Unable to read checksum file {path.name}: {exc}") from exc
+    for line_number, line in enumerate(lines, 1):
+        match = re.fullmatch(r"([0-9a-fA-F]{64})  ([^/\\]+)", line)
+        require(match is not None, f"Malformed SHA-256 entry at {path.name}:{line_number}")
+        assert match is not None
+        name = match.group(2)
+        require(name not in checksums, f"Duplicate SHA-256 entry for {name}")
+        checksums[name] = match.group(1).lower()
+    return checksums
+
+
+def validate_update_manifest(
+    release_dir: Path,
+    date_tag: str,
+    release_tag: str,
+    prerelease: bool,
+) -> None:
+    manifest_path = release_dir / "lizzieyzy-next-update-manifest.json"
+    manifest = load_json(manifest_path)
+    require(manifest.get("schemaVersion") == 1, "Update manifest schemaVersion must be 1")
+    require(
+        manifest.get("releaseTag") == release_tag,
+        f"Update manifest releaseTag must be {release_tag}",
+    )
+    require(
+        manifest.get("publishedAt") == f"{date_tag}T00:00:00Z",
+        f"Update manifest publishedAt must match {date_tag}",
+    )
+    require(
+        type(manifest.get("prerelease")) is bool
+        and manifest.get("prerelease") is prerelease,
+        f"Update manifest prerelease must be {str(prerelease).lower()}",
+    )
+    expected_notes_url = (
+        f"https://github.com/{EXPECTED_RELEASE_REPOSITORY}/releases/tag/{release_tag}"
+    )
+    require(
+        manifest.get("notesUrl") == expected_notes_url,
+        "Update manifest notesUrl must use the exact official repository and release tag",
+    )
+
+    components = manifest.get("components")
+    require(
+        isinstance(components, list) and bool(components),
+        "Update manifest must include components",
+    )
+    cores = [
+        item
+        for item in components
+        if isinstance(item, dict) and item.get("id") == "core"
+    ]
+    require(len(cores) == 1, "Update manifest must include exactly one core component")
+    core = cores[0]
+    expected_asset = f"{date_tag}-windows64.core-update.zip"
+    require(core.get("assetName") == expected_asset, "Core update assetName is incorrect")
+    require(core.get("platform") == "windows", "Core update platform must be windows")
+    require(core.get("flavor") == "all", "Core update flavor must be all")
+    require(core.get("version") == release_tag, "Core update version must match release tag")
+    require(
+        core.get("installAction") == "replace-core",
+        "Core installAction is incorrect",
+    )
+    require(
+        core.get("defaultSelectedIfChanged") is True,
+        "Core update must be selected when changed",
+    )
+    expected_download_url = (
+        f"https://github.com/{EXPECTED_RELEASE_REPOSITORY}/releases/download/"
+        f"{release_tag}/{expected_asset}"
+    )
+    require(
+        core.get("downloadUrl") == expected_download_url,
+        "Core update downloadUrl must use the exact official repository, tag, and asset",
+    )
+    core_path = release_dir / expected_asset
+    require(core_path.is_file(), f"Missing core update asset: {expected_asset}")
+    require(
+        core.get("sizeBytes") == core_path.stat().st_size,
+        "Core update sizeBytes is incorrect",
+    )
+    core_hash = sha256(core_path)
+    require(
+        str(core.get("sha256") or "").lower() == core_hash,
+        "Core update SHA-256 is incorrect",
+    )
+
+    try:
+        with zipfile.ZipFile(core_path) as archive:
+            entries = {
+                name.replace("\\", "/")
+                for name in archive.namelist()
+                if name and not name.endswith("/")
+            }
+    except (OSError, zipfile.BadZipFile) as exc:
+        raise ValidationError(f"Invalid core update ZIP: {exc}") from exc
+    require(
+        "app/lizzie-yzy2.5.3-shaded.jar" in entries,
+        "Core update is missing the main jar",
+    )
+    require(
+        "lizzieyzy-next-core.jar" in entries,
+        "Core update is missing the legacy updater alias",
+    )
+    require(
+        any(entry.startswith("app/LizzieYzy Next") and entry.endswith(".cfg") for entry in entries),
+        "Core update must include launcher cfg files",
+    )
+    require("README.txt" in entries, "Core update is missing README.txt")
+    require(
+        "lizzieyzy-next-core-update-manifest.json" in entries,
+        "Core update is missing its installed manifest",
+    )
+    forbidden = {
+        "weights",
+        "engines",
+        "runtime",
+        "jcef-bundle",
+        "readboard",
+        "user-data",
+    }
+    for entry in entries:
+        normalized = entry.strip("/")
+        first = normalized.split("/", 1)[0]
+        require(first not in forbidden, f"Core update contains resource path: {entry}")
+        if normalized.startswith("app/"):
+            remainder = normalized[4:]
+            second = remainder.split("/", 1)[0] if "/" in remainder else ""
+            require(second not in forbidden, f"Core update contains app resource path: {entry}")
+
+
+def validate_tensorrt_split(
+    release_dir: Path,
+    date_tag: str,
+    release_tag: str,
+) -> None:
+    prefix = f"{date_tag}-windows64.nvidia.tensorrt.portable.7z"
+    expected_names = [f"{prefix}.001", f"{prefix}.002"]
+    actual_names = sorted(
+        path.name
+        for path in release_dir.glob(f"{prefix}.[0-9][0-9][0-9]")
+    )
+    require(
+        actual_names == expected_names,
+        "TensorRT split volumes must be exactly contiguous .001 and .002; "
+        f"found {actual_names or '<none>'}",
+    )
+
+    manifest_name = f"{date_tag}-windows64.nvidia.tensorrt.portable.manifest.json"
+    readme_name = f"{date_tag}-windows64.nvidia.tensorrt.portable.README.txt"
+    checksum_name = f"{date_tag}-windows64.nvidia.tensorrt.portable.sha256.txt"
+    manifest_path = release_dir / manifest_name
+    readme_path = release_dir / readme_name
+    checksum_path = release_dir / checksum_name
+    require(readme_path.is_file(), f"Missing TensorRT README: {readme_name}")
+    manifest = load_json(manifest_path)
+    require(
+        manifest.get("dateTag") == date_tag,
+        "TensorRT manifest dateTag is incorrect",
+    )
+    require(
+        manifest.get("releaseDisplayVersion") == release_tag,
+        "TensorRT manifest releaseDisplayVersion must match release tag",
+    )
+    require(
+        manifest.get("assetKind") == "advanced-optional-tensorrt-split-package",
+        "TensorRT manifest assetKind is incorrect",
+    )
+    require(
+        manifest.get("archivePrefix") == prefix,
+        "TensorRT manifest archivePrefix is incorrect",
+    )
+    require(
+        manifest.get("engineBackend") == "nvidia-tensorrt",
+        "TensorRT engineBackend is incorrect",
+    )
+    parts = manifest.get("parts")
+    require(isinstance(parts, list), "TensorRT manifest parts must be a list")
+    assert isinstance(parts, list)
+    require(len(parts) == 2, "TensorRT manifest must list exactly two parts")
+
+    computed: dict[str, str] = {}
+    for index, expected_name in enumerate(expected_names):
+        part = parts[index]
+        require(
+            isinstance(part, dict),
+            f"TensorRT manifest part {index + 1} must be an object",
+        )
+        assert isinstance(part, dict)
+        require(
+            part.get("name") == expected_name,
+            "TensorRT manifest parts are not contiguous/in order",
+        )
+        path = release_dir / expected_name
+        digest = sha256(path)
+        computed[expected_name] = digest
+        require(
+            part.get("sizeBytes") == path.stat().st_size,
+            f"TensorRT size mismatch for {expected_name}",
+        )
+        require(
+            str(part.get("sha256") or "").lower() == digest,
+            f"TensorRT SHA mismatch for {expected_name}",
+        )
+
+    computed[readme_name] = sha256(readme_path)
+    computed[manifest_name] = sha256(manifest_path)
+    checksums = parse_sha256_file(checksum_path)
+    require(
+        set(checksums) == set(computed),
+        "TensorRT checksum inventory must contain exactly both parts, README, and manifest",
+    )
+    for name, digest in computed.items():
+        require(checksums[name] == digest, f"TensorRT checksum mismatch for {name}")
+
+
+def validate_windows_release_assets(
+    release_dir: Path,
+    date_tag: str,
+    release_tag: str,
+    prerelease: bool,
+) -> None:
+    require(
+        re.fullmatch(r"\d{4}-\d{2}-\d{2}", date_tag) is not None,
+        "Invalid date tag",
+    )
+    require(
+        re.fullmatch(rf"next-{re.escape(date_tag)}\.[1-9][0-9]*", release_tag) is not None,
+        "Release tag must exactly match the date tag",
+    )
+    validate_update_manifest(release_dir, date_tag, release_tag, prerelease)
+    validate_tensorrt_split(release_dir, date_tag, release_tag)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("release_dir", type=Path)
+    parser.add_argument("date_tag")
+    parser.add_argument("release_tag")
+    parser.add_argument("prerelease", choices=("true", "false"))
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        validate_windows_release_assets(
+            args.release_dir,
+            args.date_tag,
+            args.release_tag,
+            args.prerelease == "true",
+        )
+    except ValidationError as exc:
+        print(f"Windows release validation failed: {exc}", file=sys.stderr)
+        return 1
+    print("Validated Windows update manifest and TensorRT split integrity.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/main/java/featurecat/lizzie/analysis/AnalysisEngine.java
+++ b/src/main/java/featurecat/lizzie/analysis/AnalysisEngine.java
@@ -403,16 +403,14 @@ public class AnalysisEngine {
   }
 
   public void tryToDignostic(String message) {
-    EngineFailedMessage engineFailedMessage =
-        new EngineFailedMessage(
-            commands,
-            engineCommand,
-            message,
-            !useJavaSSH && !useRemoteCompute && OS.isWindows(),
-            false,
-            false);
-    engineFailedMessage.setModal(true);
-    engineFailedMessage.setVisible(true);
+    EngineFailedMessage.showDialog(
+        commands,
+        engineCommand,
+        message,
+        !useJavaSSH && !useRemoteCompute && OS.isWindows(),
+        false,
+        false,
+        true);
   }
 
   private void initializeStreams() {

--- a/src/main/java/featurecat/lizzie/analysis/ContributeEngine.java
+++ b/src/main/java/featurecat/lizzie/analysis/ContributeEngine.java
@@ -1112,11 +1112,14 @@ public class ContributeEngine {
   }
 
   public void tryToDignostic(String message) {
-    EngineFailedMessage engineFailedMessage =
-        new EngineFailedMessage(
-            commands, engineCommand, message, !useJavaSSH && OS.isWindows(), false, true);
-    engineFailedMessage.setModal(true);
-    engineFailedMessage.setVisible(true);
+    EngineFailedMessage.showDialog(
+        commands,
+        engineCommand,
+        message,
+        !useJavaSSH && OS.isWindows(),
+        false,
+        true,
+        true);
   }
 
   private void startWatchingGameThread() {

--- a/src/main/java/featurecat/lizzie/analysis/EngineManager.java
+++ b/src/main/java/featurecat/lizzie/analysis/EngineManager.java
@@ -2636,9 +2636,15 @@ public class EngineManager {
 
   public void clearEngineGame() {
     if (isEngineGame || isPreEngineGame) {
-      Lizzie.frame.addInput(true);
       isPreEngineGame = false;
-      if (!isEngineGame) return;
+      if (!isEngineGame) {
+        if (Lizzie.board != null) {
+          Lizzie.board.isPkBoard = false;
+        }
+        restoreUiAfterEngineGameStartAbort();
+        return;
+      }
+      Lizzie.frame.addInput(true);
       isEngineGame = false;
       LizzieFrame.menu.toggleDoubleMenuGameStatus();
       LizzieFrame.toolbar.isPkStop = false;
@@ -2646,14 +2652,22 @@ public class EngineManager {
   }
 
   private void restoreUiAfterEngineGameStartAbort() {
-    if (Lizzie.frame != null) {
-      Lizzie.frame.addInput(true);
-    }
-    if (LizzieFrame.toolbar != null) {
-      LizzieFrame.toolbar.enableDisabelForEngineGame(true);
-    }
-    if (Menu.engineMenu != null) {
-      Menu.engineMenu.setEnabled(true);
+    Runnable restore =
+        () -> {
+          if (Lizzie.frame != null) {
+            Lizzie.frame.addInput(true);
+          }
+          if (LizzieFrame.toolbar != null) {
+            LizzieFrame.toolbar.enableDisabelForEngineGame(true);
+          }
+          if (Menu.engineMenu != null) {
+            Menu.engineMenu.setEnabled(true);
+          }
+        };
+    if (SwingUtilities.isEventDispatchThread()) {
+      restore.run();
+    } else {
+      SwingUtilities.invokeLater(restore);
     }
   }
 

--- a/src/main/java/featurecat/lizzie/analysis/KataEstimate.java
+++ b/src/main/java/featurecat/lizzie/analysis/KataEstimate.java
@@ -206,6 +206,11 @@ public class KataEstimate {
   }
 
   private void showErrMsg(Exception e) {
+    EngineFailedMessage.runOnEventDispatchThreadAndWait(
+        () -> showErrMsgOnEventDispatchThread(e));
+  }
+
+  private void showErrMsgOnEventDispatchThread(Exception e) {
     if (isPreLoad) return;
     String errMas = "";
     if (Lizzie.config.useZenEstimate) {
@@ -703,15 +708,14 @@ public class KataEstimate {
   }
 
   public void tryToDignostic(String message) {
-    EngineFailedMessage engineFailedMessage =
-        new EngineFailedMessage(
-            commands,
-            engineCommand,
-            message,
-            !this.useJavaSSH && !this.useRemoteCompute && OS.isWindows(),
-            true,
-            false);
-    engineFailedMessage.setVisible(true);
+    EngineFailedMessage.showDialog(
+        commands,
+        engineCommand,
+        message,
+        !this.useJavaSSH && !this.useRemoteCompute && OS.isWindows(),
+        true,
+        false,
+        false);
   }
 
   public boolean isOperational() {

--- a/src/main/java/featurecat/lizzie/analysis/Leelaz.java
+++ b/src/main/java/featurecat/lizzie/analysis/Leelaz.java
@@ -23,6 +23,7 @@ import featurecat.lizzie.util.KataGoRuntimeHelper;
 import featurecat.lizzie.util.Utils;
 import featurecat.lizzie.util.YikeSyncDebugLog;
 import java.awt.Component;
+import java.awt.GraphicsEnvironment;
 import java.io.BufferedOutputStream;
 import java.io.BufferedReader;
 import java.io.File;
@@ -4184,6 +4185,7 @@ public class Leelaz {
   }
 
   private void finishReaderTerminalCleanup(ReaderStreamBinding binding) {
+    String deferredNonModalDiagnostic = null;
     try {
       if (binding.terminalFailure != null) {
         binding.terminalFailure.printStackTrace();
@@ -4198,16 +4200,20 @@ public class Leelaz {
         javaSSHClosed = true;
       }
       started = false;
-      finishTerminatedReaderIncarnation(binding);
+      deferredNonModalDiagnostic = finishTerminatedReaderIncarnation(binding);
     } finally {
       synchronized (engineArbitrationLock()) {
         readerTerminalCleanupInProgress = false;
         engineArbitrationLock().notifyAll();
       }
     }
+    if (deferredNonModalDiagnostic != null) {
+      String diagnostic = deferredNonModalDiagnostic;
+      SwingUtilities.invokeLater(() -> tryToDignostic(diagnostic, false));
+    }
   }
 
-  private void finishTerminatedReaderIncarnation(ReaderStreamBinding binding) {
+  private String finishTerminatedReaderIncarnation(ReaderStreamBinding binding) {
     ExclusiveGtpSession interruptedForegroundWork;
     synchronized (engineArbitrationLock()) {
       interruptedForegroundWork =
@@ -4259,17 +4265,17 @@ public class Leelaz {
       if (Lizzie.engineManager != null) {
         Lizzie.engineManager.restartUnresponsiveRemoteEngine(this, currentEngineN);
       }
-      return;
+      return null;
     }
     if (!isNormalEnd && !tryRecoverBundledOpenClNativeExit(binding.process)) {
       isDownWithError = true;
       // isLoaded=false;
-      tryToDignostic(
-          buildEngineExitDiagnostic(Lizzie.resourceBundle.getString("Leelaz.engineEndUnormalHint")),
-          false);
+      return buildEngineExitDiagnostic(
+          Lizzie.resourceBundle.getString("Leelaz.engineEndUnormalHint"));
       // ("打开Gtp窗口(快捷键E)查看报错信息");
       // LizzieFrame.openMoreEngineDialog();
     }
+    return null;
   }
 
   private void shutdownReaderTransport(ReaderStreamBinding binding) {
@@ -13196,6 +13202,11 @@ public class Leelaz {
   }
 
   public void tryToDignostic(String message, boolean isModal) {
+    EngineFailedMessage.runOnEventDispatchThreadAndWait(
+        () -> showDiagnosticOnEventDispatchThread(message, isModal));
+  }
+
+  private void showDiagnosticOnEventDispatchThread(String message, boolean isModal) {
     closeBundledStartupDialog();
     boolean primaryEngine = this == Lizzie.leelaz;
     if (primaryEngine) {
@@ -13210,14 +13221,22 @@ public class Leelaz {
     if (!shouldOpenInteractiveDiagnostic(primaryEngine, Lizzie.isFirstLaunchSession())) {
       return;
     }
-    if (!Lizzie.config.autoCheckEngineAlive && EngineManager.isEngineGame())
+    if (Lizzie.config != null
+        && !Lizzie.config.autoCheckEngineAlive
+        && Lizzie.engineManager != null
+        && EngineManager.isEngineGame())
       Lizzie.engineManager.clearEngineGame();
+    if (GraphicsEnvironment.isHeadless()) return;
     if (engineFailedMessage != null && engineFailedMessage.isVisible()) return;
-    engineFailedMessage =
-        new EngineFailedMessage(
-            commands, engineCommand, message, !useJavaSSH && OS.isWindows(), true, false);
-    engineFailedMessage.setModal(isModal);
-    engineFailedMessage.setVisible(true);
+    EngineFailedMessage.showDialog(
+        commands,
+        engineCommand,
+        message,
+        !useJavaSSH && OS.isWindows(),
+        true,
+        false,
+        isModal,
+        dialog -> engineFailedMessage = dialog);
   }
 
   private boolean shouldOpenInteractiveDiagnostic() {

--- a/src/main/java/featurecat/lizzie/gui/EngineFailedMessage.java
+++ b/src/main/java/featurecat/lizzie/gui/EngineFailedMessage.java
@@ -2,9 +2,16 @@ package featurecat.lizzie.gui;
 
 import featurecat.lizzie.Config;
 import featurecat.lizzie.Lizzie;
+import java.awt.BorderLayout;
 import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.FlowLayout;
 import java.awt.Font;
+import java.awt.GraphicsConfiguration;
+import java.awt.GraphicsEnvironment;
 import java.awt.Insets;
+import java.awt.Rectangle;
+import java.awt.Toolkit;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.KeyEvent;
@@ -13,20 +20,116 @@ import java.io.FileOutputStream;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
+import java.lang.reflect.InvocationTargetException;
 import java.util.List;
+import java.util.function.Consumer;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import javax.imageio.ImageIO;
 import javax.swing.AbstractAction;
+import javax.swing.BorderFactory;
 import javax.swing.InputMap;
 import javax.swing.JButton;
 import javax.swing.JComponent;
 import javax.swing.JDialog;
 import javax.swing.JLabel;
+import javax.swing.JPanel;
 import javax.swing.JRootPane;
 import javax.swing.JScrollPane;
 import javax.swing.JTextArea;
 import javax.swing.KeyStroke;
+import javax.swing.SwingUtilities;
 
 public class EngineFailedMessage extends JDialog {
+  static final int MAX_DIALOG_WIDTH = 980;
+  static final int SCREEN_MARGIN = 64;
+  static final String REDACTED_VALUE = "<redacted>";
+  private static final String SENSITIVE_KEY =
+      "(?:password|passwd|token|api[-_]?key|secret)";
+  private static final Pattern QUOTED_SENSITIVE_ASSIGNMENT_START =
+      Pattern.compile(
+          "(?i)([\\\"'])(\\s*" + SENSITIVE_KEY + "\\b\\s*[:=]\\s*)");
+  private static final Pattern SENSITIVE_ASSIGNMENT_START =
+      Pattern.compile(
+          "(?i)\\b" + SENSITIVE_KEY + "\\b[\\\"']?\\s*[:=]\\s*");
+  private static final Pattern SENSITIVE_FLAG_START =
+      Pattern.compile(
+          "(?i)(?<!\\S)(?:-{1,2}|/)"
+              + SENSITIVE_KEY
+              + "\\b(?:\\s*[:=]\\s*|\\s+)");
+
+  public static void runOnEventDispatchThreadAndWait(Runnable action) {
+    if (action == null) {
+      throw new IllegalArgumentException("The event-dispatch action must not be null.");
+    }
+    if (SwingUtilities.isEventDispatchThread()) {
+      action.run();
+      return;
+    }
+    try {
+      SwingUtilities.invokeAndWait(action);
+    } catch (InterruptedException interrupted) {
+      Thread.currentThread().interrupt();
+      throw new IllegalStateException(
+          "Interrupted while waiting for the Swing event-dispatch thread.", interrupted);
+    } catch (InvocationTargetException failure) {
+      Throwable cause = failure.getCause();
+      if (cause instanceof RuntimeException) {
+        throw (RuntimeException) cause;
+      }
+      if (cause instanceof Error) {
+        throw (Error) cause;
+      }
+      throw new IllegalStateException("Swing event-dispatch action failed.", cause);
+    }
+  }
+
+  public static void showDialog(
+      List<String> commands,
+      String command,
+      String message,
+      boolean canUseCmdDignostic,
+      boolean isGtpEngine,
+      boolean restartContribute,
+      boolean modal) {
+    showDialog(
+        commands,
+        command,
+        message,
+        canUseCmdDignostic,
+        isGtpEngine,
+        restartContribute,
+        modal,
+        null);
+  }
+
+  public static void showDialog(
+      List<String> commands,
+      String command,
+      String message,
+      boolean canUseCmdDignostic,
+      boolean isGtpEngine,
+      boolean restartContribute,
+      boolean modal,
+      Consumer<EngineFailedMessage> onCreated) {
+    runOnEventDispatchThreadAndWait(
+        () -> {
+          EngineFailedMessage dialog =
+              new EngineFailedMessage(
+                  commands,
+                  command,
+                  message,
+                  canUseCmdDignostic,
+                  isGtpEngine,
+                  restartContribute);
+          if (onCreated != null) {
+            onCreated.accept(dialog);
+          }
+          dialog.setModal(modal);
+          dialog.setVisible(true);
+        });
+  }
+
   public EngineFailedMessage(
       List<String> commands,
       String command,
@@ -43,46 +146,28 @@ public class EngineFailedMessage extends JDialog {
     } catch (IOException e) {
       e.printStackTrace();
     }
-    getContentPane().setLayout(null);
+    JPanel root = new JPanel(new BorderLayout(0, 10));
+    root.setBorder(BorderFactory.createEmptyBorder(10, 10, 10, 10));
 
-    JLabel lblEngineFaied = new JFontLabel(message);
-    getContentPane().add(lblEngineFaied);
-    String regex = "[\u4e00-\u9fa5]";
-    lblEngineFaied.setBounds(
-        10,
-        9,
-        (int)
-            (lblEngineFaied.getText().replaceAll(regex, "12").length()
-                * (Config.frameFontSize / 1.9)),
-        20);
-    Lizzie.setFrameSize(
-        this,
-        Math.max(
-            Lizzie.config.isFrameFontSmall()
-                ? 580
-                : (Lizzie.config.isFrameFontMiddle() ? 660 : 730),
-            (int)
-                (lblEngineFaied.getText().replaceAll(regex, "12").length()
-                    * (Config.frameFontSize / 1.9))),
-        canUseCmdDignostic ? 190 : restartContribute ? 180 : 160);
+    Font textFont = new Font(Config.sysDefaultFontName, Font.PLAIN, Config.frameFontSize);
+    JScrollPane messagePane = createScrollableText(message, textFont);
+    messagePane.setPreferredSize(new Dimension(1, 92));
+    messagePane
+        .getAccessibleContext()
+        .setAccessibleName(Lizzie.resourceBundle.getString("Leelaz.engineFailed"));
+    root.add(messagePane, BorderLayout.NORTH);
 
-    JTextArea engineCmd = new JTextArea();
-    engineCmd.setLineWrap(true);
-    engineCmd.setFont(new Font(Config.sysDefaultFontName, Font.PLAIN, Config.frameFontSize));
-    engineCmd.setText(command);
-
-    JScrollPane scrollPane = new JScrollPane(engineCmd);
-    scrollPane.setBounds(
-        Lizzie.config.isFrameFontSmall() ? 72 : (Lizzie.config.isFrameFontMiddle() ? 90 : 110),
-        40,
-        Lizzie.config.isFrameFontSmall() ? 476 : (Lizzie.config.isFrameFontMiddle() ? 550 : 600),
-        70);
-    getContentPane().add(scrollPane);
-
+    JPanel commandPanel = new JPanel(new BorderLayout(8, 0));
     JLabel lblEngineCmd =
         new JFontLabel(Lizzie.resourceBundle.getString("EngineFailedMessage.engineCmd"));
-    lblEngineCmd.setBounds(10, 40, 120, 20);
-    getContentPane().add(lblEngineCmd);
+    commandPanel.add(lblEngineCmd, BorderLayout.WEST);
+    JScrollPane commandPane = createScrollableText(command, textFont);
+    commandPane.setPreferredSize(new Dimension(1, 112));
+    commandPane.getAccessibleContext().setAccessibleName(lblEngineCmd.getText());
+    commandPanel.add(commandPane, BorderLayout.CENTER);
+    root.add(commandPanel, BorderLayout.CENTER);
+
+    JPanel footer = new JPanel(new BorderLayout(8, 0));
 
     if (restartContribute) {
       JButton btnRestart =
@@ -94,15 +179,7 @@ public class EngineFailedMessage extends JDialog {
               setVisible(false);
             }
           });
-      btnRestart.setBounds(
-          345
-              + (Lizzie.config.isFrameFontSmall()
-                  ? 85
-                  : (Lizzie.config.isFrameFontMiddle() ? 95 : 108)),
-          117,
-          120,
-          25);
-      getContentPane().add(btnRestart);
+      footer.add(btnRestart, BorderLayout.EAST);
     }
 
     if (canUseCmdDignostic) {
@@ -124,9 +201,9 @@ public class EngineFailedMessage extends JDialog {
                   bw.newLine();
                 }
                 if (commands != null && !commands.isEmpty()) {
-                  bw.write(buildCommandLine(commands));
+                  bw.write(buildDiagnosticCommand(commands, command));
                 } else {
-                  bw.write(command.trim());
+                  bw.write(buildDiagnosticCommand(null, command));
                 }
                 if (isGtpEngine) {
                   bw.write(" < test_commands.txt");
@@ -159,27 +236,37 @@ public class EngineFailedMessage extends JDialog {
       btnRunInCmd.setFocusPainted(false);
       btnRunInCmd.setMargin(new Insets(0, 0, 0, 0));
       btnRunInCmd.setContentAreaFilled(false);
-      btnRunInCmd.setBounds(
-          Lizzie.config.isFrameFontSmall() ? 40 : (Lizzie.config.isFrameFontMiddle() ? 45 : 50),
-          Lizzie.config.isFrameFontSmall() ? 120 : (Lizzie.config.isFrameFontMiddle() ? 120 : 121),
-          Lizzie.config.isFrameFontSmall() ? 41 : (Lizzie.config.isFrameFontMiddle() ? 50 : 60),
-          19);
-      getContentPane().add(btnRunInCmd);
 
       JLabel lblClick =
           new JFontLabel(Lizzie.resourceBundle.getString("EngineFailedMessage.lblClick"));
-      lblClick.setBounds(13, 119, 45, 20);
-      getContentPane().add(lblClick);
-
       JLabel lblRunInCmd =
           new JFontLabel(Lizzie.resourceBundle.getString("EngineFailedMessage.lblRunInCmd"));
-      lblRunInCmd.setBounds(
-          Lizzie.config.isFrameFontSmall() ? 85 : (Lizzie.config.isFrameFontMiddle() ? 95 : 108),
-          119,
-          332,
-          20);
-      getContentPane().add(lblRunInCmd);
+      JPanel diagnosticActions = new JPanel(new FlowLayout(FlowLayout.LEFT, 4, 0));
+      diagnosticActions.add(lblClick);
+      diagnosticActions.add(btnRunInCmd);
+      diagnosticActions.add(lblRunInCmd);
+      footer.add(diagnosticActions, BorderLayout.CENTER);
     }
+
+    root.add(footer, BorderLayout.SOUTH);
+    setContentPane(root);
+    int minimumWidth =
+        Lizzie.config.isFrameFontSmall()
+            ? 580
+            : (Lizzie.config.isFrameFontMiddle() ? 660 : 730);
+    int preferredHeight = canUseCmdDignostic ? 360 : restartContribute ? 340 : 320;
+    Rectangle usableScreenBounds = usableScreenBounds();
+    Dimension dialogSize =
+        calculateDialogSize(
+            message,
+            command,
+            Config.frameFontSize,
+            minimumWidth,
+            preferredHeight,
+            usableScreenBounds.getSize());
+    setSize(dialogSize);
+    setMinimumSize(
+        new Dimension(Math.min(dialogSize.width, 480), Math.min(dialogSize.height, 260)));
 
     JRootPane rp = this.getRootPane();
     KeyStroke stroke = KeyStroke.getKeyStroke(KeyEvent.VK_E, 0);
@@ -195,11 +282,155 @@ public class EngineFailedMessage extends JDialog {
             });
 
     setLocationRelativeTo(Lizzie.frame != null ? Lizzie.frame : null);
-    setVisible(true);
-    setVisible(false);
+    setBounds(clampDialogBounds(getBounds(), usableScreenBounds));
   }
 
-  private String buildCommandLine(List<String> commands) {
+  static Dimension calculateDialogSize(
+      String message,
+      String command,
+      int fontSize,
+      int minimumWidth,
+      int preferredHeight,
+      Dimension usableScreen) {
+    int usableWidth = Math.max(1, usableScreen == null ? 1280 : usableScreen.width);
+    int usableHeight = Math.max(1, usableScreen == null ? 800 : usableScreen.height);
+    int widthMargin = Math.min(SCREEN_MARGIN, Math.max(0, usableWidth / 4));
+    int heightMargin = Math.min(SCREEN_MARGIN, Math.max(0, usableHeight / 4));
+    int widthLimit = Math.max(1, usableWidth - widthMargin);
+    int heightLimit = Math.max(1, usableHeight - heightMargin);
+    int boundedMinimum = Math.min(Math.max(320, minimumWidth), widthLimit);
+    int preferredWidth =
+        Math.max(
+            boundedMinimum,
+            estimateTextWidth(
+                (message == null ? "" : message) + "\n" + (command == null ? "" : command),
+                fontSize));
+    int width = Math.min(widthLimit, Math.min(MAX_DIALOG_WIDTH, preferredWidth));
+    int height = Math.min(heightLimit, Math.max(260, preferredHeight));
+    return new Dimension(width, height);
+  }
+
+  static JScrollPane createScrollableText(String text, Font font) {
+    JTextArea area = new JTextArea(redactSensitiveText(text));
+    area.setEditable(false);
+    area.setLineWrap(true);
+    area.setWrapStyleWord(true);
+    if (font != null) {
+      area.setFont(font);
+    }
+    area.setCaretPosition(0);
+    return new JScrollPane(
+        area,
+        JScrollPane.VERTICAL_SCROLLBAR_AS_NEEDED,
+        JScrollPane.HORIZONTAL_SCROLLBAR_NEVER);
+  }
+
+  static String redactSensitiveText(String text) {
+    if (text == null || text.isEmpty()) {
+      return "";
+    }
+    return redactSensitiveRemainder(text);
+  }
+
+  private static String redactSensitiveRemainder(String text) {
+    int firstStart = Integer.MAX_VALUE;
+    int valueStart = -1;
+    String closingQuote = "";
+
+    Matcher quotedAssignment = QUOTED_SENSITIVE_ASSIGNMENT_START.matcher(text);
+    if (quotedAssignment.find()) {
+      firstStart = quotedAssignment.start();
+      valueStart = quotedAssignment.end();
+      closingQuote = quotedAssignment.group(1);
+    }
+
+    Matcher assignment = SENSITIVE_ASSIGNMENT_START.matcher(text);
+    if (assignment.find() && assignment.start() < firstStart) {
+      firstStart = assignment.start();
+      valueStart = assignment.end();
+      closingQuote = "";
+    }
+
+    Matcher flag = SENSITIVE_FLAG_START.matcher(text);
+    if (flag.find() && flag.start() < firstStart) {
+      valueStart = flag.end();
+      closingQuote = "";
+    }
+
+    if (valueStart < 0) {
+      return text;
+    }
+    // Sensitive values are user-controlled and may contain whitespace, separators, quotes, or
+    // line breaks. Once a sensitive assignment starts, keeping any later text can retain a secret
+    // fragment or quote-comma/newline injection. Preserve the useful command prefix and key, then
+    // deliberately over-redact the entire remainder.
+    return text.substring(0, valueStart) + REDACTED_VALUE + closingQuote;
+  }
+
+  static String buildDiagnosticCommand(List<String> commands, String fallbackCommand) {
+    String commandLine =
+        commands == null || commands.isEmpty()
+            ? (fallbackCommand == null ? "" : fallbackCommand.trim())
+            : buildCommandLine(commands);
+    return redactSensitiveText(commandLine);
+  }
+
+  static Rectangle calculateUsableBounds(Rectangle screenBounds, Insets insets) {
+    Rectangle bounds = screenBounds == null ? new Rectangle(0, 0, 1280, 800) : screenBounds;
+    Insets safeInsets = insets == null ? new Insets(0, 0, 0, 0) : insets;
+    return new Rectangle(
+        bounds.x + safeInsets.left,
+        bounds.y + safeInsets.top,
+        Math.max(1, bounds.width - safeInsets.left - safeInsets.right),
+        Math.max(1, bounds.height - safeInsets.top - safeInsets.bottom));
+  }
+
+  static Rectangle clampDialogBounds(Rectangle dialogBounds, Rectangle usableBounds) {
+    Rectangle available =
+        usableBounds == null ? new Rectangle(0, 0, 1280, 800) : usableBounds;
+    Rectangle proposed =
+        dialogBounds == null
+            ? new Rectangle(available.x, available.y, 1, 1)
+            : dialogBounds;
+    int width = Math.min(Math.max(1, proposed.width), Math.max(1, available.width));
+    int height = Math.min(Math.max(1, proposed.height), Math.max(1, available.height));
+    int maximumX = available.x + available.width - width;
+    int maximumY = available.y + available.height - height;
+    int x = Math.max(available.x, Math.min(proposed.x, maximumX));
+    int y = Math.max(available.y, Math.min(proposed.y, maximumY));
+    return new Rectangle(x, y, width, height);
+  }
+
+  private static int estimateTextWidth(String text, int fontSize) {
+    int longestLine = 0;
+    for (String line : text.split("\\R", -1)) {
+      longestLine = Math.max(longestLine, line.codePointCount(0, line.length()));
+    }
+    double averageGlyphWidth = Math.max(7.0, Math.max(1, fontSize) * 0.62);
+    return 48 + (int) Math.ceil(Math.min(longestLine, 500) * averageGlyphWidth);
+  }
+
+  private Rectangle usableScreenBounds() {
+    if (GraphicsEnvironment.isHeadless()) {
+      return new Rectangle(0, 0, 1280, 800);
+    }
+    GraphicsConfiguration configuration =
+        Lizzie.frame == null ? null : Lizzie.frame.getGraphicsConfiguration();
+    if (configuration == null) {
+      configuration = getGraphicsConfiguration();
+    }
+    if (configuration == null) {
+      configuration =
+          GraphicsEnvironment.getLocalGraphicsEnvironment()
+              .getDefaultScreenDevice()
+              .getDefaultConfiguration();
+    }
+    Rectangle bounds = configuration.getBounds();
+    Insets insets = Toolkit.getDefaultToolkit().getScreenInsets(configuration);
+    return calculateUsableBounds(bounds, insets);
+  }
+
+  private static String buildCommandLine(List<String> commands) {
     StringBuilder builder = new StringBuilder();
     for (int i = 0; i < commands.size(); i++) {
       if (i > 0) {
@@ -210,7 +441,7 @@ public class EngineFailedMessage extends JDialog {
     return builder.toString();
   }
 
-  private String quoteForCmd(String token) {
+  private static String quoteForCmd(String token) {
     if (token == null) {
       return "\"\"";
     }

--- a/src/main/java/featurecat/lizzie/gui/HumanSlDialogBounds.java
+++ b/src/main/java/featurecat/lizzie/gui/HumanSlDialogBounds.java
@@ -1,0 +1,62 @@
+package featurecat.lizzie.gui;
+
+import java.awt.Dimension;
+import java.awt.GraphicsConfiguration;
+import java.awt.GraphicsEnvironment;
+import java.awt.Insets;
+import java.awt.Rectangle;
+import java.awt.Toolkit;
+import java.awt.Window;
+
+/** Shared high-DPI and small-screen sizing rules for the AI Coach dialogs. */
+final class HumanSlDialogBounds {
+  private static final int SCREEN_MARGIN = 40;
+
+  private HumanSlDialogBounds() {}
+
+  static Rectangle usableBounds(Window owner, Window dialog) {
+    GraphicsConfiguration configuration =
+        owner != null ? owner.getGraphicsConfiguration() : dialog.getGraphicsConfiguration();
+    if (configuration == null) {
+      return GraphicsEnvironment.getLocalGraphicsEnvironment().getMaximumWindowBounds();
+    }
+    Rectangle bounds = configuration.getBounds();
+    Insets insets = Toolkit.getDefaultToolkit().getScreenInsets(configuration);
+    return new Rectangle(
+        bounds.x + insets.left,
+        bounds.y + insets.top,
+        Math.max(1, bounds.width - insets.left - insets.right),
+        Math.max(1, bounds.height - insets.top - insets.bottom));
+  }
+
+  static Dimension fit(
+      Dimension packed,
+      Dimension current,
+      Rectangle usableBounds,
+      int preferredWidth,
+      int preferredHeight) {
+    int availableWidth = Math.max(1, usableBounds.width - SCREEN_MARGIN);
+    int availableHeight = Math.max(1, usableBounds.height - SCREEN_MARGIN);
+    int packedWidth = packed == null ? 0 : packed.width;
+    int packedHeight = packed == null ? 0 : packed.height;
+    int currentWidth = current == null ? 0 : current.width;
+    int currentHeight = current == null ? 0 : current.height;
+    return new Dimension(
+        Math.min(availableWidth, Math.max(preferredWidth, Math.max(packedWidth, currentWidth))),
+        Math.min(
+            availableHeight, Math.max(preferredHeight, Math.max(packedHeight, currentHeight))));
+  }
+
+  static Dimension minimum(Dimension target, int preferredWidth, int preferredHeight) {
+    return new Dimension(
+        Math.min(preferredWidth, target.width), Math.min(preferredHeight, target.height));
+  }
+
+  static void keepOnScreen(Window window, Rectangle usableBounds) {
+    int maxX = usableBounds.x + usableBounds.width - window.getWidth();
+    int maxY = usableBounds.y + usableBounds.height - window.getHeight();
+    window.setLocation(
+        Math.max(usableBounds.x, Math.min(window.getX(), maxX)),
+        Math.max(usableBounds.y, Math.min(window.getY(), maxY)));
+  }
+}

--- a/src/main/java/featurecat/lizzie/gui/HumanSlGameController.java
+++ b/src/main/java/featurecat/lizzie/gui/HumanSlGameController.java
@@ -357,11 +357,13 @@ public final class HumanSlGameController {
     aiThinking = true;
     Lizzie.frame.updateHumanSlTrainingBar();
     long generation = requestGeneration.get();
+    Board requestBoard = Lizzie.board;
+    BoardHistoryNode positionNode = requestBoard.getHistory().getCurrentHistoryNode();
+    long positionContextRevision = requestBoard.getContextRevision();
     try {
       gameExecutor.execute(
           () -> {
             long startedAt = System.currentTimeMillis();
-            BoardHistoryNode positionNode = Lizzie.board.getHistory().getCurrentHistoryNode();
             Optional<String> move = Optional.empty();
             for (int attempt = 0;
                 attempt < AI_MOVE_RETRIES
@@ -383,12 +385,14 @@ public final class HumanSlGameController {
                 runner.cancelActiveRequests();
               }
             }
-            waitMinimumThinkTime(startedAt, generation);
+            waitMinimumThinkTime(
+                startedAt, generation, requestBoard, positionNode, positionContextRevision);
             Optional<String> resolved = move;
             SwingUtilities.invokeLater(
                 () -> {
                   if (generation == requestGeneration.get()) {
-                    applyAiMove(resolved);
+                    applyAiMoveIfCurrent(
+                        resolved, requestBoard, positionNode, positionContextRevision);
                   }
                 });
           });
@@ -397,8 +401,15 @@ public final class HumanSlGameController {
     }
   }
 
-  private void waitMinimumThinkTime(long startedAt, long generation) {
-    if (finished || generation != requestGeneration.get()) {
+  private void waitMinimumThinkTime(
+      long startedAt,
+      long generation,
+      Board requestBoard,
+      BoardHistoryNode positionNode,
+      long positionContextRevision) {
+    if (finished
+        || generation != requestGeneration.get()
+        || !isCurrentAiRequestPosition(requestBoard, positionNode, positionContextRevision)) {
       return;
     }
     long target =
@@ -415,6 +426,28 @@ public final class HumanSlGameController {
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
     }
+  }
+
+  private void applyAiMoveIfCurrent(
+      Optional<String> move,
+      Board requestBoard,
+      BoardHistoryNode positionNode,
+      long positionContextRevision) {
+    if (!isCurrentAiRequestPosition(requestBoard, positionNode, positionContextRevision)) {
+      // A coaching game owns one live board position. If another action navigated or replaced that
+      // position while HumanSL was thinking, ending the session is safer than applying a response
+      // to an unrelated node or leaving a half-active controller behind.
+      abort();
+      return;
+    }
+    applyAiMove(move);
+  }
+
+  private boolean isCurrentAiRequestPosition(
+      Board requestBoard, BoardHistoryNode positionNode, long positionContextRevision) {
+    return Lizzie.board == requestBoard
+        && requestBoard.getContextRevision() == positionContextRevision
+        && requestBoard.getHistory().getCurrentHistoryNode() == positionNode;
   }
 
   private void applyAiMove(Optional<String> move) {

--- a/src/main/java/featurecat/lizzie/gui/HumanSlTrainingReportDialog.java
+++ b/src/main/java/featurecat/lizzie/gui/HumanSlTrainingReportDialog.java
@@ -17,6 +17,7 @@ import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.awt.Insets;
 import java.awt.RenderingHints;
+import java.awt.Rectangle;
 import java.awt.Window;
 import java.text.MessageFormat;
 import java.util.ResourceBundle;
@@ -50,9 +51,12 @@ public final class HumanSlTrainingReportDialog extends JDialog {
     setDefaultCloseOperation(WindowConstants.HIDE_ON_CLOSE);
     setContentPane(buildContent());
     pack();
-    setMinimumSize(new Dimension(900, 520));
-    setSize(Math.max(1040, getWidth()), Math.max(590, getHeight()));
+    Rectangle usableBounds = HumanSlDialogBounds.usableBounds(owner, this);
+    Dimension target = HumanSlDialogBounds.fit(getSize(), null, usableBounds, 1040, 590);
+    setMinimumSize(HumanSlDialogBounds.minimum(target, 900, 520));
+    setSize(target);
     setLocationRelativeTo(owner);
+    HumanSlDialogBounds.keepOnScreen(this, usableBounds);
   }
 
   public void showReport() {
@@ -175,7 +179,7 @@ public final class HumanSlTrainingReportDialog extends JDialog {
     scroll.setBorder(null);
     scroll.getViewport().setOpaque(false);
     scroll.setOpaque(false);
-    scroll.setHorizontalScrollBarPolicy(JScrollPane.HORIZONTAL_SCROLLBAR_NEVER);
+    scroll.setHorizontalScrollBarPolicy(JScrollPane.HORIZONTAL_SCROLLBAR_AS_NEEDED);
     return scroll;
   }
 

--- a/src/main/java/featurecat/lizzie/gui/Input.java
+++ b/src/main/java/featurecat/lizzie/gui/Input.java
@@ -412,7 +412,11 @@ public class Input implements MouseListener, KeyListener, MouseWheelListener, Mo
         break;
 
       case VK_P:
-        Lizzie.board.pass();
+        if (Lizzie.frame.humanSlGame != null && !Lizzie.frame.humanSlGame.isFinished()) {
+          Lizzie.frame.humanSlGame.humanPass();
+        } else {
+          Lizzie.board.pass();
+        }
         break;
 
       case VK_COMMA:

--- a/src/main/java/featurecat/lizzie/gui/KataGoAutoSetupDialog.java
+++ b/src/main/java/featurecat/lizzie/gui/KataGoAutoSetupDialog.java
@@ -54,6 +54,7 @@ import java.awt.geom.Arc2D;
 import java.awt.geom.Ellipse2D;
 import java.awt.geom.RoundRectangle2D;
 import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
 import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -2985,6 +2986,7 @@ public class KataGoAutoSetupDialog extends JDialog {
           result, message, reloadWarning, showSuccessPopup, includeWeightPathInPopup);
       return;
     }
+    publishAcceptedWeightSwitch(result);
     if (Lizzie.engineManager != null
         && result.engineIndex >= 0
         && !isAppliedEngineReady(result.engineIndex)) {
@@ -2992,6 +2994,26 @@ public class KataGoAutoSetupDialog extends JDialog {
       return;
     }
     finishSetupApplied(result, message, null, showSuccessPopup, includeWeightPathInPopup);
+  }
+
+  private void publishAcceptedWeightSwitch(SetupResult result) {
+    // EngineManager publishes currentEngineNo only after startup synchronization. The switch has
+    // already been accepted here, so render the requested weight instead of leaving the old
+    // "currently using" badge visible throughout the readiness poll.
+    runWeightSwitchUiUpdate(
+        () -> {
+          snapshot =
+              advanceWeightSwitchDisplay(
+                  snapshot,
+                  result == null ? null : result.snapshot,
+                  null,
+                  WeightSwitchDisplayPhase.ACCEPTED,
+                  false);
+          renderSnapshot();
+          selectRemoteWeightByModelName(
+              KataGoAutoSetupHelper.resolveActiveWeightModelName(snapshot));
+          updateSelectedRemoteWeightInfo();
+        });
   }
 
   private void waitForAppliedEngine(
@@ -3052,32 +3074,105 @@ public class KataGoAutoSetupDialog extends JDialog {
       String reloadWarning,
       boolean showSuccessPopup,
       boolean includeWeightPathInPopup) {
-    setBusy(false, reloadWarning == null ? message : reloadWarning, 0, 0);
-    snapshot = KataGoAutoSetupHelper.inspectLocalSetup();
-    renderSnapshot();
-    selectRemoteWeightByModelName(KataGoAutoSetupHelper.resolveActiveWeightModelName(snapshot));
-    updateSelectedRemoteWeightInfo();
-    if (reloadWarning == null || reloadWarning.trim().isEmpty()) {
-      lblStatus.setText(message);
-      lblStatus.setForeground(OK_COLOR);
-      if (showSuccessPopup) {
-        Utils.showMsg(
-            includeWeightPathInPopup ? message + "\n" + result.snapshot.activeWeightPath : message,
-            this);
-      }
-    } else {
-      lblStatus.setText(reloadWarning);
-      lblStatus.setForeground(WARN_COLOR);
-      if (showSuccessPopup || includeWeightPathInPopup) {
-        Utils.showMsg(
-            message
-                + (includeWeightPathInPopup ? "\n" + result.snapshot.activeWeightPath : "")
-                + "\n\n"
-                + reloadWarning,
-            this);
-      }
+    SetupSnapshot authoritativeSnapshot = KataGoAutoSetupHelper.inspectLocalSetup();
+    boolean succeeded = reloadWarning == null || reloadWarning.trim().isEmpty();
+    boolean requestedEngineIsPendingPrimary = isRequestedEngineStillPendingPrimary(result);
+    runWeightSwitchUiUpdate(
+        () -> {
+          setBusy(false, succeeded ? message : reloadWarning, 0, 0);
+          snapshot =
+              advanceWeightSwitchDisplay(
+                  snapshot,
+                  result == null ? null : result.snapshot,
+                  authoritativeSnapshot,
+                  succeeded ? WeightSwitchDisplayPhase.SUCCEEDED : WeightSwitchDisplayPhase.FAILED,
+                  requestedEngineIsPendingPrimary);
+          renderSnapshot();
+          selectRemoteWeightByModelName(
+              KataGoAutoSetupHelper.resolveActiveWeightModelName(snapshot));
+          updateSelectedRemoteWeightInfo();
+          if (succeeded) {
+            lblStatus.setText(message);
+            lblStatus.setForeground(OK_COLOR);
+            if (showSuccessPopup) {
+              Utils.showMsg(
+                  includeWeightPathInPopup
+                      ? message + "\n" + result.snapshot.activeWeightPath
+                      : message,
+                  this);
+            }
+          } else {
+            lblStatus.setText(reloadWarning);
+            lblStatus.setForeground(WARN_COLOR);
+            if (showSuccessPopup || includeWeightPathInPopup) {
+              Utils.showMsg(
+                  message
+                      + (includeWeightPathInPopup ? "\n" + result.snapshot.activeWeightPath : "")
+                      + "\n\n"
+                      + reloadWarning,
+                  this);
+            }
+          }
+          resumeQuickAnalysisAfterWeightSwitchIfNeeded();
+        });
+  }
+
+  static SetupSnapshot advanceWeightSwitchDisplay(
+      SetupSnapshot currentDisplay,
+      SetupSnapshot requestedSnapshot,
+      SetupSnapshot authoritativeSnapshot,
+      WeightSwitchDisplayPhase phase,
+      boolean requestedEngineIsPendingPrimary) {
+    if (phase == WeightSwitchDisplayPhase.ACCEPTED) {
+      return requestedSnapshot == null ? currentDisplay : requestedSnapshot;
     }
-    resumeQuickAnalysisAfterWeightSwitchIfNeeded();
+    if (phase == WeightSwitchDisplayPhase.SUCCEEDED
+        || (phase == WeightSwitchDisplayPhase.FAILED && requestedEngineIsPendingPrimary)) {
+      return requestedSnapshot == null
+          ? (authoritativeSnapshot == null ? currentDisplay : authoritativeSnapshot)
+          : requestedSnapshot;
+    }
+    return authoritativeSnapshot == null ? currentDisplay : authoritativeSnapshot;
+  }
+
+  private static boolean isRequestedEngineStillPendingPrimary(SetupResult result) {
+    EngineManager manager = Lizzie.engineManager;
+    if (result == null
+        || manager == null
+        || manager.engineList == null
+        || result.engineIndex < 0
+        || result.engineIndex >= manager.engineList.size()) {
+      return false;
+    }
+    Leelaz requestedEngine = manager.engineList.get(result.engineIndex);
+    return requestedEngine != null
+        && Lizzie.capturePrimaryEngineGeneration(requestedEngine) >= 0
+        && !(requestedEngine.isDownWithError && !requestedEngine.isStarted());
+  }
+
+  static void runWeightSwitchUiUpdate(Runnable update) {
+    if (update == null) {
+      return;
+    }
+    if (SwingUtilities.isEventDispatchThread()) {
+      update.run();
+      return;
+    }
+    try {
+      SwingUtilities.invokeAndWait(update);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new IllegalStateException("Interrupted while updating the weight-switch interface", e);
+    } catch (InvocationTargetException e) {
+      Throwable cause = e.getCause();
+      if (cause instanceof RuntimeException) {
+        throw (RuntimeException) cause;
+      }
+      if (cause instanceof Error) {
+        throw (Error) cause;
+      }
+      throw new IllegalStateException("Failed to update the weight-switch interface", cause);
+    }
   }
 
   private void resumeQuickAnalysisAfterWeightSwitchIfNeeded() {
@@ -4220,6 +4315,12 @@ public class KataGoAutoSetupDialog extends JDialog {
     WAIT_FOR_QUICK_ANALYSIS,
     BLOCKED_BY_ANALYSIS,
     BLOCKED_BY_ENGINE_TASK
+  }
+
+  enum WeightSwitchDisplayPhase {
+    ACCEPTED,
+    SUCCEEDED,
+    FAILED
   }
 
   private static final class WeightCatalogEntry {

--- a/src/main/java/featurecat/lizzie/gui/LizzieFrame.java
+++ b/src/main/java/featurecat/lizzie/gui/LizzieFrame.java
@@ -11358,13 +11358,20 @@ public class LizzieFrame extends JFrame {
     runWithForegroundEngineModeReservation(this::startEngineGameDialogReserved);
   }
 
-  private void startEngineGameDialogReserved() {
+  protected void startEngineGameDialogReserved() {
     if (EngineManager.isEngineGame) {
       Utils.showMsg(
           Lizzie.resourceBundle.getString(
               "LizzieFrame.engineGameStopFirstHint")); // "请等待当前引擎对战结束,或手动终止对局");
       return;
     }
+    // Opening another mode is an explicit ownership transfer; cancelling its dialog does not
+    // resume the previous coaching session.
+    endHumanSlGameIfActive();
+    showEngineGameDialogAfterModeTransition();
+  }
+
+  protected void showEngineGameDialogAfterModeTransition() {
     if (Lizzie.frame.isPlayingAgainstLeelaz || Lizzie.frame.isAnaPlayingAgainstLeelaz) {
       Lizzie.frame.togglePonderMannul();
     }
@@ -11403,7 +11410,20 @@ public class LizzieFrame extends JFrame {
       Lizzie.leelaz.togglePonder();
       isPondering = true;
     }
+    // A retained mode action owns the foreground engine once this point is reached. Cancelling
+    // its dialog must not leave the previous AI Coach alive beside a later mode.
     Lizzie.frame.stopAiPlayingAndPolicy();
+    // Ending AI Coach restores the analysis state that existed before coaching, which may include
+    // pondering. Keep the replacement mode's dialog quiet and restore it only if that dialog is
+    // cancelled.
+    if (Lizzie.leelaz.isPondering()) {
+      Lizzie.leelaz.togglePonder();
+      isPondering = true;
+    }
+    showAnalyzeGameDialogAfterModeTransition(isPondering);
+  }
+
+  protected void showAnalyzeGameDialogAfterModeTransition(boolean wasPondering) {
     // Lizzie.frame.isPlayingAgainstLeelaz = false;
     // GameInfo gameInfo = Lizzie.board.getHistory().getGameInfo();
     NewAnaGameDialog newgame = new NewAnaGameDialog(this);
@@ -11411,7 +11431,7 @@ public class LizzieFrame extends JFrame {
     newgame.setVisible(true);
     newgame.dispose();
     if (newgame.isCancelled()) {
-      if (isPondering) Lizzie.leelaz.togglePonder();
+      if (wasPondering) Lizzie.leelaz.togglePonder();
       Lizzie.frame.isAnaPlayingAgainstLeelaz = false;
       return;
     }
@@ -11440,7 +11460,9 @@ public class LizzieFrame extends JFrame {
       showUnsupportedWebSocketAdvancedClock();
       return;
     }
-    if (isPlayingAgainstLeelaz || isAnaPlayingAgainstLeelaz) {
+    if (isPlayingAgainstLeelaz
+        || isAnaPlayingAgainstLeelaz
+        || (humanSlGame != null && !humanSlGame.isFinished())) {
       stopAiPlayingAndPolicy();
     }
     if (Lizzie.config.limitMyTime)
@@ -12018,10 +12040,17 @@ public class LizzieFrame extends JFrame {
   }
 
   public boolean stopAiPlayingAndPolicy() {
+    boolean wasHumanSlGame =
+        Lizzie.frame.humanSlGame != null && !Lizzie.frame.humanSlGame.isFinished();
+    if (wasHumanSlGame) {
+      Lizzie.frame.endHumanSlGameIfActive();
+    }
     toolbar.isPkStop = false;
     Lizzie.leelaz.isGamePaused = false;
     boolean isGaming =
-        Lizzie.frame.isPlayingAgainstLeelaz || Lizzie.frame.isAnaPlayingAgainstLeelaz;
+        wasHumanSlGame
+            || Lizzie.frame.isPlayingAgainstLeelaz
+            || Lizzie.frame.isAnaPlayingAgainstLeelaz;
     if (Lizzie.frame.isShowingHeatmap) {
       Lizzie.leelaz.toggleHeatmap(true);
       Lizzie.leelaz.notPondering();

--- a/src/main/java/featurecat/lizzie/gui/NewHumanSlGameDialog.java
+++ b/src/main/java/featurecat/lizzie/gui/NewHumanSlGameDialog.java
@@ -24,6 +24,7 @@ import java.awt.Font;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.awt.Insets;
+import java.awt.Rectangle;
 import java.awt.Window;
 import java.awt.event.KeyEvent;
 import java.awt.event.WindowAdapter;
@@ -45,6 +46,7 @@ import javax.swing.JDialog;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JProgressBar;
+import javax.swing.JScrollPane;
 import javax.swing.JSpinner;
 import javax.swing.JToggleButton;
 import javax.swing.KeyStroke;
@@ -99,13 +101,16 @@ public final class NewHumanSlGameDialog extends JDialog {
       setIconImage(ImageIO.read(MoreEngines.class.getResourceAsStream("/assets/logo.png")));
     } catch (IOException ignored) {
     }
-    setContentPane(buildContent());
+    JScrollPane contentScroll = new JScrollPane(buildContent());
+    contentScroll.setBorder(null);
+    contentScroll.getViewport().setBackground(HumanSlTrainingStyle.BACKGROUND);
+    contentScroll.setHorizontalScrollBarPolicy(JScrollPane.HORIZONTAL_SCROLLBAR_AS_NEEDED);
+    contentScroll.setVerticalScrollBarPolicy(JScrollPane.VERTICAL_SCROLLBAR_AS_NEEDED);
+    setContentPane(contentScroll);
     installBehavior();
     refreshModelStatus();
     pack();
-    setMinimumSize(new Dimension(860, 390));
-    setSize(Math.max(920, getWidth()), Math.max(410, getHeight()));
-    setLocationRelativeTo(owner);
+    fitToScreen(null, 410);
   }
 
   private JComponent buildContent() {
@@ -492,8 +497,17 @@ public final class NewHumanSlGameDialog extends JDialog {
     Dimension current = getSize();
     pack();
     int contentHeight = moreButton.isSelected() || downloading ? 500 : 410;
-    setSize(Math.max(current.width, 920), Math.max(getHeight(), contentHeight));
+    fitToScreen(current, contentHeight);
+  }
+
+  private void fitToScreen(Dimension current, int preferredHeight) {
+    Rectangle usableBounds = HumanSlDialogBounds.usableBounds(getOwner(), this);
+    Dimension target =
+        HumanSlDialogBounds.fit(getSize(), current, usableBounds, 920, preferredHeight);
+    setMinimumSize(HumanSlDialogBounds.minimum(target, 860, 390));
+    setSize(target);
     setLocationRelativeTo(getOwner());
+    HumanSlDialogBounds.keepOnScreen(this, usableBounds);
   }
 
   private void updateTrainingSummary() {

--- a/src/test/java/featurecat/lizzie/analysis/EngineManagerEngineGameStartTest.java
+++ b/src/test/java/featurecat/lizzie/analysis/EngineManagerEngineGameStartTest.java
@@ -4,9 +4,14 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import featurecat.lizzie.Lizzie;
+import featurecat.lizzie.gui.BottomToolbar;
+import featurecat.lizzie.gui.JFontMenu;
 import featurecat.lizzie.gui.LizzieFrame;
+import featurecat.lizzie.gui.Menu;
+import featurecat.lizzie.rules.Board;
 import java.lang.reflect.Field;
 import java.util.List;
+import javax.swing.SwingUtilities;
 import org.junit.jupiter.api.Test;
 
 class EngineManagerEngineGameStartTest {
@@ -33,6 +38,54 @@ class EngineManagerEngineGameStartTest {
     } finally {
       Lizzie.frame = previousFrame;
       Lizzie.leelaz = previousEngine;
+      EngineManager.isEngineGame = previousEngineGame;
+      EngineManager.isPreEngineGame = previousPreEngineGame;
+    }
+  }
+
+  @Test
+  void asynchronousEngineGameStartFailureRestoresEveryDisabledControl() throws Exception {
+    LizzieFrame previousFrame = Lizzie.frame;
+    BottomToolbar previousToolbar = LizzieFrame.toolbar;
+    JFontMenu previousEngineMenu = Menu.engineMenu;
+    Board previousBoard = Lizzie.board;
+    boolean previousEngineGame = EngineManager.isEngineGame;
+    boolean previousPreEngineGame = EngineManager.isPreEngineGame;
+    try {
+      TrackingFrame frame = allocate(TrackingFrame.class);
+      TrackingToolbar toolbar = allocate(TrackingToolbar.class);
+      JFontMenu engineMenu = new JFontMenu();
+      engineMenu.setEnabled(false);
+      Lizzie.frame = frame;
+      LizzieFrame.toolbar = toolbar;
+      Menu.engineMenu = engineMenu;
+      Board board = allocate(Board.class);
+      board.isPkBoard = true;
+      Lizzie.board = board;
+      EngineManager.isEngineGame = false;
+      EngineManager.isPreEngineGame = true;
+      EngineManager manager = new EngineManager(List.of());
+
+      EngineManager.PkEngineSynchronization black =
+          manager.startEngineForPkSynchronization(-1);
+      EngineManager.PkEngineSynchronization white =
+          manager.startEngineForPkSynchronization(-1);
+
+      assertFalse(manager.finishPkEngineSynchronizations(black, white));
+      assertFalse(Lizzie.board.isPkBoard);
+      SwingUtilities.invokeAndWait(() -> {});
+
+      assertFalse(EngineManager.isPreEngineGame);
+      assertFalse(EngineManager.isEngineGame);
+      assertTrue(frame.inputRestored);
+      assertTrue(toolbar.controlsEnabled);
+      assertTrue(toolbar.updatedOnEventDispatchThread);
+      assertTrue(engineMenu.isEnabled());
+    } finally {
+      Lizzie.frame = previousFrame;
+      LizzieFrame.toolbar = previousToolbar;
+      Menu.engineMenu = previousEngineMenu;
+      Lizzie.board = previousBoard;
       EngineManager.isEngineGame = previousEngineGame;
       EngineManager.isPreEngineGame = previousPreEngineGame;
     }
@@ -89,5 +142,25 @@ class EngineManagerEngineGameStartTest {
 
     @Override
     public void setResult(String result) {}
+  }
+
+  private static final class TrackingFrame extends LizzieFrame {
+    private boolean inputRestored;
+
+    @Override
+    public void addInput(boolean shouldAdd) {
+      inputRestored = shouldAdd;
+    }
+  }
+
+  private static final class TrackingToolbar extends BottomToolbar {
+    private boolean controlsEnabled;
+    private boolean updatedOnEventDispatchThread;
+
+    @Override
+    public void enableDisabelForEngineGame(boolean enable) {
+      controlsEnabled = enable;
+      updatedOnEventDispatchThread = SwingUtilities.isEventDispatchThread();
+    }
   }
 }

--- a/src/test/java/featurecat/lizzie/analysis/EngineManagerLifecycleReservationTest.java
+++ b/src/test/java/featurecat/lizzie/analysis/EngineManagerLifecycleReservationTest.java
@@ -4315,7 +4315,7 @@ class EngineManagerLifecycleReservationTest {
     private final UpdateForegroundLeelaz previousSecondaryEngine;
     private final UpdateBoard board;
     private final EngineManager manager;
-    private final Path commandScript;
+    private final String updateEngineCommand;
     private final Path commandLog;
     private final Path startupGate;
     private final Path boardFenceGate;
@@ -4349,7 +4349,6 @@ class EngineManagerLifecycleReservationTest {
         previousSecondaryEngine.started = true;
         previousSecondaryEngine.isLoaded = true;
       }
-      commandScript = Files.createTempFile("lizzie-update-engine-", ".sh");
       commandLog = Files.createTempFile("lizzie-update-engine-", ".log");
       startupGate = Files.createTempFile("lizzie-update-engine-startup-", ".gate");
       boardFenceGate = Files.createTempFile("lizzie-update-engine-fence-", ".gate");
@@ -4361,8 +4360,14 @@ class EngineManagerLifecycleReservationTest {
       Files.delete(boardFenceGate);
       Files.delete(catchUpGate);
       Files.delete(fenceFailure);
-      Files.writeString(commandScript, updateEngineScript());
-      assertTrue(commandScript.toFile().setExecutable(true));
+      updateEngineCommand =
+          updateEngineCommand(
+              commandLog,
+              startupGate,
+              loadSgfFailure,
+              boardFenceGate,
+              catchUpGate,
+              fenceFailure);
       board = allocate(UpdateBoard.class);
       board.startStonelist = new ArrayList<>();
       board.hasStartStone = false;
@@ -4377,21 +4382,7 @@ class EngineManagerLifecycleReservationTest {
       config.extraMode = doubleEngine ? ExtraMode.Double_Engine : ExtraMode.Normal;
       JSONObject engineConfig =
           new JSONObject()
-              .put(
-                  "command",
-                  commandScript.toString()
-                      + " "
-                      + commandLog
-                      + " "
-                      + startupGate
-                      + " "
-                      + loadSgfFailure
-                      + " "
-                      + boardFenceGate
-                      + " "
-                      + catchUpGate
-                      + " "
-                      + fenceFailure)
+              .put("command", updateEngineCommand)
               .put("name", "update-target")
               .put("preload", false)
               .put("width", targetWidth)
@@ -4431,6 +4422,7 @@ class EngineManagerLifecycleReservationTest {
     }
 
     private void releaseStartup() throws Exception {
+      waitForLog(commandLog, "name", 10000L);
       Files.writeString(startupGate, "ready");
     }
 
@@ -4450,7 +4442,7 @@ class EngineManagerLifecycleReservationTest {
 
     private void restore() {
       try {
-        releaseStartup();
+        Files.writeString(startupGate, "ready");
       } catch (Exception ignored) {
       }
       try {
@@ -4511,55 +4503,53 @@ class EngineManagerLifecycleReservationTest {
       }
     }
 
-    private static String updateEngineScript() {
-      return String.join(
-              "\n",
-              "#!/bin/sh",
-              "log=\"$1\"",
-              "gate=\"$2\"",
-              "loadsgf_failure=\"$3\"",
-              "fence_gate=\"$4\"",
-              "catchup_gate=\"$5\"",
-              "fence_failure=\"$6\"",
-              "name_count=0",
-              "loadsgf_count=0",
-              "while IFS= read -r line; do",
-              "  printf '%s\\n' \"$line\" >> \"$log\"",
-              "  rest=\"$line\"",
-              "  id=\"\"",
-              "  case \"$line\" in",
-              "    [0-9]*\\ *) id=\"${line%% *}\"; rest=\"${line#* }\" ;;",
-              "  esac",
-              "  case \"$rest\" in",
-              "    loadsgf\\ *)",
-              "      loadsgf_count=$((loadsgf_count + 1))",
-              "      printf 'SGF:%s\\n' \"$(cat \"${rest#loadsgf }\")\" >> \"$log\"",
-              "      if [ -f \"$loadsgf_failure\" ]; then",
-              "        if [ -n \"$id\" ]; then printf '?%s controlled restore failure\\n\\n' \"$id\"; else printf '? controlled restore failure\\n\\n'; fi",
-              "        continue",
-              "      fi",
-              "      if [ \"$loadsgf_count\" -ge 2 ]; then while [ ! -f \"$catchup_gate\" ]; do sleep 0.01; done; fi ;;",
-              "  esac",
-              "  case \"$rest\" in",
-              "    name)",
-              "      name_count=$((name_count + 1))",
-              "      if [ \"$name_count\" -eq 1 ]; then while [ ! -f \"$gate\" ]; do sleep 0.01; done; else while [ ! -f \"$fence_gate\" ]; do sleep 0.01; done; fi",
-              "      if [ \"$name_count\" -ge 2 ] && [ -f \"$fence_failure\" ]; then",
-              "        if [ -n \"$id\" ]; then printf '?%s controlled fence failure\\n\\n' \"$id\"; else printf '? controlled fence failure\\n\\n'; fi",
-              "        continue",
-              "      fi ;;",
-              "  esac",
-              "  if [ -n \"$id\" ]; then printf '=%s\\n\\n' \"$id\"; else",
-              "    case \"$rest\" in",
-              "      name) printf '= KataGo\\n\\n' ;;",
-              "      version) printf '= 1.15\\n\\n' ;;",
-              "      list_commands) printf '= protocol_version\\n\\n' ;;",
-              "      *) printf '=\\n\\n' ;;",
-              "    esac",
-              "  fi",
-              "  [ \"$rest\" = quit ] && exit 0",
-              "done")
-          + "\n";
+    private static String updateEngineCommand(
+        Path commandLog,
+        Path startupGate,
+        Path loadSgfFailure,
+        Path boardFenceGate,
+        Path catchUpGate,
+        Path fenceFailure)
+        throws Exception {
+      boolean windows =
+          System.getProperty("os.name", "").toLowerCase(java.util.Locale.ROOT).contains("win");
+      Path javaExecutable =
+          Path.of(System.getProperty("java.home"), "bin", windows ? "java.exe" : "java")
+              .toAbsolutePath()
+              .normalize();
+      Path testClasses =
+          Path.of(
+                  UpdateEngineGtpFixture.class
+                      .getProtectionDomain()
+                      .getCodeSource()
+                      .getLocation()
+                      .toURI())
+              .toAbsolutePath()
+              .normalize();
+      return commandQuote(javaExecutable.toString())
+          + " -cp "
+          + commandQuote(testClasses.toString())
+          + " "
+          + UpdateEngineGtpFixture.class.getName()
+          + " "
+          + commandQuote(commandLog.toString())
+          + " "
+          + commandQuote(startupGate.toString())
+          + " "
+          + commandQuote(loadSgfFailure.toString())
+          + " "
+          + commandQuote(boardFenceGate.toString())
+          + " "
+          + commandQuote(catchUpGate.toString())
+          + " "
+          + commandQuote(fenceFailure.toString());
+    }
+
+    private static String commandQuote(String value) {
+      if (value.indexOf('"') >= 0) {
+        throw new IllegalArgumentException("command argument contains a double quote: " + value);
+      }
+      return "\"" + value + "\"";
     }
   }
 

--- a/src/test/java/featurecat/lizzie/analysis/EngineStartupDialogPolicyTest.java
+++ b/src/test/java/featurecat/lizzie/analysis/EngineStartupDialogPolicyTest.java
@@ -3,9 +3,16 @@ package featurecat.lizzie.analysis;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
+import featurecat.lizzie.Config;
+import featurecat.lizzie.ConfigTestHelper;
 import featurecat.lizzie.EngineStartupStatus;
 import featurecat.lizzie.Lizzie;
+import featurecat.lizzie.gui.LizzieFrame;
+import featurecat.lizzie.rules.Board;
+import java.awt.GraphicsEnvironment;
+import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -26,6 +33,50 @@ class EngineStartupDialogPolicyTest {
   void secondaryEngineDiagnosticsRemainAvailableOutsideFirstLaunch() {
     assertTrue(Leelaz.shouldOpenInteractiveDiagnostic(false, false));
     assertFalse(Leelaz.shouldOpenInteractiveDiagnostic(false, true));
+  }
+
+  @Test
+  void headlessSecondaryDiagnosticPreservesStatusAndClearsPendingEngineGame() throws Exception {
+    assumeTrue(GraphicsEnvironment.isHeadless());
+    Config previousConfig = Lizzie.config;
+    Leelaz previousPrimary = Lizzie.leelaz;
+    EngineManager previousManager = Lizzie.engineManager;
+    Board previousBoard = Lizzie.board;
+    LizzieFrame previousFrame = Lizzie.frame;
+    boolean previousEngineGame = EngineManager.isEngineGame;
+    boolean previousPreEngineGame = EngineManager.isPreEngineGame;
+    boolean previousFirstLaunch = forceFirstLaunchSession(false);
+    try {
+      Lizzie.config =
+          ConfigTestHelper.createForTests(tempDir.resolve("headless-secondary-diagnostic"));
+      Lizzie.config.autoCheckEngineAlive = false;
+      Leelaz primary = new Leelaz("");
+      Leelaz secondary = new Leelaz("");
+      Lizzie.leelaz = primary;
+      Lizzie.engineManager = new EngineManager(List.of(primary, secondary));
+      Lizzie.board = new Board();
+      Lizzie.board.isPkBoard = true;
+      Lizzie.frame = null;
+      EngineManager.isEngineGame = false;
+      EngineManager.isPreEngineGame = true;
+      Lizzie.engineStartupStatus.ready();
+
+      secondary.tryToDignostic("controlled headless secondary failure", false);
+
+      assertEquals(EngineStartupStatus.State.READY, Lizzie.engineStartupStatus.snapshot().state);
+      assertFalse(EngineManager.isPreEngineGame);
+      assertFalse(Lizzie.board.isPkBoard);
+    } finally {
+      Lizzie.config = previousConfig;
+      Lizzie.leelaz = previousPrimary;
+      Lizzie.engineManager = previousManager;
+      Lizzie.board = previousBoard;
+      Lizzie.frame = previousFrame;
+      EngineManager.isEngineGame = previousEngineGame;
+      EngineManager.isPreEngineGame = previousPreEngineGame;
+      forceFirstLaunchSession(previousFirstLaunch);
+      Lizzie.engineStartupStatus.ready();
+    }
   }
 
   @Test
@@ -160,6 +211,14 @@ class EngineStartupDialogPolicyTest {
             "publishBundledStartupStatus", String.class, String.class);
     method.setAccessible(true);
     method.invoke(engine, statusKey, statusFallback);
+  }
+
+  private static boolean forceFirstLaunchSession(boolean value) throws Exception {
+    Field field = Lizzie.class.getDeclaredField("firstLaunchSession");
+    field.setAccessible(true);
+    boolean previous = field.getBoolean(null);
+    field.setBoolean(null, value);
+    return previous;
   }
 
 }

--- a/src/test/java/featurecat/lizzie/analysis/LeelazReaderIncarnationTest.java
+++ b/src/test/java/featurecat/lizzie/analysis/LeelazReaderIncarnationTest.java
@@ -27,6 +27,8 @@ import java.nio.file.Files;
 import java.util.ArrayDeque;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import javax.swing.SwingUtilities;
 import org.junit.jupiter.api.Test;
@@ -268,6 +270,89 @@ class LeelazReaderIncarnationTest {
   }
 
   @Test
+  void abnormalReaderCleanupQueuesDiagnosticAfterAnEdtRebindWaitIsReleased() throws Exception {
+    try (GlobalState ignored = GlobalState.install()) {
+      DeferredDiagnosticLeelaz engine = new DeferredDiagnosticLeelaz();
+      RecordingProcess process = new RecordingProcess();
+      setField(engine, "process", process);
+      initializeStreams(engine, bytes(""), bytes(""));
+      Object binding = getField(engine, "readerStreamBinding");
+      Lizzie.leelaz = new Leelaz("");
+      boolean previousFirstLaunch = forceFirstLaunchSession(false);
+      engine.started = true;
+      engine.isLoaded = true;
+      engine.isNormalEnd = false;
+
+      AtomicReference<Throwable> terminalFailure = new AtomicReference<>();
+      AtomicReference<Throwable> rebindFailure = new AtomicReference<>();
+      AtomicReference<Thread> edtThread = new AtomicReference<>();
+      CountDownLatch rebindEntered = new CountDownLatch(1);
+      CountDownLatch rebindFinished = new CountDownLatch(1);
+      Thread terminalThread =
+          new Thread(
+              () -> {
+                try {
+                  invokeTerminal(
+                      engine, binding, new IOException("controlled reader terminal failure"));
+                } catch (Throwable failure) {
+                  terminalFailure.set(failure);
+                }
+              },
+              "test-reader-terminal-cleanup");
+      terminalThread.setDaemon(true);
+
+      try {
+        terminalThread.start();
+        assertTrue(engine.cleanupReached.await(5, TimeUnit.SECONDS));
+        assertTrue((boolean) getField(engine, "readerTerminalCleanupInProgress"));
+
+        SwingUtilities.invokeLater(
+            () -> {
+              edtThread.set(Thread.currentThread());
+              rebindEntered.countDown();
+              try {
+                initializeStreams(engine, bytes(""), bytes(""));
+              } catch (Throwable failure) {
+                rebindFailure.set(failure);
+              } finally {
+                rebindFinished.countDown();
+              }
+            });
+        assertTrue(rebindEntered.await(5, TimeUnit.SECONDS));
+        assertTrue(awaitThreadState(edtThread, Thread.State.WAITING, 5, TimeUnit.SECONDS));
+
+        engine.allowCleanupToFinish.countDown();
+        terminalThread.join(TimeUnit.SECONDS.toMillis(5));
+        assertFalse(terminalThread.isAlive(), "reader cleanup must not wait for the EDT");
+        assertTrue(rebindFinished.await(5, TimeUnit.SECONDS), "EDT rebind must be notified");
+        assertTrue(
+            engine.diagnosticShown.await(5, TimeUnit.SECONDS),
+            "the deferred diagnostic must run after rebind completes");
+        SwingUtilities.invokeAndWait(() -> {});
+
+        assertEquals(null, terminalFailure.get());
+        assertEquals(null, rebindFailure.get());
+        assertEquals(null, engine.diagnosticFailure.get());
+        assertEquals(
+            java.awt.GraphicsEnvironment.isHeadless(),
+            engine.diagnosticRanWithNullConfig.get());
+        assertEquals(1, engine.diagnosticCount.get());
+        assertTrue(engine.diagnosticOnEdt.get());
+        assertFalse(engine.diagnosticModal);
+        assertFalse((boolean) getField(engine, "readerTerminalCleanupInProgress"));
+      } finally {
+        engine.allowCleanupToFinish.countDown();
+        if (terminalThread.isAlive()) {
+          terminalThread.interrupt();
+          terminalThread.join(TimeUnit.SECONDS.toMillis(5));
+        }
+        SwingUtilities.invokeAndWait(() -> {});
+        forceFirstLaunchSession(previousFirstLaunch);
+      }
+    }
+  }
+
+  @Test
   void parserTriggeredTerminalCleansUpOnceAfterCurrentLineIsReleased() throws Exception {
     try (GlobalState ignored = GlobalState.install()) {
       Leelaz engine = new Leelaz("");
@@ -414,11 +499,16 @@ class LeelazReaderIncarnationTest {
   }
 
   private static void invokeTerminal(Leelaz engine, Object binding) throws Exception {
+    invokeTerminal(engine, binding, null);
+  }
+
+  private static void invokeTerminal(Leelaz engine, Object binding, Throwable failure)
+      throws Exception {
     Method method =
         Leelaz.class.getDeclaredMethod(
             "terminateReaderIncarnation", binding.getClass(), Throwable.class);
     method.setAccessible(true);
-    method.invoke(engine, binding, null);
+    method.invoke(engine, binding, failure);
   }
 
   private static BufferedReader currentReader(Leelaz engine, String name) throws Exception {
@@ -464,6 +554,29 @@ class LeelazReaderIncarnationTest {
       Thread.sleep(5L);
     } while (System.nanoTime() < deadline);
     return engine.getRcentLine == expected;
+  }
+
+  private static boolean awaitThreadState(
+      AtomicReference<Thread> thread, Thread.State expected, long timeout, TimeUnit unit)
+      throws InterruptedException {
+    long deadline = System.nanoTime() + unit.toNanos(timeout);
+    do {
+      Thread current = thread.get();
+      if (current != null && current.getState() == expected) {
+        return true;
+      }
+      Thread.sleep(5L);
+    } while (System.nanoTime() < deadline);
+    Thread current = thread.get();
+    return current != null && current.getState() == expected;
+  }
+
+  private static boolean forceFirstLaunchSession(boolean value) throws Exception {
+    Field field = Lizzie.class.getDeclaredField("firstLaunchSession");
+    field.setAccessible(true);
+    boolean previous = field.getBoolean(null);
+    field.setBoolean(null, value);
+    return previous;
   }
 
   private static void setField(Leelaz engine, String name, Object value) throws Exception {
@@ -618,6 +731,54 @@ class LeelazReaderIncarnationTest {
     public void failReadBoardGmaEngineRestore(String detail) {
       readBoardCleanupCount++;
       super.failReadBoardGmaEngineRestore(detail);
+    }
+  }
+
+  private static final class DeferredDiagnosticLeelaz extends Leelaz {
+    private final CountDownLatch cleanupReached = new CountDownLatch(1);
+    private final CountDownLatch allowCleanupToFinish = new CountDownLatch(1);
+    private final CountDownLatch diagnosticShown = new CountDownLatch(1);
+    private final AtomicInteger diagnosticCount = new AtomicInteger();
+    private final AtomicBoolean diagnosticOnEdt = new AtomicBoolean();
+    private final AtomicBoolean diagnosticRanWithNullConfig = new AtomicBoolean();
+    private final AtomicReference<Throwable> diagnosticFailure = new AtomicReference<>();
+    private volatile boolean diagnosticModal = true;
+
+    private DeferredDiagnosticLeelaz() throws IOException {
+      super("");
+    }
+
+    @Override
+    public void failReadBoardGmaEngineRestore(String detail) {
+      cleanupReached.countDown();
+      try {
+        if (!allowCleanupToFinish.await(5, TimeUnit.SECONDS)) {
+          throw new AssertionError("timed out waiting to finish reader cleanup");
+        }
+      } catch (InterruptedException interrupted) {
+        Thread.currentThread().interrupt();
+        throw new AssertionError(interrupted);
+      }
+    }
+
+    @Override
+    public void tryToDignostic(String message, boolean isModal) {
+      Config config = Lizzie.config;
+      try {
+        if (java.awt.GraphicsEnvironment.isHeadless()) {
+          Lizzie.config = null;
+          diagnosticRanWithNullConfig.set(true);
+          super.tryToDignostic(message, isModal);
+        }
+      } catch (Throwable failure) {
+        diagnosticFailure.set(failure);
+      } finally {
+        Lizzie.config = config;
+        diagnosticCount.incrementAndGet();
+        diagnosticOnEdt.set(SwingUtilities.isEventDispatchThread());
+        diagnosticModal = isModal;
+        diagnosticShown.countDown();
+      }
     }
   }
 

--- a/src/test/java/featurecat/lizzie/analysis/UpdateEngineGtpFixture.java
+++ b/src/test/java/featurecat/lizzie/analysis/UpdateEngineGtpFixture.java
@@ -14,12 +14,18 @@ public final class UpdateEngineGtpFixture {
   private UpdateEngineGtpFixture() {}
 
   public static void main(String[] args) throws Exception {
-    if (args.length != 3) {
-      throw new IllegalArgumentException("expected log, startup gate, and loadsgf failure paths");
+    if (args.length != 6) {
+      throw new IllegalArgumentException(
+          "expected log, startup gate, loadsgf failure, fence gate, catchup gate, and fence failure paths");
     }
     Path log = Path.of(args[0]);
     Path startupGate = Path.of(args[1]);
     Path loadSgfFailure = Path.of(args[2]);
+    Path fenceGate = Path.of(args[3]);
+    Path catchUpGate = Path.of(args[4]);
+    Path fenceFailure = Path.of(args[5]);
+    int nameCount = 0;
+    int loadSgfCount = 0;
     try (BufferedReader input =
             new BufferedReader(new InputStreamReader(System.in, StandardCharsets.UTF_8));
         BufferedWriter output =
@@ -29,16 +35,26 @@ public final class UpdateEngineGtpFixture {
         append(log, line);
         ParsedCommand parsed = ParsedCommand.parse(line);
         if (parsed.command.startsWith("loadsgf ")) {
+          loadSgfCount++;
           Path sgf = Path.of(parsed.command.substring("loadsgf ".length()));
-          append(log, "SGF:" + Files.readString(sgf));
+          append(
+              log,
+              "SGF:"
+                  + stripTrailingNewlines(Files.readString(sgf, StandardCharsets.UTF_8)));
           if (Files.isRegularFile(loadSgfFailure)) {
             writeResponse(output, parsed.id, false, "controlled restore failure");
             continue;
           }
+          if (loadSgfCount >= 2) {
+            waitForMarker(catchUpGate);
+          }
         }
         if ("name".equals(parsed.command)) {
-          while (!Files.isRegularFile(startupGate)) {
-            Thread.sleep(10L);
+          nameCount++;
+          waitForMarker(nameCount == 1 ? startupGate : fenceGate);
+          if (nameCount >= 2 && Files.isRegularFile(fenceFailure)) {
+            writeResponse(output, parsed.id, false, "controlled fence failure");
+            continue;
           }
         }
         String body =
@@ -58,10 +74,24 @@ public final class UpdateEngineGtpFixture {
     }
   }
 
+  private static void waitForMarker(Path marker) throws InterruptedException {
+    while (!Files.isRegularFile(marker)) {
+      Thread.sleep(10L);
+    }
+  }
+
+  private static String stripTrailingNewlines(String content) {
+    int end = content.length();
+    while (end > 0 && content.charAt(end - 1) == '\n') {
+      end--;
+    }
+    return content.substring(0, end);
+  }
+
   private static void append(Path log, String line) throws Exception {
     Files.writeString(
         log,
-        line + System.lineSeparator(),
+        line + "\n",
         StandardCharsets.UTF_8,
         StandardOpenOption.CREATE,
         StandardOpenOption.APPEND);

--- a/src/test/java/featurecat/lizzie/gui/EngineFailedMessageLayoutTest.java
+++ b/src/test/java/featurecat/lizzie/gui/EngineFailedMessageLayoutTest.java
@@ -1,0 +1,404 @@
+package featurecat.lizzie.gui;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.awt.Dimension;
+import java.awt.Font;
+import java.awt.Insets;
+import java.awt.Rectangle;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import javax.swing.JScrollPane;
+import javax.swing.JTextArea;
+import javax.swing.SwingUtilities;
+import org.junit.jupiter.api.Test;
+
+class EngineFailedMessageLayoutTest {
+  @Test
+  void longFailureDetailsStayBoundedOnFourKAtOneHundredFiftyPercent() {
+    String longMessage = "Exit code: -1 Recent stderr: " + "failure details ".repeat(2_000);
+    String longCommand = "C:\\very long engine path\\" + "nested directory\\".repeat(2_000);
+
+    Dimension size =
+        EngineFailedMessage.calculateDialogSize(
+            longMessage, longCommand, 18, 730, 360, new Dimension(2560, 1440));
+
+    assertEquals(EngineFailedMessage.MAX_DIALOG_WIDTH, size.width);
+    assertEquals(360, size.height);
+    assertTrue(size.width <= 2560 - EngineFailedMessage.SCREEN_MARGIN);
+    assertTrue(size.height <= 1440 - EngineFailedMessage.SCREEN_MARGIN);
+  }
+
+  @Test
+  void dialogSizeAlsoFitsASmallUsableScreen() {
+    Dimension size =
+        EngineFailedMessage.calculateDialogSize(
+            "short failure", "katago.exe gtp", 16, 730, 360, new Dimension(640, 480));
+
+    assertEquals(576, size.width);
+    assertEquals(360, size.height);
+    assertTrue(size.height <= 480 - EngineFailedMessage.SCREEN_MARGIN);
+  }
+
+  @Test
+  void longTextUsesReadOnlyWrappedVerticalScrolling() {
+    Font font = new Font(Font.MONOSPACED, Font.PLAIN, 18);
+    JScrollPane pane = EngineFailedMessage.createScrollableText("command ".repeat(5_000), font);
+
+    assertEquals(JScrollPane.VERTICAL_SCROLLBAR_AS_NEEDED, pane.getVerticalScrollBarPolicy());
+    assertEquals(JScrollPane.HORIZONTAL_SCROLLBAR_NEVER, pane.getHorizontalScrollBarPolicy());
+    assertTrue(pane.getViewport().getView() instanceof JTextArea);
+    JTextArea area = (JTextArea) pane.getViewport().getView();
+    assertFalse(area.isEditable());
+    assertTrue(area.getLineWrap());
+    assertTrue(area.getWrapStyleWord());
+    assertEquals(0, area.getCaretPosition());
+    assertSame(font, area.getFont());
+  }
+
+  @Test
+  void sensitiveValuesNeverReachVisibleOrPersistedDiagnosticText() {
+    String password = "qa-password-do-not-leak";
+    String passwd = "qa-passwd-do-not-leak";
+    String token = "qa-token-do-not-leak";
+    String apiKey = "qa-api-key-do-not-leak";
+    String secret = "qa-secret-do-not-leak";
+    String message =
+        "Recent stderr: password="
+            + password
+            + " token:"
+            + token
+            + " --secret \""
+            + secret
+            + "\"";
+    String command =
+        "engine.exe --password "
+            + password
+            + " --token=\""
+            + token
+            + "\" api_key="
+            + apiKey;
+    String contributeCommand =
+        "engine.exe -override-config \"username=qa\",\"password="
+            + password
+            + "\",\"maxSimultaneousGames=1\"";
+
+    JScrollPane messagePane =
+        EngineFailedMessage.createScrollableText(
+            message, new Font(Font.MONOSPACED, Font.PLAIN, 14));
+    String visibleMessage = ((JTextArea) messagePane.getViewport().getView()).getText();
+    String visibleCommand =
+        EngineFailedMessage.redactSensitiveText(command + "\n" + contributeCommand);
+    String diagnosticCommand =
+        EngineFailedMessage.buildDiagnosticCommand(
+            List.of(
+                "engine.exe",
+                "--password",
+                password,
+                "--passwd",
+                passwd,
+                "--token=" + token,
+                "api-key=" + apiKey,
+                "secret=" + secret),
+            command);
+
+    for (String sensitiveValue : List.of(password, passwd, token, apiKey, secret)) {
+      assertFalse(visibleMessage.contains(sensitiveValue));
+      assertFalse(visibleCommand.contains(sensitiveValue));
+      assertFalse(diagnosticCommand.contains(sensitiveValue));
+    }
+    assertTrue(visibleMessage.contains(EngineFailedMessage.REDACTED_VALUE));
+    assertTrue(visibleCommand.contains(EngineFailedMessage.REDACTED_VALUE));
+    assertTrue(diagnosticCommand.contains(EngineFailedMessage.REDACTED_VALUE));
+  }
+
+  @Test
+  void contributionSecretsWithSeparatorsAndQuoteInjectionAreFailSafeRedacted() {
+    List<SensitiveCase> cases =
+        List.of(
+            contributionCase(
+                '"',
+                "QaSpaceLeft42 QaSpaceRight42",
+                "QaSpaceLeft42",
+                "QaSpaceRight42"),
+            contributionCase(
+                '"',
+                "QaCommaLeft42,QaCommaRight42",
+                "QaCommaLeft42",
+                "QaCommaRight42"),
+            contributionCase(
+                '"',
+                "QaSemiLeft42;QaSemiRight42",
+                "QaSemiLeft42",
+                "QaSemiRight42"),
+            contributionCase(
+                '"',
+                "QaDoubleLeft42\"QaDoubleRight42",
+                "QaDoubleLeft42",
+                "QaDoubleRight42"),
+            contributionCase(
+                '\'',
+                "QaSingleLeft42'QaSingleRight42",
+                "QaSingleLeft42",
+                "QaSingleRight42"),
+            contributionCase(
+                '"',
+                "QaInjectLead42\",\"token=QaInjectedToken42\",\"QaInjectTail42",
+                "QaInjectLead42",
+                "QaInjectedToken42",
+                "QaInjectTail42"),
+            contributionCase(
+                '\'',
+                "QaSingleInjectLead42','secret=QaInjectedSecret42','QaSingleInjectTail42",
+                "QaSingleInjectLead42",
+                "QaInjectedSecret42",
+                "QaSingleInjectTail42"),
+            contributionCase(
+                '"',
+                "QaCrLeft42\rQaCrRight42",
+                "QaCrLeft42",
+                "QaCrRight42"),
+            contributionCase(
+                '\'',
+                "QaLfLeft42\nQaLfRight42",
+                "QaLfLeft42",
+                "QaLfRight42"),
+            contributionCase(
+                '"',
+                "QaMultilineLead42\r\n\",\"token=QaMultilineInjected42\",\"QaMultilineTail42",
+                "QaMultilineLead42",
+                "QaMultilineInjected42",
+                "QaMultilineTail42"),
+            new SensitiveCase(
+                "Recent stderr: password=QaMessageLeft42 QaMessageRight42; status=failed",
+                List.of(
+                    "engine.exe",
+                    "--password",
+                    "QaMessageLeft42 QaMessageRight42",
+                    "--mode",
+                    "gtp"),
+                List.of(
+                    "QaMessageLeft42 QaMessageRight42",
+                    "QaMessageLeft42",
+                    "QaMessageRight42")),
+            new SensitiveCase(
+                "Recent stderr: token=QaMessageCrLeft42\r\nQaMessageCrRight42\nstatus=failed",
+                List.of(
+                    "engine.exe",
+                    "--token",
+                    "QaMessageCrLeft42\r\nQaMessageCrRight42",
+                    "--mode",
+                    "gtp"),
+                List.of(
+                    "QaMessageCrLeft42\r\nQaMessageCrRight42",
+                    "QaMessageCrLeft42",
+                    "QaMessageCrRight42")),
+            new SensitiveCase(
+                "engine.exe --api-key QaFlagLeft42 QaFlagRight42 --mode gtp",
+                List.of(
+                    "engine.exe", "--api-key", "QaFlagLeft42 QaFlagRight42", "--mode", "gtp"),
+                List.of(
+                    "QaFlagLeft42 QaFlagRight42", "QaFlagLeft42", "QaFlagRight42")));
+
+    for (SensitiveCase sensitiveCase : cases) {
+      JScrollPane pane =
+          EngineFailedMessage.createScrollableText(
+              sensitiveCase.text, new Font(Font.MONOSPACED, Font.PLAIN, 14));
+      String visibleText = ((JTextArea) pane.getViewport().getView()).getText();
+      String fallbackDiagnostic =
+          EngineFailedMessage.buildDiagnosticCommand(null, sensitiveCase.text);
+      String tokenizedDiagnostic =
+          EngineFailedMessage.buildDiagnosticCommand(
+              sensitiveCase.commandTokens, sensitiveCase.text);
+
+      for (String output : List.of(visibleText, fallbackDiagnostic, tokenizedDiagnostic)) {
+        assertTrue(output.contains(EngineFailedMessage.REDACTED_VALUE), output);
+        for (String secretOrFragment : sensitiveCase.secretAndFragments) {
+          assertFalse(output.contains(secretOrFragment), output);
+        }
+      }
+    }
+  }
+
+  private static SensitiveCase contributionCase(
+      char quote, String secret, String... secretFragments) {
+    String delimiter = String.valueOf(quote);
+    String override =
+        delimiter
+            + "username=qa-dummy-user"
+            + delimiter
+            + ","
+            + delimiter
+            + "password="
+            + secret
+            + delimiter
+            + ","
+            + delimiter
+            + "maxSimultaneousGames=1"
+            + delimiter;
+    List<String> secretAndFragments = new java.util.ArrayList<>();
+    secretAndFragments.add(secret);
+    secretAndFragments.addAll(List.of(secretFragments));
+    return new SensitiveCase(
+        "engine.exe contribute -override-config " + override,
+        List.of("engine.exe", "contribute", "-override-config", override),
+        secretAndFragments);
+  }
+
+  private static final class SensitiveCase {
+    private final String text;
+    private final List<String> commandTokens;
+    private final List<String> secretAndFragments;
+
+    private SensitiveCase(
+        String text, List<String> commandTokens, List<String> secretAndFragments) {
+      this.text = text;
+      this.commandTokens = commandTokens;
+      this.secretAndFragments = secretAndFragments;
+    }
+  }
+
+  @Test
+  void secondaryMonitorBoundsKeepInsetsAndClampTheDialog() {
+    Rectangle usable =
+        EngineFailedMessage.calculateUsableBounds(
+            new Rectangle(-2560, -120, 2560, 1440), new Insets(40, 0, 80, 12));
+
+    assertEquals(new Rectangle(-2560, -80, 2548, 1320), usable);
+    assertEquals(
+        new Rectangle(-2560, -80, 980, 360),
+        EngineFailedMessage.clampDialogBounds(
+            new Rectangle(-2700, -200, 980, 360), usable));
+    assertEquals(
+        new Rectangle(-992, 880, 980, 360),
+        EngineFailedMessage.clampDialogBounds(new Rectangle(-600, 1300, 980, 360), usable));
+  }
+
+  @Test
+  void backgroundCallerRunsSynchronouslyOnTheEventDispatchThread() throws Exception {
+    AtomicBoolean actionRanOnEventThread = new AtomicBoolean();
+    AtomicBoolean actionCompletedBeforeReturn = new AtomicBoolean();
+    AtomicInteger executionCount = new AtomicInteger();
+    Thread worker =
+        new Thread(
+            () -> {
+              EngineFailedMessage.runOnEventDispatchThreadAndWait(
+                  () -> {
+                    executionCount.incrementAndGet();
+                    actionRanOnEventThread.set(SwingUtilities.isEventDispatchThread());
+                  });
+              actionCompletedBeforeReturn.set(actionRanOnEventThread.get());
+            },
+            "engine-failure-dialog-test");
+
+    worker.start();
+    worker.join(TimeUnit.SECONDS.toMillis(5));
+
+    assertFalse(worker.isAlive());
+    assertEquals(1, executionCount.get());
+    assertTrue(actionRanOnEventThread.get());
+    assertTrue(actionCompletedBeforeReturn.get());
+  }
+
+  @Test
+  void eventDispatchCallerRunsInline() throws Exception {
+    AtomicReference<Thread> actionThread = new AtomicReference<>();
+
+    SwingUtilities.invokeAndWait(
+        () -> {
+          Thread eventThread = Thread.currentThread();
+          EngineFailedMessage.runOnEventDispatchThreadAndWait(
+              () -> actionThread.set(Thread.currentThread()));
+          assertSame(eventThread, actionThread.get());
+        });
+  }
+
+  @Test
+  void eventDispatchFailureIsPropagatedToTheCaller() {
+    IllegalArgumentException expected = new IllegalArgumentException("diagnostic failed");
+
+    IllegalArgumentException actual =
+        assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                EngineFailedMessage.runOnEventDispatchThreadAndWait(
+                    () -> {
+                      throw expected;
+                    }));
+
+    assertSame(expected, actual);
+  }
+
+  @Test
+  void eventDispatchErrorIsPropagatedToTheCaller() {
+    AssertionError expected = new AssertionError("diagnostic error");
+
+    AssertionError actual =
+        assertThrows(
+            AssertionError.class,
+            () ->
+                EngineFailedMessage.runOnEventDispatchThreadAndWait(
+                    () -> {
+                      throw expected;
+                    }));
+
+    assertSame(expected, actual);
+  }
+
+  @Test
+  void interruptedWaitRestoresTheCallerInterruptFlag() throws Exception {
+    CountDownLatch eventThreadBlocked = new CountDownLatch(1);
+    CountDownLatch releaseEventThread = new CountDownLatch(1);
+    SwingUtilities.invokeLater(
+        () -> {
+          eventThreadBlocked.countDown();
+          try {
+            releaseEventThread.await();
+          } catch (InterruptedException interrupted) {
+            Thread.currentThread().interrupt();
+          }
+        });
+    assertTrue(eventThreadBlocked.await(5, TimeUnit.SECONDS));
+
+    AtomicReference<Throwable> failure = new AtomicReference<>();
+    AtomicBoolean interruptRestored = new AtomicBoolean();
+    Thread worker =
+        new Thread(
+            () -> {
+              try {
+                EngineFailedMessage.runOnEventDispatchThreadAndWait(() -> {});
+              } catch (Throwable thrown) {
+                failure.set(thrown);
+                interruptRestored.set(Thread.currentThread().isInterrupted());
+              }
+            },
+            "engine-failure-dialog-interrupt-test");
+
+    try {
+      worker.start();
+      long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5);
+      while (worker.getState() != Thread.State.WAITING && System.nanoTime() < deadline) {
+        Thread.yield();
+      }
+      assertEquals(Thread.State.WAITING, worker.getState());
+      worker.interrupt();
+      worker.join(TimeUnit.SECONDS.toMillis(5));
+      assertFalse(worker.isAlive());
+      assertTrue(failure.get() instanceof IllegalStateException);
+      assertTrue(failure.get().getCause() instanceof InterruptedException);
+      assertTrue(interruptRestored.get());
+    } finally {
+      releaseEventThread.countDown();
+      worker.join(TimeUnit.SECONDS.toMillis(5));
+      SwingUtilities.invokeAndWait(() -> {});
+    }
+  }
+}

--- a/src/test/java/featurecat/lizzie/gui/HumanSlDialogBoundsTest.java
+++ b/src/test/java/featurecat/lizzie/gui/HumanSlDialogBoundsTest.java
@@ -1,0 +1,48 @@
+package featurecat.lizzie.gui;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.awt.Dimension;
+import java.awt.Rectangle;
+import org.junit.jupiter.api.Test;
+
+class HumanSlDialogBoundsTest {
+  @Test
+  void setupDialogFitsA1366By768DisplayAt150PercentScaling() {
+    Rectangle logicalUsableBounds = new Rectangle(0, 0, 911, 512);
+
+    Dimension target =
+        HumanSlDialogBounds.fit(new Dimension(920, 500), null, logicalUsableBounds, 920, 500);
+    Dimension minimum = HumanSlDialogBounds.minimum(target, 860, 390);
+
+    assertEquals(new Dimension(871, 472), target);
+    assertTrue(minimum.width <= target.width);
+    assertTrue(minimum.height <= target.height);
+  }
+
+  @Test
+  void reportDialogFitsA1080pDisplayAt200PercentScaling() {
+    Rectangle logicalUsableBounds = new Rectangle(0, 0, 960, 520);
+
+    Dimension target =
+        HumanSlDialogBounds.fit(new Dimension(1040, 590), null, logicalUsableBounds, 1040, 590);
+    Dimension minimum = HumanSlDialogBounds.minimum(target, 900, 520);
+
+    assertEquals(new Dimension(920, 480), target);
+    assertEquals(new Dimension(900, 480), minimum);
+  }
+
+  @Test
+  void expandingTheSetupDialogNeverEscapesTheCurrentMonitor() {
+    Rectangle logicalUsableBounds = new Rectangle(1920, 0, 800, 450);
+
+    Dimension target =
+        HumanSlDialogBounds.fit(
+            new Dimension(940, 540), new Dimension(920, 410), logicalUsableBounds, 920, 500);
+
+    assertEquals(new Dimension(760, 410), target);
+    assertTrue(target.width <= logicalUsableBounds.width);
+    assertTrue(target.height <= logicalUsableBounds.height);
+  }
+}

--- a/src/test/java/featurecat/lizzie/gui/HumanSlGameControllerIntegrationTest.java
+++ b/src/test/java/featurecat/lizzie/gui/HumanSlGameControllerIntegrationTest.java
@@ -1,0 +1,498 @@
+package featurecat.lizzie.gui;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import featurecat.lizzie.Config;
+import featurecat.lizzie.Lizzie;
+import featurecat.lizzie.analysis.EngineManager;
+import featurecat.lizzie.analysis.HumanSlAnalysisRunner;
+import featurecat.lizzie.analysis.Leelaz;
+import featurecat.lizzie.rules.Board;
+import featurecat.lizzie.rules.BoardData;
+import featurecat.lizzie.rules.BoardHistoryList;
+import featurecat.lizzie.rules.BoardHistoryNode;
+import featurecat.lizzie.rules.Zobrist;
+import featurecat.lizzie.training.HumanSlTrainingConfig;
+import featurecat.lizzie.training.HumanSlTrainingSession;
+import java.awt.Window;
+import java.awt.event.KeyEvent;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.BooleanSupplier;
+import javax.swing.JPanel;
+import javax.swing.SwingUtilities;
+import org.junit.jupiter.api.Test;
+
+class HumanSlGameControllerIntegrationTest {
+  private static final int BOARD_SIZE = 3;
+
+  @Test
+  void passShortcutUsesCoachControllerAndSchedulesTheAiTurn() throws Exception {
+    try (CoachEnvironment env = CoachEnvironment.open()) {
+      BlockingHumanSlRunner runner = new BlockingHumanSlRunner();
+      HumanSlGameController controller = env.startCoach(runner);
+      Input input = new Input();
+      JPanel source = new JPanel();
+
+      SwingUtilities.invokeAndWait(() -> input.keyPressed(keyPressed(source, KeyEvent.VK_P)));
+
+      assertTrue(runner.awaitRequest(), "the coach pass must schedule HumanSL immediately");
+      assertEquals(1, Lizzie.board.getHistory().getMoveNumber());
+      assertTrue(controller.isAiThinking());
+      assertSame(controller, Lizzie.frame.humanSlGame);
+
+      controller.abort();
+      assertTrue(controller.isFinished());
+    }
+  }
+
+  @Test
+  void passShortcutDuringTheAiTurnDoesNotChangeTheBoardOrScheduleAnotherRequest() throws Exception {
+    try (CoachEnvironment env = CoachEnvironment.open()) {
+      BlockingHumanSlRunner runner = new BlockingHumanSlRunner();
+      HumanSlGameController controller =
+          env.startCoach(runner, HumanSlTrainingConfig.PlayerColor.WHITE);
+      Input input = new Input();
+      JPanel source = new JPanel();
+
+      assertTrue(runner.awaitRequest(), "the opening HumanSL turn must already be in flight");
+      SwingUtilities.invokeAndWait(() -> input.keyPressed(keyPressed(source, KeyEvent.VK_P)));
+
+      assertEquals(0, Lizzie.board.getHistory().getMoveNumber());
+      assertEquals(1, runner.requestCount());
+      assertTrue(controller.isAiThinking());
+      assertSame(controller, Lizzie.frame.humanSlGame);
+
+      controller.abort();
+      assertTrue(controller.isFinished());
+    }
+  }
+
+  @Test
+  void staleAiResponseEndsCoachWithoutChangingTheNavigatedPosition() throws Exception {
+    try (CoachEnvironment env = CoachEnvironment.open()) {
+      BlockingHumanSlRunner runner = new BlockingHumanSlRunner();
+      HumanSlGameController controller = env.startCoach(runner);
+      BoardHistoryNode root = Lizzie.board.getHistory().getStart();
+
+      controller.humanPass();
+      assertTrue(runner.awaitRequest());
+      assertEquals(1, root.numberOfChildren());
+
+      assertTrue(Lizzie.board.getHistory().previous().isPresent());
+      assertSame(root, Lizzie.board.getHistory().getCurrentHistoryNode());
+      runner.releaseResponse();
+
+      assertTrue(awaitCondition(controller::isFinished, Duration.ofSeconds(2)));
+      SwingUtilities.invokeAndWait(() -> {});
+      assertNull(Lizzie.frame.humanSlGame);
+      assertSame(root, Lizzie.board.getHistory().getCurrentHistoryNode());
+      assertEquals(
+          1,
+          root.numberOfChildren(),
+          "the stale HumanSL pass must not become a variation on the navigated node");
+    }
+  }
+
+  @Test
+  void unifiedAiModeStopEndsCoachAndReportsThatItStoppedAnActiveMode() throws Exception {
+    try (CoachEnvironment env = CoachEnvironment.open()) {
+      HumanSlGameController controller = env.startCoach(new BlockingHumanSlRunner());
+      CoachFrame frame = (CoachFrame) Lizzie.frame;
+
+      assertTrue(frame.stopAiPlayingAndPolicy());
+
+      assertTrue(controller.isFinished());
+      assertNull(frame.humanSlGame);
+      assertFalse(frame.isPlayingAgainstLeelaz);
+      assertFalse(frame.isAnaPlayingAgainstLeelaz);
+    }
+  }
+
+  @Test
+  void newGameTransitionEndsCoachBeforeOpeningTheNextMode() throws Exception {
+    try (CoachEnvironment env = CoachEnvironment.open()) {
+      HumanSlGameController controller = env.startCoach(new BlockingHumanSlRunner());
+      ModeTransitionFrame frame = allocate(ModeTransitionFrame.class);
+      frame.events = new ArrayList<String>();
+      frame.newGameDialog = allocate(CancelledNewGameDialog.class);
+      frame.humanSlGame = controller;
+      Lizzie.frame = frame;
+      Lizzie.leelaz = new Leelaz("");
+
+      frame.startNewGame();
+
+      assertEquals(List.of("stop-old-mode", "end-coach", "new-game-dialog"), frame.events);
+      assertTrue(
+          controller.isFinished(), "cancelling the new-game dialog must not revive AI Coach");
+      assertNull(frame.humanSlGame);
+    }
+  }
+
+  @Test
+  void analyzeGameTransitionEndsCoachEvenWhenTheDialogIsCancelled() throws Exception {
+    try (CoachEnvironment env = CoachEnvironment.open()) {
+      HumanSlGameController controller = env.startCoach(new BlockingHumanSlRunner());
+      ModeTransitionFrame frame = allocate(ModeTransitionFrame.class);
+      frame.events = new ArrayList<String>();
+      frame.humanSlGame = controller;
+      Lizzie.frame = frame;
+      Lizzie.leelaz.noAnalyze = false;
+
+      frame.startAnalyzeGameDialogReserved();
+
+      assertEquals(List.of("stop-old-mode", "end-coach", "analyze-game-dialog"), frame.events);
+      assertTrue(controller.isFinished());
+      assertNull(frame.humanSlGame);
+    }
+  }
+
+  @Test
+  void continuePlayingTransitionEndsCoachBeforeStartingTheEngineMode() throws Exception {
+    try (CoachEnvironment env = CoachEnvironment.open()) {
+      HumanSlGameController controller = env.startCoach(new BlockingHumanSlRunner());
+      ModeTransitionFrame frame = allocate(ModeTransitionFrame.class);
+      frame.events = new ArrayList<String>();
+      frame.humanSlGame = controller;
+      Lizzie.frame = frame;
+      Lizzie.config.genmoveGameNoTime = true;
+
+      frame.continueAiPlayingReserved(true, false, true, false);
+
+      assertEquals(List.of("stop-old-mode", "end-coach"), frame.events);
+      assertTrue(controller.isFinished());
+      assertNull(frame.humanSlGame);
+      assertTrue(frame.isPlayingAgainstLeelaz);
+    }
+  }
+
+  @Test
+  void engineGameTransitionEndsCoachBeforeOpeningTheNextMode() throws Exception {
+    try (CoachEnvironment env = CoachEnvironment.open()) {
+      HumanSlGameController controller = env.startCoach(new BlockingHumanSlRunner());
+      ModeTransitionFrame frame = allocate(ModeTransitionFrame.class);
+      frame.events = new ArrayList<String>();
+      frame.humanSlGame = controller;
+      Lizzie.frame = frame;
+      EngineManager.isEngineGame = false;
+
+      frame.startEngineGameDialogReserved();
+
+      assertEquals(List.of("end-coach", "engine-game-dialog"), frame.events);
+      assertTrue(
+          controller.isFinished(), "closing the engine-game dialog must not revive AI Coach");
+      assertNull(frame.humanSlGame);
+    }
+  }
+
+  private static HumanSlTrainingConfig coachConfig(HumanSlTrainingConfig.PlayerColor playerColor) {
+    return HumanSlTrainingConfig.builder()
+        .playerColor(playerColor)
+        .fromCurrentPosition(true)
+        .moveTimeSeconds(2)
+        .build();
+  }
+
+  private static KeyEvent keyPressed(JPanel source, int keyCode) {
+    return new KeyEvent(source, KeyEvent.KEY_PRESSED, 0L, 0, keyCode, KeyEvent.CHAR_UNDEFINED);
+  }
+
+  private static boolean awaitCondition(BooleanSupplier condition, Duration timeout)
+      throws InterruptedException {
+    long deadline = System.nanoTime() + timeout.toNanos();
+    while (System.nanoTime() < deadline) {
+      if (condition.getAsBoolean()) {
+        return true;
+      }
+      Thread.sleep(10L);
+    }
+    return condition.getAsBoolean();
+  }
+
+  @SuppressWarnings("unchecked")
+  private static <T> T allocate(Class<T> type) throws Exception {
+    java.lang.reflect.Field unsafeField = sun.misc.Unsafe.class.getDeclaredField("theUnsafe");
+    unsafeField.setAccessible(true);
+    sun.misc.Unsafe unsafe = (sun.misc.Unsafe) unsafeField.get(null);
+    return (T) unsafe.allocateInstance(type);
+  }
+
+  private static final class BlockingHumanSlRunner extends HumanSlAnalysisRunner {
+    private final CountDownLatch requestStarted = new CountDownLatch(1);
+    private final CountDownLatch releaseResponse = new CountDownLatch(1);
+    private final AtomicInteger requestCount = new AtomicInteger();
+
+    private BlockingHumanSlRunner() {
+      super("katago analysis", Path.of("human.bin"));
+    }
+
+    @Override
+    public Optional<String> bestHumanMove(
+        BoardHistoryNode positionNode,
+        String profile,
+        int maxVisits,
+        int rootSymmetries,
+        Duration timeout) {
+      requestCount.incrementAndGet();
+      requestStarted.countDown();
+      try {
+        if (!releaseResponse.await(5, TimeUnit.SECONDS)) {
+          return Optional.empty();
+        }
+      } catch (InterruptedException interrupted) {
+        Thread.currentThread().interrupt();
+        return Optional.empty();
+      }
+      return Optional.of("pass");
+    }
+
+    @Override
+    public void cancelActiveRequests() {
+      releaseResponse.countDown();
+    }
+
+    @Override
+    public void close() {
+      releaseResponse.countDown();
+    }
+
+    private boolean awaitRequest() throws InterruptedException {
+      return requestStarted.await(2, TimeUnit.SECONDS);
+    }
+
+    private void releaseResponse() {
+      releaseResponse.countDown();
+    }
+
+    private int requestCount() {
+      return requestCount.get();
+    }
+  }
+
+  private static class CoachFrame extends LizzieFrame {
+    @Override
+    public void clearKataEstimate() {}
+
+    @Override
+    public void showHumanSlTrainingBar(HumanSlGameController controller) {}
+
+    @Override
+    public void hideHumanSlTrainingBar(HumanSlGameController controller) {}
+
+    @Override
+    public void hideHumanSlCorrection(HumanSlGameController controller) {}
+
+    @Override
+    public void updateHumanSlTrainingBar() {}
+
+    @Override
+    public void setMainPanelFocus() {}
+
+    @Override
+    public void refresh() {}
+
+    @Override
+    public void updateTitle() {}
+  }
+
+  private static final class CoachBoard extends Board {
+    @Override
+    public void clearAfterMove() {}
+  }
+
+  private static final class ModeTransitionFrame extends CoachFrame {
+    private List<String> events;
+    private CancelledNewGameDialog newGameDialog;
+
+    @Override
+    public void endHumanSlGameIfActive() {
+      events.add("end-coach");
+      super.endHumanSlGameIfActive();
+    }
+
+    @Override
+    public boolean stopAiPlayingAndPolicy() {
+      events.add("stop-old-mode");
+      boolean wasHumanSlGame = humanSlGame != null && !humanSlGame.isFinished();
+      endHumanSlGameIfActive();
+      return wasHumanSlGame;
+    }
+
+    @Override
+    protected NewGameDialog createNewGameDialog() {
+      events.add("new-game-dialog");
+      return newGameDialog;
+    }
+
+    @Override
+    protected void showEngineGameDialogAfterModeTransition() {
+      events.add("engine-game-dialog");
+    }
+
+    @Override
+    protected void showAnalyzeGameDialogAfterModeTransition(boolean wasPondering) {
+      events.add("analyze-game-dialog");
+    }
+  }
+
+  private static final class SilentBottomToolbar extends BottomToolbar {
+    private SilentBottomToolbar() {}
+
+    @Override
+    public void setChkShowBlack(boolean show) {}
+
+    @Override
+    public void setChkShowWhite(boolean show) {}
+  }
+
+  private static final class SilentMenu extends Menu {
+    private SilentMenu() {}
+
+    @Override
+    public void setChkShowBlack(boolean show) {}
+
+    @Override
+    public void setChkShowWhite(boolean show) {}
+
+    @Override
+    public void toggleDoubleMenuGameStatus() {}
+  }
+
+  private static final class CancelledNewGameDialog extends NewGameDialog {
+    private CancelledNewGameDialog() {
+      super((Window) null);
+    }
+
+    @Override
+    public void setVisible(boolean visible) {}
+
+    @Override
+    public boolean playerIsBlack() {
+      return true;
+    }
+
+    @Override
+    public boolean isCancelled() {
+      return true;
+    }
+
+    @Override
+    public void dispose() {}
+  }
+
+  private static final class CoachEnvironment implements AutoCloseable {
+    private final int previousBoardWidth;
+    private final int previousBoardHeight;
+    private final Config previousConfig;
+    private final Board previousBoard;
+    private final LizzieFrame previousFrame;
+    private final Leelaz previousEngine;
+    private final boolean previousEngineGame;
+    private final boolean previousPreEngineGame;
+    private final boolean previousEngineEmpty;
+    private final BottomToolbar previousToolbar;
+    private final Menu previousMenu;
+
+    private CoachEnvironment(
+        int previousBoardWidth,
+        int previousBoardHeight,
+        Config previousConfig,
+        Board previousBoard,
+        LizzieFrame previousFrame,
+        Leelaz previousEngine,
+        boolean previousEngineGame,
+        boolean previousPreEngineGame,
+        boolean previousEngineEmpty,
+        BottomToolbar previousToolbar,
+        Menu previousMenu) {
+      this.previousBoardWidth = previousBoardWidth;
+      this.previousBoardHeight = previousBoardHeight;
+      this.previousConfig = previousConfig;
+      this.previousBoard = previousBoard;
+      this.previousFrame = previousFrame;
+      this.previousEngine = previousEngine;
+      this.previousEngineGame = previousEngineGame;
+      this.previousPreEngineGame = previousPreEngineGame;
+      this.previousEngineEmpty = previousEngineEmpty;
+      this.previousToolbar = previousToolbar;
+      this.previousMenu = previousMenu;
+    }
+
+    private static CoachEnvironment open() throws Exception {
+      CoachEnvironment environment =
+          new CoachEnvironment(
+              Board.boardWidth,
+              Board.boardHeight,
+              Lizzie.config,
+              Lizzie.board,
+              Lizzie.frame,
+              Lizzie.leelaz,
+              EngineManager.isEngineGame,
+              EngineManager.isPreEngineGame,
+              EngineManager.isEmpty,
+              LizzieFrame.toolbar,
+              LizzieFrame.menu);
+      Board.boardWidth = BOARD_SIZE;
+      Board.boardHeight = BOARD_SIZE;
+      Zobrist.init();
+      Config config = allocate(Config.class);
+      config.playSound = false;
+      config.newMoveNumberInBranch = false;
+      Lizzie.config = config;
+      Lizzie.frame = allocate(CoachFrame.class);
+      Lizzie.leelaz = allocate(Leelaz.class);
+      LizzieFrame.toolbar = allocate(SilentBottomToolbar.class);
+      LizzieFrame.menu = allocate(SilentMenu.class);
+      Board board = allocate(CoachBoard.class);
+      board.setHistory(new BoardHistoryList(BoardData.empty(BOARD_SIZE, BOARD_SIZE)));
+      Lizzie.board = board;
+      EngineManager.isEngineGame = false;
+      EngineManager.isPreEngineGame = false;
+      EngineManager.isEmpty = false;
+      return environment;
+    }
+
+    private HumanSlGameController startCoach(BlockingHumanSlRunner runner) {
+      return startCoach(runner, HumanSlTrainingConfig.PlayerColor.BLACK);
+    }
+
+    private HumanSlGameController startCoach(
+        BlockingHumanSlRunner runner, HumanSlTrainingConfig.PlayerColor playerColor) {
+      HumanSlGameController controller =
+          new HumanSlGameController(runner, coachConfig(playerColor), new HumanSlTrainingSession());
+      controller.start();
+      assertFalse(controller.isFinished());
+      return controller;
+    }
+
+    @Override
+    public void close() {
+      HumanSlGameController active = Lizzie.frame == null ? null : Lizzie.frame.humanSlGame;
+      if (active != null && !active.isFinished()) {
+        active.abort();
+      }
+      Board.boardWidth = previousBoardWidth;
+      Board.boardHeight = previousBoardHeight;
+      Zobrist.init();
+      Lizzie.config = previousConfig;
+      Lizzie.board = previousBoard;
+      Lizzie.frame = previousFrame;
+      Lizzie.leelaz = previousEngine;
+      EngineManager.isEngineGame = previousEngineGame;
+      EngineManager.isPreEngineGame = previousPreEngineGame;
+      EngineManager.isEmpty = previousEngineEmpty;
+      LizzieFrame.toolbar = previousToolbar;
+      LizzieFrame.menu = previousMenu;
+    }
+  }
+}

--- a/src/test/java/featurecat/lizzie/gui/KataGoAutoSetupDialogLayoutTest.java
+++ b/src/test/java/featurecat/lizzie/gui/KataGoAutoSetupDialogLayoutTest.java
@@ -2,21 +2,30 @@ package featurecat.lizzie.gui;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import featurecat.lizzie.util.KataGoAutoSetupHelper;
+import featurecat.lizzie.util.KataGoAutoSetupHelper.SetupSnapshot;
 import java.awt.CardLayout;
 import java.awt.Dimension;
 import java.awt.FlowLayout;
 import java.awt.Font;
 import java.awt.FontMetrics;
 import java.awt.Rectangle;
+import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 import javax.swing.JButton;
 import javax.swing.JComboBox;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
+import javax.swing.SwingUtilities;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 class KataGoAutoSetupDialogLayoutTest {
   @Test
@@ -309,5 +318,127 @@ class KataGoAutoSetupDialogLayoutTest {
     assertEquals(
         KataGoAutoSetupDialog.WeightSwitchPreparation.BLOCKED_BY_ENGINE_TASK,
         KataGoAutoSetupDialog.decideWeightSwitchPreparation(true, false, false, true, false));
+  }
+
+  @Test
+  void acceptedWeightSwitchPublishesTargetImmediatelyOnTheEventDispatchThread(@TempDir Path tempDir)
+      throws IOException {
+    SetupSnapshot current = createSetupSnapshot(tempDir, "current.bin.gz");
+    SetupSnapshot requested = createSetupSnapshot(tempDir, "requested.bin.gz");
+    AtomicReference<SetupSnapshot> displayed = new AtomicReference<SetupSnapshot>(current);
+    AtomicBoolean updatedOnEdt = new AtomicBoolean(false);
+
+    KataGoAutoSetupDialog.runWeightSwitchUiUpdate(
+        () -> {
+          displayed.set(
+              KataGoAutoSetupDialog.advanceWeightSwitchDisplay(
+                  displayed.get(),
+                  requested,
+                  null,
+                  KataGoAutoSetupDialog.WeightSwitchDisplayPhase.ACCEPTED,
+                  false));
+          updatedOnEdt.set(SwingUtilities.isEventDispatchThread());
+        });
+
+    assertSame(requested, displayed.get(), "the target must be visible before readiness polling");
+    assertTrue(updatedOnEdt.get(), "Swing model and labels must only be updated on the EDT");
+  }
+
+  @Test
+  void terminalFailedWeightSwitchReconcilesWithTheAuthoritativeSetupSnapshot(
+      @TempDir Path tempDir)
+      throws IOException {
+    SetupSnapshot current = createSetupSnapshot(tempDir, "current.bin.gz");
+    SetupSnapshot requested = createSetupSnapshot(tempDir, "requested.bin.gz");
+    SetupSnapshot authoritative = createSetupSnapshot(tempDir, "authoritative.bin.gz");
+    SetupSnapshot displayed =
+        KataGoAutoSetupDialog.advanceWeightSwitchDisplay(
+            current,
+            requested,
+            null,
+            KataGoAutoSetupDialog.WeightSwitchDisplayPhase.ACCEPTED,
+            false);
+
+    displayed =
+        KataGoAutoSetupDialog.advanceWeightSwitchDisplay(
+            displayed,
+            requested,
+            authoritative,
+            KataGoAutoSetupDialog.WeightSwitchDisplayPhase.FAILED,
+            false);
+
+    assertSame(
+        authoritative,
+        displayed,
+        "a terminal failure must replace the optimistic object with the latest setup");
+    assertEquals("authoritative.bin.gz", displayed.activeWeightPath.getFileName().toString());
+  }
+
+  @Test
+  void timedOutWeightSwitchKeepsAcceptedTargetWhileItRemainsPrimary(@TempDir Path tempDir)
+      throws IOException {
+    SetupSnapshot current = createSetupSnapshot(tempDir, "current.bin.gz");
+    SetupSnapshot requested = createSetupSnapshot(tempDir, "requested.bin.gz");
+    SetupSnapshot staleAuthoritative = createSetupSnapshot(tempDir, "current.bin.gz");
+    SetupSnapshot displayed =
+        KataGoAutoSetupDialog.advanceWeightSwitchDisplay(
+            current,
+            requested,
+            null,
+            KataGoAutoSetupDialog.WeightSwitchDisplayPhase.ACCEPTED,
+            false);
+
+    displayed =
+        KataGoAutoSetupDialog.advanceWeightSwitchDisplay(
+            displayed,
+            requested,
+            staleAuthoritative,
+            KataGoAutoSetupDialog.WeightSwitchDisplayPhase.FAILED,
+            true);
+
+    assertSame(
+        requested,
+        displayed,
+        "a 35-second soft deadline must not restore stale discovery while the target is still the pending primary");
+    assertEquals("requested.bin.gz", displayed.activeWeightPath.getFileName().toString());
+  }
+
+  @Test
+  void delayedSuccessfulWeightSwitchKeepsTheTargetModelCurrent(@TempDir Path tempDir)
+      throws IOException {
+    SetupSnapshot current = createSetupSnapshot(tempDir, "current.bin.gz");
+    SetupSnapshot requested = createSetupSnapshot(tempDir, "requested.bin.gz");
+    SetupSnapshot staleAuthoritative = createSetupSnapshot(tempDir, "current.bin.gz");
+    SetupSnapshot displayed =
+        KataGoAutoSetupDialog.advanceWeightSwitchDisplay(
+            current,
+            requested,
+            null,
+            KataGoAutoSetupDialog.WeightSwitchDisplayPhase.ACCEPTED,
+            false);
+
+    displayed =
+        KataGoAutoSetupDialog.advanceWeightSwitchDisplay(
+            displayed,
+            requested,
+            staleAuthoritative,
+            KataGoAutoSetupDialog.WeightSwitchDisplayPhase.SUCCEEDED,
+            false);
+
+    assertSame(requested, displayed);
+    assertEquals("requested.bin.gz", displayed.activeWeightPath.getFileName().toString());
+  }
+
+  private SetupSnapshot createSetupSnapshot(Path tempDir, String weightFileName)
+      throws IOException {
+    Path engine = tempDir.resolve("katago.exe");
+    Path gtpConfig = tempDir.resolve("gtp.cfg");
+    Path analysisConfig = tempDir.resolve("analysis.cfg");
+    Path weight = tempDir.resolve(weightFileName);
+    Files.writeString(engine, "test engine");
+    Files.writeString(gtpConfig, "test gtp config");
+    Files.writeString(analysisConfig, "test analysis config");
+    Files.writeString(weight, "test weight");
+    return KataGoAutoSetupHelper.inspectSelectedLocalKataGo(engine, gtpConfig, weight).toSnapshot();
   }
 }


### PR DESCRIPTION
## Summary

- Mark an accepted KataGo model switch as current immediately, preserve the requested model through a readiness-only soft timeout, and still roll back on a hard failure or foreground-engine change.
- Harden HumanSL / AI Coach mode transitions, stale-response rejection, asynchronous engine-game abort cleanup, Windows engine lifecycle fixtures, and high-DPI dialog bounds.
- Rebuild the engine-failure dialog as a bounded, scrollable, EDT-safe flow and redact sensitive command values in both the UI and generated diagnostic batch file.
- Harden the release pipeline with exact CI/run identity gates, per-platform provenance manifests, exact release-asset name/size/SHA-256 validation, canonical release-note checks, safer macOS signing cleanup, and fail-closed publication behavior.
- Add the six-language notes for `next-2026-08-19.1` and synchronize packaging documentation.

## Why

The model-selection UI waited for engine readiness before publishing the selected model. On a slow Windows/NVIDIA startup, the foreground engine could already be the requested model while `currentEngineNo` remained stale; the 35-second UI deadline then incorrectly reconciled the badge back to the previous model.

The wider Windows review also found deterministic lifecycle-test portability issues, high-DPI clipping, EDT/deadlock hazards in engine-failure paths, credential exposure in diagnostics, and publication gaps where stale or replaced assets could otherwise be associated with a release.

## User impact

Model selection now reflects the accepted target within the UI refresh cycle instead of waiting tens of seconds for GTP readiness. Valid slow starts keep the target badge, hard failures still reconcile safely, and dialogs remain usable at 4K / 150% scaling. Release publication now fails closed unless CI, workflow identity, notes, provenance, and every public asset match the intended commit and tag.

## Validation

- Windows JDK 21 headless full suite: **2451 run, 2443 passed, 8 skipped, 0 failures, 0 errors**.
- Python release-script suite: **165 run, 163 passed, 2 platform skips, 0 failures/errors**.
- Engine lifecycle class: **80/80 passed**; the six formerly Windows-stable failures passed three repeated rounds after the Java fixture change.
- Focused model-switch, EDT/deadlock, headless, HumanSL, high-DPI, engine-game abort, redaction, publisher, provenance, workflow-identity, and signing-security regressions passed.
- Windows 11 hardware QA on RTX 5090 at 3840×2160 / 150%: immediate target badge, duplicate-click protection, ready state, switch-back, restart persistence, AI Coach layout, bounded/scrollable engine-failure dialog, and controlled dummy-secret redaction all passed.
- Natural cold 11B startup was observed at about 34.1 seconds; the 35-second soft-timeout branch is covered deterministically in tests and is not presented as a hardware timing claim.
- Final shaded candidate: `1F345E13E39298F8B9760AE452CF6064EE3CCBFCB308DFD5F6E49D49E68640D0` (20,974,586 bytes).
