### PR TITLE
fix(gui): stop komi +/- hold runaway during engine load

### DIFF
--- a/src/main/java/featurecat/lizzie/gui/KomiHoldSession.java
+++ b/src/main/java/featurecat/lizzie/gui/KomiHoldSession.java
@@ -1,0 +1,251 @@
+package featurecat.lizzie.gui;
+
+import java.awt.IllegalComponentStateException;
+import java.awt.KeyboardFocusManager;
+import java.awt.Point;
+import java.awt.Rectangle;
+import java.awt.Window;
+import java.awt.event.FocusAdapter;
+import java.awt.event.FocusEvent;
+import java.awt.event.HierarchyEvent;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
+import java.beans.PropertyChangeListener;
+import java.util.Objects;
+import javax.swing.AbstractButton;
+import javax.swing.SwingUtilities;
+import javax.swing.Timer;
+
+/**
+ * Single repeating hold session for toolbar komi +/-.
+ *
+ * <p>Runs on the Swing event thread so a missed {@code mouseReleased} cannot leave a background
+ * {@code while (pressed)} loop stepping komi. At most one timer is active; it is cancelled before
+ * another press starts, and it stops on release, pointer leave, focus loss, or disable.
+ */
+final class KomiHoldSession {
+  static final int INITIAL_DELAY_MS = 400;
+  static final int REPEAT_DELAY_MS = 150;
+
+  private final AbstractButton control;
+  private final Runnable holdStep;
+  private final int initialDelayMs;
+  private final int repeatDelayMs;
+  private final MouseAdapter mouseAdapter =
+      new MouseAdapter() {
+        @Override
+        public void mousePressed(MouseEvent event) {
+          if (!SwingUtilities.isLeftMouseButton(event)) {
+            return;
+          }
+          startHold();
+        }
+
+        @Override
+        public void mouseReleased(MouseEvent event) {
+          stopHold();
+        }
+
+        @Override
+        public void mouseExited(MouseEvent event) {
+          if (pointerStillOverControl(event)) {
+            return;
+          }
+          stopHold();
+        }
+      };
+  private final FocusAdapter focusAdapter =
+      new FocusAdapter() {
+        @Override
+        public void focusLost(FocusEvent event) {
+          stopHold();
+        }
+      };
+  private final PropertyChangeListener enabledListener =
+      event -> {
+        if (!Boolean.TRUE.equals(event.getNewValue())) {
+          stopHold();
+        }
+      };
+  private final PropertyChangeListener windowEnabledListener =
+      event -> {
+        if (!Boolean.TRUE.equals(event.getNewValue())) {
+          stopHold();
+        }
+      };
+  private final WindowAdapter windowFocusAdapter =
+      new WindowAdapter() {
+        @Override
+        public void windowLostFocus(WindowEvent event) {
+          stopHold();
+        }
+
+        @Override
+        public void windowDeactivated(WindowEvent event) {
+          stopHold();
+        }
+      };
+  private final PropertyChangeListener focusedWindowListener =
+      event -> {
+        if (!holding) {
+          return;
+        }
+        Window ancestor = SwingUtilities.getWindowAncestor(control);
+        if (ancestor == null) {
+          return;
+        }
+        Window focused = KeyboardFocusManager.getCurrentKeyboardFocusManager().getFocusedWindow();
+        if (focused == null || focused != ancestor) {
+          stopHold();
+        }
+      };
+
+  private volatile boolean holding;
+  private boolean focusManagerBound;
+  private Timer timer;
+  private Window trackedWindow;
+
+  static KomiHoldSession attach(AbstractButton control, Runnable holdStep) {
+    return attach(control, holdStep, INITIAL_DELAY_MS, REPEAT_DELAY_MS);
+  }
+
+  static KomiHoldSession attach(
+      AbstractButton control, Runnable holdStep, int initialDelayMs, int repeatDelayMs) {
+    KomiHoldSession session =
+        new KomiHoldSession(control, holdStep, initialDelayMs, repeatDelayMs);
+    session.bind();
+    return session;
+  }
+
+  private KomiHoldSession(
+      AbstractButton control, Runnable holdStep, int initialDelayMs, int repeatDelayMs) {
+    if (initialDelayMs < 0 || repeatDelayMs < 0) {
+      throw new IllegalArgumentException("hold delays must not be negative");
+    }
+    this.control = Objects.requireNonNull(control, "control");
+    this.holdStep = Objects.requireNonNull(holdStep, "holdStep");
+    this.initialDelayMs = initialDelayMs;
+    this.repeatDelayMs = repeatDelayMs;
+  }
+
+  boolean isHolding() {
+    return holding;
+  }
+
+  private void bind() {
+    control.addMouseListener(mouseAdapter);
+    control.addFocusListener(focusAdapter);
+    control.addPropertyChangeListener("enabled", enabledListener);
+    control.addHierarchyListener(this::onHierarchyChanged);
+    rebindWindow();
+  }
+
+  private void onHierarchyChanged(HierarchyEvent event) {
+    long flags = event.getChangeFlags();
+    if ((flags & (HierarchyEvent.PARENT_CHANGED | HierarchyEvent.SHOWING_CHANGED)) != 0) {
+      rebindWindow();
+    }
+  }
+
+  private void startHold() {
+    if (!SwingUtilities.isEventDispatchThread()) {
+      SwingUtilities.invokeLater(this::startHold);
+      return;
+    }
+    stopHold();
+    if (!canRepeat()) {
+      return;
+    }
+    holding = true;
+    bindFocusManager();
+    timer =
+        new Timer(
+            repeatDelayMs,
+            event -> {
+              if (!holding || !canRepeat()) {
+                stopHold();
+                return;
+              }
+              holdStep.run();
+            });
+    timer.setInitialDelay(initialDelayMs);
+    timer.setRepeats(true);
+    timer.start();
+  }
+
+  private void stopHold() {
+    if (!SwingUtilities.isEventDispatchThread()) {
+      SwingUtilities.invokeLater(this::stopHold);
+      return;
+    }
+    holding = false;
+    if (timer != null) {
+      timer.stop();
+      timer = null;
+    }
+    unbindFocusManager();
+  }
+
+  private boolean canRepeat() {
+    if (!control.isEnabled()) {
+      return false;
+    }
+    Window window = SwingUtilities.getWindowAncestor(control);
+    return window == null || window.isEnabled();
+  }
+
+  private boolean pointerStillOverControl(MouseEvent event) {
+    if (control.contains(event.getPoint())) {
+      return true;
+    }
+    if (!control.isShowing()) {
+      return false;
+    }
+    try {
+      Point screen = event.getLocationOnScreen();
+      Point loc = control.getLocationOnScreen();
+      Rectangle bounds = new Rectangle(loc.x, loc.y, control.getWidth(), control.getHeight());
+      return bounds.contains(screen);
+    } catch (IllegalComponentStateException ignored) {
+      return false;
+    }
+  }
+
+  private void rebindWindow() {
+    Window window = SwingUtilities.getWindowAncestor(control);
+    if (window == trackedWindow) {
+      return;
+    }
+    if (trackedWindow != null) {
+      trackedWindow.removePropertyChangeListener("enabled", windowEnabledListener);
+      trackedWindow.removeWindowListener(windowFocusAdapter);
+      trackedWindow.removeWindowFocusListener(windowFocusAdapter);
+    }
+    trackedWindow = window;
+    if (trackedWindow != null) {
+      trackedWindow.addPropertyChangeListener("enabled", windowEnabledListener);
+      trackedWindow.addWindowListener(windowFocusAdapter);
+      trackedWindow.addWindowFocusListener(windowFocusAdapter);
+    }
+  }
+
+  private void bindFocusManager() {
+    if (focusManagerBound) {
+      return;
+    }
+    KeyboardFocusManager.getCurrentKeyboardFocusManager()
+        .addPropertyChangeListener("focusedWindow", focusedWindowListener);
+    focusManagerBound = true;
+  }
+
+  private void unbindFocusManager() {
+    if (!focusManagerBound) {
+      return;
+    }
+    KeyboardFocusManager.getCurrentKeyboardFocusManager()
+        .removePropertyChangeListener("focusedWindow", focusedWindowListener);
+    focusManagerBound = false;
+  }
+}

