### PR TITLE
Fix release signing and engine lifecycle races

### DIFF
--- a/docs/MACOS_SIGNING.md
+++ b/docs/MACOS_SIGNING.md
@@ -33,7 +33,7 @@
 
 `build-macos-arm64-release.yml` 和 `build-macos-amd64-release.yml` 在 jpackage 生成 DMG 之后，如果 `APPLE_CERT_P12`、`APPLE_ID`、`APPLE_APP_PASSWORD`、`APPLE_TEAM_ID` 四个必需 secret 都已配置，会调用 `scripts/sign_macos_release.sh`：
 
-- 在导入证书前安装清理 trap，创建仅本次运行使用的随机临时 keychain 和权限为 `0600` 的证书临时文件
+- 在导入证书前安装清理 trap；证书写入随机 `0700` 临时目录中的 `certificate.p12`（文件权限 `0600`），并通过 `security import -f pkcs12` 显式按 PKCS#12 格式导入；同时创建仅本次运行使用的随机临时 keychain
 - 把 DMG 里的 `.app` 解出，按“内层原生库/辅助程序 → framework → 主程序 → 外层 `.app`”逐层执行 `codesign --options runtime --timestamp`；`--deep` 只用于签名后的递归验证，不用于签名
 - 重新打包成 DMG，再次签名 DMG
 - 用 `xcrun notarytool submit --wait` 提交公证
@@ -57,7 +57,7 @@ spctl --assess --type open --context context:primary-signature -vvv path/to/Lizz
 
 ## 失败兜底
 
-如果证书导入、逐层签名、公证、票据附着、布局校验或最终 `spctl` Gatekeeper 评估失败，workflow 会在替换原始 DMG 和上传 Release asset 之前终止，因此不会把本次未通过完整校验的 DMG 上传到 GitHub Release。清理 trap 会在任何早期失败时删除 P12 临时文件、随机 keychain、挂载点和工作目录。只有全部校验成功后，工作目录中的已签名 DMG 才会替换原文件并进入 provenance 与 Release 上传步骤。
+如果证书导入、逐层签名、公证、票据附着、布局校验或最终 `spctl` Gatekeeper 评估失败，workflow 会在替换原始 DMG 和上传 Release asset 之前终止，因此不会把本次未通过完整校验的 DMG 上传到 GitHub Release。清理 trap 会在任何早期失败时删除 `certificate.p12` 及其随机临时目录、随机 keychain、挂载点和工作目录；即使失败发生在临时路径或原 keychain 列表尚为空时也会安全完成清理。只有全部校验成功后，工作目录中的已签名 DMG 才会替换原文件并进入 provenance 与 Release 上传步骤。
 
 常见问题：
 - `notarytool` 超时 → 重跑 workflow 即可

--- a/scripts/publish_release_request.py
+++ b/scripts/publish_release_request.py
@@ -60,6 +60,7 @@ DIRECT_DOWNLOAD_SUFFIXES = (
     "linux64.nvidia.zip",
 )
 ACTIVE_RUN_STATUSES = {"queued", "in_progress", "waiting", "requested", "pending"}
+WORKFLOW_IDENTITY_CONVERGENCE_SECONDS = 90
 CI_WORKFLOW_FILE = "ci.yml"
 UNRESOLVED_NOTE_MARKERS = (
     re.compile(r"\bFULL_TEST_COUNT\b"),
@@ -993,21 +994,48 @@ class ReleasePublisher:
     def _wait_for_runs(self, runs: dict[str, int]) -> None:
         if not runs:
             return
-        deadline = time.monotonic() + self.run_timeout_seconds
+        started_at = time.monotonic()
+        deadline = started_at + self.run_timeout_seconds
+        identity_deadline = min(
+            deadline, started_at + WORKFLOW_IDENTITY_CONVERGENCE_SECONDS
+        )
         pending = dict(runs)
         last_state: dict[int, tuple[str, object]] = {}
+        identity_confirmed: set[int] = set()
+        identity_wait_announced: set[int] = set()
         while pending:
             if time.monotonic() >= deadline:
                 names = ", ".join(sorted(pending))
                 raise PublishError(f"Timed out waiting for workflows: {names}")
+            awaiting_initial_identity = False
             for name, run_id in list(pending.items()):
                 spec = next(item for item in WORKFLOWS if item.platform == name)
                 run = self.client.get_workflow_run(run_id)
                 if not self._run_has_expected_identity(spec, run):
-                    raise PublishError(
-                        f"{name} workflow run {run_id} does not match target SHA "
-                        "and exact release inputs"
-                    )
+                    if run_id in identity_confirmed:
+                        raise PublishError(
+                            f"{name} workflow run {run_id} changed identity after "
+                            "initial verification"
+                        )
+                    if time.monotonic() >= identity_deadline:
+                        raise PublishError(
+                            f"{name} workflow run {run_id} identity did not converge "
+                            "to the target SHA and exact release inputs within "
+                            f"{WORKFLOW_IDENTITY_CONVERGENCE_SECONDS} seconds"
+                        )
+                    if run_id not in identity_wait_announced:
+                        print(
+                            f"{name}: waiting for workflow run {run_id} identity "
+                            "metadata to converge",
+                            flush=True,
+                        )
+                        identity_wait_announced.add(run_id)
+                    awaiting_initial_identity = True
+                    continue
+                identity_confirmed.add(run_id)
+                if run_id in identity_wait_announced:
+                    print(f"{name}: workflow run {run_id} identity confirmed", flush=True)
+                    identity_wait_announced.remove(run_id)
                 status = str(run.get("status", "unknown"))
                 conclusion = run.get("conclusion")
                 state = (status, conclusion)
@@ -1023,7 +1051,11 @@ class ReleasePublisher:
                         )
                     del pending[name]
             if pending:
