### PR TITLE
fix(menu): lay out WRN and PDA like komi in the double menu

### DIFF
--- a/src/main/java/featurecat/lizzie/gui/Menu.java
+++ b/src/main/java/featurecat/lizzie/gui/Menu.java
@@ -149,10 +149,12 @@ public class Menu extends JMenuBar {
   JFontButton setBoardSize;
   JFontButton saveLoad;
   JFontLabel lblWRN;
-  // JFontLabel lblWRNForDouble;
+  JFontLabel lblWRNForDouble;
   public JFontTextField txtWRN;
   JFontCheckBox chkWRN;
-  // JFontLabel lblGfPDAForDouble;
+  JFontLabel lblGfPDAForDouble;
+  JPanel pdaFieldPanel;
+  JPanel wrnFieldPanel;
   JFontCheckBox chkPDA;
   JFontLabel lblGfPDA;
   public JFontTextField txtGfPDA;
@@ -7824,6 +7826,47 @@ public class Menu extends JMenuBar {
     checkBox.setMinimumSize(size);
   }
 
+  static String withTrailingColon(String text) {
+    if (text == null || text.isEmpty()) {
+      return ":";
+    }
+    if (text.endsWith(":") || text.endsWith("：")) {
+      return text;
+    }
+    return text + ":";
+  }
+
+  static JPanel attachDoubleMenuLabeledField(
+      AbstractButton enable, JLabel label, JTextField field, String labelText) {
+    enable.setText("");
+    lockDoubleMenuCheckBoxSize(enable);
+    label.setText(withTrailingColon(labelText));
+    boolean small = Lizzie.config == null || Lizzie.config.isFrameFontSmall();
+    boolean middle = Lizzie.config != null && Lizzie.config.isFrameFontMiddle();
+    int fieldWidth = small ? 48 : (middle ? 54 : 62);
+    int fieldHeight = small ? 19 : (middle ? 21 : 25);
+    int checkWidth = enable.getPreferredSize().width;
+    int labelWidth = Math.max(label.getPreferredSize().width, small ? 35 : (middle ? 40 : 47));
+    int labelX = checkWidth;
+    int fieldX = labelX + labelWidth - 4;
+    int checkY = small ? 0 : (middle ? 1 : 2);
+    int labelY = small ? 1 : (middle ? 3 : 6);
+    int fieldY = small ? 0 : (middle ? 2 : 3);
+    field.setHorizontalAlignment(JTextField.CENTER);
+    field.setPreferredSize(new Dimension(fieldWidth, fieldHeight));
+    enable.setBounds(0, checkY, checkWidth, Config.menuHeight - 3);
+    label.setBounds(labelX, labelY, labelWidth, 18);
+    field.setBounds(fieldX, fieldY, fieldWidth, fieldHeight);
+    JPanel panel = new JPanel(null);
+    panel.setOpaque(false);
+    panel.setPreferredSize(new Dimension(fieldX + fieldWidth + 2, Config.menuHeight));
+    panel.add(enable);
+    panel.add(label);
+    panel.add(field);
+    AccessibilitySupport.labelFor(label, field, label.getText());
+    return panel;
+  }
+
   public void doubleMenu(boolean first) {
     if (!Lizzie.config.showDoubleMenu) {
       Lizzie.frame.topPanel.setVisible(false);
@@ -9213,27 +9256,20 @@ public class Menu extends JMenuBar {
             Lizzie.config.isFrameFontSmall() ? 52 : (Lizzie.config.isFrameFontMiddle() ? 60 : 72),
             Lizzie.config.isFrameFontSmall() ? 18 : (Lizzie.config.isFrameFontMiddle() ? 21 : 24)));
 
-    Lizzie.frame.topPanel.add(chkPDA);
-    chkPDA.setText(resourceBundle.getString("Menu.separateLblPda"));
-    lockDoubleMenuCheckBoxSize(chkPDA);
-    // lblGfPDAForDouble = new JFontLabel(resourceBundle.getString("Menu.separateLblPda"));
-    // Lizzie.frame.topPanel.add(lblGfPDAForDouble);
-    Lizzie.frame.topPanel.add(txtGfPDA);
-    txtGfPDA.setPreferredSize(
-        new Dimension(
-            Lizzie.config.isFrameFontSmall() ? 46 : (Lizzie.config.isFrameFontMiddle() ? 50 : 56),
-            Lizzie.config.isFrameFontSmall() ? 18 : (Lizzie.config.isFrameFontMiddle() ? 21 : 23)));
-
-    Lizzie.frame.topPanel.add(chkWRN);
-    chkWRN.setText(resourceBundle.getString("Menu.separateLblWrn"));
-    lockDoubleMenuCheckBoxSize(chkWRN);
-    // lblWRNForDouble = new JFontLabel(resourceBundle.getString("Menu.separateLblWrn"));
-    // Lizzie.frame.topPanel.add(lblWRNForDouble);
-    Lizzie.frame.topPanel.add(txtWRN);
-    txtWRN.setPreferredSize(
-        new Dimension(
-            Lizzie.config.isFrameFontSmall() ? 46 : (Lizzie.config.isFrameFontMiddle() ? 52 : 60),
-            Lizzie.config.isFrameFontSmall() ? 18 : (Lizzie.config.isFrameFontMiddle() ? 21 : 23)));
+    if (lblGfPDAForDouble == null) {
+      lblGfPDAForDouble = new JFontLabel();
+    }
+    if (lblWRNForDouble == null) {
+      lblWRNForDouble = new JFontLabel();
+    }
+    pdaFieldPanel =
+        attachDoubleMenuLabeledField(
+            chkPDA, lblGfPDAForDouble, txtGfPDA, resourceBundle.getString("Menu.separateLblPda"));
+    wrnFieldPanel =
+        attachDoubleMenuLabeledField(
+            chkWRN, lblWRNForDouble, txtWRN, resourceBundle.getString("Menu.separateLblWrn"));
+    Lizzie.frame.topPanel.add(pdaFieldPanel);
+    Lizzie.frame.topPanel.add(wrnFieldPanel);
 
     setPdaAndWrnByEngineForDouble();
 
@@ -9509,7 +9545,9 @@ public class Menu extends JMenuBar {
       txtPDA.setVisible(true);
       more2.setVisible(true);
       customPDAMorePanel.setVisible(true);
-      // lblGfPDAForDouble.setVisible(false);
+      if (pdaFieldPanel != null) {
+        pdaFieldPanel.setVisible(false);
+      }
       chkPDA.setVisible(false);
       txtGfPDA.setVisible(false);
       needRemoveS = false;
@@ -9522,12 +9560,16 @@ public class Menu extends JMenuBar {
           && !isEngineGame()
           && Lizzie.leelaz != null
           && Lizzie.leelaz.isKatago) {
+        if (pdaFieldPanel != null) {
+          pdaFieldPanel.setVisible(true);
+        }
         chkPDA.setVisible(true);
-        // lblGfPDAForDouble.setVisible(true);
         txtGfPDA.setVisible(true);
         needRemoveS = false;
       } else {
-        //  lblGfPDAForDouble.setVisible(false);
+        if (pdaFieldPanel != null) {
+          pdaFieldPanel.setVisible(false);
+        }
         chkPDA.setVisible(false);
         txtGfPDA.setVisible(false);
       }
@@ -9538,11 +9580,15 @@ public class Menu extends JMenuBar {
         && Lizzie.leelaz != null
         && Lizzie.leelaz.isKatago) {
       needRemoveS = false;
-      // lblWRNForDouble.setVisible(true);
+      if (wrnFieldPanel != null) {
+        wrnFieldPanel.setVisible(true);
+      }
       chkWRN.setVisible(true);
       txtWRN.setVisible(true);
     } else {
-      // lblWRNForDouble.setVisible(false);
+      if (wrnFieldPanel != null) {
+        wrnFieldPanel.setVisible(false);
+      }
       chkWRN.setVisible(false);
       txtWRN.setVisible(false);
     }

--- a/src/main/java/featurecat/lizzie/gui/Menu.java
+++ b/src/main/java/featurecat/lizzie/gui/Menu.java
@@ -7810,6 +7810,20 @@ public class Menu extends JMenuBar {
     if (!first) doubleMenu(false);
   }
 
+  static void lockDoubleMenuCheckBoxSize(AbstractButton checkBox) {
+    if (checkBox == null) {
+      return;
+    }
+    checkBox.setPreferredSize(null);
+    int extra = Lizzie.config != null && Lizzie.config.shouldWidenCheckBox ? 4 : 0;
+    int width =
+        AccessibilitySupport.localizedControlWidth(
+            checkBox, (int) checkBox.getPreferredSize().getWidth() + extra);
+    Dimension size = new Dimension(width, Config.menuHeight - 3);
+    checkBox.setPreferredSize(size);
+    checkBox.setMinimumSize(size);
+  }
+
   public void doubleMenu(boolean first) {
     if (!Lizzie.config.showDoubleMenu) {
       Lizzie.frame.topPanel.setVisible(false);
@@ -9201,8 +9215,7 @@ public class Menu extends JMenuBar {
 
     Lizzie.frame.topPanel.add(chkPDA);
     chkPDA.setText(resourceBundle.getString("Menu.separateLblPda"));
-    chkPDA.setPreferredSize(
-        new Dimension((int) chkPDA.getPreferredSize().getWidth(), Config.menuHeight - 3));
+    lockDoubleMenuCheckBoxSize(chkPDA);
     // lblGfPDAForDouble = new JFontLabel(resourceBundle.getString("Menu.separateLblPda"));
     // Lizzie.frame.topPanel.add(lblGfPDAForDouble);
     Lizzie.frame.topPanel.add(txtGfPDA);
@@ -9213,8 +9226,7 @@ public class Menu extends JMenuBar {
 
     Lizzie.frame.topPanel.add(chkWRN);
     chkWRN.setText(resourceBundle.getString("Menu.separateLblWrn"));
-    chkWRN.setPreferredSize(
-        new Dimension((int) chkWRN.getPreferredSize().getWidth(), Config.menuHeight - 3));
+    lockDoubleMenuCheckBoxSize(chkWRN);
     // lblWRNForDouble = new JFontLabel(resourceBundle.getString("Menu.separateLblWrn"));
     // Lizzie.frame.topPanel.add(lblWRNForDouble);
     Lizzie.frame.topPanel.add(txtWRN);

--- a/src/main/java/featurecat/lizzie/gui/Menu.java
+++ b/src/main/java/featurecat/lizzie/gui/Menu.java
@@ -23,6 +23,7 @@ import java.awt.FontMetrics;
 import java.awt.Graphics;
 import java.awt.Graphics2D;
 import java.awt.Insets;
+import java.awt.FlowLayout;
 import java.awt.event.*;
 import java.io.File;
 import java.io.IOException;
@@ -7812,19 +7813,6 @@ public class Menu extends JMenuBar {
     if (!first) doubleMenu(false);
   }
 
-  static void lockDoubleMenuCheckBoxSize(AbstractButton checkBox) {
-    if (checkBox == null) {
-      return;
-    }
-    checkBox.setPreferredSize(null);
-    int extra = Lizzie.config != null && Lizzie.config.shouldWidenCheckBox ? 4 : 0;
-    int width =
-        AccessibilitySupport.localizedControlWidth(
-            checkBox, (int) checkBox.getPreferredSize().getWidth() + extra);
-    Dimension size = new Dimension(width, Config.menuHeight - 3);
-    checkBox.setPreferredSize(size);
-    checkBox.setMinimumSize(size);
-  }
 
   static String withTrailingColon(String text) {
     if (text == null || text.isEmpty()) {
@@ -7839,27 +7827,36 @@ public class Menu extends JMenuBar {
   static JPanel attachDoubleMenuLabeledField(
       AbstractButton enable, JLabel label, JTextField field, String labelText) {
     enable.setText("");
-    lockDoubleMenuCheckBoxSize(enable);
+    enable.setIconTextGap(0);
+    enable.setMargin(new Insets(0, 0, 0, 0));
+    int iconWidth = enable.getIcon() == null ? 16 : enable.getIcon().getIconWidth();
+    Insets checkInsets = enable.getInsets();
+    Dimension checkSize =
+        new Dimension(
+            iconWidth + checkInsets.left + checkInsets.right, Config.menuHeight - 3);
+    enable.setPreferredSize(checkSize);
+    enable.setMinimumSize(checkSize);
+    enable.setMaximumSize(checkSize);
     label.setText(withTrailingColon(labelText));
+    int labelWidth = label.getFontMetrics(label.getFont()).stringWidth(label.getText()) + 2;
+    label.setPreferredSize(new Dimension(labelWidth, 18));
     boolean small = Lizzie.config == null || Lizzie.config.isFrameFontSmall();
     boolean middle = Lizzie.config != null && Lizzie.config.isFrameFontMiddle();
-    int fieldWidth = small ? 48 : (middle ? 54 : 62);
-    int fieldHeight = small ? 19 : (middle ? 21 : 25);
-    int checkWidth = enable.getPreferredSize().width;
-    int labelWidth = Math.max(label.getPreferredSize().width, small ? 35 : (middle ? 40 : 47));
-    int labelX = checkWidth;
-    int fieldX = labelX + labelWidth - 4;
-    int checkY = small ? 0 : (middle ? 1 : 2);
-    int labelY = small ? 1 : (middle ? 3 : 6);
-    int fieldY = small ? 0 : (middle ? 2 : 3);
+    Dimension fieldSize =
+        new Dimension(
+            small ? 48 : (middle ? 54 : 62),
+            small
+                ? (Lizzie.config != null && Lizzie.config.useJavaLooks ? 20 : 19)
+                : (middle
+                    ? (Lizzie.config != null && Lizzie.config.useJavaLooks ? 22 : 21)
+                    : (Lizzie.config != null && Lizzie.config.useJavaLooks ? 26 : 25)));
     field.setHorizontalAlignment(JTextField.CENTER);
-    field.setPreferredSize(new Dimension(fieldWidth, fieldHeight));
-    enable.setBounds(0, checkY, checkWidth, Config.menuHeight - 3);
-    label.setBounds(labelX, labelY, labelWidth, 18);
-    field.setBounds(fieldX, fieldY, fieldWidth, fieldHeight);
-    JPanel panel = new JPanel(null);
+    field.setPreferredSize(fieldSize);
+    field.setMinimumSize(fieldSize);
+    field.setMaximumSize(fieldSize);
+    JPanel panel = new JPanel(new FlowLayout(FlowLayout.LEFT, 0, 0));
     panel.setOpaque(false);
-    panel.setPreferredSize(new Dimension(fieldX + fieldWidth + 2, Config.menuHeight));
+    panel.setBorder(new EmptyBorder(0, 0, 0, 0));
     panel.add(enable);
     panel.add(label);
     panel.add(field);

--- a/src/test/java/featurecat/lizzie/gui/DoubleMenuEngineCheckBoxLayoutTest.java
+++ b/src/test/java/featurecat/lizzie/gui/DoubleMenuEngineCheckBoxLayoutTest.java
@@ -5,9 +5,11 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import featurecat.lizzie.Lizzie;
+import java.awt.Insets;
 import java.util.List;
 import java.util.Locale;
 import java.util.ResourceBundle;
+import javax.swing.Icon;
 import javax.swing.JButton;
 import javax.swing.JPanel;
 import org.junit.jupiter.api.Test;
@@ -28,8 +30,9 @@ class DoubleMenuEngineCheckBoxLayoutTest {
     JFontCheckBox enable = new JFontCheckBox();
     JFontLabel label = new JFontLabel();
     JFontTextField field = new JFontTextField();
-
     JPanel panel = Menu.attachDoubleMenuLabeledField(enable, label, field, rawLabel);
+    panel.setSize(panel.getPreferredSize());
+    panel.doLayout();
 
     assertEquals("", enable.getText());
     assertTrue(
@@ -38,12 +41,18 @@ class DoubleMenuEngineCheckBoxLayoutTest {
     assertTrue(label.getText().startsWith(rawLabel.replaceAll("[:：]+$", "")));
     assertEquals(3, panel.getComponentCount());
     assertFalse(containsSpinner(panel));
+
+    Icon icon = enable.getIcon();
+    int iconWidth = icon == null ? 16 : icon.getIconWidth();
+    Insets insets = enable.getInsets();
     assertTrue(
-        field.getX() <= label.getX() + label.getWidth(),
-        () -> "field x=" + field.getX() + " should sit against label " + label.getBounds());
+        enable.getPreferredSize().width <= iconWidth + insets.left + insets.right,
+        () -> "checkbox wider than icon: " + enable.getPreferredSize().width);
+
+    assertEquals(0, field.getX() - (label.getX() + label.getWidth()));
     assertTrue(
-        field.getX() >= label.getX() + label.getWidth() - 8,
-        () -> "field x=" + field.getX() + " too far from label " + label.getBounds());
+        field.getX() - (enable.getX() + enable.getWidth()) >= label.getWidth() - 2,
+        () -> "label not sitting between checkbox and field: " + panel.getBounds());
   }
 
   private static boolean containsSpinner(JPanel panel) {

--- a/src/test/java/featurecat/lizzie/gui/DoubleMenuEngineCheckBoxLayoutTest.java
+++ b/src/test/java/featurecat/lizzie/gui/DoubleMenuEngineCheckBoxLayoutTest.java
@@ -1,0 +1,69 @@
+package featurecat.lizzie.gui;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import featurecat.lizzie.Config;
+import featurecat.lizzie.Lizzie;
+import java.awt.Dimension;
+import java.awt.FontMetrics;
+import java.awt.Insets;
+import java.util.List;
+import java.util.Locale;
+import java.util.ResourceBundle;
+import javax.swing.AbstractButton;
+import javax.swing.Icon;
+import org.junit.jupiter.api.Test;
+
+class DoubleMenuEngineCheckBoxLayoutTest {
+  @Test
+  void wrnAndPdaPreferredWidthCoversIconAndLabelAfterDoubleMenuRebuild() {
+    for (ResourceBundle bundle :
+        List.of(
+            Lizzie.resourceBundle,
+            ResourceBundle.getBundle("l10n.DisplayStrings", Locale.SIMPLIFIED_CHINESE))) {
+      assertUnclippedAfterRebuild(bundle.getString("Menu.separateLblWrn"));
+      assertUnclippedAfterRebuild(bundle.getString("Menu.separateLblPda"));
+    }
+  }
+
+  private static void assertUnclippedAfterRebuild(String label) {
+    JFontCheckBox checkBox = new JFontCheckBox();
+    checkBox.setText(label);
+    checkBox.setPreferredSize(new Dimension(20, Config.menuHeight - 3));
+
+    Menu.lockDoubleMenuCheckBoxSize(checkBox);
+    Menu.lockDoubleMenuCheckBoxSize(checkBox);
+
+    int minimum = unclippedLabelWidth(checkBox);
+    assertTrue(
+        checkBox.getPreferredSize().width >= minimum,
+        () ->
+            "preferred width "
+                + checkBox.getPreferredSize().width
+                + " < unclipped "
+                + minimum
+                + " for "
+                + label);
+    assertTrue(
+        checkBox.getMinimumSize().width >= minimum,
+        () ->
+            "minimum width "
+                + checkBox.getMinimumSize().width
+                + " < unclipped "
+                + minimum
+                + " for "
+                + label);
+  }
+
+  private static int unclippedLabelWidth(AbstractButton button) {
+    Insets insets = button.getInsets();
+    Icon icon = button.getIcon();
+    int iconWidth = icon == null ? 0 : icon.getIconWidth();
+    FontMetrics metrics = button.getFontMetrics(button.getFont());
+    return insets.left
+        + iconWidth
+        + button.getIconTextGap()
+        + metrics.stringWidth(button.getText())
+        + insets.right;
+  }
+}

--- a/src/test/java/featurecat/lizzie/gui/DoubleMenuEngineCheckBoxLayoutTest.java
+++ b/src/test/java/featurecat/lizzie/gui/DoubleMenuEngineCheckBoxLayoutTest.java
@@ -1,69 +1,57 @@
 package featurecat.lizzie.gui;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import featurecat.lizzie.Config;
 import featurecat.lizzie.Lizzie;
-import java.awt.Dimension;
-import java.awt.FontMetrics;
-import java.awt.Insets;
 import java.util.List;
 import java.util.Locale;
 import java.util.ResourceBundle;
-import javax.swing.AbstractButton;
-import javax.swing.Icon;
+import javax.swing.JButton;
+import javax.swing.JPanel;
 import org.junit.jupiter.api.Test;
 
 class DoubleMenuEngineCheckBoxLayoutTest {
   @Test
-  void wrnAndPdaPreferredWidthCoversIconAndLabelAfterDoubleMenuRebuild() {
+  void wrnAndPdaUseKomiStyleLabelColonAndAdjacentField() {
     for (ResourceBundle bundle :
         List.of(
             Lizzie.resourceBundle,
             ResourceBundle.getBundle("l10n.DisplayStrings", Locale.SIMPLIFIED_CHINESE))) {
-      assertUnclippedAfterRebuild(bundle.getString("Menu.separateLblWrn"));
-      assertUnclippedAfterRebuild(bundle.getString("Menu.separateLblPda"));
+      assertKomiStyleGroup(bundle.getString("Menu.separateLblWrn"));
+      assertKomiStyleGroup(bundle.getString("Menu.separateLblPda"));
     }
   }
 
-  private static void assertUnclippedAfterRebuild(String label) {
-    JFontCheckBox checkBox = new JFontCheckBox();
-    checkBox.setText(label);
-    checkBox.setPreferredSize(new Dimension(20, Config.menuHeight - 3));
+  private static void assertKomiStyleGroup(String rawLabel) {
+    JFontCheckBox enable = new JFontCheckBox();
+    JFontLabel label = new JFontLabel();
+    JFontTextField field = new JFontTextField();
 
-    Menu.lockDoubleMenuCheckBoxSize(checkBox);
-    Menu.lockDoubleMenuCheckBoxSize(checkBox);
+    JPanel panel = Menu.attachDoubleMenuLabeledField(enable, label, field, rawLabel);
 
-    int minimum = unclippedLabelWidth(checkBox);
+    assertEquals("", enable.getText());
     assertTrue(
-        checkBox.getPreferredSize().width >= minimum,
-        () ->
-            "preferred width "
-                + checkBox.getPreferredSize().width
-                + " < unclipped "
-                + minimum
-                + " for "
-                + label);
+        label.getText().endsWith(":") || label.getText().endsWith("："),
+        () -> "label should end with colon: " + label.getText());
+    assertTrue(label.getText().startsWith(rawLabel.replaceAll("[:：]+$", "")));
+    assertEquals(3, panel.getComponentCount());
+    assertFalse(containsSpinner(panel));
     assertTrue(
-        checkBox.getMinimumSize().width >= minimum,
-        () ->
-            "minimum width "
-                + checkBox.getMinimumSize().width
-                + " < unclipped "
-                + minimum
-                + " for "
-                + label);
+        field.getX() <= label.getX() + label.getWidth(),
+        () -> "field x=" + field.getX() + " should sit against label " + label.getBounds());
+    assertTrue(
+        field.getX() >= label.getX() + label.getWidth() - 8,
+        () -> "field x=" + field.getX() + " too far from label " + label.getBounds());
   }
 
-  private static int unclippedLabelWidth(AbstractButton button) {
-    Insets insets = button.getInsets();
-    Icon icon = button.getIcon();
-    int iconWidth = icon == null ? 0 : icon.getIconWidth();
-    FontMetrics metrics = button.getFontMetrics(button.getFont());
-    return insets.left
-        + iconWidth
-        + button.getIconTextGap()
-        + metrics.stringWidth(button.getText())
-        + insets.right;
+  private static boolean containsSpinner(JPanel panel) {
+    for (var component : panel.getComponents()) {
+      if (component instanceof JButton) {
+        return true;
+      }
+    }
+    return false;
   }
 }


### PR DESCRIPTION
## Summary

- Double-menu WRN / PDA used to clip to a blue checkbox sliver with the label missing. They now follow the komi control: enable checkbox, `广度:` / `激进度:` (or locale equivalent), then a compact number field immediately to the right. No spinner arrows.
- Needed because `WrapLayout` does not shrink children, and locking preferred width on the labeled checkbox was too narrow after Apple checkbox chrome.

## Type Of Change

- [x] Bug fix
- [ ] Feature
- [ ] Packaging / release update
- [ ] Docs / translation
- [ ] Refactor

## Testing

- [x] Tested locally
- [ ] Verified package contents if packaging changed
- [ ] Verified Fox sync flow if related
- [x] Added screenshots if UI changed
- [ ] Updated README / docs if user-facing behavior changed
- [x] Noted affected platforms if the change is platform-specific
- [x] Verified there is no unrelated formatting or line-ending churn
- [x] Ran `python3 scripts/check_line_endings.py` (or equivalent `python` on Windows)

Focused: `unset DISPLAY && mvn -Dtest=DoubleMenuEngineCheckBoxLayoutTest test`

Windows: shaded JAR from this branch, custom strip, user confirmed the top header looks correct.

## Notes

- Independent of https://github.com/wimi321/lizzieyzy-next/pull/281 (ReadBoard `play>` WRN). Do not mix.
- Single-menu `updateSingleMenu()` bounds are unchanged.
- Platform: Windows custom strip (`Menu presentation: mode=custom`) with `showDoubleMenu=true`.
