### PR TITLE
fix(readboard): keep WRN enabled on play authorization

### DIFF
--- a/src/main/java/featurecat/lizzie/analysis/ReadBoard.java
+++ b/src/main/java/featurecat/lizzie/analysis/ReadBoard.java
@@ -946,7 +946,6 @@ public class ReadBoard implements ReadBoardTrackingEligibilityAdapter.Eligibilit
           Lizzie.config.UsePureNetInGame = false;
           Lizzie.frame.isAnaPlayingAgainstLeelaz = true;
           LizzieFrame.toolbar.isAutoPlay = true;
-          Lizzie.frame.clearWRNforGame(false);
         } else if (params[1].equals("white")) {
           LizzieFrame.toolbar.chkAutoPlayBlack.setSelected(false);
           LizzieFrame.toolbar.chkAutoPlayWhite.setSelected(true);
@@ -956,7 +955,6 @@ public class ReadBoard implements ReadBoardTrackingEligibilityAdapter.Eligibilit
           Lizzie.config.UsePureNetInGame = false;
           Lizzie.frame.isAnaPlayingAgainstLeelaz = true;
           LizzieFrame.toolbar.isAutoPlay = true;
-          Lizzie.frame.clearWRNforGame(false);
         }
         if (!readBoardGmaAutoPlayActive) {
           Lizzie.leelaz.ponder();

--- a/src/test/java/featurecat/lizzie/analysis/ReadBoardEngineResumeTest.java
+++ b/src/test/java/featurecat/lizzie/analysis/ReadBoardEngineResumeTest.java
@@ -11,6 +11,8 @@ import featurecat.lizzie.Config;
 import featurecat.lizzie.Lizzie;
 import featurecat.lizzie.gui.BoardRenderer;
 import featurecat.lizzie.gui.BottomToolbar;
+import featurecat.lizzie.gui.JFontCheckBox;
+import featurecat.lizzie.gui.JFontTextField;
 import featurecat.lizzie.gui.LizzieFrame;
 import featurecat.lizzie.gui.Menu;
 import featurecat.lizzie.rules.Board;
@@ -1004,6 +1006,16 @@ class ReadBoardEngineResumeTest {
       assertEquals(1, harness.leelaz.ponderCount);
       assertEquals(0, harness.frame.flashAnalyzeGameCount);
     }
+  }
+
+  @Test
+  void readBoardPlayLineKeepsAnalysisWideRootNoiseEnabled() throws Exception {
+    assertPlayLineKeepsAnalysisWideRootNoise("play>black>5 1000 0", false);
+  }
+
+  @Test
+  void readBoardGmaPlayLineKeepsAnalysisWideRootNoiseEnabled() throws Exception {
+    assertPlayLineKeepsAnalysisWideRootNoise("play>white>5 1000 0 gma", true);
   }
 
   @Test
@@ -2108,6 +2120,42 @@ class ReadBoardEngineResumeTest {
 
   private static Placement placement(int x, int y, Stone color) {
     return new Placement(x, y, color);
+  }
+
+  private static void assertPlayLineKeepsAnalysisWideRootNoise(String playLine, boolean gma)
+      throws Exception {
+    Menu previousMenu = LizzieFrame.menu;
+    try (EngineResumeHarness harness =
+        EngineResumeHarness.create(rootHistory(emptyStones(), true))) {
+      LizzieFrame.menu = allocate(SilentMenu.class);
+      JFontCheckBox chkWRN = new JFontCheckBox();
+      setField(LizzieFrame.menu, "chkWRN", chkWRN);
+      LizzieFrame.menu.txtWRN = new JFontTextField("0.04");
+      chkWRN.setSelected(true);
+      LizzieFrame.menu.txtWRN.setEnabled(true);
+      Lizzie.config.disableWRNInGame = true;
+      Lizzie.config.chkKataEngineWRN = true;
+      harness.leelaz.isKatago = true;
+      harness.leelaz.wrn = 0.04;
+      if (gma) {
+        harness.leelaz.enableReadBoardGmaSupport();
+      }
+
+      harness.readBoard.parseLine(playLine);
+
+      assertTrue(harness.frame.isAnaPlayingAgainstLeelaz);
+      assertTrue(LizzieFrame.toolbar.isAutoPlay);
+      assertTrue(chkWRN.isSelected(), "ReadBoard play> must not uncheck WRN");
+      assertTrue(LizzieFrame.menu.txtWRN.isEnabled());
+      assertTrue(Lizzie.config.chkKataEngineWRN);
+      assertEquals(0.04, harness.leelaz.wrn);
+      assertFalse(
+          harness.leelaz.sentCommands.stream()
+              .anyMatch(command -> command.startsWith("kata-set-param analysisWideRootNoise")),
+          "ReadBoard play> must not reset analysisWideRootNoise");
+    } finally {
+      LizzieFrame.menu = previousMenu;
+    }
   }
 
   @SuppressWarnings("unchecked")


### PR DESCRIPTION
## Why

ReadBoard Fox autoplay was turning off LizzieYzy WRN (`chkWRN` / `analysisWideRootNoise`).

`play>` reuses the human-vs-AI path: it sets `isAnaPlayingAgainstLeelaz` and then called `clearWRNforGame(false)`. With the default `disableWRNInGame=true`, that unchecked WRN and sent `kata-set-param analysisWideRootNoise 0`. `stopAutoPlay` does not restore WRN.

Reported as [qiyi71w/readboard#61](https://github.com/qiyi71w/readboard/issues/61). The ReadBoard `play>` wire is unchanged; the host was applying in-game WRN-off to sync autoplay.

## What

- `ReadBoard.parseLine("play>...")` no longer calls `clearWRNforGame`
- Still arms `isAnaPlayingAgainstLeelaz` and `toolbar.isAutoPlay`
- NewAnaGameDialog / engine-game WRN-off is unchanged
- Tests: first-candidate `play>black>5 1000 0` and GMA `play>white>5 1000 0 gma` keep WRN selected and do not send `analysisWideRootNoise 0`

## How

First-candidate autoplay only needs toolbar autoplay + ponder. WRN-off is a human-vs-AI game policy and is not required on this path. GMA genmove can ignore WRN on its own; the menu checkbox should stay as the user left it.

## Test Plan

- [x] `ReadBoardEngineResumeTest#readBoardPlayLineKeepsAnalysisWideRootNoiseEnabled`
- [x] `ReadBoardEngineResumeTest#readBoardGmaPlayLineKeepsAnalysisWideRootNoiseEnabled`
- [x] `ReadBoardEngineResumeTest#readBoardGmaPlayLineWaitsForSyncedBoardBeforeStartingEngineDecision`
- [x] Windows desktop: enable WRN, connect ReadBoard, autoplay one move; WRN stays checked

## Related

- https://github.com/qiyi71w/readboard/issues/61