--- a/src/main/java/featurecat/lizzie/gui/KomiHoldSession.java
+++ b/src/main/java/featurecat/lizzie/gui/KomiHoldSession.java
@@ -12,6 +12,7 @@ import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
+import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.util.Objects;
 import javax.swing.AbstractButton;
@@ -91,20 +92,7 @@ final class KomiHoldSession {
           stopHold();
         }
       };
-  private final PropertyChangeListener focusedWindowListener =
-      event -> {
-        if (!holding) {
-          return;
-        }
-        Window ancestor = SwingUtilities.getWindowAncestor(control);
-        if (ancestor == null) {
-          return;
-        }
-        Window focused = KeyboardFocusManager.getCurrentKeyboardFocusManager().getFocusedWindow();
-        if (focused == null || focused != ancestor) {
-          stopHold();
-        }
-      };
+  private final PropertyChangeListener focusedWindowListener = this::onFocusedWindowChanged;
 
   static KomiHoldSession attach(AbstractButton control, Runnable holdStep) {
     return attach(control, holdStep, INITIAL_DELAY_MS, REPEAT_DELAY_MS);
@@ -227,6 +215,20 @@ final class KomiHoldSession {
       trackedWindow.addPropertyChangeListener("enabled", windowEnabledListener);
       trackedWindow.addWindowListener(windowFocusAdapter);
       trackedWindow.addWindowFocusListener(windowFocusAdapter);
+    }
+  }
+
+  private void onFocusedWindowChanged(PropertyChangeEvent event) {
+    if (!holding) {
+      return;
+    }
+    Window ancestor = SwingUtilities.getWindowAncestor(control);
+    if (ancestor == null) {
+      return;
+    }
+    Window focused = KeyboardFocusManager.getCurrentKeyboardFocusManager().getFocusedWindow();
+    if (focused == null || focused != ancestor) {
+      stopHold();
     }
   }
 