-                self.sleep(self.poll_seconds)
+                self.sleep(
+                    min(self.poll_seconds, 5)
+                    if awaiting_initial_identity
+                    else self.poll_seconds
+                )
 
     def _require_successful_target_runs(
         self, selected_runs: dict[str, int] | None = None

--- a/scripts/sign_macos_release.sh
+++ b/scripts/sign_macos_release.sh
@@ -81,6 +81,7 @@ fi
 keychain=""
 keychain_dir=""
 keychain_password=""
+cert_dir=""
 cert_path=""
 sign_identity=""
 work_dir=""
@@ -94,6 +95,10 @@ cleanup() {
   local path
   trap - EXIT HUP INT TERM
   set +e
+  # Bash 3.2 treats an empty array expansion as unbound under `set -u`.
+  # Cleanup must remain best-effort even when failure happens before either
+  # array receives its first entry.
+  set +u
 
   if [[ -n "$mounted_target" ]] && command -v hdiutil >/dev/null 2>&1; then
     hdiutil detach "$mounted_target" -force -quiet >/dev/null 2>&1 || true
@@ -106,6 +111,10 @@ cleanup() {
   if [[ -n "$cert_path" ]]; then
     rm -f -- "$cert_path"
     cert_path=""
+  fi
+  if [[ -n "$cert_dir" ]]; then
+    rm -rf -- "$cert_dir"
+    cert_dir=""
   fi
   for path in "${temporary_paths[@]}"; do
     [[ -z "$path" ]] || rm -rf -- "$path"
@@ -388,7 +397,10 @@ security create-keychain -p "$keychain_password" "$keychain" >/dev/null
 security set-keychain-settings -lut 21600 "$keychain" >/dev/null
 security unlock-keychain -p "$keychain_password" "$keychain" >/dev/null
 
-cert_path="$(mktemp "$temp_root/lizzieyzy-cert.XXXXXXXX")"
+cert_dir="$(mktemp -d "$temp_root/lizzieyzy-cert.XXXXXXXX")"
+chmod 700 "$cert_dir"
+cert_path="$cert_dir/certificate.p12"
+: > "$cert_path"
 chmod 600 "$cert_path"
 if ! printf '%s' "$APPLE_CERT_P12" | base64 -D > "$cert_path"; then
   : > "$cert_path"
@@ -401,11 +413,14 @@ if [[ ! -s "$cert_path" ]]; then
   echo "APPLE_CERT_P12 decoded to an empty certificate." >&2
   exit 1
 fi
-security import "$cert_path" -k "$keychain" -P "${APPLE_CERT_PASSWORD:-}" -T /usr/bin/codesign >/dev/null
-security list-keychains -d user -s "$keychain" "${original_keychains[@]}" >/dev/null
+security import "$cert_path" -f pkcs12 -k "$keychain" -P "${APPLE_CERT_PASSWORD:-}" -T /usr/bin/codesign >/dev/null
+security list-keychains -d user -s "$keychain" \
+  "${original_keychains[@]+"${original_keychains[@]}"}" >/dev/null
 security set-key-partition-list -S apple-tool:,apple: -s -k "$keychain_password" "$keychain" >/dev/null
 rm -f -- "$cert_path"
 cert_path=""
+rm -rf -- "$cert_dir"
+cert_dir=""
 
 sign_identity="${APPLE_SIGN_IDENTITY:-}"
 if [[ -z "$sign_identity" ]]; then

--- a/scripts/test_macos_signing_security.py
+++ b/scripts/test_macos_signing_security.py
@@ -3,12 +3,101 @@
 
 from __future__ import annotations
 
+import base64
+import json
+import os
 from pathlib import Path
+import shutil
+import stat
+import subprocess
+import sys
+import tempfile
+import textwrap
 import unittest
 
 
 ROOT = Path(__file__).resolve().parents[1]
 SIGN_SCRIPT = ROOT / "scripts" / "sign_macos_release.sh"
+
+
+def find_bash() -> str | None:
+    discovered = shutil.which("bash")
+    if discovered:
+        return discovered
+    for candidate in (Path("/bin/bash"), Path("/usr/bin/bash")):
+        if candidate.is_file():
+            return str(candidate)
+    return None
+
+
+BASH = find_bash()
+
+
+def write_executable(path: Path, content: str) -> None:
+    path.write_text(textwrap.dedent(content).lstrip(), encoding="utf-8")
+    path.chmod(path.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+
+
+def write_fake_security(path: Path) -> None:
+    write_executable(
+        path,
+        r"""
+        #!/usr/bin/env python3
+        import json
+        import os
+        from pathlib import Path
+        import stat
+        import sys
+
+        args = sys.argv[1:]
+        command = args[0] if args else ""
+        record = {"args": args}
+
+        if command == "import" and len(args) >= 2:
+            certificate = Path(args[1])
+            explicit_pkcs12 = any(
+                args[index] == "-f"
+                and index + 1 < len(args)
+                and args[index + 1].lower() == "pkcs12"
+                for index in range(len(args))
+            )
+            forced_failure = os.environ.get("FAKE_SECURITY_FAIL_IMPORT") == "1"
+            accepted = (
+                certificate.suffix.lower() == ".p12" or explicit_pkcs12
+            ) and not forced_failure
+            record.update(
+                {
+                    "accepted": accepted,
+                    "forced_failure": forced_failure,
+                    "explicit_pkcs12": explicit_pkcs12,
+                    "certificate": str(certificate),
+                    "certificate_mode": (
+                        stat.S_IMODE(certificate.stat().st_mode)
+                        if certificate.exists()
+                        else None
+                    ),
+                    "parent_mode": (
+                        stat.S_IMODE(certificate.parent.stat().st_mode)
+                        if certificate.parent.exists()
+                        else None
+                    ),
+                }
+            )
+
+        log_path = os.environ.get("SECURITY_LOG")
+        if log_path:
+            with open(log_path, "a", encoding="utf-8") as log:
+                log.write(json.dumps(record) + "\n")
+
+        if command == "list-keychains" and "-s" not in args:
+            for keychain in os.environ.get("FAKE_ORIGINAL_KEYCHAINS", "").splitlines():
+                if keychain:
+                    print(f'"{keychain}"')
+        if command == "import":
+            sys.exit(0 if record["accepted"] else 65)
+        sys.exit(0)
+        """,
+    )
 
 
 class MacOSSigningSecurityTest(unittest.TestCase):
@@ -19,7 +108,7 @@ class MacOSSigningSecurityTest(unittest.TestCase):
     def test_cleanup_trap_precedes_all_keychain_and_certificate_creation(self) -> None:
         trap = self.script.index("trap cleanup EXIT")
         self.assertLess(trap, self.script.index("security create-keychain"))
-        self.assertLess(trap, self.script.index('cert_path="$(mktemp'))
+        self.assertLess(trap, self.script.index('cert_dir="$(mktemp'))
         self.assertIn("trap 'exit 129' HUP", self.script)
         self.assertIn("trap 'exit 130' INT", self.script)
         self.assertIn("trap 'exit 143' TERM", self.script)
@@ -27,12 +116,20 @@ class MacOSSigningSecurityTest(unittest.TestCase):
     def test_keychain_and_sensitive_files_are_unique_and_restrictive(self) -> None:
         self.assertNotIn('keychain="lizzieyzy-sign.keychain-db"', self.script)
         self.assertNotIn("mktemp -t", self.script)
-        self.assertNotIn(").p12", self.script)
         self.assertIn("lizzieyzy-keychain.XXXXXXXX", self.script)
         self.assertIn('keychain="$keychain_dir/signing.keychain-db"', self.script)
         self.assertIn('chmod 700 "$keychain_dir"', self.script)
-        self.assertIn("lizzieyzy-cert.XXXXXXXX", self.script)
+        self.assertIn(
+            'cert_dir="$(mktemp -d "$temp_root/lizzieyzy-cert.XXXXXXXX")"',
+            self.script,
+        )
+        self.assertIn('chmod 700 "$cert_dir"', self.script)
+        self.assertIn('cert_path="$cert_dir/certificate.p12"', self.script)
         self.assertIn('chmod 600 "$cert_path"', self.script)
+        self.assertIn(
+            'security import "$cert_path" -f pkcs12',
+            self.script,
+        )
 
     def test_partial_secrets_fail_closed_and_all_absent_explicitly_skip(self) -> None:
         for name in (
@@ -51,7 +148,10 @@ class MacOSSigningSecurityTest(unittest.TestCase):
         cleanup_start = self.script.index("cleanup() {")
         cleanup_end = self.script.index("trap cleanup EXIT", cleanup_start)
         cleanup = self.script[cleanup_start:cleanup_end]
+        self.assertIn("set +u", cleanup)
         self.assertIn('rm -f -- "$cert_path"', cleanup)
+        self.assertIn('rm -rf -- "$cert_dir"', cleanup)
+        self.assertIn('for path in "${temporary_paths[@]}"', cleanup)
         self.assertIn('security delete-keychain "$keychain"', cleanup)
         self.assertIn('rm -rf -- "$keychain_dir"', cleanup)
         self.assertIn('rm -rf -- "$work_dir"', cleanup)
@@ -98,6 +198,138 @@ class MacOSSigningSecurityTest(unittest.TestCase):
         self.assertNotIn("这步失败不会阻断 artifact 上传", documentation)
         self.assertIn("逐层执行", documentation)
         self.assertIn("`--deep` 只用于签名后的递归验证", documentation)
+        self.assertIn("随机 `0700` 临时目录", documentation)
+        self.assertIn("`certificate.p12`", documentation)
+        self.assertIn("`security import -f pkcs12`", documentation)
+
+    def test_mock_security_import_contract_requires_a_hint_for_pkcs12(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            fake_security = root / "security.py"
+            write_fake_security(fake_security)
+            log_path = root / "security.log"
+            environment = os.environ.copy()
+            environment["SECURITY_LOG"] = str(log_path)
+
+            no_extension = root / "certificate"
+            with_extension = root / "certificate.p12"
+            no_extension.write_bytes(b"certificate")
+            with_extension.write_bytes(b"certificate")
+
+            rejected = subprocess.run(
+                [sys.executable, str(fake_security), "import", str(no_extension)],
+                env=environment,
+                check=False,
+            )
+            accepted_by_extension = subprocess.run(
+                [sys.executable, str(fake_security), "import", str(with_extension)],
+                env=environment,
+                check=False,
+            )
+            accepted_by_format = subprocess.run(
+                [
+                    sys.executable,
+                    str(fake_security),
+                    "import",
+                    str(no_extension),
+                    "-f",
+                    "pkcs12",
+                ],
+                env=environment,
+                check=False,
+            )
+
+            self.assertNotEqual(rejected.returncode, 0)
+            self.assertEqual(accepted_by_extension.returncode, 0)
+            self.assertEqual(accepted_by_format.returncode, 0)
+
+    @unittest.skipUnless(BASH, "bash is required for the executable cleanup regression")
+    def test_early_failure_cleans_empty_arrays_and_private_certificate(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            fixture = Path(temporary_directory)
+            repository = fixture / "repository"
+            scripts = repository / "scripts"
+            packaging = repository / "packaging"
+            release = repository / "release"
+            fake_bin = fixture / "fake-bin"
+            temp_root = fixture / "temporary"
+            for directory in (scripts, packaging, release, fake_bin, temp_root):
+                directory.mkdir(parents=True, exist_ok=True)
+
+            signing_script = scripts / SIGN_SCRIPT.name
+            shutil.copyfile(SIGN_SCRIPT, signing_script)
+            signing_script.chmod(0o755)
+            (packaging / "macos-entitlements.plist").write_text(
+                "<plist version=\"1.0\"></plist>\n", encoding="utf-8"
+            )
+            for helper_name in (
+                "create_macos_drag_dmg.sh",
+                "validate_macos_dmg_layout.sh",
+            ):
+                write_executable(scripts / helper_name, "#!/bin/sh\nexit 0\n")
+            (release / "LizzieYzy-mac-apple-silicon-test.dmg").write_bytes(b"dmg")
+
+            security_log = fixture / "security.log"
+            write_fake_security(fake_bin / "security")
+            for command_name in ("codesign", "xcrun"):
+                write_executable(fake_bin / command_name, "#!/bin/sh\nexit 0\n")
+            write_executable(
+                fake_bin / "openssl",
+                "#!/bin/sh\nprintf '%s\\n' 0123456789abcdef0123456789abcdef\n",
+            )
+
+            environment = os.environ.copy()
+            environment.update(
+                {
+                    "APPLE_CERT_P12": base64.b64encode(b"certificate").decode(),
+                    "APPLE_CERT_PASSWORD": "",
+                    "APPLE_ID": "qa@example.invalid",
+                    "APPLE_APP_PASSWORD": "qa-app-password",
+                    "APPLE_TEAM_ID": "QA12345678",
+                    "APPLE_SIGN_IDENTITY": "",
+                    "BASH_COMPAT": "3.2",
+                    "PATH": str(fake_bin) + os.pathsep + environment.get("PATH", ""),
+                    "SECURITY_LOG": str(security_log),
+                    "FAKE_SECURITY_FAIL_IMPORT": "1",
+                    "TMPDIR": str(temp_root),
+                }
+            )
+
+            completed = subprocess.run(
+                [
+                    BASH,
+                    str(signing_script),
+                    str(release),
+                    "mac-arm64",
+                    "v-test",
+                ],
+                cwd=repository,
+                env=environment,
+                text=True,
+                capture_output=True,
+                timeout=30,
+                check=False,
+            )
+
+            self.assertNotEqual(completed.returncode, 0, completed.stderr)
+            self.assertNotIn("unbound variable", completed.stderr.lower())
+
+            records = [
+                json.loads(line)
+                for line in security_log.read_text(encoding="utf-8").splitlines()
+            ]
+            imported = next(record for record in records if record["args"][0] == "import")
+            certificate_path = Path(imported["certificate"])
+            self.assertEqual(certificate_path.name, "certificate.p12")
+            self.assertTrue(imported["explicit_pkcs12"])
+            self.assertTrue(imported["forced_failure"])
+            self.assertEqual(imported["certificate_mode"], 0o600)
+            self.assertEqual(imported["parent_mode"], 0o700)
+            self.assertFalse(certificate_path.exists())
+            self.assertFalse(certificate_path.parent.exists())
+            self.assertTrue(
+                any(record["args"][0] == "delete-keychain" for record in records)
+            )
 
 
 if __name__ == "__main__":

--- a/scripts/test_publish_release_request.py
+++ b/scripts/test_publish_release_request.py
@@ -1155,6 +1155,95 @@ class ReleasePublisherTest(unittest.TestCase):
         self.assertTrue(client.release["draft"])
         self.assertTrue(client.release["prerelease"])
 
+    def test_wait_for_runs_allows_initial_identity_metadata_to_converge(self) -> None:
+        client = FakeClient()
+        spec = PUBLISH.WORKFLOWS[0]
+        run_id = client.seed_workflow_run(spec.workflow_file)
+        expected = client.get_workflow_run(run_id)
+        snapshots = [
+            {**expected, "head_sha": "b" * 40},
+            {**expected, "display_title": "temporarily stale run title"},
+            expected,
+        ]
+        calls = 0
+
+        def get_workflow_run(_run_id: int) -> dict[str, object]:
+            nonlocal calls
+            self.assertEqual(run_id, _run_id)
+            calls += 1
+            return dict(snapshots.pop(0))
+
+        client.get_workflow_run = get_workflow_run  # type: ignore[method-assign]
+        publisher = self.publisher(client)
+
+        publisher._wait_for_runs({spec.platform: run_id})
+
+        self.assertEqual(3, calls)
+        self.assertEqual(expected["html_url"], publisher.run_urls[spec.platform])
+
+    def test_wait_for_runs_fails_when_identity_never_converges(self) -> None:
+        client = FakeClient()
+        spec = PUBLISH.WORKFLOWS[0]
+        run_id = client.seed_workflow_run(spec.workflow_file)
+        stale = client.get_workflow_run(run_id)
+        stale["display_title"] = "permanently stale run title"
+        now = [0.0]
+        calls = 0
+
+        def get_workflow_run(_run_id: int) -> dict[str, object]:
+            nonlocal calls
+            self.assertEqual(run_id, _run_id)
+            calls += 1
+            return dict(stale)
+
+        def advance(seconds: float) -> None:
+            now[0] += seconds
+
+        client.get_workflow_run = get_workflow_run  # type: ignore[method-assign]
+        publisher = PUBLISH.ReleasePublisher(
+            client,
+            self.request(),
+            TARGET_SHA,
+            self.release_notes(),
+            sleep=advance,
+            poll_seconds=2,
+            run_timeout_seconds=30,
+        )
+
+        with (
+            mock.patch.object(PUBLISH, "WORKFLOW_IDENTITY_CONVERGENCE_SECONDS", 5),
+            mock.patch.object(PUBLISH.time, "monotonic", side_effect=lambda: now[0]),
+            self.assertRaisesRegex(PUBLISH.PublishError, "identity did not converge"),
+        ):
+            publisher._wait_for_runs({spec.platform: run_id})
+
+        self.assertEqual(4, calls)
+        self.assertEqual(6.0, now[0])
+        self.assertNotIn(spec.platform, publisher.run_urls)
+
+    def test_wait_for_runs_fails_if_confirmed_identity_changes(self) -> None:
+        client = FakeClient()
+        spec = PUBLISH.WORKFLOWS[0]
+        run_id = client.seed_workflow_run(spec.workflow_file, status="in_progress")
+        expected = client.get_workflow_run(run_id)
+        snapshots = [expected, {**expected, "head_sha": "b" * 40}]
+        calls = 0
+
+        def get_workflow_run(_run_id: int) -> dict[str, object]:
+            nonlocal calls
+            self.assertEqual(run_id, _run_id)
+            calls += 1
+            return dict(snapshots.pop(0))
+
+        client.get_workflow_run = get_workflow_run  # type: ignore[method-assign]
+
+        with self.assertRaisesRegex(
+            PUBLISH.PublishError, "changed identity after initial verification"
+        ):
+            self.publisher(client)._wait_for_runs({spec.platform: run_id})
+
+        self.assertEqual(2, calls)
+
     def test_waits_for_target_ci_before_creating_release(self) -> None:
         client = FakeClient()
         client.ci_run_snapshots = [

--- a/src/main/java/featurecat/lizzie/analysis/AnalysisResourceCoordinator.java
+++ b/src/main/java/featurecat/lizzie/analysis/AnalysisResourceCoordinator.java
@@ -128,15 +128,18 @@ public final class AnalysisResourceCoordinator {
     if (!diagnosticsEnabled()) {
       return;
     }
+    long stoppedPid = processId(process);
     synchronized (REGISTERED_PROCESSES) {
-      if (REGISTERED_PROCESSES.remove(owner) == null) {
+      Long registeredPid = REGISTERED_PROCESSES.get(owner);
+      if (registeredPid == null || registeredPid.longValue() != stoppedPid) {
         return;
       }
+      REGISTERED_PROCESSES.remove(owner);
     }
     JSONObject details = new JSONObject();
     details.put("owner", ownerId(owner));
     details.put("purpose", normalizedPurpose(purpose).name());
-    details.put("pid", processId(process));
+    details.put("pid", stoppedPid);
     appendEvent("process-stopped", details);
     synchronized (FOREGROUND_SAMPLES) {
       FOREGROUND_SAMPLES.remove(owner);
@@ -161,6 +164,12 @@ public final class AnalysisResourceCoordinator {
         }
       }
       return alive;
+    }
+  }
+
+  static int rawLocalComputeProcessCountForTesting() {
+    synchronized (ACTIVE_LOCAL_COMPUTE_PROCESSES) {
+      return ACTIVE_LOCAL_COMPUTE_PROCESSES.size();
     }
   }
 

--- a/src/main/java/featurecat/lizzie/analysis/Leelaz.java
+++ b/src/main/java/featurecat/lizzie/analysis/Leelaz.java
@@ -939,12 +939,11 @@ public class Leelaz {
     // new Thread(this::read).start();
     // can stop engine for switching weights
     ReaderStreamBinding startedReaderStreamBinding = currentReaderStreamBinding();
-    started = true;
-    executor = Executors.newSingleThreadScheduledExecutor();
-    isNormalEnd = false;
-    executor.execute(() -> read(startedReaderStreamBinding));
-    executorErr = Executors.newSingleThreadScheduledExecutor();
-    executorErr.execute(() -> readError(startedReaderStreamBinding));
+    ScheduledExecutorService stdoutExecutor = Executors.newSingleThreadScheduledExecutor();
+    ScheduledExecutorService stderrExecutor = Executors.newSingleThreadScheduledExecutor();
+    if (!startReaderExecutors(startedReaderStreamBinding, stdoutExecutor, stderrExecutor)) {
+      return;
+    }
 
     if (Lizzie.leelaz2 != null && this == Lizzie.leelaz2) {
       if (index > 19) LizzieFrame.menu.changeEngineIcon2(20, 1);
@@ -955,6 +954,55 @@ public class Leelaz {
     }
     if (Lizzie.frame.isShowingHeatmap) Lizzie.frame.isShowingHeatmap = false;
     if (Lizzie.frame.isShowingPolicy) Lizzie.frame.isShowingPolicy = false;
+  }
+
+  private boolean startReaderExecutors(
+      ReaderStreamBinding startedReaderStreamBinding,
+      ScheduledExecutorService stdoutExecutor,
+      ScheduledExecutorService stderrExecutor) {
+    CountDownLatch readerStartGate = new CountDownLatch(1);
+    boolean readersSubmitted = false;
+    synchronized (engineArbitrationLock()) {
+      synchronized (startedReaderStreamBinding.readerExecutorLock) {
+        if (readerStreamBinding != startedReaderStreamBinding
+            || startedReaderStreamBinding.terminated
+            || startedReaderStreamBinding.readerShutdownRequested) {
+          startedReaderStreamBinding.readerShutdownRequested = true;
+          stdoutExecutor.shutdown();
+          stderrExecutor.shutdown();
+          return false;
+        }
+        started = true;
+        isNormalEnd = false;
+        startedReaderStreamBinding.stdoutExecutor = stdoutExecutor;
+        startedReaderStreamBinding.stderrExecutor = stderrExecutor;
+        executor = stdoutExecutor;
+        executorErr = stderrExecutor;
+        try {
+          stdoutExecutor.execute(
+              () -> {
+                if (awaitReaderStart(readerStartGate)) read(startedReaderStreamBinding);
+              });
+          stderrExecutor.execute(
+              () -> {
+                if (awaitReaderStart(readerStartGate)) readError(startedReaderStreamBinding);
+              });
+          readersSubmitted = true;
+        } finally {
+          if (!readersSubmitted) {
+            startedReaderStreamBinding.readerShutdownRequested = true;
+            stdoutExecutor.shutdownNow();
+            stderrExecutor.shutdownNow();
+            if (readerStreamBinding == startedReaderStreamBinding) {
+              started = false;
+              isNormalEnd = true;
+            }
+          }
+          readerStartGate.countDown();
+        }
+      }
+    }
+    return true;
   }
 
   //	public void restartEngine(int index) throws IOException {
@@ -1236,30 +1284,77 @@ public class Leelaz {
   }
 
   public void normalQuit() {
+    ReaderStreamBinding binding = currentReaderStreamBinding();
     closeBundledStartupDialog();
-    isNormalEnd = true;
     leela0110StopPonder();
-    if (Lizzie.leelaz2 != null && this == Lizzie.leelaz2) {
-      if (currentEngineN > 20) LizzieFrame.menu.changeEngineIcon2(20, 0);
-      else LizzieFrame.menu.changeEngineIcon2(currentEngineN, 0);
-    } else {
-      if (currentEngineN > 20) LizzieFrame.menu.changeEngineIcon(20, 0);
-      else LizzieFrame.menu.changeEngineIcon(currentEngineN, 0);
+    ReaderExecutorSnapshot executors = requestReaderShutdown(binding, true);
+    if (markReaderBindingNormalExitIfCurrent(binding)) {
+      if (Lizzie.leelaz2 != null && this == Lizzie.leelaz2) {
+        if (currentEngineN > 20) LizzieFrame.menu.changeEngineIcon2(20, 0);
+        else LizzieFrame.menu.changeEngineIcon2(currentEngineN, 0);
+      } else {
+        if (currentEngineN > 20) LizzieFrame.menu.changeEngineIcon(20, 0);
+        else LizzieFrame.menu.changeEngineIcon(currentEngineN, 0);
+      }
     }
 
     //		if(isScreen)
     //			sendCommand("name");
-    sendCommand("quit");
-    if (this.useJavaSSH) {
-      javaSSH.close();
-    } else {
-      if (this.useRemoteCompute && remoteTransport != null) remoteTransport.close();
-      shutdownExecutor(executor);
-      shutdownExecutor(executorErr);
-      shutdown();
+    if (executors.ownsTransportClose) {
+      sendQuitToBinding(binding);
     }
-    started = false;
-    isLoaded = false;
+    if (binding.javaSSH != null || binding.remoteTransport != null) {
+      try {
+        shutdown(binding, executors);
+      } finally {
+        shutdownExecutor(executors.stdoutExecutor);
+        shutdownExecutor(executors.stderrExecutor);
+      }
+    } else {
+      shutdownExecutor(executors.stdoutExecutor);
+      shutdownExecutor(executors.stderrExecutor);
+      shutdown(binding, executors);
+    }
+    markReaderBindingStoppedIfCurrent(binding);
+  }
+
+  private void sendQuitToBinding(ReaderStreamBinding binding) {
+    BufferedOutputStream bindingOutput = binding.output;
+    if (bindingOutput == null) {
+      return;
+    }
+    try {
+      synchronized (bindingOutput) {
+        bindingOutput.write("quit\n".getBytes());
+        bindingOutput.flush();
+      }
+    } catch (IOException failure) {
+      String detail = failure.getLocalizedMessage();
+      if (detail == null || detail.trim().isEmpty()) {
+        detail = failure.getClass().getSimpleName();
+      }
+      rememberRecentLine(recentStderrLines, "Failed to send GTP command 'quit': " + detail);
+      System.err.println("Failed to send GTP command 'quit': " + detail);
+    }
+  }
+
+  private boolean markReaderBindingNormalExitIfCurrent(ReaderStreamBinding binding) {
+    synchronized (engineArbitrationLock()) {
+      if (readerStreamBinding != binding) {
+        return false;
+      }
+      isNormalEnd = true;
+      return true;
+    }
+  }
+
+  private void markReaderBindingStoppedIfCurrent(ReaderStreamBinding binding) {
+    synchronized (engineArbitrationLock()) {
+      if (readerStreamBinding == binding) {
+        started = false;
+        isLoaded = false;
+      }
+    }
   }
 
   private void shutdownExecutor(ScheduledExecutorService service) {
@@ -1277,44 +1372,106 @@ public class Leelaz {
     }
   }
 
+  private static void shutdownReaderExecutors(
+      ScheduledExecutorService stdoutExecutor, ScheduledExecutorService stderrExecutor) {
+    if (stdoutExecutor != null) stdoutExecutor.shutdown();
+    if (stderrExecutor != null) stderrExecutor.shutdown();
+  }
+
+  private static boolean awaitReaderStart(CountDownLatch readerStartGate) {
+    try {
+      readerStartGate.await();
+      return true;
+    } catch (InterruptedException interrupted) {
+      Thread.currentThread().interrupt();
+      return false;
+    }
+  }
+
+  private static ReaderExecutorSnapshot requestReaderShutdown(ReaderStreamBinding binding) {
+    return requestReaderShutdown(binding, false);
+  }
+
+  private static ReaderExecutorSnapshot requestReaderShutdown(
+      ReaderStreamBinding binding, boolean normalExitRequested) {
+    synchronized (binding.readerExecutorLock) {
+      binding.readerShutdownRequested = true;
+      binding.normalExitRequested |= normalExitRequested;
+      boolean ownsTransportClose = !binding.transportCloseClaimed;
+      binding.transportCloseClaimed = true;
+      return new ReaderExecutorSnapshot(
+          binding.stdoutExecutor, binding.stderrExecutor, ownsTransportClose);
+    }
+  }
+
+  private static void shutdownReaderExecutors(ReaderExecutorSnapshot executors) {
+    shutdownReaderExecutors(executors.stdoutExecutor, executors.stderrExecutor);
+  }
+
+  private static final class ReaderExecutorSnapshot {
+    private final ScheduledExecutorService stdoutExecutor;
+    private final ScheduledExecutorService stderrExecutor;
+    private final boolean ownsTransportClose;
+
+    private ReaderExecutorSnapshot(
+        ScheduledExecutorService stdoutExecutor,
+        ScheduledExecutorService stderrExecutor,
+        boolean ownsTransportClose) {
+      this.stdoutExecutor = stdoutExecutor;
+      this.stderrExecutor = stderrExecutor;
+      this.ownsTransportClose = ownsTransportClose;
+    }
+  }
+
   public void forceQuit() {
-    AnalysisResourceCoordinator.processStopped(
-        this, AnalysisResourceCoordinator.Purpose.MAIN_BOARD, process);
-    isNormalEnd = true;
-    started = false;
-    isLoaded = false;
+    ReaderStreamBinding binding = currentReaderStreamBinding();
     try {
       leela0110StopPonder();
-      sendCommand("quit");
     } catch (Exception e) {
       e.printStackTrace();
     }
+    ReaderExecutorSnapshot executors = requestReaderShutdown(binding, true);
+    AnalysisResourceCoordinator.processStopped(
+        this, AnalysisResourceCoordinator.Purpose.MAIN_BOARD, binding.process);
+    boolean currentBinding = markReaderBindingNormalExitIfCurrent(binding);
+    markReaderBindingStoppedIfCurrent(binding);
     //		if(isScreen)
     //			sendCommand("name");
-    if (Lizzie.leelaz2 != null && this == Lizzie.leelaz2) {
-      if (currentEngineN > 20) LizzieFrame.menu.changeEngineIcon2(20, 0);
-      else LizzieFrame.menu.changeEngineIcon2(currentEngineN, 0);
-    } else {
-      if (currentEngineN > 20) LizzieFrame.menu.changeEngineIcon(20, 0);
-      else LizzieFrame.menu.changeEngineIcon(currentEngineN, 0);
-    }
-    if (this.useJavaSSH) {
-      javaSSH.close();
-    } else if (this.useRemoteCompute) {
-      if (remoteTransport != null) remoteTransport.close();
-      if (executor != null) executor.shutdownNow();
-      if (executorErr != null) executorErr.shutdownNow();
-    } else {
-      try {
-        Process runningProcess = process;
-        if (runningProcess != null) {
-          runningProcess.destroyForcibly();
-        }
-      } catch (Exception e) {
-        e.printStackTrace();
+    if (currentBinding) {
+      if (Lizzie.leelaz2 != null && this == Lizzie.leelaz2) {
+        if (currentEngineN > 20) LizzieFrame.menu.changeEngineIcon2(20, 0);
+        else LizzieFrame.menu.changeEngineIcon2(currentEngineN, 0);
+      } else {
+        if (currentEngineN > 20) LizzieFrame.menu.changeEngineIcon(20, 0);
+        else LizzieFrame.menu.changeEngineIcon(currentEngineN, 0);
       }
     }
-    outputStream = null;
+    try {
+      if (binding.javaSSH != null) {
+        if (executors.ownsTransportClose) {
+          binding.javaSSH.close();
+        }
+      } else if (binding.remoteTransport != null) {
+        if (executors.ownsTransportClose) {
+          binding.remoteTransport.close();
+        }
+      } else {
+        try {
+          if (binding.process != null) binding.process.destroyForcibly();
+        } catch (Exception e) {
+          e.printStackTrace();
+        }
+      }
+    } finally {
+      shutdownReaderExecutors(executors);
+      clearOutputStreamIfCurrent(binding);
+    }
+  }
+
+  private void clearOutputStreamIfCurrent(ReaderStreamBinding binding) {
+    synchronized (engineArbitrationLock()) {
+      if (readerStreamBinding == binding) outputStream = null;
+    }
   }
 
   /** Initializes the input and output streams */
@@ -1423,17 +1580,18 @@ public class Leelaz {
         outputStream = nextOutputStream;
         errorStream = nextErrorStream;
         loadSgfResponseQuarantined = false;
-          readerStreamBinding =
+        readerStreamBinding =
             new ReaderStreamBinding(
                 nextInputStream,
                 nextErrorStream,
+                nextOutputStream,
                 process,
                 useRemoteCompute ? remoteTransport : null,
                 useJavaSSH ? javaSSH : null,
                 processIncarnationIds.incrementAndGet());
-          synchronized (commandQueue()) {
-            publishRestartBootstrapReceiptLocked(readerStreamBinding, nextOutputStream);
-          }
+        synchronized (commandQueue()) {
+          publishRestartBootstrapReceiptLocked(readerStreamBinding, nextOutputStream);
+        }
         if (ownsRebindGateAfterTrackingCleanup) {
           readerStreamRebindInProgress = false;
           engineArbitrationLock().notifyAll();
@@ -1468,6 +1626,7 @@ public class Leelaz {
               new ReaderStreamBinding(
                   nextInputStream,
                   nextErrorStream,
+                  nextOutputStream,
                   process,
                   useRemoteCompute ? remoteTransport : null,
                   useJavaSSH ? javaSSH : null,
@@ -1520,6 +1679,7 @@ public class Leelaz {
             new ReaderStreamBinding(
                 inputStream,
                 errorStream,
+                outputStream,
                 process,
                 useRemoteCompute ? remoteTransport : null,
                 useJavaSSH ? javaSSH : null,
@@ -1722,10 +1882,17 @@ public class Leelaz {
   private static final class ReaderStreamBinding {
     private final BufferedReader stdout;
     private final BufferedReader stderr;
+    private final BufferedOutputStream output;
     private final Process process;
     private final EngineTransport remoteTransport;
     private final SSHController javaSSH;
     private final long incarnation;
+    private final Object readerExecutorLock = new Object();
+    private ScheduledExecutorService stdoutExecutor;
+    private ScheduledExecutorService stderrExecutor;
+    private boolean readerShutdownRequested;
+    private boolean transportCloseClaimed;
+    private volatile boolean normalExitRequested;
     private RestartBootstrapReceipt restartBootstrapReceipt;
     private int linesInProgress;
     private Throwable terminalFailure;
@@ -1735,12 +1902,14 @@ public class Leelaz {
     private ReaderStreamBinding(
         BufferedReader stdout,
         BufferedReader stderr,
+        BufferedOutputStream output,
         Process process,
         EngineTransport remoteTransport,
         SSHController javaSSH,
         long incarnation) {
       this.stdout = stdout;
       this.stderr = stderr;
+      this.output = output;
       this.process = process;
       this.remoteTransport = remoteTransport;
       this.javaSSH = javaSSH;
@@ -4196,10 +4365,7 @@ public class Leelaz {
       } catch (RuntimeException shutdownFailure) {
         shutdownFailure.printStackTrace();
       }
-      if (binding.javaSSH != null) {
-        javaSSHClosed = true;
-      }
-      started = false;
+      markReaderBindingTerminatedIfCurrent(binding);
       deferredNonModalDiagnostic = finishTerminatedReaderIncarnation(binding);
     } finally {
       synchronized (engineArbitrationLock()) {
@@ -4267,7 +4433,7 @@ public class Leelaz {
       }
       return null;
     }
-    if (!isNormalEnd && !tryRecoverBundledOpenClNativeExit(binding.process)) {
+    if (!binding.normalExitRequested && !tryRecoverBundledOpenClNativeExit(binding.process)) {
       isDownWithError = true;
       // isLoaded=false;
       return buildEngineExitDiagnostic(
@@ -4279,14 +4445,34 @@ public class Leelaz {
   }
 
   private void shutdownReaderTransport(ReaderStreamBinding binding) {
+    ReaderExecutorSnapshot executors = requestReaderShutdown(binding);
     cancelPositionEstimateRequest();
     leela0110StopPonder();
-    if (binding.javaSSH != null) {
-      binding.javaSSH.close();
-    } else if (binding.remoteTransport != null) {
-      binding.remoteTransport.close();
-    } else if (binding.process != null) {
-      binding.process.destroy();
+    try {
+      if (executors.ownsTransportClose) {
+        if (binding.javaSSH != null) {
+          binding.javaSSH.close();
+        } else {
+          if (binding.remoteTransport != null) {
+            binding.remoteTransport.close();
+          } else if (binding.process != null) {
+            binding.process.destroy();
+          }
+        }
+      }
+    } finally {
+      shutdownReaderExecutors(executors);
+    }
+  }
+
+  private void markReaderBindingTerminatedIfCurrent(ReaderStreamBinding binding) {
+    synchronized (engineArbitrationLock()) {
+      if (readerStreamBinding == binding) {
+        if (binding.javaSSH != null) {
+          javaSSHClosed = true;
+        }
+        started = false;
+      }
     }
   }
 
@@ -5117,7 +5303,8 @@ public class Leelaz {
         },
         failure -> {
           if (onFailure != null) {
-            onFailure.accept(failure == null ? "Failed to send configuration" : failure.getMessage());
+            onFailure.accept(
+                failure == null ? "Failed to send configuration" : failure.getMessage());
           }
         },
         true,
@@ -9443,7 +9630,9 @@ public class Leelaz {
         synchronization.start();
       } catch (IOException | RuntimeException failure) {
         failBeforeFence(
-            failure.getMessage() == null ? "automatic engine restart failed" : failure.getMessage());
+            failure.getMessage() == null
+                ? "automatic engine restart failed"
+                : failure.getMessage());
         throw failure;
       }
     }
@@ -9553,30 +9742,22 @@ public class Leelaz {
         completeReadBoardGmaRecoveryAfterBoardSync();
       }
       resumeClosedEngineAfterBoardSynchronization(resumePonder);
-      notifyCompletion();
-      state.compareAndSet(AutomaticRestartState.FENCE_PENDING, AutomaticRestartState.COMPLETED);
+      if (state.compareAndSet(
+          AutomaticRestartState.FENCE_PENDING, AutomaticRestartState.COMPLETED)) {
+        notifyCompletionAfterEndpointRelease();
+      }
     }
 
     private void completeWithoutFence() {
-      if (state.get() != AutomaticRestartState.CONVERGING) {
+      if (!state.compareAndSet(AutomaticRestartState.CONVERGING, AutomaticRestartState.COMPLETED)) {
         return;
       }
-      try {
-        notifyCompletion();
-        state.compareAndSet(AutomaticRestartState.CONVERGING, AutomaticRestartState.COMPLETED);
-      } catch (RuntimeException failure) {
-        failBeforeFence(
-            failure.getMessage() == null
-                ? "automatic engine restart completion failed"
-                : failure.getMessage());
-      } finally {
-        completionClaim.abandonBeforeFence();
-      }
+      notifyCompletionAfterEndpointRelease();
+      completionClaim.abandonBeforeFence();
     }
 
     private void failAfterFence(String detail) {
-      if (!state.compareAndSet(
-          AutomaticRestartState.FENCE_PENDING, AutomaticRestartState.FAILED)) {
+      if (!state.compareAndSet(AutomaticRestartState.FENCE_PENDING, AutomaticRestartState.FAILED)) {
         return;
       }
       failCapturedEndpointsClosed();
@@ -9584,7 +9765,7 @@ public class Leelaz {
           detail, preserveUnrestoredState || engineStateUnrestored);
       endBoardSynchronization();
       notifyFailure(detail);
-      notifyCompletion();
+      notifyCompletionAfterEndpointRelease();
     }
 
     private void failBeforeFence(String detail) {
@@ -9640,18 +9821,34 @@ public class Leelaz {
       }
     }
 
+    private void notifyCompletionAfterEndpointRelease() {
+      // Public completion means both endpoints are fully reopened; owner-internal state changes
+      // above still execute while the lifecycle claim excludes unrelated engine work.
+      completionClaim.runAfterEndpointRelease(this::notifyCompletion);
+    }
+
     private void notifyCompletion() {
       Runnable completion = afterBoardRestore;
       if (completion != null && completionNotified.compareAndSet(false, true)) {
-        completion.run();
+        try {
+          completion.run();
+        } catch (RuntimeException failure) {
+          String detail = failure.getMessage();
+          if (detail == null || detail.trim().isEmpty()) {
+            detail = failure.getClass().getSimpleName();
+          }
+          String message = "Automatic restart completion callback failed: " + detail;
+          rememberRecentLine(recentStderrLines, message);
+          System.err.println(message);
+        }
       }
     }
   }
 
   /**
-   * Owner-identified lifecycle completion claim installed atomically on an authority and its
-   * frozen mirror. It owns final dual-leg fencing and holds endpoint exclusion through the owner
-   * callback, then releases both endpoints with identity-safe compare-and-clear.
+   * Owner-identified lifecycle completion claim installed atomically on an authority and its frozen
+   * mirror. It owns final dual-leg fencing, releases both endpoints with identity-safe
+   * compare-and-clear, then notifies the external completion observer.
    */
   static final class LifecycleCompletionClaim {
     private final Leelaz authority;
@@ -12806,16 +13003,27 @@ public class Leelaz {
 
   /** End the process */
   public void shutdown() {
-    AnalysisResourceCoordinator.processStopped(
-        this, AnalysisResourceCoordinator.Purpose.MAIN_BOARD, process);
+    ReaderStreamBinding binding = currentReaderStreamBinding();
+    shutdown(binding, requestReaderShutdown(binding, true));
+  }
+
+  private void shutdown(ReaderStreamBinding binding, ReaderExecutorSnapshot executors) {
     cancelPositionEstimateRequest();
     leela0110StopPonder();
-    if (this.useJavaSSH) {
-      javaSSH.close();
-    } else if (this.useRemoteCompute) {
-      if (remoteTransport != null) remoteTransport.close();
-    } else {
-      if (process != null) process.destroy();
+    try {
+      if (executors.ownsTransportClose) {
+        AnalysisResourceCoordinator.processStopped(
+            this, AnalysisResourceCoordinator.Purpose.MAIN_BOARD, binding.process);
+        if (binding.javaSSH != null) {
+          binding.javaSSH.close();
+        } else if (binding.remoteTransport != null) {
+          binding.remoteTransport.close();
+        } else {
+          if (binding.process != null) binding.process.destroy();
+        }
+      }
+    } finally {
+      shutdownReaderExecutors(executors);
     }
   }
 

--- a/src/test/java/featurecat/lizzie/analysis/AnalysisResourceCoordinatorTest.java
+++ b/src/test/java/featurecat/lizzie/analysis/AnalysisResourceCoordinatorTest.java
@@ -12,6 +12,7 @@ import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import org.json.JSONObject;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -144,9 +145,65 @@ class AnalysisResourceCoordinatorTest {
     }
   }
 
+  @Test
+  void staleProcessStopCannotRemoveReplacementDiagnosticsRegistration() throws Exception {
+    Path output = tempDir.resolve("generation-safe-diagnostics.jsonl");
+    String previousEnabled = System.getProperty("lizzie.analysis.diagnostics");
+    String previousPath = System.getProperty("lizzie.analysis.diagnostics.path");
+    System.setProperty("lizzie.analysis.diagnostics", "true");
+    System.setProperty("lizzie.analysis.diagnostics.path", output.toString());
+    Object owner = new Object();
+    ControllableProcess retired = new ControllableProcess(101L);
+    ControllableProcess replacement = new ControllableProcess(202L);
+    try {
+      AnalysisResourceCoordinator.processStarted(
+          owner, AnalysisResourceCoordinator.Purpose.MAIN_BOARD, "retired", retired);
+      AnalysisResourceCoordinator.processStarted(
+          owner, AnalysisResourceCoordinator.Purpose.MAIN_BOARD, "replacement", replacement);
+
+      retired.destroy();
+      AnalysisResourceCoordinator.processStopped(
+          owner, AnalysisResourceCoordinator.Purpose.MAIN_BOARD, retired);
+      replacement.destroy();
+      AnalysisResourceCoordinator.processStopped(
+          owner, AnalysisResourceCoordinator.Purpose.MAIN_BOARD, replacement);
+
+      List<JSONObject> stoppedEvents =
+          Files.readAllLines(output, StandardCharsets.UTF_8).stream()
+              .map(JSONObject::new)
+              .filter(event -> "process-stopped".equals(event.getString("event")))
+              .toList();
+      assertEquals(1, stoppedEvents.size());
+      assertEquals(202L, stoppedEvents.get(0).getJSONObject("details").getLong("pid"));
+    } finally {
+      retired.destroy();
+      replacement.destroy();
+      AnalysisResourceCoordinator.activeLocalComputeProcessCount();
+      restoreSystemProperty("lizzie.analysis.diagnostics", previousEnabled);
+      restoreSystemProperty("lizzie.analysis.diagnostics.path", previousPath);
+    }
+  }
+
+  private static void restoreSystemProperty(String name, String value) {
+    if (value == null) {
+      System.clearProperty(name);
+    } else {
+      System.setProperty(name, value);
+    }
+  }
+
   private static final class ControllableProcess extends Process {
     private volatile boolean alive = true;
     private final CompletableFuture<Process> exit = new CompletableFuture<>();
+    private final long pid;
+
+    private ControllableProcess() {
+      this(-1L);
+    }
+
+    private ControllableProcess(long pid) {
+      this.pid = pid;
+    }
 
     @Override
     public OutputStream getOutputStream() {
@@ -192,6 +249,11 @@ class AnalysisResourceCoordinatorTest {
     @Override
     public CompletableFuture<Process> onExit() {
       return exit;
+    }
+
+    @Override
+    public long pid() {
+      return pid;
     }
   }
 }

--- a/src/test/java/featurecat/lizzie/analysis/AnalysisResourceCoordinatorTestAccess.java
+++ b/src/test/java/featurecat/lizzie/analysis/AnalysisResourceCoordinatorTestAccess.java
@@ -1,0 +1,12 @@
+package featurecat.lizzie.analysis;
+
+/**
+ * Test-only access to registry state that must be observed without triggering dead-process pruning.
+ */
+public final class AnalysisResourceCoordinatorTestAccess {
+  private AnalysisResourceCoordinatorTestAccess() {}
+
+  public static int rawLocalComputeProcessCount() {
+    return AnalysisResourceCoordinator.rawLocalComputeProcessCountForTesting();
+  }
+}

--- a/src/test/java/featurecat/lizzie/analysis/EngineManagerLifecycleReservationTest.java
+++ b/src/test/java/featurecat/lizzie/analysis/EngineManagerLifecycleReservationTest.java
@@ -14,6 +14,7 @@ import featurecat.lizzie.Config;
 import featurecat.lizzie.EngineStartupStatus;
 import featurecat.lizzie.ExtraMode;
 import featurecat.lizzie.Lizzie;
+import featurecat.lizzie.analysis.remote.EngineTransport;
 import featurecat.lizzie.analysis.remote.RemoteComputeConfig;
 import featurecat.lizzie.gui.BoardRenderer;
 import featurecat.lizzie.gui.BottomToolbar;
@@ -37,6 +38,9 @@ import java.util.AbstractList;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
@@ -726,6 +730,478 @@ class EngineManagerLifecycleReservationTest {
     } finally {
       state.restore();
       forceFirstLaunchSession(previousFirstLaunchSession);
+    }
+  }
+
+  @Test
+  void updateEnginesRestoreSettlesInFlightReplacementBeforeRestoringGlobals() throws Exception {
+    UpdateEnginesState state = new UpdateEnginesState(19, 19);
+    try {
+      state.install();
+      state.manager.updateEngines();
+      Leelaz replacement = state.manager.engineList.get(0);
+
+      // The first name response is deliberately gated, so teardown begins while replacement startup
+      // still owns the lifecycle transition.
+      assertTrue(replacement.hasExclusiveGtpLifecycleTransitionForTest());
+      state.restore();
+
+      Process replacementProcess = (Process) getLeelazField(replacement, "process");
+      ScheduledExecutorService stdoutExecutor =
+          (ScheduledExecutorService) getLeelazField(replacement, "executor");
+      ScheduledExecutorService stderrExecutor =
+          (ScheduledExecutorService) getLeelazField(replacement, "executorErr");
+      assertTrue(state.cleanupLifecycleSettled);
+      assertTrue(state.cleanupProcessesStopped);
+      assertTrue(state.cleanupExecutorsStopped);
+      assertEquals(2, state.capturedReaderExecutors.size());
+      assertTrue(
+          state.capturedReaderExecutors.stream().allMatch(ScheduledExecutorService::isShutdown));
+      assertTrue(
+          state.capturedReaderExecutors.stream().allMatch(ScheduledExecutorService::isTerminated));
+      assertFalse(replacement.hasExclusiveGtpLifecycleTransitionForTest());
+      assertTrue(replacementProcess == null || !replacementProcess.isAlive());
+      assertNotNull(stdoutExecutor);
+      assertNotNull(stderrExecutor);
+      assertTrue(stdoutExecutor.isShutdown());
+      assertTrue(stderrExecutor.isShutdown());
+      assertTrue(stdoutExecutor.isTerminated());
+      assertTrue(stderrExecutor.isTerminated());
+      assertSame(state.previousConfig, Lizzie.config);
+      assertSame(state.previousMenu, LizzieFrame.menu);
+    } finally {
+      state.restore();
+    }
+  }
+
+  @Test
+  void testOnlyProcessFallbackCannotRescueProductionCleanupResult() throws Exception {
+    FallbackCleanupLeelaz engine = new FallbackCleanupLeelaz();
+    FallbackProcess process = new FallbackProcess();
+    setLeelazField(engine, "process", process);
+
+    assertFalse(UpdateEnginesState.stopReplacementProcesses(List.of(engine), 1L));
+    assertEquals(1, process.forcibleDestroyCount.get());
+    assertFalse(process.isAlive());
+  }
+
+  @Test
+  void testOnlyExecutorFallbackCannotRescueProductionCleanupResult() throws Exception {
+    ScheduledExecutorService executor = runningReaderExecutor();
+    try {
+      assertFalse(UpdateEnginesState.awaitCapturedReaderExecutorsStopped(List.of(executor), 1L));
+      assertTrue(executor.isShutdown());
+      assertTrue(executor.awaitTermination(3, TimeUnit.SECONDS));
+    } finally {
+      executor.shutdownNow();
+    }
+  }
+
+  @Test
+  void capturedReaderExecutorsShareOneProductionTerminationDeadline() {
+    BudgetConsumingExecutor first = new BudgetConsumingExecutor(80L);
+    BudgetConsumingExecutor second = new BudgetConsumingExecutor(80L);
+    try {
+      assertFalse(
+          UpdateEnginesState.awaitCapturedReaderExecutorsStopped(List.of(first, second), 120L));
+      assertEquals(0, first.fallbackShutdownCount.get());
+      assertEquals(1, second.fallbackShutdownCount.get());
+      assertTrue(first.isTerminated());
+      assertTrue(second.isTerminated());
+    } finally {
+      first.shutdownNow();
+      second.shutdownNow();
+    }
+  }
+
+  @Test
+  void readerExecutorShutdownFromItsOwnWorkerDoesNotAwaitItself() throws Exception {
+    ScheduledExecutorService stdoutExecutor = Executors.newSingleThreadScheduledExecutor();
+    ScheduledExecutorService stderrExecutor = Executors.newSingleThreadScheduledExecutor();
+    CountDownLatch shutdownReturned = new CountDownLatch(1);
+    AtomicReference<Throwable> failure = new AtomicReference<>();
+    long[] shutdownElapsedNanos = new long[1];
+    Method shutdownReaderExecutors =
+        Leelaz.class.getDeclaredMethod(
+            "shutdownReaderExecutors",
+            ScheduledExecutorService.class,
+            ScheduledExecutorService.class);
+    shutdownReaderExecutors.setAccessible(true);
+    try {
+      stdoutExecutor.execute(
+          () -> {
+            try {
+              long startedAt = System.nanoTime();
+              shutdownReaderExecutors.invoke(null, stdoutExecutor, stderrExecutor);
+              shutdownElapsedNanos[0] = System.nanoTime() - startedAt;
+              assertFalse(Thread.currentThread().isInterrupted());
+            } catch (Throwable invocationFailure) {
+              failure.set(invocationFailure);
+            } finally {
+              shutdownReturned.countDown();
+            }
+          });
+
+      assertTrue(shutdownReturned.await(3, TimeUnit.SECONDS));
+      assertTrue(stdoutExecutor.awaitTermination(3, TimeUnit.SECONDS));
+      assertTrue(stderrExecutor.awaitTermination(3, TimeUnit.SECONDS));
+      assertNull(failure.get());
+      assertTrue(shutdownElapsedNanos[0] < TimeUnit.MILLISECONDS.toNanos(500L));
+      assertTrue(stdoutExecutor.isTerminated());
+      assertTrue(stderrExecutor.isTerminated());
+    } finally {
+      stdoutExecutor.shutdownNow();
+      stderrExecutor.shutdownNow();
+    }
+  }
+
+  @Test
+  void javaSshExitPathsCloseExactSessionAndBothReaderExecutors() throws Exception {
+    Leelaz previousPrimary = Lizzie.leelaz;
+    Leelaz previousSecondary = Lizzie.leelaz2;
+    Menu previousMenu = LizzieFrame.menu;
+    try {
+      Lizzie.leelaz2 = null;
+      LizzieFrame.menu = allocate(SilentUpdateMenu.class);
+      for (String exitPath : List.of("normal", "force", "shutdown", "terminal")) {
+        QuietExitLeelaz engine = new QuietExitLeelaz();
+        RecordingSshController ssh = new RecordingSshController(engine);
+        ScheduledExecutorService stdout = runningReaderExecutor();
+        ScheduledExecutorService stderr = runningReaderExecutor();
+        Object binding = installJavaSshReaderBinding(engine, ssh, stdout, stderr);
+        Lizzie.leelaz = engine;
+
+        switch (exitPath) {
+          case "normal" -> engine.normalQuit();
+          case "force" -> engine.forceQuit();
+          case "shutdown" -> engine.shutdown();
+          case "terminal" -> invokeShutdownReaderTransport(engine, binding);
+          default -> throw new AssertionError(exitPath);
+        }
+
+        assertEquals(1, ssh.closeCount.get(), exitPath);
+        assertTrue(stdout.isShutdown(), exitPath);
+        assertTrue(stderr.isShutdown(), exitPath);
+        assertTrue(stdout.awaitTermination(3, TimeUnit.SECONDS), exitPath);
+        assertTrue(stderr.awaitTermination(3, TimeUnit.SECONDS), exitPath);
+        assertEquals(
+            !exitPath.equals("terminal"),
+            (boolean) getField(binding, "normalExitRequested"),
+            exitPath);
+      }
+    } finally {
+      Lizzie.leelaz = previousPrimary;
+      Lizzie.leelaz2 = previousSecondary;
+      LizzieFrame.menu = previousMenu;
+    }
+  }
+
+  @Test
+  void readerShutdownBeforeInstallSkipsBothSubmissionsWithoutRejection() throws Exception {
+    QuietExitLeelaz engine = new QuietExitLeelaz();
+    RecordingSshController ssh = new RecordingSshController(engine);
+    Object binding = installJavaSshReaderBinding(engine, ssh, null, null);
+    engine.shutdown();
+    RecordingSubmissionExecutor stdout = new RecordingSubmissionExecutor(false);
+    RecordingSubmissionExecutor stderr = new RecordingSubmissionExecutor(false);
+    try {
+      assertFalse(invokeStartReaderExecutors(engine, binding, stdout, stderr));
+      assertEquals(0, stdout.submissionCount.get());
+      assertEquals(0, stderr.submissionCount.get());
+      assertTrue(stdout.isShutdown());
+      assertTrue(stderr.isShutdown());
+    } finally {
+      stdout.shutdownNow();
+      stderr.shutdownNow();
+    }
+  }
+
+  @Test
+  void readerInstallAndShutdownSerializeAcrossBothTaskSubmissions() throws Exception {
+    QuietExitLeelaz engine = new QuietExitLeelaz();
+    RecordingSshController ssh = new RecordingSshController(engine);
+    Object binding = installJavaSshReaderBinding(engine, ssh, null, null);
+    RecordingSubmissionExecutor stdout = new RecordingSubmissionExecutor(true);
+    RecordingSubmissionExecutor stderr = new RecordingSubmissionExecutor(false);
+    AtomicReference<Throwable> installFailure = new AtomicReference<>();
+    AtomicReference<Throwable> shutdownFailure = new AtomicReference<>();
+    Thread install =
+        new Thread(
+            () -> {
+              try {
+                assertTrue(invokeStartReaderExecutors(engine, binding, stdout, stderr));
+              } catch (Throwable failure) {
+                installFailure.set(failure);
+              }
+            });
+    Thread shutdown =
+        new Thread(
+            () -> {
+              try {
+                engine.shutdown();
+              } catch (Throwable failure) {
+                shutdownFailure.set(failure);
+              }
+            });
+    try {
+      install.start();
+      assertTrue(stdout.submissionEntered.await(3, TimeUnit.SECONDS));
+      shutdown.start();
+      assertTrue(awaitThreadState(shutdown, Thread.State.BLOCKED, 3_000L));
+      assertFalse(stdout.isShutdown());
+      assertFalse(stderr.isShutdown());
+      stdout.allowSubmission.countDown();
+      install.join(3_000L);
+      shutdown.join(3_000L);
+
+      assertFalse(install.isAlive());
+      assertFalse(shutdown.isAlive());
+      assertNull(installFailure.get());
+      assertNull(shutdownFailure.get());
+      assertEquals(1, stdout.submissionCount.get());
+      assertEquals(1, stderr.submissionCount.get());
+      assertEquals(1, ssh.closeCount.get());
+      assertTrue(stdout.awaitTermination(3, TimeUnit.SECONDS));
+      assertTrue(stderr.awaitTermination(3, TimeUnit.SECONDS));
+    } finally {
+      stdout.allowSubmission.countDown();
+      stdout.shutdownNow();
+      stderr.shutdownNow();
+      install.join(3_000L);
+      shutdown.join(3_000L);
+    }
+  }
+
+  @Test
+  void staleBindingNormalQuitUsesCapturedOutputAndCannotOverwriteReplacementState()
+      throws Exception {
+    assertStaleBindingExitDoesNotAffectReplacement(true);
+  }
+
+  @Test
+  void staleBindingForceQuitDoesNotWriteOrOverwriteReplacementState() throws Exception {
+    assertStaleBindingExitDoesNotAffectReplacement(false);
+  }
+
+  private static void assertStaleBindingExitDoesNotAffectReplacement(boolean normalQuit)
+      throws Exception {
+    Leelaz previousPrimary = Lizzie.leelaz;
+    Leelaz previousSecondary = Lizzie.leelaz2;
+    Menu previousMenu = LizzieFrame.menu;
+    BlockingPonderExitLeelaz engine = new BlockingPonderExitLeelaz();
+    RecordingSshController retiredSsh = new RecordingSshController(engine);
+    RecordingSshController replacementSsh = new RecordingSshController(engine);
+    ScheduledExecutorService retiredStdout = runningReaderExecutor();
+    ScheduledExecutorService retiredStderr = runningReaderExecutor();
+    ScheduledExecutorService replacementStdout = runningReaderExecutor();
+    ScheduledExecutorService replacementStderr = runningReaderExecutor();
+    ByteArrayOutputStream retiredBytes = new ByteArrayOutputStream();
+    BufferedOutputStream retiredOutput = new BufferedOutputStream(retiredBytes);
+    ByteArrayOutputStream replacementBytes = new ByteArrayOutputStream();
+    BufferedOutputStream replacementOutput = new BufferedOutputStream(replacementBytes);
+    installJavaSshReaderBinding(engine, retiredSsh, retiredStdout, retiredStderr, retiredOutput);
+    Object replacementBinding =
+        newJavaSshReaderBinding(
+            replacementSsh, replacementStdout, replacementStderr, replacementOutput, 2L);
+    AtomicReference<Throwable> exitFailure = new AtomicReference<>();
+    Thread exit =
+        new Thread(
+            () -> {
+              try {
+                if (normalQuit) {
+                  engine.normalQuit();
+                } else {
+                  engine.forceQuit();
+                }
+              } catch (Throwable failure) {
+                exitFailure.set(failure);
+              }
+            });
+    try {
+      Lizzie.leelaz = engine;
+      Lizzie.leelaz2 = null;
+      LizzieFrame.menu = allocate(SilentUpdateMenu.class);
+      engine.started = true;
+      engine.isLoaded = true;
+      engine.isNormalEnd = false;
+      exit.start();
+      assertTrue(engine.stopPonderEntered.await(3, TimeUnit.SECONDS));
+      setLeelazField(engine, "readerStreamBinding", replacementBinding);
+      setLeelazField(engine, "javaSSH", replacementSsh);
+      setLeelazField(engine, "executor", replacementStdout);
+      setLeelazField(engine, "executorErr", replacementStderr);
+      setLeelazField(engine, "outputStream", replacementOutput);
+      engine.started = true;
+      engine.isLoaded = true;
+      engine.isNormalEnd = false;
+      engine.allowStopPonder.countDown();
+      exit.join(3_000L);
+
+      assertFalse(exit.isAlive());
+      assertNull(exitFailure.get());
+      assertEquals(1, retiredSsh.closeCount.get());
+      assertEquals(0, replacementSsh.closeCount.get());
+      assertTrue(retiredStdout.awaitTermination(3, TimeUnit.SECONDS));
+      assertTrue(retiredStderr.awaitTermination(3, TimeUnit.SECONDS));
+      assertFalse(replacementStdout.isShutdown());
+      assertFalse(replacementStderr.isShutdown());
+      assertSame(replacementOutput, getLeelazField(engine, "outputStream"));
+      assertEquals(normalQuit ? "quit\n" : "", retiredBytes.toString(StandardCharsets.UTF_8));
+      assertEquals("", replacementBytes.toString(StandardCharsets.UTF_8));
+      assertTrue(engine.started);
+      assertTrue(engine.isLoaded);
+      assertFalse(engine.isNormalEnd);
+    } finally {
+      engine.allowStopPonder.countDown();
+      exit.join(3_000L);
+      retiredStdout.shutdownNow();
+      retiredStderr.shutdownNow();
+      replacementStdout.shutdownNow();
+      replacementStderr.shutdownNow();
+      Lizzie.leelaz = previousPrimary;
+      Lizzie.leelaz2 = previousSecondary;
+      LizzieFrame.menu = previousMenu;
+    }
+  }
+
+  @Test
+  void staleOrTerminatedBindingCannotInstallOrPublishReaderExecutors() throws Exception {
+    QuietExitLeelaz engine = new QuietExitLeelaz();
+    RecordingSshController retiredSsh = new RecordingSshController(engine);
+    Object staleBinding = installJavaSshReaderBinding(engine, retiredSsh, null, null);
+    ScheduledExecutorService replacementStdout = runningReaderExecutor();
+    ScheduledExecutorService replacementStderr = runningReaderExecutor();
+    Object replacementBinding =
+        newJavaSshReaderBinding(
+            new RecordingSshController(engine), replacementStdout, replacementStderr, 2L);
+    RecordingSubmissionExecutor staleStdout = new RecordingSubmissionExecutor(false);
+    RecordingSubmissionExecutor staleStderr = new RecordingSubmissionExecutor(false);
+    RecordingSubmissionExecutor terminatedStdout = new RecordingSubmissionExecutor(false);
+    RecordingSubmissionExecutor terminatedStderr = new RecordingSubmissionExecutor(false);
+    try {
+      setLeelazField(engine, "readerStreamBinding", replacementBinding);
+      setLeelazField(engine, "executor", replacementStdout);
+      setLeelazField(engine, "executorErr", replacementStderr);
+
+      assertFalse(invokeStartReaderExecutors(engine, staleBinding, staleStdout, staleStderr));
+      assertEquals(0, staleStdout.submissionCount.get());
+      assertEquals(0, staleStderr.submissionCount.get());
+      assertSame(replacementStdout, getLeelazField(engine, "executor"));
+      assertSame(replacementStderr, getLeelazField(engine, "executorErr"));
+
+      setField(replacementBinding, "terminated", true);
+      assertFalse(
+          invokeStartReaderExecutors(
+              engine, replacementBinding, terminatedStdout, terminatedStderr));
+      assertEquals(0, terminatedStdout.submissionCount.get());
+      assertEquals(0, terminatedStderr.submissionCount.get());
+      assertSame(replacementStdout, getLeelazField(engine, "executor"));
+      assertSame(replacementStderr, getLeelazField(engine, "executorErr"));
+      assertTrue(staleStdout.isShutdown());
+      assertTrue(staleStderr.isShutdown());
+      assertTrue(terminatedStdout.isShutdown());
+      assertTrue(terminatedStderr.isShutdown());
+    } finally {
+      staleStdout.shutdownNow();
+      staleStderr.shutdownNow();
+      terminatedStdout.shutdownNow();
+      terminatedStderr.shutdownNow();
+      replacementStdout.shutdownNow();
+      replacementStderr.shutdownNow();
+    }
+  }
+
+  @Test
+  void externalExitAndTerminalCleanupCloseEachExactTransportOnlyOnce() throws Exception {
+    for (boolean remote : List.of(false, true)) {
+      QuietExitLeelaz engine = new QuietExitLeelaz();
+      RecordingSshController ssh = remote ? null : new RecordingSshController(engine, true);
+      RecordingTransport transport = remote ? new RecordingTransport(true) : null;
+      ScheduledExecutorService stdout = runningReaderExecutor();
+      ScheduledExecutorService stderr = runningReaderExecutor();
+      Object binding =
+          remote
+              ? installRemoteReaderBinding(engine, transport, stdout, stderr)
+              : installJavaSshReaderBinding(engine, ssh, stdout, stderr);
+      CountDownLatch closeEntered = remote ? transport.closeEntered : ssh.closeEntered;
+      CountDownLatch allowClose = remote ? transport.allowClose : ssh.allowClose;
+      AtomicInteger closeCount = remote ? transport.closeCount : ssh.closeCount;
+      AtomicReference<Throwable> externalFailure = new AtomicReference<>();
+      AtomicReference<Throwable> terminalFailure = new AtomicReference<>();
+      Thread external =
+          new Thread(
+              () -> {
+                try {
+                  engine.shutdown();
+                } catch (Throwable failure) {
+                  externalFailure.set(failure);
+                }
+              });
+      Thread terminal =
+          new Thread(
+              () -> {
+                try {
+                  invokeShutdownReaderTransport(engine, binding);
+                } catch (Throwable failure) {
+                  terminalFailure.set(failure);
+                }
+              });
+      try {
+        external.start();
+        assertTrue(closeEntered.await(3, TimeUnit.SECONDS), "remote=" + remote);
+        terminal.start();
+        terminal.join(3_000L);
+        assertFalse(terminal.isAlive(), "remote=" + remote);
+        assertEquals(1, closeCount.get(), "remote=" + remote);
+        allowClose.countDown();
+        external.join(3_000L);
+        assertFalse(external.isAlive(), "remote=" + remote);
+        assertNull(externalFailure.get(), "remote=" + remote);
+        assertNull(terminalFailure.get(), "remote=" + remote);
+        assertEquals(1, closeCount.get(), "remote=" + remote);
+        assertTrue(stdout.awaitTermination(3, TimeUnit.SECONDS), "remote=" + remote);
+        assertTrue(stderr.awaitTermination(3, TimeUnit.SECONDS), "remote=" + remote);
+      } finally {
+        allowClose.countDown();
+        external.join(3_000L);
+        terminal.join(3_000L);
+        stdout.shutdownNow();
+        stderr.shutdownNow();
+      }
+    }
+  }
+
+  @Test
+  void localGracefulCloseCanBeEscalatedByForceQuit() throws Exception {
+    Leelaz previousPrimary = Lizzie.leelaz;
+    Leelaz previousSecondary = Lizzie.leelaz2;
+    Menu previousMenu = LizzieFrame.menu;
+    QuietExitLeelaz engine = new QuietExitLeelaz();
+    FallbackProcess process = new FallbackProcess();
+    try {
+      Lizzie.leelaz = engine;
+      Lizzie.leelaz2 = null;
+      LizzieFrame.menu = allocate(SilentUpdateMenu.class);
+      setLeelazField(engine, "process", process);
+      Method currentBinding = Leelaz.class.getDeclaredMethod("currentReaderStreamBinding");
+      currentBinding.setAccessible(true);
+      Object binding = currentBinding.invoke(engine);
+
+      invokeShutdownReaderTransport(engine, binding);
+      assertTrue(process.isAlive(), "the controlled process ignores graceful destroy");
+      assertEquals(0, process.forcibleDestroyCount.get());
+
+      engine.forceQuit();
+
+      assertFalse(process.isAlive());
+      assertEquals(1, process.forcibleDestroyCount.get());
+    } finally {
+      if (process.isAlive()) {
+        process.destroyForcibly();
+      }
+      Lizzie.leelaz = previousPrimary;
+      Lizzie.leelaz2 = previousSecondary;
+      LizzieFrame.menu = previousMenu;
     }
   }
 
@@ -3624,6 +4100,124 @@ class EngineManagerLifecycleReservationTest {
     return field.get(target);
   }
 
+  private static void setField(Object target, String name, Object value)
+      throws ReflectiveOperationException {
+    Field field = target.getClass().getDeclaredField(name);
+    field.setAccessible(true);
+    field.set(target, value);
+  }
+
+  private static ScheduledExecutorService runningReaderExecutor() throws Exception {
+    ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor();
+    executor.submit(() -> {}).get(3, TimeUnit.SECONDS);
+    return executor;
+  }
+
+  private static Object installJavaSshReaderBinding(
+      Leelaz engine,
+      SSHController ssh,
+      ScheduledExecutorService stdout,
+      ScheduledExecutorService stderr)
+      throws Exception {
+    return installJavaSshReaderBinding(engine, ssh, stdout, stderr, null);
+  }
+
+  private static Object installJavaSshReaderBinding(
+      Leelaz engine,
+      SSHController ssh,
+      ScheduledExecutorService stdout,
+      ScheduledExecutorService stderr,
+      BufferedOutputStream output)
+      throws Exception {
+    engine.useJavaSSH = true;
+    setLeelazField(engine, "javaSSH", ssh);
+    setLeelazField(engine, "outputStream", output);
+    Method currentBinding = Leelaz.class.getDeclaredMethod("currentReaderStreamBinding");
+    currentBinding.setAccessible(true);
+    Object binding = currentBinding.invoke(engine);
+    setField(binding, "stdoutExecutor", stdout);
+    setField(binding, "stderrExecutor", stderr);
+    setLeelazField(engine, "executor", stdout);
+    setLeelazField(engine, "executorErr", stderr);
+    return binding;
+  }
+
+  private static Object installRemoteReaderBinding(
+      Leelaz engine,
+      EngineTransport transport,
+      ScheduledExecutorService stdout,
+      ScheduledExecutorService stderr)
+      throws Exception {
+    engine.useRemoteCompute = true;
+    setLeelazField(engine, "remoteTransport", transport);
+    Method currentBinding = Leelaz.class.getDeclaredMethod("currentReaderStreamBinding");
+    currentBinding.setAccessible(true);
+    Object binding = currentBinding.invoke(engine);
+    setField(binding, "stdoutExecutor", stdout);
+    setField(binding, "stderrExecutor", stderr);
+    setLeelazField(engine, "executor", stdout);
+    setLeelazField(engine, "executorErr", stderr);
+    return binding;
+  }
+
+  private static Object newJavaSshReaderBinding(
+      SSHController ssh,
+      ScheduledExecutorService stdout,
+      ScheduledExecutorService stderr,
+      long incarnation)
+      throws Exception {
+    return newJavaSshReaderBinding(ssh, stdout, stderr, null, incarnation);
+  }
+
+  private static Object newJavaSshReaderBinding(
+      SSHController ssh,
+      ScheduledExecutorService stdout,
+      ScheduledExecutorService stderr,
+      BufferedOutputStream output,
+      long incarnation)
+      throws Exception {
+    Class<?> bindingType = Class.forName(Leelaz.class.getName() + "$ReaderStreamBinding");
+    java.lang.reflect.Constructor<?> constructor = bindingType.getDeclaredConstructors()[0];
+    constructor.setAccessible(true);
+    Object binding = constructor.newInstance(null, null, output, null, null, ssh, incarnation);
+    setField(binding, "stdoutExecutor", stdout);
+    setField(binding, "stderrExecutor", stderr);
+    return binding;
+  }
+
+  private static boolean invokeStartReaderExecutors(
+      Leelaz engine,
+      Object binding,
+      ScheduledExecutorService stdout,
+      ScheduledExecutorService stderr)
+      throws Exception {
+    Method start =
+        Leelaz.class.getDeclaredMethod(
+            "startReaderExecutors",
+            binding.getClass(),
+            ScheduledExecutorService.class,
+            ScheduledExecutorService.class);
+    start.setAccessible(true);
+    return (boolean) start.invoke(engine, binding, stdout, stderr);
+  }
+
+  private static void invokeShutdownReaderTransport(Leelaz engine, Object binding)
+      throws Exception {
+    Method shutdown = Leelaz.class.getDeclaredMethod("shutdownReaderTransport", binding.getClass());
+    shutdown.setAccessible(true);
+    shutdown.invoke(engine, binding);
+  }
+
+  private static boolean awaitThreadState(Thread thread, Thread.State state, long timeoutMillis)
+      throws InterruptedException {
+    long deadline = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(timeoutMillis);
+    while (System.nanoTime() < deadline) {
+      if (thread.getState() == state) return true;
+      Thread.sleep(5L);
+    }
+    return thread.getState() == state;
+  }
+
   private static boolean hasRestartBootstrapReceiptContext(Leelaz engine) {
     try {
       @SuppressWarnings("unchecked")
@@ -4089,6 +4683,255 @@ class EngineManagerLifecycleReservationTest {
     public void setText(String text) {}
   }
 
+  private static final class QuietExitLeelaz extends Leelaz {
+    private QuietExitLeelaz() throws Exception {
+      super("");
+    }
+
+    @Override
+    public void leela0110StopPonder() {}
+  }
+
+  private static final class FallbackCleanupLeelaz extends Leelaz {
+    private FallbackCleanupLeelaz() throws Exception {
+      super("");
+    }
+
+    @Override
+    public void forceQuit() {}
+  }
+
+  private static final class FallbackProcess extends Process {
+    private final AtomicInteger forcibleDestroyCount = new AtomicInteger();
+    private volatile boolean alive = true;
+
+    @Override
+    public java.io.OutputStream getOutputStream() {
+      return new ByteArrayOutputStream();
+    }
+
+    @Override
+    public java.io.InputStream getInputStream() {
+      return java.io.InputStream.nullInputStream();
+    }
+
+    @Override
+    public java.io.InputStream getErrorStream() {
+      return java.io.InputStream.nullInputStream();
+    }
+
+    @Override
+    public int waitFor() {
+      alive = false;
+      return 0;
+    }
+
+    @Override
+    public boolean waitFor(long timeout, TimeUnit unit) {
+      return !alive;
+    }
+
+    @Override
+    public int exitValue() {
+      if (alive) {
+        throw new IllegalThreadStateException("controlled process still alive");
+      }
+      return 0;
+    }
+
+    @Override
+    public void destroy() {}
+
+    @Override
+    public Process destroyForcibly() {
+      forcibleDestroyCount.incrementAndGet();
+      alive = false;
+      return this;
+    }
+
+    @Override
+    public boolean isAlive() {
+      return alive;
+    }
+  }
+
+  private static final class BlockingPonderExitLeelaz extends Leelaz {
+    private final CountDownLatch stopPonderEntered = new CountDownLatch(1);
+    private final CountDownLatch allowStopPonder = new CountDownLatch(1);
+
+    private BlockingPonderExitLeelaz() throws Exception {
+      super("");
+    }
+
+    @Override
+    public void leela0110StopPonder() {
+      stopPonderEntered.countDown();
+      try {
+        if (!allowStopPonder.await(5, TimeUnit.SECONDS)) {
+          throw new AssertionError("timed out waiting to release controlled stop-ponder");
+        }
+      } catch (InterruptedException interrupted) {
+        Thread.currentThread().interrupt();
+        throw new AssertionError(interrupted);
+      }
+    }
+  }
+
+  private static final class RecordingSshController extends SSHController {
+    private final boolean blockClose;
+    private final AtomicInteger closeCount = new AtomicInteger();
+    private final CountDownLatch closeEntered = new CountDownLatch(1);
+    private final CountDownLatch allowClose = new CountDownLatch(1);
+
+    private RecordingSshController(Leelaz owner) {
+      this(owner, false);
+    }
+
+    private RecordingSshController(Leelaz owner, boolean blockClose) {
+      super(owner, "127.0.0.1", "22");
+      this.blockClose = blockClose;
+    }
+
+    @Override
+    public void close() {
+      closeCount.incrementAndGet();
+      closeEntered.countDown();
+      if (!blockClose) return;
+      try {
+        if (!allowClose.await(5, TimeUnit.SECONDS)) {
+          throw new AssertionError("timed out waiting to release controlled SSH close");
+        }
+      } catch (InterruptedException interrupted) {
+        Thread.currentThread().interrupt();
+        throw new AssertionError(interrupted);
+      }
+    }
+  }
+
+  private static final class RecordingTransport implements EngineTransport {
+    private final boolean blockClose;
+    private final AtomicInteger closeCount = new AtomicInteger();
+    private final CountDownLatch closeEntered = new CountDownLatch(1);
+    private final CountDownLatch allowClose = new CountDownLatch(1);
+
+    private RecordingTransport(boolean blockClose) {
+      this.blockClose = blockClose;
+    }
+
+    @Override
+    public void start() {}
+
+    @Override
+    public java.io.InputStream stdout() {
+      return null;
+    }
+
+    @Override
+    public java.io.OutputStream stdin() {
+      return null;
+    }
+
+    @Override
+    public java.io.InputStream stderr() {
+      return null;
+    }
+
+    @Override
+    public boolean isOpen() {
+      return true;
+    }
+
+    @Override
+    public String description() {
+      return "recording transport";
+    }
+
+    @Override
+    public void close() {
+      closeCount.incrementAndGet();
+      closeEntered.countDown();
+      if (!blockClose) return;
+      try {
+        if (!allowClose.await(5, TimeUnit.SECONDS)) {
+          throw new AssertionError("timed out waiting to release controlled transport close");
+        }
+      } catch (InterruptedException interrupted) {
+        Thread.currentThread().interrupt();
+        throw new AssertionError(interrupted);
+      }
+    }
+  }
+
+  private static final class RecordingSubmissionExecutor extends ScheduledThreadPoolExecutor {
+    private final boolean gateFirstSubmission;
+    private final AtomicInteger submissionCount = new AtomicInteger();
+    private final CountDownLatch submissionEntered = new CountDownLatch(1);
+    private final CountDownLatch allowSubmission = new CountDownLatch(1);
+
+    private RecordingSubmissionExecutor(boolean gateFirstSubmission) {
+      super(1);
+      this.gateFirstSubmission = gateFirstSubmission;
+    }
+
+    @Override
+    public void execute(Runnable command) {
+      int submission = submissionCount.incrementAndGet();
+      if (gateFirstSubmission && submission == 1) {
+        submissionEntered.countDown();
+        try {
+          if (!allowSubmission.await(5, TimeUnit.SECONDS)) {
+            throw new AssertionError("timed out waiting to release controlled reader submission");
+          }
+        } catch (InterruptedException interrupted) {
+          Thread.currentThread().interrupt();
+          throw new AssertionError(interrupted);
+        }
+      }
+      super.execute(() -> {});
+    }
+  }
+
+  private static final class BudgetConsumingExecutor extends ScheduledThreadPoolExecutor {
+    private final long requiredWaitNanos;
+    private final AtomicInteger fallbackShutdownCount = new AtomicInteger();
+    private volatile boolean terminated;
+
+    private BudgetConsumingExecutor(long requiredWaitMillis) {
+      super(1);
+      requiredWaitNanos = TimeUnit.MILLISECONDS.toNanos(requiredWaitMillis);
+    }
+
+    @Override
+    public boolean isShutdown() {
+      return true;
+    }
+
+    @Override
+    public boolean isTerminated() {
+      return terminated;
+    }
+
+    @Override
+    public boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
+      if (terminated) {
+        return true;
+      }
+      long allowedWaitNanos = Math.max(0L, unit.toNanos(timeout));
+      TimeUnit.NANOSECONDS.sleep(Math.min(requiredWaitNanos, allowedWaitNanos));
+      if (allowedWaitNanos >= requiredWaitNanos) {
+        terminated = true;
+      }
+      return terminated;
+    }
+
+    @Override
+    public List<Runnable> shutdownNow() {
+      fallbackShutdownCount.incrementAndGet();
+      terminated = true;
+      return super.shutdownNow();
+    }
+  }
+
   private static final class SilentGtpConsole extends GtpConsolePane {
     private SilentGtpConsole() {
       super((java.awt.Window) null);
@@ -4322,6 +5165,11 @@ class EngineManagerLifecycleReservationTest {
     private final Path loadSgfFailure;
     private final Path catchUpGate;
     private final Path fenceFailure;
+    private boolean cleanupLifecycleSettled;
+    private boolean cleanupProcessesStopped;
+    private boolean cleanupExecutorsStopped;
+    private List<ScheduledExecutorService> capturedReaderExecutors = List.of();
+    private boolean restored;
 
     private UpdateEnginesState(int targetWidth, int targetHeight) throws Exception {
       this(targetWidth, targetHeight, false);
@@ -4422,8 +5270,24 @@ class EngineManagerLifecycleReservationTest {
     }
 
     private void releaseStartup() throws Exception {
-      waitForLog(commandLog, "name", 10000L);
+      awaitReplacementProcessLaunch(30_000L);
+      waitForLog(commandLog, "name", 10_000L);
       Files.writeString(startupGate, "ready");
+    }
+
+    private void awaitReplacementProcessLaunch(long timeoutMillis) throws Exception {
+      assertFalse(manager.engineList == null || manager.engineList.isEmpty());
+      Leelaz replacement = manager.engineList.get(0);
+      long deadline = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(timeoutMillis);
+      Process replacementProcess = null;
+      while (replacementProcess == null && System.nanoTime() < deadline) {
+        replacementProcess = (Process) getLeelazField(replacement, "process");
+        if (replacementProcess == null) {
+          Thread.sleep(10L);
+        }
+      }
+      assertNotNull(replacementProcess, "timed out waiting for replacement process launch");
+      assertTrue(replacementProcess.isAlive(), "replacement process exited before sending name");
     }
 
     private void releaseBoardFence() throws Exception {
@@ -4441,6 +5305,9 @@ class EngineManagerLifecycleReservationTest {
     }
 
     private void restore() {
+      if (restored) {
+        return;
+      }
       try {
         Files.writeString(startupGate, "ready");
       } catch (Exception ignored) {
@@ -4453,17 +5320,24 @@ class EngineManagerLifecycleReservationTest {
         releaseCatchUp();
       } catch (Exception ignored) {
       }
-      if (manager.engineList != null) {
-        for (Leelaz engine : manager.engineList) {
-          try {
-            Process runningProcess = (Process) getLeelazField(engine, "process");
-            engine.forceQuit();
-            if (runningProcess != null) {
-              runningProcess.waitFor(2, TimeUnit.SECONDS);
-            }
-          } catch (Exception ignored) {
-          }
-        }
+      List<Leelaz> replacementEngines =
+          manager.engineList == null ? List.of() : new ArrayList<>(manager.engineList);
+      List<Leelaz> lifecycleParticipants = new ArrayList<>(replacementEngines);
+      lifecycleParticipants.add(previousForegroundEngine);
+      if (previousSecondaryEngine != null) {
+        lifecycleParticipants.add(previousSecondaryEngine);
+      }
+      cleanupLifecycleSettled = awaitReplacementLifecycleSettlement(lifecycleParticipants, 10_000L);
+      CapturedReaderExecutors executorCapture = captureReaderExecutors(replacementEngines);
+      capturedReaderExecutors = executorCapture.executors;
+      cleanupProcessesStopped = stopReplacementProcesses(replacementEngines);
+      boolean capturedExecutorsStopped =
+          awaitCapturedReaderExecutorsStopped(capturedReaderExecutors, 2_000L);
+      cleanupExecutorsStopped = executorCapture.complete && capturedExecutorsStopped;
+      if (!cleanupLifecycleSettled) {
+        // Drain late work for isolation, but never let test cleanup overwrite the production
+        // settlement result captured before forceQuit.
+        awaitReplacementLifecycleSettlement(lifecycleParticipants, 2_000L);
       }
       try {
         SwingUtilities.invokeAndWait(() -> {});
@@ -4493,6 +5367,194 @@ class EngineManagerLifecycleReservationTest {
       EngineManager.currentEngineNo2 = previousEngineNo2;
       Board.boardWidth = previousBoardWidth;
       Board.boardHeight = previousBoardHeight;
+      restored = true;
+      if (!cleanupLifecycleSettled || !cleanupProcessesStopped || !cleanupExecutorsStopped) {
+        throw new AssertionError(
+            "updateEngines teardown did not settle: lifecycleSettled="
+                + cleanupLifecycleSettled
+                + ", processesStopped="
+                + cleanupProcessesStopped
+                + ", executorsStopped="
+                + cleanupExecutorsStopped);
+      }
+    }
+
+    private static boolean awaitReplacementLifecycleSettlement(
+        List<Leelaz> lifecycleParticipants, long timeoutMillis) {
+      long deadline = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(timeoutMillis);
+      while (System.nanoTime() < deadline) {
+        boolean lifecycleActive = false;
+        for (Leelaz engine : lifecycleParticipants) {
+          if (engine != null && engine.hasExclusiveGtpWorkInProgress()) {
+            lifecycleActive = true;
+            break;
+          }
+        }
+        if (!lifecycleActive) {
+          return true;
+        }
+        try {
+          Thread.sleep(10L);
+        } catch (InterruptedException interrupted) {
+          Thread.currentThread().interrupt();
+          return false;
+        }
+      }
+      for (Leelaz engine : lifecycleParticipants) {
+        if (engine != null && engine.hasExclusiveGtpWorkInProgress()) {
+          return false;
+        }
+      }
+      return true;
+    }
+
+    private static boolean stopReplacementProcesses(List<Leelaz> replacementEngines) {
+      return stopReplacementProcesses(replacementEngines, 2_000L);
+    }
+
+    private static boolean stopReplacementProcesses(
+        List<Leelaz> replacementEngines, long productionExitTimeoutMillis) {
+      boolean allStopped = true;
+      for (Leelaz engine : replacementEngines) {
+        Process runningProcess = null;
+        try {
+          runningProcess = (Process) getLeelazField(engine, "process");
+          engine.forceQuit();
+        } catch (Exception cleanupFailure) {
+          allStopped = false;
+        }
+        if (runningProcess == null) {
+          continue;
+        }
+        if (!awaitExactProcessExit(runningProcess, productionExitTimeoutMillis)) {
+          // This is test-only leak prevention. A fallback can make teardown safe, but it must
+          // never turn a missed production deadline green.
+          allStopped = false;
+          try {
+            runningProcess.destroyForcibly();
+          } catch (RuntimeException cleanupFailure) {
+            allStopped = false;
+          }
+          if (!awaitExactProcessExit(runningProcess, 2_000L)) {
+            allStopped = false;
+          }
+        }
+        if (runningProcess.isAlive()) {
+          allStopped = false;
+        }
+      }
+      return allStopped;
+    }
+
+    private static CapturedReaderExecutors captureReaderExecutors(List<Leelaz> replacementEngines) {
+      List<ScheduledExecutorService> captured = new ArrayList<>();
+      boolean complete = true;
+      for (Leelaz engine : replacementEngines) {
+        try {
+          Object binding = getLeelazField(engine, "readerStreamBinding");
+          if (binding == null) {
+            continue;
+          }
+          Object readerExecutorLock = getField(binding, "readerExecutorLock");
+          synchronized (readerExecutorLock) {
+            for (String fieldName : List.of("stdoutExecutor", "stderrExecutor")) {
+              ScheduledExecutorService service =
+                  (ScheduledExecutorService) getField(binding, fieldName);
+              if (service != null
+                  && captured.stream().noneMatch(capturedService -> capturedService == service)) {
+                captured.add(service);
+              }
+            }
+          }
+        } catch (Exception captureFailure) {
+          complete = false;
+        }
+      }
+      return new CapturedReaderExecutors(List.copyOf(captured), complete);
+    }
+
+    private static boolean awaitExactProcessExit(Process process, long timeoutMillis) {
+      boolean interrupted = false;
+      long deadline = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(timeoutMillis);
+      try {
+        while (process.isAlive()) {
+          long remaining = deadline - System.nanoTime();
+          if (remaining <= 0L) {
+            break;
+          }
+          try {
+            if (process.waitFor(remaining, TimeUnit.NANOSECONDS)) {
+              break;
+            }
+          } catch (InterruptedException interruption) {
+            interrupted = true;
+          }
+        }
+        return !process.isAlive();
+      } finally {
+        if (interrupted) {
+          Thread.currentThread().interrupt();
+        }
+      }
+    }
+
+    private static boolean awaitCapturedReaderExecutorsStopped(
+        List<ScheduledExecutorService> capturedExecutors, long timeoutMillis) {
+      boolean allStopped = true;
+      long productionDeadline = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(timeoutMillis);
+      List<ScheduledExecutorService> fallbackCleanup = new ArrayList<>();
+      for (ScheduledExecutorService service : capturedExecutors) {
+        boolean shutdownByProduction = service.isShutdown();
+        boolean terminatedByProduction =
+            shutdownByProduction && awaitExactExecutorTerminationUntil(service, productionDeadline);
+        if (!terminatedByProduction) {
+          allStopped = false;
+          fallbackCleanup.add(service);
+        }
+      }
+      for (ScheduledExecutorService service : fallbackCleanup) {
+        service.shutdownNow();
+      }
+      long fallbackDeadline = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(timeoutMillis);
+      for (ScheduledExecutorService service : fallbackCleanup) {
+        awaitExactExecutorTerminationUntil(service, fallbackDeadline);
+      }
+      return allStopped;
+    }
+
+    private static final class CapturedReaderExecutors {
+      private final List<ScheduledExecutorService> executors;
+      private final boolean complete;
+
+      private CapturedReaderExecutors(List<ScheduledExecutorService> executors, boolean complete) {
+        this.executors = executors;
+        this.complete = complete;
+      }
+    }
+
+    private static boolean awaitExactExecutorTerminationUntil(
+        ScheduledExecutorService service, long deadlineNanos) {
+      boolean interrupted = false;
+      try {
+        while (!service.isTerminated()) {
+          long remaining = deadlineNanos - System.nanoTime();
+          if (remaining <= 0L) {
+            break;
+          }
+          try {
+            if (service.awaitTermination(remaining, TimeUnit.NANOSECONDS)) {
+              break;
+            }
+          } catch (InterruptedException interruption) {
+            interrupted = true;
+          }
+        }
+        return service.isTerminated();
+      } finally {
+        if (interrupted) {
+          Thread.currentThread().interrupt();
+        }
+      }
     }
 
     private static <T> T allocateUnchecked(Class<T> type) {

--- a/src/test/java/featurecat/lizzie/analysis/LeelazAutomaticRestartConvergenceTest.java
+++ b/src/test/java/featurecat/lizzie/analysis/LeelazAutomaticRestartConvergenceTest.java
@@ -1,5 +1,6 @@
 package featurecat.lizzie.analysis;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -22,6 +23,7 @@ import featurecat.lizzie.rules.BoardData;
 import featurecat.lizzie.rules.BoardHistoryList;
 import featurecat.lizzie.rules.Stone;
 import featurecat.lizzie.rules.Zobrist;
+import featurecat.lizzie.util.KataGoRuntimeHelper;
 import java.awt.Window;
 import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
@@ -310,6 +312,80 @@ class LeelazAutomaticRestartConvergenceTest {
   }
 
   @Test
+  void completionObserverFailureCannotRetireSuccessfulRestart() throws Exception {
+    try (RestartTestEnvironment env = RestartTestEnvironment.open()) {
+      ConvergingRestartLeelaz engine = new ConvergingRestartLeelaz();
+      Board board = boardWithHistory(snapshotHistoryWithTail(false));
+      env.publish(engine, board);
+
+      Leelaz.AutomaticRestartAttempt attempt = engine.beginAutomaticEngineRestartAttempt();
+      assertNotNull(attempt);
+      AtomicInteger completionCount = new AtomicInteger();
+      attempt.restartClosedEngine(
+          0,
+          () -> {
+            completionCount.incrementAndGet();
+            throw new IllegalStateException("controlled completion observer failure");
+          });
+
+      assertTrue(waitForRawCommandPrefix(engine.transport, "name", 5, TimeUnit.SECONDS));
+      assertDoesNotThrow(() -> invokeFenceResponse(engine));
+      assertEquals(1, completionCount.get(), "the failing observer must remain one-shot");
+      assertTrue(engine.isLoaded(), "an observer failure must not retire a ready engine");
+      assertTrue(
+          engineModeAdmissionOpen(engine),
+          "an observer failure must not re-block engine-mode admission");
+      assertAutomaticRestartRetryAvailable(engine);
+    }
+  }
+
+  @Test
+  void benchmarkSuppressedRestartCompletionObservesReleasedClaimWithoutFence() throws Exception {
+    try (RestartTestEnvironment env = RestartTestEnvironment.open()) {
+      try {
+        ConvergingRestartLeelaz engine = new ConvergingRestartLeelaz();
+        Board board = boardWithHistory(snapshotHistoryWithTail(false));
+        env.publish(engine, board);
+        KataGoRuntimeHelper.BenchmarkPauseResult pause =
+            KataGoRuntimeHelper.pauseCurrentAnalysisForBenchmark();
+        assertTrue(pause.accepted(), "the controlled benchmark pause must be admitted");
+
+        Leelaz.AutomaticRestartAttempt attempt = engine.beginAutomaticEngineRestartAttempt();
+        assertNotNull(attempt);
+        CountDownLatch completed = new CountDownLatch(1);
+        AtomicInteger completionCount = new AtomicInteger();
+        AtomicInteger failureCount = new AtomicInteger();
+        AtomicBoolean admissionOpenInCompletion = new AtomicBoolean(false);
+        attempt.restartClosedEngine(
+            0,
+            () -> {
+              completionCount.incrementAndGet();
+              admissionOpenInCompletion.set(engineModeAdmissionOpen(engine));
+              completed.countDown();
+            },
+            detail -> failureCount.incrementAndGet());
+
+        assertTrue(completed.await(5, TimeUnit.SECONDS));
+        assertEquals(1, completionCount.get(), "the no-fence completion must remain one-shot");
+        assertEquals(0, failureCount.get(), "the no-fence restart must complete successfully");
+        assertTrue(engine.isLoaded(), "the no-fence restart must leave the engine loaded");
+        assertTrue(
+            admissionOpenInCompletion.get(),
+            "the no-fence completion must observe endpoint admission reopened");
+        assertFalse(
+            waitForNumberedRawCommandPrefix(engine.transport, "name", 200, TimeUnit.MILLISECONDS),
+            "benchmark suppression must bypass the final board fence");
+        assertEquals(
+            0, engine.readyCount.get(), "the no-fence branch must not publish fence ready");
+      } finally {
+        if (KataGoRuntimeHelper.isBenchmarkEngineSyncSuppressed()) {
+          KataGoRuntimeHelper.restoreAnalysisAfterBenchmark(false);
+        }
+      }
+    }
+  }
+
+  @Test
   void openClRecoveryConvergesWithNavigationDuringRestore() throws Exception {
     Config previousConfig = Lizzie.config;
     Board previousBoard = Lizzie.board;
@@ -525,7 +601,8 @@ class LeelazAutomaticRestartConvergenceTest {
 
       assertTrue(completed.await(2, TimeUnit.SECONDS));
       assertFalse(engine.isLoaded(), "the authority must fail closed after readiness timeout");
-      assertFalse(mirror.isLoaded(), "the captured mirror must fail closed after readiness timeout");
+      assertFalse(
+          mirror.isLoaded(), "the captured mirror must fail closed after readiness timeout");
       Leelaz.EngineModeReservation afterFailure = engine.beginEngineModeReservation();
       assertNotNull(afterFailure, "readiness failure must release the completion claim");
       afterFailure.close();
@@ -980,7 +1057,14 @@ class LeelazAutomaticRestartConvergenceTest {
       Leelaz.AutomaticRestartAttempt attempt = engine.beginAutomaticEngineRestartAttempt();
       assertNotNull(attempt);
       CountDownLatch completed = new CountDownLatch(1);
-      attempt.restartClosedEngine(0, completed::countDown);
+      AtomicBoolean admissionOpenInCompletion = new AtomicBoolean(false);
+      attempt.restartClosedEngine(
+          0,
+          () -> {
+            admissionOpenInCompletion.set(
+                engineModeAdmissionOpen(engine) && engineModeAdmissionOpen(mirror));
+            completed.countDown();
+          });
 
       assertTrue(
           firstLoadSgfReceived.await(2, TimeUnit.SECONDS),
@@ -1026,9 +1110,9 @@ class LeelazAutomaticRestartConvergenceTest {
       assertEquals(1, engine.resumeCount.get(), "ponder must resume exactly once");
       assertEquals(1, engine.analyzeCount.get(), "one analysis starts after the convergence");
       assertTrue(engine.isLoaded());
-      Leelaz.EngineModeReservation afterFence = engine.beginEngineModeReservation();
-      assertNotNull(afterFence, "admission must reopen after the first owner completes");
-      afterFence.close();
+      assertTrue(
+          admissionOpenInCompletion.get(),
+          "the completion callback must observe both endpoints reopened after release");
     }
   }
 
@@ -1182,14 +1266,21 @@ class LeelazAutomaticRestartConvergenceTest {
       Leelaz.AutomaticRestartAttempt attempt = engine.beginAutomaticEngineRestartAttempt();
       assertNotNull(attempt);
       CountDownLatch completed = new CountDownLatch(1);
-      attempt.restartClosedEngine(0, completed::countDown);
+      AtomicBoolean admissionOpenInCompletion = new AtomicBoolean(false);
+      attempt.restartClosedEngine(
+          0,
+          () -> {
+            admissionOpenInCompletion.set(
+                engineModeAdmissionOpen(engine) && engineModeAdmissionOpen(mirror));
+            completed.countDown();
+          });
 
-      assertTrue(completed.await(2, TimeUnit.SECONDS));
+      assertTrue(completed.await(5, TimeUnit.SECONDS));
       assertFalse(engine.isLoaded());
       assertFalse(mirror.isLoaded());
-      Leelaz.EngineModeReservation afterFailure = engine.beginEngineModeReservation();
-      assertNotNull(afterFailure, "a synchronous fence start failure must release the claim");
-      afterFailure.close();
+      assertTrue(
+          admissionOpenInCompletion.get(),
+          "a synchronous fence start failure must release the claim before completion");
       assertOrdinaryForwardingReopened(engine);
       assertOrdinaryForwardingReopened(mirror);
       assertAutomaticRestartRetryAvailable(engine);
@@ -1260,7 +1351,8 @@ class LeelazAutomaticRestartConvergenceTest {
           "a fence timeout must settle the completion callback");
       assertTrue(
           handlersRetiredInCallback.get(),
-          "the failure callback must observe every dispatched fence handler already retired; authority="
+          "the failure callback must observe every dispatched fence handler already retired;"
+              + " authority="
               + pendingBoardSynchronizationHandlerCount(engine)
               + ", mirror="
               + pendingBoardSynchronizationHandlerCount(mirror));
@@ -1542,6 +1634,12 @@ class LeelazAutomaticRestartConvergenceTest {
         engine.submitOrdinaryLiveBoardForwarding(
             EngineManager.OrdinaryLiveBoardForwardingIntent.of(() -> true)),
         "ordinary live-board forwarding must reopen after the barrier ends");
+  }
+
+  private static boolean engineModeAdmissionOpen(Leelaz engine) {
+    try (Leelaz.EngineModeReservation reservation = engine.beginEngineModeReservation()) {
+      return reservation != null;
+    }
   }
 
   private static void assertAutomaticRestartRetryAvailable(ConvergingRestartLeelaz engine) {

--- a/src/test/java/featurecat/lizzie/analysis/LeelazReadBoardGmaTest.java
+++ b/src/test/java/featurecat/lizzie/analysis/LeelazReadBoardGmaTest.java
@@ -244,7 +244,8 @@ class LeelazReadBoardGmaTest {
           Leelaz.ExclusiveGtpLeaseAvailability.ENGINE_STATE_UNRESTORED,
           engine.previewForegroundAnalysisLeaseAvailability());
       assertFalse(
-          output.commands().stream().anyMatch(command -> command.startsWith("kata-genmove_analyze")));
+          output.commands().stream()
+              .anyMatch(command -> command.startsWith("kata-genmove_analyze")));
 
       invokeProcessCommandResponseLine(
           engine, successResponseFor(output.rawCommands(), "maxTime"));
@@ -493,7 +494,8 @@ class LeelazReadBoardGmaTest {
           engine, successResponseFor(output.rawCommands(), "maxVisits"));
 
       assertFalse(
-          output.commands().stream().anyMatch(command -> command.startsWith("kata-genmove_analyze")));
+          output.commands().stream()
+              .anyMatch(command -> command.startsWith("kata-genmove_analyze")));
       assertTrue(output.commands().contains("kata-set-param maxTime 2"));
       assertTrue(output.commands().contains("kata-set-param maxVisits 800"));
       assertEquals(
@@ -562,7 +564,8 @@ class LeelazReadBoardGmaTest {
           output.commands(),
           "the acknowledged preparation must send one command at a time");
       assertFalse(
-          output.commands().stream().anyMatch(command -> command.startsWith("kata-genmove_analyze")),
+          output.commands().stream()
+              .anyMatch(command -> command.startsWith("kata-genmove_analyze")),
           "the genmove must not be sent before every required get/set ACK");
 
       invokeProcessCommandResponseLine(
@@ -740,7 +743,8 @@ class LeelazReadBoardGmaTest {
               "kata-set-param ponderingEnabled false",
               "kata-set-param maxTime 2"),
           output.commands(),
-          "a zero limit must restore the previously acknowledged override instead of re-snapshotting");
+          "a zero limit must restore the previously acknowledged override instead of"
+              + " re-snapshotting");
       invokeProcessCommandResponseLine(
           engine, successResponseFor(output.rawCommands(), "maxTime"));
       assertEquals(
@@ -786,7 +790,8 @@ class LeelazReadBoardGmaTest {
           Leelaz.ExclusiveGtpLeaseAvailability.ENGINE_STATE_UNRESTORED,
           engine.previewForegroundAnalysisLeaseAvailability());
       assertFalse(
-          output.commands().stream().anyMatch(command -> command.startsWith("kata-genmove_analyze")),
+          output.commands().stream()
+              .anyMatch(command -> command.startsWith("kata-genmove_analyze")),
           "a preparation restore failure must never admit the session or send the genmove");
     }
   }
@@ -2007,7 +2012,8 @@ class LeelazReadBoardGmaTest {
       assertThrows(
           IllegalStateException.class,
           () -> engine.restartClosedEngine(0),
-          "a second restart caller must not fall back to a generic root replay while the first attempt is live");
+          "a second restart caller must not fall back to a generic root replay while the first"
+              + " attempt is live");
       assertEquals(
           1,
           output.commands().stream().filter("name"::equals).count(),
@@ -2048,7 +2054,8 @@ class LeelazReadBoardGmaTest {
       attempt.restartClosedEngine(0, completed::countDown);
 
       assertTrue(waitForRawCommand(output, "name", 1, TimeUnit.SECONDS));
-      assertFalse(output.commands().stream().anyMatch(command -> command.startsWith("kata-analyze")));
+      assertFalse(
+          output.commands().stream().anyMatch(command -> command.startsWith("kata-analyze")));
       invokeProcessCommandResponseLine(engine, numberedResponseFor(output.rawCommands(), "name"));
       assertTrue(completed.await(1, TimeUnit.SECONDS));
       invokeProcessCommandResponseLine(engine, "=");
@@ -2473,7 +2480,8 @@ class LeelazReadBoardGmaTest {
       assertTrue(
           readBoard.failReadBoardGmaSessionForEngineTermination(engine, "engine transport closed"));
       assertFalse(
-          readBoard.failReadBoardGmaSessionForEngineTermination(engine, "duplicate transport close"));
+          readBoard.failReadBoardGmaSessionForEngineTermination(
+              engine, "duplicate transport close"));
 
       ReadBoardGmaSession.Terminal terminal =
           assertInstanceOf(ReadBoardGmaSession.Terminal.class, session.state());
@@ -2794,7 +2802,8 @@ class LeelazReadBoardGmaTest {
           boundReadBoardGmaSession(readBoard),
           "the session must not be admitted before every matching get/set ACK");
       assertFalse(
-          output.commands().stream().anyMatch(command -> command.startsWith("kata-genmove_analyze")),
+          output.commands().stream()
+              .anyMatch(command -> command.startsWith("kata-genmove_analyze")),
           "the genmove must not be sent before every required get/set ACK");
 
       // Pre-admission deferred restore: the helper owes one engine restore for the current node
@@ -2814,7 +2823,8 @@ class LeelazReadBoardGmaTest {
       assertTrue(
           output.commands().stream()
               .anyMatch(command -> command.startsWith("kata-genmove_analyze ")),
-          "the admitted session must send the genmove only after the acknowledged preparation; commands="
+          "the admitted session must send the genmove only after the acknowledged preparation;"
+              + " commands="
               + output.commands());
       AtomicReference<ReadBoardGmaSession> sessionRef = new AtomicReference<>(session);
       ExactSnapshotRestoreProtocolFixture.Transport transport =
@@ -3354,7 +3364,8 @@ class LeelazReadBoardGmaTest {
       invokeParseLine(engine, "play pass");
 
       assertTrue(
-          waitForFixtureCommandPrefix(transport, "kata-set-param maxVisits 800", 1, TimeUnit.SECONDS),
+          waitForFixtureCommandPrefix(
+              transport, "kata-set-param maxVisits 800", 1, TimeUnit.SECONDS),
           "the runtime participant must dispatch every captured parameter restore");
       assertInstanceOf(ReadBoardGmaSession.RestoringRuntime.class, sessionRef.get().state());
       assertNotNull(
@@ -3411,7 +3422,8 @@ class LeelazReadBoardGmaTest {
       invokeParseLine(engine, "play pass");
 
       assertTrue(
-          waitForFixtureCommandPrefix(transport, "kata-set-param maxVisits 800", 1, TimeUnit.SECONDS));
+          waitForFixtureCommandPrefix(
+              transport, "kata-set-param maxVisits 800", 1, TimeUnit.SECONDS));
       assertInstanceOf(ReadBoardGmaSession.RestoringRuntime.class, sessionRef.get().state());
       String staleAck = successResponseFor(transport.rawCommands(), "maxTime");
       Object staleBinding = replaceReaderStreamBinding(engine);
@@ -3746,7 +3758,8 @@ class LeelazReadBoardGmaTest {
       invokeParseLine(engine, "play pass");
 
       assertTrue(
-          waitForFixtureCommandPrefix(transport, "kata-set-param maxVisits 800", 1, TimeUnit.SECONDS),
+          waitForFixtureCommandPrefix(
+              transport, "kata-set-param maxVisits 800", 1, TimeUnit.SECONDS),
           "the runtime participant must dispatch its restore commands");
 
       ReadBoardGmaSession.Terminal terminal = awaitGmaSessionTerminal(sessionRef);
@@ -4010,17 +4023,20 @@ class LeelazReadBoardGmaTest {
     Class<?> bindingClass = current.getClass();
     Field stdout = bindingClass.getDeclaredField("stdout");
     Field stderr = bindingClass.getDeclaredField("stderr");
+    Field output = bindingClass.getDeclaredField("output");
     Field process = bindingClass.getDeclaredField("process");
     Field remoteTransport = bindingClass.getDeclaredField("remoteTransport");
     Field javaSSH = bindingClass.getDeclaredField("javaSSH");
     Field incarnation = bindingClass.getDeclaredField("incarnation");
-    for (Field field : List.of(stdout, stderr, process, remoteTransport, javaSSH, incarnation)) {
+    for (Field field :
+        List.of(stdout, stderr, output, process, remoteTransport, javaSSH, incarnation)) {
       field.setAccessible(true);
     }
     java.lang.reflect.Constructor<?> constructor =
         bindingClass.getDeclaredConstructor(
             stdout.getType(),
             stderr.getType(),
+            output.getType(),
             process.getType(),
             remoteTransport.getType(),
             javaSSH.getType(),
@@ -4030,6 +4046,7 @@ class LeelazReadBoardGmaTest {
         constructor.newInstance(
             stdout.get(current),
             stderr.get(current),
+            output.get(current),
             process.get(current),
             remoteTransport.get(current),
             javaSSH.get(current),
@@ -4528,7 +4545,8 @@ class LeelazReadBoardGmaTest {
             + output.commands());
     assertTrue(
         output.commands().stream().anyMatch(command -> command.startsWith("kata-genmove_analyze ")),
-        "the admitted session must send the genmove only after the acknowledged preparation; commands="
+        "the admitted session must send the genmove only after the acknowledged preparation;"
+            + " commands="
             + output.commands());
     return session;
   }
@@ -4547,11 +4565,14 @@ class LeelazReadBoardGmaTest {
     assertTrue(
         waitForFixtureCommandPrefix(transport, "kata-set-param maxTime 2", 1, TimeUnit.SECONDS));
     assertTrue(
-        waitForFixtureCommandPrefix(transport, "kata-set-param maxVisits 800", 1, TimeUnit.SECONDS));
+        waitForFixtureCommandPrefix(
+            transport, "kata-set-param maxVisits 800", 1, TimeUnit.SECONDS));
     invokeProcessCommandResponseLine(
         engine, successResponseFor(transport.rawCommands(), "ponderingEnabled"));
-    invokeProcessCommandResponseLine(engine, successResponseFor(transport.rawCommands(), "maxTime"));
-    invokeProcessCommandResponseLine(engine, successResponseFor(transport.rawCommands(), "maxVisits"));
+    invokeProcessCommandResponseLine(
+        engine, successResponseFor(transport.rawCommands(), "maxTime"));
+    invokeProcessCommandResponseLine(
+        engine, successResponseFor(transport.rawCommands(), "maxVisits"));
   }
 
   private static ReadBoardGmaSession.Terminal awaitGmaSessionTerminal(

--- a/src/test/java/featurecat/lizzie/analysis/gtpconfig/GtpConfigurationProbeTest.java
+++ b/src/test/java/featurecat/lizzie/analysis/gtpconfig/GtpConfigurationProbeTest.java
@@ -6,26 +6,45 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import featurecat.lizzie.analysis.AnalysisResourceCoordinator;
+import featurecat.lizzie.analysis.AnalysisResourceCoordinatorTestAccess;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.PrintWriter;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardWatchEventKinds;
+import java.nio.file.WatchEvent;
+import java.nio.file.WatchKey;
+import java.nio.file.WatchService;
 import java.time.Duration;
+import java.time.Instant;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Queue;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 import org.json.JSONObject;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 class GtpConfigurationProbeTest {
+  private static final long REAL_PROCESS_HANDSHAKE_TIMEOUT_SECONDS = 10L;
+
+  @TempDir Path tempDir;
+
   @Test
   void reportsUnsupportedEngineWithoutRequestingSchema() throws Exception {
     ScriptedFactory factory = new ScriptedFactory(response(true, "false"));
@@ -145,36 +164,297 @@ class GtpConfigurationProbeTest {
 
   @Test
   void realProbeChildParticipatesInLocalComputeIsolationRegistry() throws Exception {
+    assertTrue(
+        awaitRawRegistryEmpty(REAL_PROCESS_HANDSHAKE_TIMEOUT_SECONDS, TimeUnit.SECONDS),
+        "the real-process registry test requires an isolated raw zero-process baseline");
+    Path schemaGate = tempDir.resolve("probe-registry-schema-gate");
+    Path childPid = childPidPath(schemaGate);
     GtpConfigurationProbe probe = new GtpConfigurationProbe();
     ExecutorService executor = Executors.newSingleThreadExecutor();
-    Future<?> worker =
-        executor.submit(
-            () -> {
-              try {
-                probe.inspect(fakeEngineCommand(true), Duration.ofSeconds(5));
-              } catch (IOException expected) {
-                // Cancellation closes and terminates the deliberately blocked probe child.
-              }
-            });
-    try {
-      long registrationDeadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(2);
-      while (!AnalysisResourceCoordinator.hasActiveLocalComputeProcess()
-          && System.nanoTime() < registrationDeadline) {
-        Thread.sleep(10L);
-      }
-      assertTrue(AnalysisResourceCoordinator.hasActiveLocalComputeProcess());
+    CountDownLatch workerFinished = new CountDownLatch(1);
+    AtomicBoolean workerStarted = new AtomicBoolean(false);
+    AtomicReference<Throwable> workerFailure = new AtomicReference<>();
+    Future<?> worker = null;
+    ProcessHandle child = null;
+    try (WatchService gateWatcher = FileSystems.getDefault().newWatchService()) {
+      tempDir.register(gateWatcher, StandardWatchEventKinds.ENTRY_CREATE);
+      worker =
+          executor.submit(
+              () -> {
+                workerStarted.set(true);
+                try {
+                  probe.inspect(
+                      fakeEngineCommand(schemaGate),
+                      Duration.ofSeconds(REAL_PROCESS_HANDSHAKE_TIMEOUT_SECONDS));
+                } catch (Throwable failure) {
+                  workerFailure.set(failure);
+                } finally {
+                  workerFinished.countDown();
+                }
+              });
+      awaitSchemaGate(gateWatcher, schemaGate);
+      child = requireVerifiedGatedChild(childPid, schemaGate);
+
+      assertTrue(child.isAlive(), "the schema gate must hold the real probe child open");
+      assertEquals(
+          1,
+          AnalysisResourceCoordinatorTestAccess.rawLocalComputeProcessCount(),
+          "the probe must be present in the raw registry at its schema gate");
+
+      assertTrue(worker.cancel(true), "the gated probe worker must accept cancellation");
+      Future<?> cancelledWorker = worker;
+      assertThrows(CancellationException.class, cancelledWorker::get);
+      assertTrue(
+          workerFinished.await(REAL_PROCESS_HANDSHAKE_TIMEOUT_SECONDS, TimeUnit.SECONDS),
+          "the cancelled probe worker must finish its ProcessSession.close path");
+      Throwable cancellationFailure = workerFailure.get();
+      assertTrue(
+          cancellationFailure instanceof IOException
+              && cancellationFailure.getMessage() != null
+              && cancellationFailure.getMessage().contains("Interrupted"),
+          "cancellation must interrupt the blocked probe request");
+      assertTrue(
+          awaitExactChildExit(child, REAL_PROCESS_HANDSHAKE_TIMEOUT_SECONDS, TimeUnit.SECONDS),
+          "the cancelled probe must terminate its exact child without test-side process killing");
+      assertTrue(
+          awaitRawRegistryEmpty(REAL_PROCESS_HANDSHAKE_TIMEOUT_SECONDS, TimeUnit.SECONDS),
+          "processStopped/onExit must remove the child from the raw registry before test cleanup");
     } finally {
-      worker.cancel(true);
-      executor.shutdownNow();
-      executor.awaitTermination(2, TimeUnit.SECONDS);
+      cleanupRealProbeChild(
+          schemaGate, childPid, worker, workerStarted, workerFinished, child, executor);
     }
 
-    long shutdownDeadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(2);
-    while (AnalysisResourceCoordinator.hasActiveLocalComputeProcess()
-        && System.nanoTime() < shutdownDeadline) {
+    assertEquals(
+        0,
+        AnalysisResourceCoordinatorTestAccess.rawLocalComputeProcessCount(),
+        "the raw registry must remain empty after the cancelled child has exited");
+    assertFalse(
+        AnalysisResourceCoordinator.hasActiveLocalComputeProcess(),
+        "the registry must be empty after the cancelled child has exited");
+  }
+
+  private static void cleanupRealProbeChild(
+      Path schemaGate,
+      Path childPid,
+      Future<?> worker,
+      AtomicBoolean workerStarted,
+      CountDownLatch workerFinished,
+      ProcessHandle capturedChild,
+      ExecutorService executor)
+      throws Exception {
+    CleanupState cleanup = new CleanupState();
+    ProcessHandle exactChild = capturedChild;
+    if (exactChild == null) {
+      try {
+        exactChild = findVerifiedGatedChild(childPid, schemaGate);
+      } catch (Exception pidFailure) {
+        cleanup.record(pidFailure);
+      }
+    }
+    cleanup.run(() -> Files.deleteIfExists(schemaGate));
+    cleanup.run(
+        () -> {
+          if (worker != null) {
+            worker.cancel(true);
+          }
+        });
+    if (workerStarted.get()) {
+      cleanup.call(() -> workerFinished.await(2L, TimeUnit.SECONDS));
+    }
+
+    ProcessHandle verifiedChild = exactChild;
+    if (verifiedChild != null && cleanup.call(verifiedChild::isAlive)) {
+      cleanup.run(() -> verifiedChild.destroy());
+      boolean childExited =
+          cleanup.call(() -> awaitExactChildExit(verifiedChild, 2L, TimeUnit.SECONDS));
+      if (!childExited) {
+        cleanup.run(() -> verifiedChild.destroyForcibly());
+        childExited =
+            cleanup.call(
+                () ->
+                    awaitExactChildExit(
+                        verifiedChild, REAL_PROCESS_HANDSHAKE_TIMEOUT_SECONDS, TimeUnit.SECONDS));
+      }
+      cleanup.require(childExited, "the exact gated probe child survived forced cleanup");
+    }
+
+    if (workerStarted.get() && workerFinished.getCount() != 0L) {
+      cleanup.require(
+          cleanup.call(
+              () -> workerFinished.await(REAL_PROCESS_HANDSHAKE_TIMEOUT_SECONDS, TimeUnit.SECONDS)),
+          "the cancelled real probe worker did not terminate");
+    }
+
+    cleanup.run(() -> executor.shutdownNow());
+    cleanup.require(
+        cleanup.call(
+            () ->
+                executor.awaitTermination(
+                    REAL_PROCESS_HANDSHAKE_TIMEOUT_SECONDS, TimeUnit.SECONDS)),
+        "the real probe executor did not terminate during cleanup");
+    cleanup.run(() -> Files.deleteIfExists(schemaGate));
+    cleanup.run(() -> Files.deleteIfExists(childPid));
+
+    boolean rawRegistryEmpty =
+        cleanup.call(
+            () -> awaitRawRegistryEmpty(REAL_PROCESS_HANDSHAKE_TIMEOUT_SECONDS, TimeUnit.SECONDS));
+    cleanup.require(
+        rawRegistryEmpty,
+        "the real probe raw registry remained populated after exact-child cleanup");
+    if (!rawRegistryEmpty) {
+      cleanup.run(() -> AnalysisResourceCoordinator.hasActiveLocalComputeProcess());
+    }
+    cleanup.finish();
+  }
+
+  private static ProcessHandle requireVerifiedGatedChild(Path childPid, Path schemaGate)
+      throws IOException {
+    ProcessHandle child = findVerifiedGatedChild(childPid, schemaGate);
+    if (child == null) {
+      throw new AssertionError("the gated probe identity did not match its live child");
+    }
+    return child;
+  }
+
+  private static ProcessHandle findVerifiedGatedChild(Path childPid, Path schemaGate)
+      throws IOException {
+    if (!Files.exists(schemaGate) || !Files.isRegularFile(childPid)) {
+      return null;
+    }
+    List<String> identity = Files.readAllLines(childPid, StandardCharsets.UTF_8);
+    if (identity.size() != 4
+        || !FakeGtpEngine.class.getName().equals(identity.get(2))
+        || !schemaGate.toAbsolutePath().toString().equals(identity.get(3))) {
+      return null;
+    }
+    long pid;
+    Instant expectedStart;
+    try {
+      pid = Long.parseLong(identity.get(0));
+      expectedStart = Instant.parse(identity.get(1));
+    } catch (RuntimeException invalidIdentity) {
+      return null;
+    }
+    ProcessHandle child = ProcessHandle.of(pid).orElse(null);
+    return child != null
+            && child.isAlive()
+            && child.info().startInstant().filter(expectedStart::equals).isPresent()
+        ? child
+        : null;
+  }
+
+  private static boolean awaitRawRegistryEmpty(long timeout, TimeUnit unit)
+      throws InterruptedException {
+    long deadline = System.nanoTime() + unit.toNanos(timeout);
+    while (AnalysisResourceCoordinatorTestAccess.rawLocalComputeProcessCount() != 0
+        && System.nanoTime() < deadline) {
       Thread.sleep(10L);
     }
-    assertFalse(AnalysisResourceCoordinator.hasActiveLocalComputeProcess());
+    return AnalysisResourceCoordinatorTestAccess.rawLocalComputeProcessCount() == 0;
+  }
+
+  private static boolean awaitExactChildExit(ProcessHandle child, long timeout, TimeUnit unit)
+      throws InterruptedException {
+    if (child == null || !child.isAlive()) {
+      return true;
+    }
+    try {
+      child.onExit().get(timeout, unit);
+    } catch (ExecutionException | TimeoutException failure) {
+      return !child.isAlive();
+    }
+    return !child.isAlive();
+  }
+
+  private static void awaitSchemaGate(WatchService watcher, Path schemaGate)
+      throws InterruptedException {
+    long deadline =
+        System.nanoTime() + TimeUnit.SECONDS.toNanos(REAL_PROCESS_HANDSHAKE_TIMEOUT_SECONDS);
+    while (!Files.exists(schemaGate)) {
+      long remaining = deadline - System.nanoTime();
+      if (remaining <= 0L) {
+        break;
+      }
+      WatchKey key = watcher.poll(remaining, TimeUnit.NANOSECONDS);
+      if (key == null) {
+        break;
+      }
+      for (WatchEvent<?> event : key.pollEvents()) {
+        if (event.kind() == StandardWatchEventKinds.ENTRY_CREATE
+            && schemaGate.getFileName().equals(event.context())) {
+          return;
+        }
+      }
+      if (!key.reset()) {
+        break;
+      }
+    }
+    assertTrue(Files.exists(schemaGate), "the real probe child never reached its schema gate");
+  }
+
+  private static Path childPidPath(Path schemaGate) {
+    return schemaGate.resolveSibling(schemaGate.getFileName() + ".pid");
+  }
+
+  @FunctionalInterface
+  private interface CleanupAction {
+    void run() throws Exception;
+  }
+
+  @FunctionalInterface
+  private interface CleanupCondition {
+    boolean test() throws Exception;
+  }
+
+  private static final class CleanupState {
+    private Throwable failure;
+    private boolean interrupted;
+
+    private void run(CleanupAction action) {
+      call(
+          () -> {
+            action.run();
+            return true;
+          });
+    }
+
+    private boolean call(CleanupCondition condition) {
+      try {
+        return condition.test();
+      } catch (InterruptedException interruption) {
+        interrupted = true;
+        record(interruption);
+      } catch (Exception cleanupFailure) {
+        record(cleanupFailure);
+      }
+      return false;
+    }
+
+    private void require(boolean satisfied, String message) {
+      if (!satisfied) {
+        record(new AssertionError(message));
+      }
+    }
+
+    private void record(Throwable next) {
+      if (failure == null) {
+        failure = next;
+      } else {
+        failure.addSuppressed(next);
+      }
+    }
+
+    private void finish() throws Exception {
+      if (interrupted) {
+        Thread.currentThread().interrupt();
+      }
+      if (failure instanceof Exception exception) {
+        throw exception;
+      }
+      if (failure instanceof Error error) {
+        throw error;
+      }
+    }
   }
 
   private static String fakeEngineCommand(boolean hangOnSchema) {
@@ -192,6 +472,10 @@ class GtpConfigurationProbeTest {
         + " "
         + FakeGtpEngine.class.getName()
         + (hangOnSchema ? " hang" : "");
+  }
+
+  private static String fakeEngineCommand(Path schemaGate) {
+    return fakeEngineCommand(false) + " gate " + quote(schemaGate.toAbsolutePath().toString());
   }
 
   private static String quote(String value) {
@@ -256,6 +540,7 @@ class GtpConfigurationProbeTest {
 
     public static void main(String[] args) throws Exception {
       boolean hangOnSchema = args.length > 0 && "hang".equals(args[0]);
+      Path schemaGate = args.length > 1 && "gate".equals(args[0]) ? Path.of(args[1]) : null;
       String profile = "{}";
       try (BufferedReader input =
               new BufferedReader(new InputStreamReader(System.in, StandardCharsets.UTF_8));
@@ -277,6 +562,31 @@ class GtpConfigurationProbeTest {
             if (hangOnSchema) {
               Thread.sleep(10_000);
             } else {
+              if (schemaGate != null) {
+                Path childPid =
+                    schemaGate.resolveSibling(schemaGate.getFileName().toString() + ".pid");
+                ProcessHandle current = ProcessHandle.current();
+                Instant start =
+                    current
+                        .info()
+                        .startInstant()
+                        .orElseThrow(
+                            () ->
+                                new IllegalStateException(
+                                    "The child start instant is unavailable"));
+                Files.write(
+                    childPid,
+                    List.of(
+                        Long.toString(current.pid()),
+                        start.toString(),
+                        FakeGtpEngine.class.getName(),
+                        schemaGate.toAbsolutePath().toString()),
+                    StandardCharsets.UTF_8);
+                Files.createFile(schemaGate);
+                while (Files.exists(schemaGate)) {
+                  Thread.sleep(10L);
+                }
+              }
               respond(output, id, SCHEMA);
             }
           } else if (command.startsWith("zengtp_config_set ")) {


### PR DESCRIPTION
## Summary

- restore macOS PKCS#12 import with a private `certificate.p12`, explicit `-f pkcs12`, and Bash 3.2-safe early cleanup
- allow only bounded initial GitHub Actions run-metadata convergence while retaining exact SHA/title checks and fail-closed post-verification
- release automatic-restart endpoint claims before notifying external completion observers, isolate observer failures, and cover success/failure/no-fence paths
- bind reader streams, command output, transports, processes, and executor pools to the exact engine incarnation so stale exits cannot overwrite or close a replacement
- make local force-quit escalate a prior graceful close, keep SSH/remote close-once, and preserve diagnostics registration by exact PID
- replace Windows timing guesses in process fixtures with causal PID/start-instant/gate handshakes and fail-closed cleanup

## Root causes fixed

The failed `next-2026-08-19.1` candidate stayed draft because both macOS jobs could not infer the PKCS#12 format after the hardened certificate path lost its suffix; cleanup then hit Bash 3.2 `nounset` on empty arrays. The publisher also needed a short bounded window for newly dispatched workflow identity metadata to converge.

The Windows CI failure exposed a completion callback firing before lifecycle claims were released. Deeper testing found reader executors and transports were engine-global, allowing stale-generation shutdown, submit/quit races, and leaked pools. The new per-binding ownership and exact teardown rules close those races.

## Verification

- Windows full suite: **2467 run / 2459 passed / 8 skipped / 0 failures / 0 errors**
- Python release suite: **170 run / 167 passed / 3 platform skips / 0 failures**
- formatted-test recheck: **111/111 passed**
- line-ending policy, local Markdown links, Java formatting of changed hunks, and `git diff --check`: pass
- final shaded JAR: **20,978,114 bytes**, SHA-256 `0360E75F75B4F0E11942DC4503317957E69BF4FA4E78DC9F30A6423948B61671`
- Windows 4K/150% isolated GUI:
  - 10B→11B immediately showed 11B “使用中”; a 100 ms repeat click did not create a duplicate process
  - GTP became ready in about 31.0 s; badge, title, and model path stayed consistent
  - switch-back, normal exit, and restart persistence passed
  - the engine-failure dialog stayed bounded/scrollable and both UI and `dignostic.bat` contained only `password=<redacted>`
  - configuration and TRT cache were byte-restored; isolated processes ended at zero; the user's original four processes were unchanged

The real engine became ready before 35 seconds, so the “still pending at 35 s” branch is covered by deterministic automation rather than artificial process suspension or cache eviction.

The incomplete `.1` draft remains unpublished and is not reused.