### PR TITLE
fix(readboard): do not restore WRN on endsync after play>

### DIFF
--- a/src/main/java/featurecat/lizzie/analysis/ReadBoard.java
+++ b/src/main/java/featurecat/lizzie/analysis/ReadBoard.java
@@ -946,6 +946,7 @@ public class ReadBoard implements ReadBoardTrackingEligibilityAdapter.Eligibilit
           Lizzie.config.UsePureNetInGame = false;
           Lizzie.frame.isAnaPlayingAgainstLeelaz = true;
           LizzieFrame.toolbar.isAutoPlay = true;
+          Lizzie.frame.discardWRNRestoreSnapshot();
         } else if (params[1].equals("white")) {
           LizzieFrame.toolbar.chkAutoPlayBlack.setSelected(false);
           LizzieFrame.toolbar.chkAutoPlayWhite.setSelected(true);
@@ -955,6 +956,7 @@ public class ReadBoard implements ReadBoardTrackingEligibilityAdapter.Eligibilit
           Lizzie.config.UsePureNetInGame = false;
           Lizzie.frame.isAnaPlayingAgainstLeelaz = true;
           LizzieFrame.toolbar.isAutoPlay = true;
+          Lizzie.frame.discardWRNRestoreSnapshot();
         }
         if (!readBoardGmaAutoPlayActive) {
           Lizzie.leelaz.ponder();

--- a/src/main/java/featurecat/lizzie/analysis/ReadBoard.java
+++ b/src/main/java/featurecat/lizzie/analysis/ReadBoard.java
@@ -946,7 +946,6 @@ public class ReadBoard implements ReadBoardTrackingEligibilityAdapter.Eligibilit
           Lizzie.config.UsePureNetInGame = false;
           Lizzie.frame.isAnaPlayingAgainstLeelaz = true;
           LizzieFrame.toolbar.isAutoPlay = true;
-          Lizzie.frame.clearWRNforGame(false);
         } else if (params[1].equals("white")) {
           LizzieFrame.toolbar.chkAutoPlayBlack.setSelected(false);
           LizzieFrame.toolbar.chkAutoPlayWhite.setSelected(true);
@@ -956,7 +955,6 @@ public class ReadBoard implements ReadBoardTrackingEligibilityAdapter.Eligibilit
           Lizzie.config.UsePureNetInGame = false;
           Lizzie.frame.isAnaPlayingAgainstLeelaz = true;
           LizzieFrame.toolbar.isAutoPlay = true;
-          Lizzie.frame.clearWRNforGame(false);
         }
         if (!readBoardGmaAutoPlayActive) {
           Lizzie.leelaz.ponder();

--- a/src/main/java/featurecat/lizzie/gui/LizzieFrame.java
+++ b/src/main/java/featurecat/lizzie/gui/LizzieFrame.java
@@ -713,8 +713,8 @@ public class LizzieFrame extends JFrame {
   public boolean ponderStatusBeforeScore = false;
   private KeyListener gtpShortKey;
 
-  private boolean WRNStatusBeforeGame = Lizzie.config.chkKataEngineWRN;
-  private boolean autoWRNStatusBeforeGame = Lizzie.config.autoLoadKataEngineWRN;
+  private boolean WRNStatusBeforeGame = false;
+  private boolean autoWRNStatusBeforeGame = false;
   private double WRNValueBeforeGenmove = 0;
   private boolean WRNSelectedBeforeGenmove = false;
 
@@ -19003,6 +19003,10 @@ public class LizzieFrame extends JFrame {
         }
       }
     }