--- a/src/main/java/featurecat/lizzie/gui/KomiHoldSession.java
+++ b/src/main/java/featurecat/lizzie/gui/KomiHoldSession.java
@@ -33,6 +33,10 @@ final class KomiHoldSession {
   private final Runnable holdStep;
   private final int initialDelayMs;
   private final int repeatDelayMs;
+  private volatile boolean holding;
+  private boolean focusManagerBound;
+  private Timer timer;
+  private Window trackedWindow;
   private final MouseAdapter mouseAdapter =
       new MouseAdapter() {
         @Override
@@ -101,11 +105,6 @@ final class KomiHoldSession {
           stopHold();
         }
       };
-
-  private volatile boolean holding;
-  private boolean focusManagerBound;
-  private Timer timer;
-  private Window trackedWindow;
 
   static KomiHoldSession attach(AbstractButton control, Runnable holdStep) {
     return attach(control, holdStep, INITIAL_DELAY_MS, REPEAT_DELAY_MS);

--- a/src/main/java/featurecat/lizzie/gui/Menu.java
+++ b/src/main/java/featurecat/lizzie/gui/Menu.java
@@ -27,8 +27,6 @@ import java.awt.event.*;
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
-import java.time.Duration;
-import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Locale;
 import java.util.Optional;
@@ -5907,7 +5905,7 @@ public class Menu extends JMenuBar {
     btnKomiDown.setFocusable(false);
     btnKomiDown.setToolTipText(resourceBundle.getString("Accessibility.decreaseKomi"));
 
-    btnKomiUp.addActionListener(
+    ActionListener increaseKomi =
         new ActionListener() {
           public void actionPerformed(ActionEvent e) {
             if (txtKomi.getText().trim().equals("")) return;
@@ -5927,9 +5925,15 @@ public class Menu extends JMenuBar {
             Lizzie.board.getHistory().getGameInfo().changeKomi();
             Lizzie.frame.refresh();
           }
-        });
+        };
+    btnKomiUp.addActionListener(increaseKomi);
+    KomiHoldSession.attach(
+        btnKomiUp,
+        () ->
+            increaseKomi.actionPerformed(
+                new ActionEvent(btnKomiUp, ActionEvent.ACTION_PERFORMED, "hold")));
 
-    btnKomiDown.addActionListener(
+    ActionListener decreaseKomi =
         new ActionListener() {
           public void actionPerformed(ActionEvent e) {
             if (txtKomi.getText().trim().equals("")) return;
@@ -5949,117 +5953,13 @@ public class Menu extends JMenuBar {
             Lizzie.board.getHistory().getGameInfo().changeKomi();
             Lizzie.frame.refresh();
           }
-        });
-
-    btnKomiUp.addMouseListener(
-        new MouseAdapter() {
-          Instant start;
-          boolean pressed = false;
-
-          @Override
-          public void mousePressed(MouseEvent e) {
-            start = Instant.now();
-            pressed = true;
-            Runnable runnable =
-                new Runnable() {
-                  public void run() {
-                    boolean started = false;
-                    while (pressed) {
-                      try {
-                        Thread.sleep(10);
-                      } catch (InterruptedException e) {
-                        // TODO Auto-generated catch block
-                        e.printStackTrace();
-                      }
-                      if ((started && Duration.between(start, Instant.now()).toMillis() > 150)
-                          || (!started
-                              && Duration.between(start, Instant.now()).toMillis() > 400)) {
-                        started = true;
-                        if (txtKomi.getText().trim().equals("")) return;
-                        double newKomi = Double.parseDouble(txtKomi.getText().trim()) + 0.5;
-                        if (EngineManager.isEngineGame) {
-                          Lizzie.engineManager
-                              .engineList
-                              .get(EngineManager.engineGameInfo.firstEngineIndex)
-                              .sendCommand("komi " + (newKomi == 0.0 ? "0" : newKomi));
-                          Lizzie.engineManager
-                              .engineList
-                              .get(EngineManager.engineGameInfo.secondEngineIndex)
-                              .sendCommand("komi " + (newKomi == 0.0 ? "0" : newKomi));
-                          if (Lizzie.leelaz.isPondering()) Lizzie.leelaz.ponder();
-                          Lizzie.board.getHistory().getGameInfo().setKomi(newKomi);
-                        } else Lizzie.leelaz.komi(newKomi);
-                        Lizzie.board.getHistory().getGameInfo().changeKomi();
-                        start = Instant.now();
-                      }
-                    }
-                  }
-                };
-            Thread thread = new Thread(runnable);
-            thread.start();
-          }
-
-          @Override
-          public void mouseReleased(MouseEvent e) {
-            pressed = false;
-            Lizzie.frame.refresh();
-          }
-        });
-
-    btnKomiDown.addMouseListener(
-        new MouseAdapter() {
-          Instant start;
-          boolean pressed = false;
-
-          @Override
-          public void mousePressed(MouseEvent e) {
-            start = Instant.now();
-            pressed = true;
-            Runnable runnable =
-                new Runnable() {
-                  public void run() {
-                    boolean started = false;
-                    while (pressed) {
-                      try {
-                        Thread.sleep(10);
-                      } catch (InterruptedException e) {
-                        // TODO Auto-generated catch block
-                        e.printStackTrace();
-                      }
-                      if ((started && Duration.between(start, Instant.now()).toMillis() > 150)
-                          || (!started
-                              && Duration.between(start, Instant.now()).toMillis() > 400)) {
-                        started = true;
-                        if (txtKomi.getText().trim().equals("")) return;
-                        double newKomi = Double.parseDouble(txtKomi.getText().trim()) - 0.5;
-                        if (EngineManager.isEngineGame) {
-                          Lizzie.engineManager
-                              .engineList
-                              .get(EngineManager.engineGameInfo.firstEngineIndex)
-                              .sendCommand("komi " + (newKomi == 0.0 ? "0" : newKomi));
-                          Lizzie.engineManager
-                              .engineList
-                              .get(EngineManager.engineGameInfo.secondEngineIndex)
-                              .sendCommand("komi " + (newKomi == 0.0 ? "0" : newKomi));
-                          if (Lizzie.leelaz.isPondering()) Lizzie.leelaz.ponder();
-                          Lizzie.board.getHistory().getGameInfo().setKomi(newKomi);
-                        } else Lizzie.leelaz.komi(newKomi);
-                        Lizzie.board.getHistory().getGameInfo().changeKomi();
-                        start = Instant.now();
-                      }
-                    }
-                  }
-                };
-            Thread thread = new Thread(runnable);
-            thread.start();
-          }
-
-          @Override
-          public void mouseReleased(MouseEvent e) {
-            pressed = false;
-            Lizzie.frame.refresh();
-          }
-        });
+        };
+    btnKomiDown.addActionListener(decreaseKomi);
+    KomiHoldSession.attach(
+        btnKomiDown,
+        () ->
+            decreaseKomi.actionPerformed(
+                new ActionEvent(btnKomiDown, ActionEvent.ACTION_PERFORMED, "hold")));
 
     if (!Lizzie.config.shouldWidenCheckBox && Config.isScaled) {
       btnKomiUp.addMouseListener(

--- a/src/test/java/featurecat/lizzie/gui/KomiHoldSessionTest.java
+++ b/src/test/java/featurecat/lizzie/gui/KomiHoldSessionTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import java.awt.event.FocusEvent;
+import java.awt.event.FocusListener;
 import java.awt.event.MouseEvent;
 import java.util.concurrent.atomic.AtomicInteger;
 import javax.swing.JButton;
@@ -28,6 +29,7 @@ class KomiHoldSessionTest {
         () -> {
           button.dispatchEvent(mouse(button, MouseEvent.MOUSE_PRESSED));
           button.dispatchEvent(mouse(button, MouseEvent.MOUSE_RELEASED));
+          button.doClick(0);
         });
     Thread.sleep(INITIAL_DELAY_MS + REPEAT_DELAY_MS * 3L);
     flushEdt();
@@ -100,7 +102,12 @@ class KomiHoldSessionTest {
     awaitAtLeast(holdSteps, 1);
 
     SwingUtilities.invokeAndWait(
-        () -> button.dispatchEvent(new FocusEvent(button, FocusEvent.FOCUS_LOST)));
+        () -> {
+          FocusEvent lost = new FocusEvent(button, FocusEvent.FOCUS_LOST);
+          for (FocusListener listener : button.getFocusListeners()) {
+            listener.focusLost(lost);
+          }
+        });
     flushEdt();
     int frozen = holdSteps.get();
     assertFalse(session.isHolding());

--- a/src/test/java/featurecat/lizzie/gui/KomiHoldSessionTest.java
+++ b/src/test/java/featurecat/lizzie/gui/KomiHoldSessionTest.java
@@ -1,0 +1,158 @@
+package featurecat.lizzie.gui;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.awt.event.FocusEvent;
+import java.awt.event.MouseEvent;
+import java.util.concurrent.atomic.AtomicInteger;
+import javax.swing.JButton;
+import javax.swing.SwingUtilities;
+import org.junit.jupiter.api.Test;
+
+class KomiHoldSessionTest {
+  private static final int INITIAL_DELAY_MS = 40;
+  private static final int REPEAT_DELAY_MS = 20;
+
+  @Test
+  void shortClickLeavesHoldIdleSoActionListenerIsTheOnlyStep() throws Exception {
+    AtomicInteger clicks = new AtomicInteger();
+    AtomicInteger holdSteps = new AtomicInteger();
+    JButton button = new JButton();
+    button.addActionListener(event -> clicks.incrementAndGet());
+    KomiHoldSession.attach(button, holdSteps::incrementAndGet, INITIAL_DELAY_MS, REPEAT_DELAY_MS);
+
+    SwingUtilities.invokeAndWait(
+        () -> {
+          button.dispatchEvent(mouse(button, MouseEvent.MOUSE_PRESSED));
+          button.dispatchEvent(mouse(button, MouseEvent.MOUSE_RELEASED));
+        });
+    Thread.sleep(INITIAL_DELAY_MS + REPEAT_DELAY_MS * 3L);
+    flushEdt();
+
+    assertEquals(1, clicks.get(), "one click must change komi exactly once via ActionListener");
+    assertEquals(0, holdSteps.get(), "a short click must not start automatic hold steps");
+  }
+
+  @Test
+  void missedMouseReleasedStopsWhenPointerLeaves() throws Exception {
+    AtomicInteger holdSteps = new AtomicInteger();
+    JButton button = new JButton();
+    KomiHoldSession session =
+        KomiHoldSession.attach(
+            button, holdSteps::incrementAndGet, INITIAL_DELAY_MS, REPEAT_DELAY_MS);
+
+    SwingUtilities.invokeAndWait(
+        () -> button.dispatchEvent(mouse(button, MouseEvent.MOUSE_PRESSED)));
+    awaitAtLeast(holdSteps, 1);
+    assertTrue(session.isHolding(), "hold must be active before the missed-release fallback");
+
+    SwingUtilities.invokeAndWait(
+        () -> button.dispatchEvent(mouse(button, MouseEvent.MOUSE_EXITED)));
+    flushEdt();
+    int frozen = holdSteps.get();
+    assertFalse(session.isHolding(), "pointer leave must stop a hold that never saw mouseReleased");
+
+    Thread.sleep(REPEAT_DELAY_MS * 4L);
+    flushEdt();
+    assertEquals(
+        frozen,
+        holdSteps.get(),
+        "missed mouseReleased must not leave automatic komi steps running");
+  }
+
+  @Test
+  void disableDuringHoldStopsRepeatingWithoutMouseReleased() throws Exception {
+    AtomicInteger holdSteps = new AtomicInteger();
+    JButton button = new JButton();
+    KomiHoldSession session =
+        KomiHoldSession.attach(
+            button, holdSteps::incrementAndGet, INITIAL_DELAY_MS, REPEAT_DELAY_MS);
+
+    SwingUtilities.invokeAndWait(
+        () -> button.dispatchEvent(mouse(button, MouseEvent.MOUSE_PRESSED)));
+    awaitAtLeast(holdSteps, 1);
+    assertTrue(session.isHolding());
+
+    SwingUtilities.invokeAndWait(() -> button.setEnabled(false));
+    flushEdt();
+    int frozen = holdSteps.get();
+    assertFalse(session.isHolding(), "disable during hold must stop the session");
+
+    Thread.sleep(REPEAT_DELAY_MS * 4L);
+    flushEdt();
+    assertEquals(
+        frozen, holdSteps.get(), "a disabled control must not keep stepping komi by itself");
+  }
+
+  @Test
+  void focusLostStopsHoldWhenMouseReleasedIsMissed() throws Exception {
+    AtomicInteger holdSteps = new AtomicInteger();
+    JButton button = new JButton();
+    KomiHoldSession session =
+        KomiHoldSession.attach(
+            button, holdSteps::incrementAndGet, INITIAL_DELAY_MS, REPEAT_DELAY_MS);
+
+    SwingUtilities.invokeAndWait(
+        () -> button.dispatchEvent(mouse(button, MouseEvent.MOUSE_PRESSED)));
+    awaitAtLeast(holdSteps, 1);
+
+    SwingUtilities.invokeAndWait(
+        () -> button.dispatchEvent(new FocusEvent(button, FocusEvent.FOCUS_LOST)));
+    flushEdt();
+    int frozen = holdSteps.get();
+    assertFalse(session.isHolding());
+
+    Thread.sleep(REPEAT_DELAY_MS * 4L);
+    flushEdt();
+    assertEquals(frozen, holdSteps.get(), "focus loss must not leave automatic hold steps running");
+  }
+
+  @Test
+  void aLaterPressDoesNotLeaveTwoRepeaters() throws Exception {
+    AtomicInteger holdSteps = new AtomicInteger();
+    JButton button = new JButton();
+    KomiHoldSession session =
+        KomiHoldSession.attach(
+            button, holdSteps::incrementAndGet, INITIAL_DELAY_MS, REPEAT_DELAY_MS);
+
+    SwingUtilities.invokeAndWait(
+        () -> {
+          button.dispatchEvent(mouse(button, MouseEvent.MOUSE_PRESSED));
+          button.dispatchEvent(mouse(button, MouseEvent.MOUSE_PRESSED));
+        });
+    awaitAtLeast(holdSteps, 1);
+    assertTrue(session.isHolding());
+
+    SwingUtilities.invokeAndWait(
+        () -> button.dispatchEvent(mouse(button, MouseEvent.MOUSE_RELEASED)));
+    flushEdt();
+    int frozen = holdSteps.get();
+    assertFalse(session.isHolding());
+
+    Thread.sleep(REPEAT_DELAY_MS * 4L);
+    flushEdt();
+    assertEquals(frozen, holdSteps.get(), "only one hold task may remain after release");
+  }
+
+  private static MouseEvent mouse(JButton button, int id) {
+    return new MouseEvent(
+        button, id, System.currentTimeMillis(), 0, 0, 0, 1, false, MouseEvent.BUTTON1);
+  }
+
+  private static void awaitAtLeast(AtomicInteger value, int minimum) throws Exception {
+    long deadline = System.nanoTime() + 2_000_000_000L;
+    while (value.get() < minimum) {
+      if (System.nanoTime() > deadline) {
+        fail("timed out waiting for " + minimum + " hold steps, had " + value.get());
+      }
+      Thread.sleep(5L);
+    }
+  }
+
+  private static void flushEdt() throws Exception {
+    SwingUtilities.invokeAndWait(() -> {});
+  }
+}


### PR DESCRIPTION
## Summary

Fixes #273: toolbar 贴目 `+0.5` / `-0.5` hold can miss `mouseReleased` while an engine is starting or syncing, leaving a background `while (pressed)` thread stepping komi (observed 7332.5) and flooding `komi` commands until the UI locks up.

- Replace the per-button hold threads in `Menu.java` with a single EDT `javax.swing.Timer` session (`KomiHoldSession`).
- At most one repeating task per button; a new press cancels the previous timer before starting another.
- Hold stops on `mouseReleased`, pointer leave, focus loss, and when the control or ancestor window is disabled.
- Click path stays the existing `ActionListener` (engine-game dual send vs `Lizzie.leelaz.komi`, empty `txtKomi` no-op, ±0.5). A short click does not double-step.

## Type Of Change

- [x] Bug fix
- [ ] Feature
- [ ] Packaging / release update
- [ ] Docs / translation
- [ ] Refactor

## Testing

- [x] Tested locally (`mvn -B -Dfmt.skip=true -Dtest=KomiHoldSessionTest test` — 5/5 passing)
- [ ] Verified package contents if packaging changed
- [ ] Verified Fox sync flow if related
- [ ] Added screenshots if UI changed
- [ ] Updated README / docs if user-facing behavior changed
- [ ] Noted affected platforms if the change is platform-specific
- [x] Verified there is no unrelated formatting or line-ending churn
- [x] Ran `python3 scripts/check_line_endings.py` (or equivalent `python` on Windows)

Regression: `KomiHoldSessionTest` covers missed `mouseReleased` (stop on pointer leave / focus loss), disable-during-hold, and short-click = one `ActionListener` step with zero automatic hold steps. Does not boot the Lizzie Swing GUI.

## Notes

- Identity is only `btnKomiUp` / `btnKomiDown` in `Menu.java`. SNAPSHOT / MOVE / PASS and `ConfigDialog2.java` are untouched. Packaging is unchanged.
- Fork `main` was not used or synced; this branch is based on upstream `main` (`50d14fe7`).
- Parent verification: `gh pr view` / `gh pr diff` / `gh pr checks` on this upstream PR. Do not expect a Swing GUI run.