### PR TITLE
Request next-2026-08-19.1 prerelease

### DIFF
--- a/.github/release-requests/next-2026-08-19.1.json
+++ b/.github/release-requests/next-2026-08-19.1.json
@@ -1,0 +1,7 @@
+{
+  "date_tag": "2026-08-19",
+  "release_tag": "next-2026-08-19.1",
+  "title": "LizzieYzy Next next-2026-08-19.1",
+  "prerelease": true,
+  "notes_file": ".github/release-notes/next-2026-08-19.1.md"
+}


### PR DESCRIPTION
## Summary

Request publication of `next-2026-08-19.1` from the already-reviewed and merged release notes.

## Scope

This PR intentionally adds exactly one file:

- `.github/release-requests/next-2026-08-19.1.json`

The request binds:

- date: `2026-08-19`
- tag: `next-2026-08-19.1`
- title: `LizzieYzy Next next-2026-08-19.1`
- prerelease: `true`
- notes: `.github/release-notes/next-2026-08-19.1.md`

Merging this PR is the explicit publication trigger. The hardened publisher will wait for the target commit's CI, dispatch and verify the four platform builds, validate per-run provenance plus the exact public asset inventory/digests, and only then make the prerelease public.

## Validation

- `ReleaseRequest.load(...)` accepted the file and all identity constraints.
- Release-note validator tests passed 5/5.
- Cached diff contains only the request JSON and `git diff --check` passes.