+  }
+
+  public void discardWRNRestoreSnapshot() {
+    WRNStatusBeforeGame = false;
   }
 
   public void restoreWRN(boolean isGenmove) {

--- a/src/test/java/featurecat/lizzie/analysis/ReadBoardEngineResumeTest.java
+++ b/src/test/java/featurecat/lizzie/analysis/ReadBoardEngineResumeTest.java
@@ -1019,6 +1019,17 @@ class ReadBoardEngineResumeTest {
   }
 
   @Test
+  void readBoardEndsyncLeavesWRNOffAfterUserUnchecks() throws Exception {
+    assertEndsyncKeepsUserWRNChoice(true);
+  }
+
+  @Test
+  void readBoardEndsyncLeavesWRNOnIfStillOn() throws Exception {
+    assertEndsyncKeepsUserWRNChoice(false);
+  }
+
+
+  @Test
   void readBoardGmaPlayLineWaitsForSyncedBoardBeforeStartingEngineDecision() throws Exception {
     try (EngineResumeHarness harness =
         EngineResumeHarness.create(rootHistory(emptyStones(), true))) {
@@ -2158,6 +2169,46 @@ class ReadBoardEngineResumeTest {
     }
   }
 
+  private static void assertEndsyncKeepsUserWRNChoice(boolean uncheckAfterPlay) throws Exception {
+    Menu previousMenu = LizzieFrame.menu;
+    try (EngineResumeHarness harness =
+        EngineResumeHarness.create(rootHistory(emptyStones(), true))) {
+      LizzieFrame.menu = allocate(SilentMenu.class);
+      JFontCheckBox chkWRN = new JFontCheckBox();
+      setField(LizzieFrame.menu, "chkWRN", chkWRN);
+      LizzieFrame.menu.txtWRN = new JFontTextField("0.04");
+      chkWRN.setSelected(true);
+      LizzieFrame.menu.txtWRN.setEnabled(true);
+      Lizzie.config.disableWRNInGame = true;
+      Lizzie.config.chkKataEngineWRN = true;
+      harness.leelaz.isKatago = true;
+      harness.leelaz.wrn = 0.04;
+      setField(harness.frame, "WRNStatusBeforeGame", true);
+
+      harness.readBoard.parseLine("play>black>5 1000 0");
+      assertFalse(getBooleanField(harness.frame, "WRNStatusBeforeGame"));
+
+      if (uncheckAfterPlay) {
+        chkWRN.setSelected(false);
+        LizzieFrame.menu.txtWRN.setEnabled(false);
+        Lizzie.config.chkKataEngineWRN = false;
+      }
+      harness.leelaz.sentCommands.clear();
+
+      harness.readBoard.parseLine("endsync");
+
+      assertEquals(!uncheckAfterPlay, chkWRN.isSelected());
+      assertEquals(!uncheckAfterPlay, Lizzie.config.chkKataEngineWRN);
+      assertFalse(
+          harness.leelaz.sentCommands.stream()
+              .anyMatch(command -> command.startsWith("kata-set-param analysisWideRootNoise")),
+          "endsync must not restore WRN that ReadBoard play> never cleared");
+    } finally {
+      LizzieFrame.menu = previousMenu;
+    }
+  }
+
+
   @SuppressWarnings("unchecked")
   private static <T> T allocate(Class<T> type) throws Exception {
     return (T) UnsafeHolder.UNSAFE.allocateInstance(type);
@@ -2642,6 +2693,11 @@ class ReadBoardEngineResumeTest {
     public boolean stopAiPlayingAndPolicy() {
       stopAiPlayingAndPolicyCount++;
       boolean wasGaming = isPlayingAgainstLeelaz || isAnaPlayingAgainstLeelaz;
+      if (isAnaPlayingAgainstLeelaz
+          && LizzieFrame.menu != null
+          && LizzieFrame.menu.txtWRN != null) {
+        restoreWRN(false);
+      }
       isPlayingAgainstLeelaz = false;
       isAnaPlayingAgainstLeelaz = false;
       if (Lizzie.leelaz != null) {

--- a/src/test/java/featurecat/lizzie/analysis/ReadBoardEngineResumeTest.java
+++ b/src/test/java/featurecat/lizzie/analysis/ReadBoardEngineResumeTest.java
@@ -11,6 +11,8 @@ import featurecat.lizzie.Config;
 import featurecat.lizzie.Lizzie;
 import featurecat.lizzie.gui.BoardRenderer;
 import featurecat.lizzie.gui.BottomToolbar;
+import featurecat.lizzie.gui.JFontCheckBox;
+import featurecat.lizzie.gui.JFontTextField;
 import featurecat.lizzie.gui.LizzieFrame;
 import featurecat.lizzie.gui.Menu;
 import featurecat.lizzie.rules.Board;
@@ -1004,6 +1006,16 @@ class ReadBoardEngineResumeTest {
       assertEquals(1, harness.leelaz.ponderCount);
       assertEquals(0, harness.frame.flashAnalyzeGameCount);
     }
+  }
+
+  @Test
+  void readBoardPlayLineKeepsAnalysisWideRootNoiseEnabled() throws Exception {
+    assertPlayLineKeepsAnalysisWideRootNoise("play>black>5 1000 0", false);
+  }
+
+  @Test
+  void readBoardGmaPlayLineKeepsAnalysisWideRootNoiseEnabled() throws Exception {
+    assertPlayLineKeepsAnalysisWideRootNoise("play>white>5 1000 0 gma", true);
   }
 
   @Test
@@ -2108,6 +2120,42 @@ class ReadBoardEngineResumeTest {
 
   private static Placement placement(int x, int y, Stone color) {
     return new Placement(x, y, color);
+  }
+
+  private static void assertPlayLineKeepsAnalysisWideRootNoise(String playLine, boolean gma)
+      throws Exception {
+    Menu previousMenu = LizzieFrame.menu;
+    try (EngineResumeHarness harness =
+        EngineResumeHarness.create(rootHistory(emptyStones(), true))) {
+      LizzieFrame.menu = allocate(SilentMenu.class);
+      JFontCheckBox chkWRN = new JFontCheckBox();
+      setField(LizzieFrame.menu, "chkWRN", chkWRN);
+      LizzieFrame.menu.txtWRN = new JFontTextField("0.04");
+      chkWRN.setSelected(true);
+      LizzieFrame.menu.txtWRN.setEnabled(true);
+      Lizzie.config.disableWRNInGame = true;
+      Lizzie.config.chkKataEngineWRN = true;
+      harness.leelaz.isKatago = true;
+      harness.leelaz.wrn = 0.04;
+      if (gma) {
+        harness.leelaz.enableReadBoardGmaSupport();
+      }
+
+      harness.readBoard.parseLine(playLine);
+
+      assertTrue(harness.frame.isAnaPlayingAgainstLeelaz);
+      assertTrue(LizzieFrame.toolbar.isAutoPlay);
+      assertTrue(chkWRN.isSelected(), "ReadBoard play> must not uncheck WRN");
+      assertTrue(LizzieFrame.menu.txtWRN.isEnabled());
+      assertTrue(Lizzie.config.chkKataEngineWRN);
+      assertEquals(0.04, harness.leelaz.wrn);
+      assertFalse(
+          harness.leelaz.sentCommands.stream()
+              .anyMatch(command -> command.startsWith("kata-set-param analysisWideRootNoise")),
+          "ReadBoard play> must not reset analysisWideRootNoise");
+    } finally {
+      LizzieFrame.menu = previousMenu;
+    }
   }
 
   @SuppressWarnings("unchecked")


### PR DESCRIPTION
## Merge

Merge after #281. This branch is stacked on #281. If #281 is squash-merged first, rebase this branch onto `main` before merging.

## Why

Follow-up to #281. After `play>` stopped calling `clearWRNforGame`, `WRNStatusBeforeGame` was left as a startup snapshot (`Lizzie.config.chkKataEngineWRN`). `endsync` / `stopsync` / `noponder` still call `restoreWRN(false)`. If the user unchecked WRN during an armed ReadBoard autoplay session, ending sync could turn it back on.

## What

- Initialize `WRNStatusBeforeGame` to `false` instead of the config value at frame construction
- `play>` calls `discardWRNRestoreSnapshot()` so this autoplay session does not restore WRN
- `clearWRNforGame` / NewAnaGameDialog / engine-game restore is unchanged
- Tests: after `play>`, user uncheck stays off on `endsync`; WRN left on stays on

## Test Plan

- [x] `ReadBoardEngineResumeTest#readBoardEndsyncLeavesWRNOffAfterUserUnchecks`
- [x] `ReadBoardEngineResumeTest#readBoardEndsyncLeavesWRNOnIfStillOn`
- [x] `ReadBoardEngineResumeTest#readBoardPlayLineKeepsAnalysisWideRootNoiseEnabled`
- [x] `ReadBoardEngineResumeTest#readBoardGmaPlayLineKeepsAnalysisWideRootNoiseEnabled`

## Related

- https://github.com/wimi321/lizzieyzy-next/pull/281
- https://github.com/qiyi71w/readboard/issues/61
