### PR TITLE
feat(logging): add bounded LoggingRuntime foundation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,6 +68,24 @@
 				</configuration>
 			</plugin>
 			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-failsafe-plugin</artifactId>
+				<version>3.5.2</version>
+				<executions>
+					<execution>
+						<goals>
+							<goal>integration-test</goal>
+							<goal>verify</goal>
+						</goals>
+					</execution>
+				</executions>
+				<configuration>
+					<systemPropertyVariables>
+						<lizzie.shaded.jar>${project.build.directory}/${project.build.finalName}-shaded.jar</lizzie.shaded.jar>
+					</systemPropertyVariables>
+				</configuration>
+			</plugin>
+			<plugin>
 				<groupId>com.spotify.fmt</groupId>
 				<artifactId>fmt-maven-plugin</artifactId>
 				<version>2.29</version>

--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,8 @@
 									implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
 									<mainClass>featurecat.lizzie.Lizzie</mainClass>
 								</transformer>
+								<transformer
+									implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
 							</transformers>
 							<shadedArtifactAttached>true</shadedArtifactAttached>
 						</configuration>
@@ -120,6 +122,17 @@
 			<groupId>org.json</groupId>
 			<artifactId>json</artifactId>
 			<version>20231013</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-api</artifactId>
+			<version>2.0.16</version>
+		</dependency>
+		<dependency>
+			<groupId>ch.qos.logback</groupId>
+			<artifactId>logback-classic</artifactId>
+			<version>1.6.3</version>
 		</dependency>
 
 		<dependency>
@@ -223,6 +236,12 @@
 			<groupId>org.java-websocket</groupId>
 			<artifactId>Java-WebSocket</artifactId>
 			<version>1.6.0</version>
+			<exclusions>
+				<exclusion>
+					<groupId>org.slf4j</groupId>
+					<artifactId>slf4j-api</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 
 		<dependency>

--- a/src/main/java/featurecat/lizzie/Config.java
+++ b/src/main/java/featurecat/lizzie/Config.java
@@ -3,6 +3,8 @@ package featurecat.lizzie;
 import featurecat.lizzie.analysis.EngineManager;
 import featurecat.lizzie.analysis.MoveRankEvaluationMode;
 import featurecat.lizzie.gui.LizzieFrame;
+import featurecat.lizzie.logging.LoggingSettings;
+import featurecat.lizzie.logging.WorkDirectoryResolver;
 import featurecat.lizzie.theme.Theme;
 import featurecat.lizzie.util.AnalysisEngineCommandHelper;
 import featurecat.lizzie.util.KataGoAutoSetupHelper;
@@ -19,7 +21,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.util.*;
-import java.util.stream.Stream;
 import javax.swing.*;
 import org.jdesktop.swingx.util.OS;
 import org.json.*;
@@ -148,23 +149,14 @@ public class Config {
   public JSONObject saveBoard;
   public JSONObject saveBoardConfig;
 
-  private static final String USER_WORK_DIR_NAME = ".lizzieyzy-next";
-  private static final String LEGACY_USER_WORK_DIR_NAME = ".lizzieyzy-next-foxuid";
-  private static final String WINDOWS_SHARED_WORK_DIR_NAME = "LizzieYzyNext";
   private static final String WINDOWS_PORTABLE_MARKER_NAME = ".lizzie-portable";
-  private static final String WINDOWS_PORTABLE_WORK_DIR_NAME = "user-data";
-  private static final String WINDOWS_PORTABLE_STATE_MIGRATION_KEY =
-      "migrated-windows-portable-user-state-v2";
-  private static final String WINDOWS_PORTABLE_RECOVERY_BACKUP_NAME =
-      "config.before-portable-recovery.txt";
-  private static final String WORK_DIR_PROPERTY = "lizzie.work.dir";
   private static final String HIDE_SUBBOARD_DEFAULT_MIGRATION_KEY =
       "migrated-hide-subboard-default-v1";
   private static final String RESTORE_SUBBOARD_DEFAULT_MIGRATION_KEY =
       "restored-show-subboard-default-v2";
   private static final String HIDE_BLUNDER_BAR_DEFAULT_MIGRATION_KEY =
       "migrated-hide-blunder-bar-default-v1";
-  private static final String WORK_DIR = resolveWorkDir();
+  private static final String WORK_DIR = WorkDirectoryResolver.resolve().directory().toString();
   private static final String RUNTIME_WORK_DIR = "runtime";
   private static final String BUNDLED_ENGINE_NAME = "KataGo Bundled";
   private static final String BUNDLED_ENGINE_ROOT = "engines";
@@ -284,679 +276,39 @@ public class Config {
     }
   }
 
-  private static String resolveWorkDir() {
-    try {
-      Path explicitWorkDir = resolveExplicitWorkDir();
-      if (explicitWorkDir != null) {
-        return explicitWorkDir.toString();
-      }
-    } catch (Exception e) {
-      e.printStackTrace();
-    }
-
-    if (OS.isWindows()) {
-      try {
-        Optional<Path> portableRoot = findWindowsPortablePackageRoot();
-        if (portableRoot.isPresent()) {
-          Path portableWorkDir = prepareWindowsPortableWorkDir(portableRoot.get());
-          if (portableWorkDir != null) {
-            return portableWorkDir.toString();
-          }
-        }
-      } catch (Exception e) {
-        e.printStackTrace();
-      }
-      try {
-        Path cwd = Path.of(System.getProperty("user.dir")).toAbsolutePath().normalize();
-        if (shouldUsePortableWindowsWorkDir(cwd)) {
-          return cwd.toString();
-        }
-      } catch (Exception e) {
-        e.printStackTrace();
-      }
-      try {
-        Path fallback = resolveWritableFallbackDir();
-        System.out.println("Config dir fallback: " + fallback);
-        return fallback.toString();
-      } catch (Exception e) {
-        e.printStackTrace();
-      }
-    }
-
-    try {
-      Path cwd = Path.of(System.getProperty("user.dir")).toAbsolutePath();
-      if (Files.isWritable(cwd)) {
-        return cwd.toString();
-      }
-    } catch (Exception e) {
-      e.printStackTrace();
-    }
-
-    try {
-      Path fallback = resolveWritableFallbackDir();
-      System.out.println("Config dir fallback: " + fallback);
-      return fallback.toString();
-    } catch (Exception e) {
-      e.printStackTrace();
-      return System.getProperty("user.home");
-    }
-  }
-
-  private static Path resolveExplicitWorkDir() throws IOException {
-    String configured = System.getProperty(WORK_DIR_PROPERTY, "").trim();
-    if (configured.isEmpty()) {
-      return null;
-    }
-    Path path = Path.of(configured).toAbsolutePath().normalize();
-    Files.createDirectories(path.resolve("save"));
-    return path;
-  }
-
   public static Path resolveWritableFallbackDir() throws IOException {
-    if (OS.isWindows()) {
-      return resolveWindowsWorkDir();
-    }
-
-    Path preferred = Path.of(System.getProperty("user.home"), USER_WORK_DIR_NAME);
-    Path legacy = Path.of(System.getProperty("user.home"), LEGACY_USER_WORK_DIR_NAME);
-
-    if (!Files.exists(preferred) && Files.isDirectory(legacy)) {
-      try {
-        Files.move(legacy, preferred);
-        System.out.println("Migrated config dir to " + preferred);
-      } catch (Exception moveError) {
-        System.out.println("Config dir migration skipped: " + moveError.getMessage());
-        Files.createDirectories(legacy.resolve("save"));
-        return legacy;
-      }
-    }
-
-    Files.createDirectories(preferred.resolve("save"));
-    return preferred;
-  }
-
-  private static Path resolveWindowsWorkDir() throws IOException {
-    Path preferred = Path.of(System.getProperty("user.home"), USER_WORK_DIR_NAME);
-    Path legacy = Path.of(System.getProperty("user.home"), LEGACY_USER_WORK_DIR_NAME);
-    Path target = resolveWindowsSharedWorkDirCandidate();
-
-    migrateWorkDirIfNeeded(target, preferred, legacy);
-
-    try {
-      Path cwd = Path.of(System.getProperty("user.dir")).toAbsolutePath().normalize();
-      if (!target.equals(cwd)) {
-        migrateWorkDirIfNeeded(target, cwd);
-      }
-    } catch (Exception e) {
-      e.printStackTrace();
-    }
-
-    Files.createDirectories(target.resolve("save"));
-    return target;
-  }
-
-  private static Path resolveWindowsSharedWorkDirCandidate() throws IOException {
-    List<Path> candidates = windowsSharedWorkDirCandidates();
-
-    for (Path candidate : candidates) {
-      if (candidate == null || !isAsciiSafePath(candidate)) {
-        continue;
-      }
-      try {
-        Files.createDirectories(candidate.resolve("save"));
-        if (Files.isWritable(candidate)) {
-          return candidate;
-        }
-      } catch (IOException e) {
-        e.printStackTrace();
-      }
-    }
-
-    Path preferred = Path.of(System.getProperty("user.home"), USER_WORK_DIR_NAME);
-    Files.createDirectories(preferred.resolve("save"));
-    return preferred;
-  }
-
-  private static List<Path> windowsSharedWorkDirCandidates() {
-    List<Path> candidates = new ArrayList<Path>();
-    addWindowsWorkDirCandidate(
-        candidates, System.getenv("PUBLIC"), "Documents", WINDOWS_SHARED_WORK_DIR_NAME);
-    addWindowsWorkDirCandidate(candidates, System.getenv("PUBLIC"), WINDOWS_SHARED_WORK_DIR_NAME);
-    addWindowsWorkDirCandidate(
-        candidates, System.getenv("PROGRAMDATA"), WINDOWS_SHARED_WORK_DIR_NAME);
-    return candidates;
-  }
-
-  private static void addWindowsWorkDirCandidate(
-      List<Path> candidates, String root, String... children) {
-    if (root == null || root.trim().isEmpty()) {
-      return;
-    }
-    try {
-      Path candidate = Path.of(root, children).toAbsolutePath().normalize();
-      candidates.add(candidate);
-    } catch (Exception e) {
-      e.printStackTrace();
-    }
+    return WorkDirectoryResolver.resolveWritableFallbackDir();
   }
 
   static Optional<Path> findWindowsPortablePackageRootForTests(Path seedPath) {
-    if (seedPath == null) {
-      return Optional.empty();
-    }
-    return findWindowsPortablePackageRoot(Collections.singleton(seedPath));
+    return WorkDirectoryResolver.findWindowsPortablePackageRootForTests(seedPath);
   }
 
   static Path prepareWindowsPortableWorkDirForTests(Path portableRoot) throws IOException {
-    return prepareWindowsPortableWorkDir(portableRoot, Collections.singletonList(portableRoot));
+    return WorkDirectoryResolver.prepareWindowsPortableWorkDirForTests(portableRoot);
   }
 
   static Path prepareWindowsPortableWorkDirWithSourcesForTests(
       Path portableRoot, Path... migrationSources) throws IOException {
-    return prepareWindowsPortableWorkDir(portableRoot, Arrays.asList(migrationSources));
+    return WorkDirectoryResolver.prepareWindowsPortableWorkDirWithSourcesForTests(
+        portableRoot, migrationSources);
   }
 
   static List<Path> windowsPortableMigrationSourcesForTests(Path portableRoot) {
-    return windowsPortableMigrationSources(portableRoot);
+    return WorkDirectoryResolver.windowsPortableMigrationSourcesForTests(portableRoot);
   }
 
   static List<Path> windowsPortableCredentialDirectoriesForTests(Path portableRoot) {
-    return windowsPortableCredentialDirectories(portableRoot);
+    return WorkDirectoryResolver.windowsPortableCredentialDirectoriesForTests(portableRoot);
   }
 
   /** Returns existing portable credential directories that may need one-time DPAPI migration. */
   public static List<Path> legacyWindowsCredentialDirectories() {
-    Optional<Path> portableRoot = findWindowsPortablePackageRoot();
-    if (portableRoot.isPresent()) {
-      return windowsPortableCredentialDirectories(portableRoot.get());
-    }
-    Path credentials =
-        resolvedWorkDirPath().resolve("secure-credentials").toAbsolutePath().normalize();
-    return Files.isDirectory(credentials)
-        ? Collections.singletonList(credentials)
-        : Collections.emptyList();
+    return WorkDirectoryResolver.legacyWindowsCredentialDirectories();
   }
 
   public static Path resolvedWorkDirPath() {
-    return Path.of(WORK_DIR).toAbsolutePath().normalize();
-  }
-
-  private static Optional<Path> findWindowsPortablePackageRoot() {
-    LinkedHashSet<Path> seedPaths = new LinkedHashSet<>();
-    try {
-      File codeSource =
-          new File(Config.class.getProtectionDomain().getCodeSource().getLocation().toURI());
-      seedPaths.add((codeSource.isFile() ? codeSource.toPath().getParent() : codeSource.toPath()));
-    } catch (Exception e) {
-      e.printStackTrace();
-    }
-    try {
-      seedPaths.add(Path.of("").toAbsolutePath().normalize());
-    } catch (Exception e) {
-      e.printStackTrace();
-    }
-    try {
-      seedPaths.add(Path.of(System.getProperty("user.dir")).toAbsolutePath().normalize());
-    } catch (Exception e) {
-      e.printStackTrace();
-    }
-    return findWindowsPortablePackageRoot(seedPaths);
-  }
-
-  private static Optional<Path> findWindowsPortablePackageRoot(Collection<Path> seedPaths) {
-    if (seedPaths == null) {
-      return Optional.empty();
-    }
-    for (Path seedPath : seedPaths) {
-      if (seedPath == null) {
-        continue;
-      }
-      Path current = seedPath.toAbsolutePath().normalize();
-      for (int depth = 0; current != null && depth < 8; depth++) {
-        if (Files.isRegularFile(current.resolve(WINDOWS_PORTABLE_MARKER_NAME))) {
-          return Optional.of(current);
-        }
-        current = current.getParent();
-      }
-    }
-    return Optional.empty();
-  }
-
-  private static Path prepareWindowsPortableWorkDir(Path portableRoot) throws IOException {
-    return prepareWindowsPortableWorkDir(
-        portableRoot, windowsPortableMigrationSources(portableRoot));
-  }
-
-  private static Path prepareWindowsPortableWorkDir(
-      Path portableRoot, Collection<Path> migrationSources) throws IOException {
-    if (portableRoot == null || !Files.isDirectory(portableRoot)) {
-      return null;
-    }
-    Path workDir =
-        portableRoot.resolve(WINDOWS_PORTABLE_WORK_DIR_NAME).toAbsolutePath().normalize();
-    Files.createDirectories(workDir.resolve("save"));
-    if (!Files.isWritable(workDir)) {
-      return null;
-    }
-    Collection<Path> safeSources =
-        migrationSources == null ? Collections.emptyList() : migrationSources;
-    migrateWorkDirIfNeeded(workDir, safeSources.toArray(new Path[0]));
-    return workDir;
-  }
-
-  private static List<Path> windowsPortableMigrationSources(Path portableRoot) {
-    LinkedHashSet<Path> sources = new LinkedHashSet<>();
-    addMigrationSource(sources, portableRoot);
-    addMigrationSource(sources, portableRoot.resolve("app"));
-
-    Path parent = portableRoot.getParent();
-    if (parent != null && Files.isDirectory(parent)) {
-      try (Stream<Path> stream = Files.list(parent)) {
-        for (Path sibling : (Iterable<Path>) stream::iterator) {
-          if (!Files.isDirectory(sibling)
-              || sibling.toAbsolutePath().normalize().equals(portableRoot)) {
-            continue;
-          }
-          if (hasAppRootMarker(sibling)) {
-            addMigrationSource(sources, sibling.resolve(WINDOWS_PORTABLE_WORK_DIR_NAME));
-            addMigrationSource(sources, sibling);
-            addMigrationSource(
-                sources, sibling.resolve("app").resolve(WINDOWS_PORTABLE_WORK_DIR_NAME));
-            addMigrationSource(sources, sibling.resolve("app"));
-          }
-        }
-      } catch (IOException e) {
-        System.out.println("Portable sibling scan skipped: " + e.getMessage());
-      }
-    }
-
-    for (Path shared : windowsSharedWorkDirCandidates()) {
-      addMigrationSource(sources, shared);
-    }
-    String userHome = System.getProperty("user.home", "").trim();
-    if (!userHome.isEmpty()) {
-      addMigrationSource(sources, Path.of(userHome, USER_WORK_DIR_NAME));
-      addMigrationSource(sources, Path.of(userHome, LEGACY_USER_WORK_DIR_NAME));
-    }
-    return new ArrayList<>(sources);
-  }
-
-  private static List<Path> windowsPortableCredentialDirectories(Path portableRoot) {
-    LinkedHashSet<Path> directories = new LinkedHashSet<>();
-    addExistingCredentialDirectory(
-        directories, portableRoot.resolve(WINDOWS_PORTABLE_WORK_DIR_NAME));
-    for (Path source : windowsPortableMigrationSources(portableRoot)) {
-      addExistingCredentialDirectory(directories, source);
-    }
-    return new ArrayList<>(directories);
-  }
-
-  private static void addExistingCredentialDirectory(Collection<Path> directories, Path source) {
-    if (directories == null || source == null) {
-      return;
-    }
-    try {
-      Path credentialDirectory =
-          source.resolve("secure-credentials").toAbsolutePath().normalize();
-      if (Files.isDirectory(credentialDirectory)) {
-        directories.add(credentialDirectory);
-      }
-    } catch (Exception ignored) {
-    }
-  }
-
-  private static void addMigrationSource(Collection<Path> sources, Path source) {
-    if (sources == null || source == null) {
-      return;
-    }
-    try {
-      sources.add(source.toAbsolutePath().normalize());
-    } catch (Exception ignored) {
-    }
-  }
-
-  private static boolean shouldUsePortableWindowsWorkDir(Path cwd) {
-    if (cwd == null || !Files.isDirectory(cwd) || !Files.isWritable(cwd) || !isAsciiSafePath(cwd)) {
-      return false;
-    }
-    return hasBundledAssets(cwd) || hasExistingWorkDirData(cwd);
-  }
-
-  private static boolean hasBundledAssets(Path dir) {
-    return dir != null
-        && Files.isDirectory(dir.resolve(BUNDLED_ENGINE_ROOT))
-        && Files.isDirectory(dir.resolve(BUNDLED_WEIGHT_ROOT));
-  }
-
-  private static boolean hasExistingWorkDirData(Path dir) {
-    if (dir == null) {
-      return false;
-    }
-    if (Files.isRegularFile(dir.resolve("config.txt"))
-        || Files.isRegularFile(dir.resolve("persist"))) {
-      return true;
-    }
-    Path saveDir = dir.resolve("save");
-    if (!Files.isDirectory(saveDir)) {
-      return false;
-    }
-    try (Stream<Path> stream = Files.list(saveDir)) {
-      return stream.findFirst().isPresent();
-    } catch (IOException e) {
-      return false;
-    }
-  }
-
-  private static void migrateWorkDirIfNeeded(Path target, Path... sources) throws IOException {
-    if (target == null) {
-      return;
-    }
-    Path normalizedTarget = target.toAbsolutePath().normalize();
-    Files.createDirectories(normalizedTarget);
-    List<Path> candidates = normalizedMigrationSources(normalizedTarget, sources);
-    Path configSource = selectBestConfigSource(candidates);
-    Path targetConfigFile = normalizedTarget.resolve("config.txt");
-    boolean targetHadConfig = hasUsableConfig(targetConfigFile);
-    boolean recovered = false;
-
-    if (targetHadConfig && configSource != null) {
-      recovered = recoverPortableUserStateIfNeeded(normalizedTarget, configSource);
-    } else if (!targetHadConfig && configSource != null) {
-      backupUnreadableConfig(targetConfigFile.toFile());
-      copyIfExists(
-          configSource.resolve("config.txt"), targetConfigFile, true);
-    }
-
-    Path primarySource =
-        configSource != null ? configSource : candidates.stream().findFirst().orElse(null);
-    if (primarySource != null) {
-      copyIfExists(primarySource.resolve("persist"), normalizedTarget.resolve("persist"), false);
-      Path sourceSave = primarySource.resolve("save");
-      if (Files.isDirectory(sourceSave)) {
-        copyDirectoryContents(sourceSave, normalizedTarget.resolve("save"), false);
-      }
-    }
-
-    if (configSource != null && (!targetHadConfig || recovered)) {
-      System.out.println("Migrated config dir to " + normalizedTarget + " from " + configSource);
-    }
-  }
-
-  private static List<Path> normalizedMigrationSources(Path target, Path... sources) {
-    LinkedHashSet<Path> candidates = new LinkedHashSet<>();
-    if (sources == null) {
-      return new ArrayList<>();
-    }
-    for (Path source : sources) {
-      if (source == null) {
-        continue;
-      }
-      try {
-        Path normalized = source.toAbsolutePath().normalize();
-        if (!normalized.equals(target) && hasMigratableWorkDirData(normalized)) {
-          candidates.add(normalized);
-        }
-      } catch (Exception ignored) {
-      }
-    }
-    return new ArrayList<>(candidates);
-  }
-
-  private static boolean hasMigratableWorkDirData(Path directory) {
-    return hasExistingWorkDirData(directory);
-  }
-
-  private static Path selectBestConfigSource(List<Path> candidates) {
-    Path selected = null;
-    int selectedTier = Integer.MIN_VALUE;
-    long selectedModified = Long.MIN_VALUE;
-    for (Path candidate : candidates) {
-      Path configFile = candidate.resolve("config.txt");
-      if (!hasUsableConfig(configFile)) {
-        continue;
-      }
-      int tier;
-      try {
-        tier = configUserStateTier(readJsonObject(configFile));
-      } catch (Exception e) {
-        continue;
-      }
-      long modified = Long.MIN_VALUE;
-      try {
-        modified = Files.getLastModifiedTime(configFile).toMillis();
-      } catch (IOException ignored) {
-      }
-      if (selected == null
-          || tier > selectedTier
-          || (tier == selectedTier && modified > selectedModified)) {
-        selected = candidate;
-        selectedTier = tier;
-        selectedModified = modified;
-      }
-    }
-    return selected;
-  }
-
-  private static int configUserStateTier(JSONObject root) {
-    JSONObject leelaz = root.optJSONObject("leelaz");
-    if (leelaz == null) {
-      return 0;
-    }
-    if (hasConfiguredRemoteProvider(leelaz)) {
-      return 2;
-    }
-    JSONArray engines = leelaz.optJSONArray("engine-settings-list");
-    if (engines != null) {
-      for (int i = 0; i < engines.length(); i++) {
-        JSONObject engine = engines.optJSONObject(i);
-        if (engine != null && !looksLikeManagedBundledEngine(engine)) {
-          return 2;
-        }
-      }
-    }
-    JSONArray legacyCommands = leelaz.optJSONArray("engine-command-list");
-    if (legacyCommands != null && legacyCommands.length() > 0) {
-      return 2;
-    }
-    return engines != null && engines.length() > 0 ? 1 : 0;
-  }
-
-  private static boolean hasUsableConfig(Path configFile) {
-    if (!Files.isRegularFile(configFile)) {
-      return false;
-    }
-    try {
-      JSONObject parsed = readJsonObject(configFile);
-      return parsed.optJSONObject("ui") != null || parsed.optJSONObject("leelaz") != null;
-    } catch (Exception e) {
-      return false;
-    }
-  }
-
-  private static boolean recoverPortableUserStateIfNeeded(Path target, Path source)
-      throws IOException {
-    Path targetConfigFile = target.resolve("config.txt");
-    Path sourceConfigFile = source.resolve("config.txt");
-    try {
-      JSONObject targetConfig = readJsonObject(targetConfigFile);
-      JSONObject sourceConfig = readJsonObject(sourceConfigFile);
-      JSONObject targetUi = targetConfig.optJSONObject("ui");
-      if (targetUi != null && targetUi.optBoolean(WINDOWS_PORTABLE_STATE_MIGRATION_KEY, false)) {
-        return false;
-      }
-      if (!looksLikeFreshPortableConfig(targetConfig)
-          || !containsRecoverableUserState(sourceConfig, targetConfig)) {
-        return false;
-      }
-
-      Path backup = target.resolve(WINDOWS_PORTABLE_RECOVERY_BACKUP_NAME);
-      copyIfExists(targetConfigFile, backup, false);
-      JSONObject recovered = new JSONObject(sourceConfig.toString());
-      mergeMissingJsonValues(recovered, targetConfig);
-      JSONObject recoveredUi = recovered.optJSONObject("ui");
-      if (recoveredUi == null) {
-        recoveredUi = new JSONObject();
-        recovered.put("ui", recoveredUi);
-      }
-      recoveredUi.put(WINDOWS_PORTABLE_STATE_MIGRATION_KEY, true);
-      writeJsonAtomically(targetConfigFile, recovered);
-      return true;
-    } catch (JSONException e) {
-      return false;
-    }
-  }
-
-  private static boolean looksLikeFreshPortableConfig(JSONObject root) {
-    JSONObject leelaz = root.optJSONObject("leelaz");
-    if (leelaz == null || hasConfiguredRemoteProvider(leelaz)) {
-      return false;
-    }
-    JSONArray engines = leelaz.optJSONArray("engine-settings-list");
-    if (engines == null || engines.length() == 0) {
-      return true;
-    }
-    if (engines.length() != 1) {
-      return false;
-    }
-    JSONObject engine = engines.optJSONObject(0);
-    if (engine == null) {
-      return true;
-    }
-    return looksLikeManagedBundledEngine(engine);
-  }
-
-  private static boolean looksLikeManagedBundledEngine(JSONObject engine) {
-    String name = engine.optString("name", "").trim();
-    String command = engine.optString("command", "").replace('\\', '/').toLowerCase(Locale.ROOT);
-    return (BUNDLED_ENGINE_NAME.equals(name) || "KataGo Auto Setup".equals(name))
-        && (command.isEmpty()
-            || command.contains("weights/default.bin.gz")
-            || command.contains("engines/katago/"));
-  }
-
-  private static boolean containsRecoverableUserState(JSONObject source, JSONObject target) {
-    JSONObject sourceLeelaz = source.optJSONObject("leelaz");
-    JSONObject targetLeelaz = target.optJSONObject("leelaz");
-    if (sourceLeelaz == null) {
-      return false;
-    }
-    if (hasConfiguredRemoteProvider(sourceLeelaz)
-        && (targetLeelaz == null || !hasConfiguredRemoteProvider(targetLeelaz))) {
-      return true;
-    }
-    Set<String> targetEngines = engineIdentities(targetLeelaz);
-    for (String sourceEngine : engineIdentities(sourceLeelaz)) {
-      if (!targetEngines.contains(sourceEngine)) {
-        return true;
-      }
-    }
-    JSONArray legacyCommands = sourceLeelaz.optJSONArray("engine-command-list");
-    return legacyCommands != null && legacyCommands.length() > 0;
-  }
-
-  private static boolean hasConfiguredRemoteProvider(JSONObject leelaz) {
-    if (leelaz == null) {
-      return false;
-    }
-    JSONObject remote = leelaz.optJSONObject("remote-compute");
-    if (remote == null) {
-      return false;
-    }
-    return !"local".equalsIgnoreCase(remote.optString("provider", "local"))
-        || !remote.optString("zhizi-identifier", "").isBlank()
-        || !remote.optString("custom-remote-code", "").isBlank();
-  }
-
-  private static Set<String> engineIdentities(JSONObject leelaz) {
-    LinkedHashSet<String> identities = new LinkedHashSet<>();
-    if (leelaz == null) {
-      return identities;
-    }
-    JSONArray engines = leelaz.optJSONArray("engine-settings-list");
-    if (engines == null) {
-      return identities;
-    }
-    for (int i = 0; i < engines.length(); i++) {
-      JSONObject engine = engines.optJSONObject(i);
-      if (engine == null) {
-        continue;
-      }
-      String command = engine.optString("command", "").trim().toLowerCase(Locale.ROOT);
-      String name = engine.optString("name", "").trim().toLowerCase(Locale.ROOT);
-      identities.add(command.isEmpty() ? "name:" + name : "command:" + command);
-    }
-    return identities;
-  }
-
-  private static void mergeMissingJsonValues(JSONObject target, JSONObject fallback) {
-    for (String key : fallback.keySet()) {
-      Object fallbackValue = fallback.get(key);
-      if (!target.has(key)) {
-        target.put(key, fallbackValue);
-      } else if (target.opt(key) instanceof JSONObject && fallbackValue instanceof JSONObject) {
-        mergeMissingJsonValues(target.getJSONObject(key), (JSONObject) fallbackValue);
-      }
-    }
-  }
-
-  private static void writeJsonAtomically(Path target, JSONObject value) throws IOException {
-    Files.createDirectories(target.getParent());
-    Path temporary = Files.createTempFile(target.getParent(), ".config-recovery-", ".tmp");
-    try {
-      Files.writeString(temporary, value.toString(2));
-      try {
-        Files.move(
-            temporary, target, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);
-      } catch (AtomicMoveNotSupportedException e) {
-        Files.move(temporary, target, StandardCopyOption.REPLACE_EXISTING);
-      }
-    } finally {
-      Files.deleteIfExists(temporary);
-    }
-  }
-
-  private static void copyDirectoryContents(Path source, Path target, boolean replace)
-      throws IOException {
-    Files.createDirectories(target);
-    try (Stream<Path> stream = Files.list(source)) {
-      for (Path child : (Iterable<Path>) stream::iterator) {
-        Path destination = target.resolve(child.getFileName().toString());
-        if (Files.isDirectory(child)) {
-          copyDirectoryContents(child, destination, replace);
-        } else {
-          copyIfExists(child, destination, replace);
-        }
-      }
-    }
-  }
-
-  private static void copyIfExists(Path source, Path destination, boolean replace)
-      throws IOException {
-    if (!Files.exists(source) || Files.isDirectory(source)) {
-      return;
-    }
-    if (!replace && Files.exists(destination)) {
-      return;
-    }
-    Files.createDirectories(destination.getParent());
-    if (replace) {
-      Files.copy(source, destination, StandardCopyOption.REPLACE_EXISTING);
-    } else {
-      Files.copy(source, destination);
-    }
-  }
-
-  private static boolean isAsciiSafePath(Path path) {
-    if (path == null) {
-      return false;
-    }
-    String text = path.toAbsolutePath().normalize().toString();
-    for (int i = 0; i < text.length(); i++) {
-      if (text.charAt(i) > 127) {
-        return false;
-      }
-    }
-    return true;
+    return WorkDirectoryResolver.resolve().directory();
   }
 
   private static Optional<Path> findBundledAppRoot() {
@@ -1860,6 +1212,7 @@ public class Config {
   public boolean disableMoveRankInOrigin = false;
   public boolean logConsoleToFile = false;
   public boolean logGtpToFile = false;
+  public LoggingSettings loggingSettings = LoggingSettings.defaults();
   public boolean enableStartupBenchmark = true;
   public boolean readBoardPonder = false;
   public boolean suppressReadBoardWebSocketPonderingNotice = false;
@@ -2221,6 +1574,10 @@ public class Config {
     saveBoardConfig = saveBoard.getJSONObject("save");
     uiConfig = config.getJSONObject("ui");
     persistedUi = persisted.getJSONObject("ui-persist");
+    loggingSettings = LoggingSettings.fromJson(config.optJSONObject(LoggingSettings.CONFIG_KEY));
+    if (!config.has(LoggingSettings.CONFIG_KEY)) {
+      config.put(LoggingSettings.CONFIG_KEY, loggingSettings.toJson());
+    }
     applyFirstLaunchDefaults(uiConfig, newProfile);
 
     restoreSubBoardDefaultOnce();
@@ -3571,6 +2928,7 @@ public class Config {
     ui.put("replay-branch-interval-seconds", 0.9);
     //   ui.put("gtp-console-style", defaultGtpConsoleStyle);
     config.put("ui", ui);
+    config.put(LoggingSettings.CONFIG_KEY, LoggingSettings.defaults().toJson());
     return config;
   }
 
@@ -4184,6 +3542,16 @@ public class Config {
     this.config = candidateRoot;
     this.uiConfig = candidateRoot.getJSONObject("ui");
     this.leelazConfig = candidateRoot.getJSONObject("leelaz");
+  }
+
+  public void saveLoggingSettings(LoggingSettings settings) throws IOException {
+    JSONObject candidateRoot = new JSONObject(this.config.toString());
+    candidateRoot.put(LoggingSettings.CONFIG_KEY, settings.toJson());
+    writeConfig(candidateRoot, new File(configFilename));
+    this.config = candidateRoot;
+    this.uiConfig = candidateRoot.getJSONObject("ui");
+    this.leelazConfig = candidateRoot.getJSONObject("leelaz");
+    this.loggingSettings = settings;
   }
 
   public void saveTempBoard() throws IOException {

--- a/src/main/java/featurecat/lizzie/Lizzie.java
+++ b/src/main/java/featurecat/lizzie/Lizzie.java
@@ -44,6 +44,7 @@ import java.nio.file.Path;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.List;
+import java.util.function.IntConsumer;
 import java.util.Locale;
 import java.util.ResourceBundle;
 import java.util.concurrent.Callable;
@@ -162,7 +163,12 @@ public class Lizzie {
       }
     } catch (Exception ignored) {
     }
-    LoggingRuntime.initialize(workDirectory);
+    try {
+      LoggingRuntime.initialize(workDirectory);
+    } catch (Throwable t) {
+      System.err.println(
+          LoggingRuntime.STDERR_PREFIX + "bootstrap " + t.getClass().getSimpleName());
+    }
     config = new Config();
     LoggingRuntime.current().ifPresent(runtime -> runtime.applySettings(config.loggingSettings));
     firstLaunchSession = config.isNewProfile() || config.firstTimeLoad;
@@ -1074,7 +1080,15 @@ public class Lizzie {
         e.printStackTrace();
       }
     }
-    System.exit(0);
+    shutdownLoggingThenExit(System::exit);
+  }
+
+  public static void shutdownLoggingThenExit(IntConsumer exit) {
+    try {
+      LoggingRuntime.current().ifPresent(LoggingRuntime::shutdown);
+    } catch (RuntimeException ignored) {
+    }
+    exit.accept(0);
   }
 
   public static void resetAllHints() {

--- a/src/main/java/featurecat/lizzie/Lizzie.java
+++ b/src/main/java/featurecat/lizzie/Lizzie.java
@@ -16,6 +16,9 @@ import featurecat.lizzie.gui.LizzieFrame;
 import featurecat.lizzie.gui.LoadEngine;
 import featurecat.lizzie.gui.Menu;
 import featurecat.lizzie.gui.web.WebBoardManager;
+import featurecat.lizzie.logging.LoggingRuntime;
+import featurecat.lizzie.logging.WorkDirectoryResolution;
+import featurecat.lizzie.logging.WorkDirectoryResolver;
 import featurecat.lizzie.rules.Board;
 import featurecat.lizzie.rules.BoardHistoryNode;
 import featurecat.lizzie.util.KataGoAutoSetupHelper;
@@ -151,8 +154,17 @@ public class Lizzie {
     if (System.getProperty("swing.aatext") == null) {
       System.setProperty("swing.aatext", "true");
     }
-    ensureWritableWorkingDir();
+    WorkDirectoryResolution workDirectory = WorkDirectoryResolver.resolve();
+    try {
+      Path cwd = Path.of(System.getProperty("user.dir")).toAbsolutePath();
+      if (!Files.isWritable(cwd)) {
+        System.setProperty("user.dir", workDirectory.directory().toString());
+      }
+    } catch (Exception ignored) {
+    }
+    LoggingRuntime.initialize(workDirectory);
     config = new Config();
+    LoggingRuntime.current().ifPresent(runtime -> runtime.applySettings(config.loggingSettings));
     firstLaunchSession = config.isNewProfile() || config.firstTimeLoad;
     resourceBundle = AppLocale.loadBundle(config.useLanguage);
     NetworkProxy.installSystemProxyPropertyFromSavedConfig();
@@ -560,21 +572,6 @@ public class Lizzie {
     }
     String trimmed = value.trim();
     return trimmed.isEmpty() ? null : trimmed;
-  }
-
-  private static void ensureWritableWorkingDir() {
-    try {
-      Path cwd = Path.of(System.getProperty("user.dir")).toAbsolutePath();
-      if (Files.isWritable(cwd)) {
-        return;
-      }
-      Path fallback = Config.resolveWritableFallbackDir();
-      System.setProperty("user.dir", fallback.toString());
-      System.out.println("switch user.dir to writable path: " + fallback);
-    } catch (Exception e) {
-      // Keep default behavior if we fail to switch directory.
-      e.printStackTrace();
-    }
   }
 
   private static void installApplicationIcon() {

--- a/src/main/java/featurecat/lizzie/gui/FirstUseSettings.java
+++ b/src/main/java/featurecat/lizzie/gui/FirstUseSettings.java
@@ -750,7 +750,7 @@ public class FirstUseSettings extends JDialog {
       addWindowListener(
           new WindowAdapter() {
             public void windowClosing(WindowEvent e) {
-              System.exit(0);
+              Lizzie.shutdownLoggingThenExit(System::exit);
             }
           });
     }

--- a/src/main/java/featurecat/lizzie/gui/LoadEngine.java
+++ b/src/main/java/featurecat/lizzie/gui/LoadEngine.java
@@ -17,6 +17,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Locale;
 import java.util.ResourceBundle;
+import java.util.function.IntConsumer;
 import javax.imageio.ImageIO;
 import javax.swing.*;
 import javax.swing.table.AbstractTableModel;
@@ -27,6 +28,14 @@ import javax.swing.table.TableModel;
 import javax.swing.table.TableColumn;
 
 public class LoadEngine extends JPanel {
+
+  public static void requestNormalExit() {
+    requestNormalExit(System::exit);
+  }
+
+  public static void requestNormalExit(IntConsumer exit) {
+    Lizzie.shutdownLoggingThenExit(exit);
+  }
   public static Config config;
   public TableModel dataModel;
   JPanel tablepanel;
@@ -240,7 +249,7 @@ public class LoadEngine extends JPanel {
           @Override
           public void actionPerformed(ActionEvent e) {
             // TODO Auto-generated method stub
-            System.exit(0);
+            requestNormalExit();
           }
         });
     noEngine.addActionListener(
@@ -551,7 +560,8 @@ public class LoadEngine extends JPanel {
         Lizzie.resourceBundle.getString("loadEngine.title"),
         Lizzie.resourceBundle.getString("loadEngine.title"));
     AccessibilitySupport.applyToTree(newContentPane);
-    AccessibilitySupport.installEscapeAction(engjf.getRootPane(), engjf, () -> System.exit(0));
+    AccessibilitySupport.installEscapeAction(
+        engjf.getRootPane(), engjf, LoadEngine::requestNormalExit);
     engjf.setModal(true);
     // Display the window.
     // jf.setSize(521, 320);
@@ -560,7 +570,7 @@ public class LoadEngine extends JPanel {
     engjf.addWindowListener(
         new WindowAdapter() {
           public void windowClosing(WindowEvent e) {
-            System.exit(0);
+            requestNormalExit();
           }
         });
 

--- a/src/main/java/featurecat/lizzie/logging/BoundedAsyncAppender.java
+++ b/src/main/java/featurecat/lizzie/logging/BoundedAsyncAppender.java
@@ -4,6 +4,8 @@ import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.Appender;
 import ch.qos.logback.core.UnsynchronizedAppenderBase;
+import ch.qos.logback.core.status.ErrorStatus;
+import java.nio.file.Path;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CountDownLatch;
@@ -17,11 +19,16 @@ final class BoundedAsyncAppender extends UnsynchronizedAppenderBase<ILoggingEven
   private final boolean dropInfoFirst;
   private final int discardingThreshold;
   private final AtomicLong dropped = new AtomicLong();
+  private final AtomicLong inFlight = new AtomicLong();
+  private final AtomicLong abandoned = new AtomicLong();
   private final AtomicBoolean accepting = new AtomicBoolean(true);
   private final AtomicBoolean workerFailed = new AtomicBoolean();
   private volatile Appender<ILoggingEvent> nested;
   private volatile LoggingRuntime runtime;
   private volatile CountDownLatch gate;
+  private volatile boolean failWrites;
+  private volatile long nestedStopPauseMillis;
+  private volatile Path activeFile;
   private Thread worker;
 
   BoundedAsyncAppender(LogStream stream, int capacity, boolean dropInfoFirst) {
@@ -41,6 +48,18 @@ final class BoundedAsyncAppender extends UnsynchronizedAppenderBase<ILoggingEven
 
   void setGate(CountDownLatch gate) {
     this.gate = gate;
+  }
+
+  void setFailWrites(boolean failWrites) {
+    this.failWrites = failWrites;
+  }
+
+  void setNestedStopPauseMillis(long nestedStopPauseMillis) {
+    this.nestedStopPauseMillis = nestedStopPauseMillis;
+  }
+
+  void setActiveFile(Path activeFile) {
+    this.activeFile = activeFile;
   }
 
   LogStream stream() {
@@ -86,23 +105,26 @@ final class BoundedAsyncAppender extends UnsynchronizedAppenderBase<ILoggingEven
   long shutdown(long deadlineNanos) {
     accepting.set(false);
     if (worker != null) {
-      long remaining = deadlineNanos - System.nanoTime();
-      if (remaining > 0) {
-        try {
-          worker.join(TimeUnit.NANOSECONDS.toMillis(remaining) + 1);
-        } catch (InterruptedException e) {
-          Thread.currentThread().interrupt();
-        }
-      }
-      if (worker.isAlive()) {
-        worker.interrupt();
-      }
+      worker.interrupt();
+      joinUntil(deadlineNanos);
     }
     if (nested != null && nested.isStarted()) {
-      nested.stop();
+      Deadline.run(
+          deadlineNanos,
+          () -> {
+            long pause = nestedStopPauseMillis;
+            if (pause > 0) {
+              try {
+                Thread.sleep(pause);
+              } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+              }
+            }
+            nested.stop();
+          });
     }
     super.stop();
-    return queue.size();
+    return queue.size() + inFlight.get() + abandoned.get();
   }
 
   @Override
@@ -138,11 +160,31 @@ final class BoundedAsyncAppender extends UnsynchronizedAppenderBase<ILoggingEven
           }
           continue;
         }
-        CountDownLatch currentGate = gate;
-        if (currentGate != null) {
-          currentGate.await();
+        inFlight.incrementAndGet();
+        boolean completedAppend = false;
+        try {
+          CountDownLatch currentGate = gate;
+          if (currentGate != null) {
+            currentGate.await();
+          }
+          long generation = runtime == null ? 0L : runtime.failureGeneration(stream);
+          if (failWrites) {
+            reportWriteFailure();
+          } else {
+            nested.doAppend(event);
+          }
+          completedAppend = true;
+          if (runtime != null
+              && nested.isStarted()
+              && runtime.failureGeneration(stream) == generation) {
+            runtime.recordSuccess(stream);
+          }
+        } finally {
+          if (!completedAppend) {
+            abandoned.incrementAndGet();
+          }
+          inFlight.decrementAndGet();
         }
-        nested.doAppend(event);
       } catch (InterruptedException e) {
         Thread.currentThread().interrupt();
         break;
@@ -151,6 +193,32 @@ final class BoundedAsyncAppender extends UnsynchronizedAppenderBase<ILoggingEven
           runtime.recordFailure(stream, e.getClass().getSimpleName() + ": " + e.getMessage());
         }
       }
+    }
+  }
+
+  private void reportWriteFailure() {
+    String path = activeFile == null ? stream.name() : activeFile.toAbsolutePath().toString();
+    ErrorStatus status =
+        new ErrorStatus("IO failure while writing to file [" + path + "]", nested);
+    if (getContext() != null) {
+      getContext().getStatusManager().add(status);
+    } else if (runtime != null) {
+      runtime.recordFailure(stream, status.getMessage());
+    }
+  }
+
+  private void joinUntil(long deadlineNanos) {
+    if (worker == null) {
+      return;
+    }
+    long remaining = deadlineNanos - System.nanoTime();
+    if (remaining <= 0) {
+      return;
+    }
+    try {
+      worker.join(Math.max(1L, TimeUnit.NANOSECONDS.toMillis(remaining)));
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
     }
   }
 

--- a/src/main/java/featurecat/lizzie/logging/BoundedAsyncAppender.java
+++ b/src/main/java/featurecat/lizzie/logging/BoundedAsyncAppender.java
@@ -1,0 +1,163 @@
+package featurecat.lizzie.logging;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.Appender;
+import ch.qos.logback.core.UnsynchronizedAppenderBase;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+
+final class BoundedAsyncAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
+  private final LogStream stream;
+  private final BlockingQueue<ILoggingEvent> queue;
+  private final boolean dropInfoFirst;
+  private final int discardingThreshold;
+  private final AtomicLong dropped = new AtomicLong();
+  private final AtomicBoolean accepting = new AtomicBoolean(true);
+  private final AtomicBoolean workerFailed = new AtomicBoolean();
+  private volatile Appender<ILoggingEvent> nested;
+  private volatile LoggingRuntime runtime;
+  private volatile CountDownLatch gate;
+  private Thread worker;
+
+  BoundedAsyncAppender(LogStream stream, int capacity, boolean dropInfoFirst) {
+    this.stream = stream;
+    this.queue = new ArrayBlockingQueue<>(Math.max(1, capacity));
+    this.dropInfoFirst = dropInfoFirst;
+    this.discardingThreshold = Math.max(1, capacity / 4);
+  }
+
+  void setNested(Appender<ILoggingEvent> nested) {
+    this.nested = nested;
+  }
+
+  void setRuntime(LoggingRuntime runtime) {
+    this.runtime = runtime;
+  }
+
+  void setGate(CountDownLatch gate) {
+    this.gate = gate;
+  }
+
+  LogStream stream() {
+    return stream;
+  }
+
+  long droppedCount() {
+    return dropped.get();
+  }
+
+  int queuedCount() {
+    return queue.size();
+  }
+
+  void stopAccepting() {
+    accepting.set(false);
+  }
+
+  @Override
+  public void start() {
+    if (nested == null) {
+      addError("Nested appender is required");
+      return;
+    }
+    if (!nested.isStarted()) {
+      nested.start();
+    }
+    worker = new Thread(this::drain, "lizzie-log-" + stream.name().toLowerCase());
+    worker.setDaemon(true);
+    super.start();
+    worker.start();
+  }
+
+  @Override
+  public void stop() {
+    accepting.set(false);
+    super.stop();
+    if (worker != null) {
+      worker.interrupt();
+    }
+  }
+
+  long shutdown(long deadlineNanos) {
+    accepting.set(false);
+    if (worker != null) {
+      long remaining = deadlineNanos - System.nanoTime();
+      if (remaining > 0) {
+        try {
+          worker.join(TimeUnit.NANOSECONDS.toMillis(remaining) + 1);
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+        }
+      }
+      if (worker.isAlive()) {
+        worker.interrupt();
+      }
+    }
+    if (nested != null && nested.isStarted()) {
+      nested.stop();
+    }
+    super.stop();
+    return queue.size();
+  }
+
+  @Override
+  protected void append(ILoggingEvent event) {
+    if (!accepting.get() || event == null) {
+      if (event != null) {
+        dropped.incrementAndGet();
+        notifyDrop();
+      }
+      return;
+    }
+    event.prepareForDeferredProcessing();
+    if (dropInfoFirst
+        && queue.remainingCapacity() <= discardingThreshold
+        && event.getLevel().toInt() < Level.WARN_INT) {
+      dropped.incrementAndGet();
+      notifyDrop();
+      return;
+    }
+    if (!queue.offer(event)) {
+      dropped.incrementAndGet();
+      notifyDrop();
+    }
+  }
+
+  private void drain() {
+    while (true) {
+      try {
+        ILoggingEvent event = queue.poll(50, TimeUnit.MILLISECONDS);
+        if (event == null) {
+          if (!accepting.get()) {
+            break;
+          }
+          continue;
+        }
+        CountDownLatch currentGate = gate;
+        if (currentGate != null) {
+          currentGate.await();
+        }
+        nested.doAppend(event);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        break;
+      } catch (RuntimeException e) {
+        if (workerFailed.compareAndSet(false, true) && runtime != null) {
+          runtime.recordFailure(stream, e.getClass().getSimpleName() + ": " + e.getMessage());
+        }
+      }
+    }
+  }
+
+  private void notifyDrop() {
+    LoggingRuntime current = runtime;
+    if (current != null) {
+      current.recordDrop(stream);
+    }
+  }
+}

--- a/src/main/java/featurecat/lizzie/logging/BoundedAsyncAppender.java
+++ b/src/main/java/featurecat/lizzie/logging/BoundedAsyncAppender.java
@@ -58,6 +58,11 @@ final class BoundedAsyncAppender extends UnsynchronizedAppenderBase<ILoggingEven
     this.nestedStopPauseMillis = nestedStopPauseMillis;
   }
 
+  boolean isNestedStartedForTests() {
+    Appender<ILoggingEvent> current = nested;
+    return current != null && current.isStarted();
+  }
+
   void setActiveFile(Path activeFile) {
     this.activeFile = activeFile;
   }
@@ -122,6 +127,9 @@ final class BoundedAsyncAppender extends UnsynchronizedAppenderBase<ILoggingEven
             }
             nested.stop();
           });
+      if (nested.isStarted()) {
+        nested.stop();
+      }
     }
     super.stop();
     return queue.size() + inFlight.get() + abandoned.get();

--- a/src/main/java/featurecat/lizzie/logging/CorrelationContext.java
+++ b/src/main/java/featurecat/lizzie/logging/CorrelationContext.java
@@ -1,0 +1,54 @@
+package featurecat.lizzie.logging;
+
+import org.slf4j.MDC;
+
+public final class CorrelationContext {
+  public static final String APP_SESSION = "lizzie.appSession";
+  public static final String ENGINE_ID = "lizzie.engineId";
+  public static final String COMMAND_ID = "lizzie.commandId";
+  public static final String TRACE_SESSION = "lizzie.traceSession";
+
+  private CorrelationContext() {}
+
+  public static void installAppSession(String applicationLogSessionId) {
+    put(APP_SESSION, applicationLogSessionId);
+  }
+
+  public static void installEngine(String engineId) {
+    put(ENGINE_ID, engineId);
+  }
+
+  public static void installCommand(String commandId) {
+    put(COMMAND_ID, commandId);
+  }
+
+  public static void installTraceSession(String traceSessionId) {
+    put(TRACE_SESSION, traceSessionId);
+  }
+
+  public static void clearEngine() {
+    MDC.remove(ENGINE_ID);
+  }
+
+  public static void clearCommand() {
+    MDC.remove(COMMAND_ID);
+  }
+
+  public static void clearTraceSession() {
+    MDC.remove(TRACE_SESSION);
+  }
+
+  public static void clearAsync() {
+    MDC.remove(ENGINE_ID);
+    MDC.remove(COMMAND_ID);
+    MDC.remove(TRACE_SESSION);
+  }
+
+  private static void put(String key, String value) {
+    if (value == null || value.isEmpty()) {
+      MDC.remove(key);
+    } else {
+      MDC.put(key, value);
+    }
+  }
+}

--- a/src/main/java/featurecat/lizzie/logging/CorrelationConverter.java
+++ b/src/main/java/featurecat/lizzie/logging/CorrelationConverter.java
@@ -1,0 +1,31 @@
+package featurecat.lizzie.logging;
+
+import ch.qos.logback.classic.pattern.ClassicConverter;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import java.util.Map;
+
+public final class CorrelationConverter extends ClassicConverter {
+  @Override
+  public String convert(ILoggingEvent event) {
+    Map<String, String> mdc = event.getMDCPropertyMap();
+    if (mdc == null || mdc.isEmpty()) {
+      return "";
+    }
+    StringBuilder rendered = new StringBuilder();
+    append(rendered, "session", mdc.get(CorrelationContext.APP_SESSION));
+    append(rendered, "engine", mdc.get(CorrelationContext.ENGINE_ID));
+    append(rendered, "command", mdc.get(CorrelationContext.COMMAND_ID));
+    append(rendered, "trace", mdc.get(CorrelationContext.TRACE_SESSION));
+    return rendered.toString();
+  }
+
+  private static void append(StringBuilder rendered, String label, String value) {
+    if (value == null || value.isEmpty()) {
+      return;
+    }
+    if (rendered.length() > 0) {
+      rendered.append(' ');
+    }
+    rendered.append(label).append('=').append(value);
+  }
+}

--- a/src/main/java/featurecat/lizzie/logging/Deadline.java
+++ b/src/main/java/featurecat/lizzie/logging/Deadline.java
@@ -18,5 +18,8 @@ final class Deadline {
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
     }
+    if (thread.isAlive()) {
+      thread.interrupt();
+    }
   }
 }

--- a/src/main/java/featurecat/lizzie/logging/Deadline.java
+++ b/src/main/java/featurecat/lizzie/logging/Deadline.java
@@ -1,0 +1,22 @@
+package featurecat.lizzie.logging;
+
+import java.util.concurrent.TimeUnit;
+
+final class Deadline {
+  private Deadline() {}
+
+  static void run(long deadlineNanos, Runnable action) {
+    long remaining = deadlineNanos - System.nanoTime();
+    if (remaining <= 0) {
+      return;
+    }
+    Thread thread = new Thread(action, "lizzie-log-deadline");
+    thread.setDaemon(true);
+    thread.start();
+    try {
+      thread.join(Math.max(1L, TimeUnit.NANOSECONDS.toMillis(remaining)));
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+    }
+  }
+}

--- a/src/main/java/featurecat/lizzie/logging/DiagnosticModule.java
+++ b/src/main/java/featurecat/lizzie/logging/DiagnosticModule.java
@@ -1,0 +1,33 @@
+package featurecat.lizzie.logging;
+
+public enum DiagnosticModule {
+  ENGINE("engine", LogCategories.ENGINE),
+  GTP_SUMMARY("gtp-summary", LogCategories.GTP),
+  READBOARD_YIKE("readboard-yike", LogCategories.READBOARD),
+  NETWORK_REMOTE("network-remote", LogCategories.NETWORK);
+
+  private final String wireName;
+  private final String loggerName;
+
+  DiagnosticModule(String wireName, String loggerName) {
+    this.wireName = wireName;
+    this.loggerName = loggerName;
+  }
+
+  public String wireName() {
+    return wireName;
+  }
+
+  public String loggerName() {
+    return loggerName;
+  }
+
+  public static DiagnosticModule fromWireName(String wireName) {
+    for (DiagnosticModule module : values()) {
+      if (module.wireName.equals(wireName)) {
+        return module;
+      }
+    }
+    throw new IllegalArgumentException("Unknown diagnostic module: " + wireName);
+  }
+}

--- a/src/main/java/featurecat/lizzie/logging/LogCategories.java
+++ b/src/main/java/featurecat/lizzie/logging/LogCategories.java
@@ -1,0 +1,20 @@
+package featurecat.lizzie.logging;
+
+public final class LogCategories {
+  public static final String APP = "lizzie.app";
+  public static final String CONFIG = "lizzie.config";
+  public static final String ENGINE = "lizzie.engine";
+  public static final String GTP = "lizzie.gtp";
+  public static final String ENGINE_TRACE = "lizzie.engine.trace";
+  public static final String READBOARD = "lizzie.readboard";
+  public static final String READBOARD_TRACE = "lizzie.readboard.trace";
+  public static final String NETWORK = "lizzie.network";
+  public static final String NETWORK_TRACE = "lizzie.network.trace";
+  public static final String REMOTE = "lizzie.remote";
+  public static final String SGF = "lizzie.sgf";
+  public static final String UI = "lizzie.ui";
+  public static final String CRASH = "lizzie.crash";
+  public static final String DIAGNOSTICS = "lizzie.diagnostics";
+
+  private LogCategories() {}
+}

--- a/src/main/java/featurecat/lizzie/logging/LogStream.java
+++ b/src/main/java/featurecat/lizzie/logging/LogStream.java
@@ -1,0 +1,9 @@
+package featurecat.lizzie.logging;
+
+public enum LogStream {
+  APP,
+  CRASH,
+  ENGINE_TRACE,
+  READBOARD_TRACE,
+  NETWORK_TRACE
+}

--- a/src/main/java/featurecat/lizzie/logging/LoggingLimits.java
+++ b/src/main/java/featurecat/lizzie/logging/LoggingLimits.java
@@ -1,0 +1,91 @@
+package featurecat.lizzie.logging;
+
+public final class LoggingLimits {
+  public static final int APP_QUEUE_CAPACITY = 4096;
+  public static final int ENGINE_TRACE_QUEUE_CAPACITY = 8192;
+  public static final int READBOARD_TRACE_QUEUE_CAPACITY = 4096;
+  public static final int NETWORK_TRACE_QUEUE_CAPACITY = 4096;
+  public static final int RETENTION_DAYS = 7;
+  public static final long TOTAL_SIZE_CAP_BYTES = 100L * 1024 * 1024;
+  public static final long ACTIVE_FILE_SIZE_BYTES = 10L * 1024 * 1024;
+  public static final long SHUTDOWN_BUDGET_NANOS = 3_000_000_000L;
+
+  private final int appQueueCapacity;
+  private final int engineTraceQueueCapacity;
+  private final int readboardTraceQueueCapacity;
+  private final int networkTraceQueueCapacity;
+  private final int retentionDays;
+  private final long totalSizeCapBytes;
+  private final long activeFileSizeBytes;
+
+  public LoggingLimits(
+      int appQueueCapacity,
+      int engineTraceQueueCapacity,
+      int readboardTraceQueueCapacity,
+      int networkTraceQueueCapacity,
+      int retentionDays,
+      long totalSizeCapBytes,
+      long activeFileSizeBytes) {
+    this.appQueueCapacity = appQueueCapacity;
+    this.engineTraceQueueCapacity = engineTraceQueueCapacity;
+    this.readboardTraceQueueCapacity = readboardTraceQueueCapacity;
+    this.networkTraceQueueCapacity = networkTraceQueueCapacity;
+    this.retentionDays = retentionDays;
+    this.totalSizeCapBytes = totalSizeCapBytes;
+    this.activeFileSizeBytes = activeFileSizeBytes;
+  }
+
+  public static LoggingLimits production() {
+    return new LoggingLimits(
+        APP_QUEUE_CAPACITY,
+        ENGINE_TRACE_QUEUE_CAPACITY,
+        READBOARD_TRACE_QUEUE_CAPACITY,
+        NETWORK_TRACE_QUEUE_CAPACITY,
+        RETENTION_DAYS,
+        TOTAL_SIZE_CAP_BYTES,
+        ACTIVE_FILE_SIZE_BYTES);
+  }
+
+  public int appQueueCapacity() {
+    return appQueueCapacity;
+  }
+
+  public int engineTraceQueueCapacity() {
+    return engineTraceQueueCapacity;
+  }
+
+  public int readboardTraceQueueCapacity() {
+    return readboardTraceQueueCapacity;
+  }
+
+  public int networkTraceQueueCapacity() {
+    return networkTraceQueueCapacity;
+  }
+
+  public int retentionDays() {
+    return retentionDays;
+  }
+
+  public long totalSizeCapBytes() {
+    return totalSizeCapBytes;
+  }
+
+  public long activeFileSizeBytes() {
+    return activeFileSizeBytes;
+  }
+
+  public int queueCapacity(LogStream stream) {
+    switch (stream) {
+      case ENGINE_TRACE:
+        return engineTraceQueueCapacity;
+      case READBOARD_TRACE:
+        return readboardTraceQueueCapacity;
+      case NETWORK_TRACE:
+        return networkTraceQueueCapacity;
+      case APP:
+      case CRASH:
+      default:
+        return appQueueCapacity;
+    }
+  }
+}

--- a/src/main/java/featurecat/lizzie/logging/LoggingProviderSmoke.java
+++ b/src/main/java/featurecat/lizzie/logging/LoggingProviderSmoke.java
@@ -3,6 +3,7 @@ package featurecat.lizzie.logging;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.ServiceLoader;
+import org.slf4j.ILoggerFactory;
 import org.slf4j.LoggerFactory;
 import org.slf4j.spi.SLF4JServiceProvider;
 
@@ -16,12 +17,21 @@ public final class LoggingProviderSmoke {
       System.err.println("expected one SLF4J provider, found " + providers);
       System.exit(2);
     }
+    ILoggerFactory factory = LoggerFactory.getILoggerFactory();
+    if (factory.getClass().getName().contains("NOP")) {
+      System.err.println("NOP provider is not allowed: " + factory.getClass().getName());
+      System.exit(3);
+    }
     Path workDirectory = Path.of(args[0]);
-    LoggingRuntime.resetForTests();
-    LoggingRuntime runtime =
-        LoggingRuntime.initialize(new WorkDirectoryResolution(workDirectory, List.of()));
+    WorkDirectoryResolution resolution = new WorkDirectoryResolution(workDirectory, List.of());
+    LoggingRuntime first = LoggingRuntime.initialize(resolution);
+    LoggingRuntime second = LoggingRuntime.initialize(resolution);
+    if (first != second) {
+      System.err.println("repeated initialize created a second runtime");
+      System.exit(4);
+    }
     LoggerFactory.getLogger(LogCategories.APP).info("provider-smoke");
-    runtime.awaitIdle();
-    runtime.shutdown();
+    first.awaitIdle();
+    first.shutdown();
   }
 }

--- a/src/main/java/featurecat/lizzie/logging/LoggingProviderSmoke.java
+++ b/src/main/java/featurecat/lizzie/logging/LoggingProviderSmoke.java
@@ -1,0 +1,27 @@
+package featurecat.lizzie.logging;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.ServiceLoader;
+import org.slf4j.LoggerFactory;
+import org.slf4j.spi.SLF4JServiceProvider;
+
+public final class LoggingProviderSmoke {
+  public static void main(String[] args) {
+    int providers = 0;
+    for (SLF4JServiceProvider ignored : ServiceLoader.load(SLF4JServiceProvider.class)) {
+      providers++;
+    }
+    if (providers != 1) {
+      System.err.println("expected one SLF4J provider, found " + providers);
+      System.exit(2);
+    }
+    Path workDirectory = Path.of(args[0]);
+    LoggingRuntime.resetForTests();
+    LoggingRuntime runtime =
+        LoggingRuntime.initialize(new WorkDirectoryResolution(workDirectory, List.of()));
+    LoggerFactory.getLogger(LogCategories.APP).info("provider-smoke");
+    runtime.awaitIdle();
+    runtime.shutdown();
+  }
+}

--- a/src/main/java/featurecat/lizzie/logging/LoggingRuntime.java
+++ b/src/main/java/featurecat/lizzie/logging/LoggingRuntime.java
@@ -302,6 +302,9 @@ public final class LoggingRuntime {
       }
       try {
         Deadline.run(deadline, context::stop);
+        if (context.isStarted()) {
+          context.stop();
+        }
       } catch (RuntimeException ignored) {
       }
       CorrelationContext.clearAsync();
@@ -355,6 +358,11 @@ public final class LoggingRuntime {
     if (appender != null) {
       appender.setNestedStopPauseMillis(millis);
     }
+  }
+
+  boolean isNestedStartedForTests(LogStream stream) {
+    BoundedAsyncAppender appender = appenders.get(stream);
+    return appender != null && appender.isNestedStartedForTests();
   }
 
   void replaceSanitizerForTests(PersistenceSanitizer sanitizer) {

--- a/src/main/java/featurecat/lizzie/logging/LoggingRuntime.java
+++ b/src/main/java/featurecat/lizzie/logging/LoggingRuntime.java
@@ -6,6 +6,7 @@ import ch.qos.logback.classic.LoggerContext;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.rolling.RollingFileAppender;
 import ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy;
+import ch.qos.logback.core.status.Status;
 import ch.qos.logback.core.util.FileSize;
 import java.io.IOException;
 import java.io.PrintStream;
@@ -26,12 +27,13 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
+import org.slf4j.ILoggerFactory;
 import org.slf4j.LoggerFactory;
 
 public final class LoggingRuntime {
+  public static final String STDERR_PREFIX = "LizzieYzy logging: ";
   private static final String PATTERN =
-      "%d{yyyy-MM-dd HH:mm:ss.SSS} %-5level [%logger] session=%X{lizzie.appSession} %msg%n%ex";
-  private static final String STDERR_PREFIX = "LizzieYzy logging: ";
+      "%d{yyyy-MM-dd HH:mm:ss.SSS} %-5level [%logger] %corr %msg%n%ex";
   private static final Object LOCK = new Object();
   private static LoggingRuntime instance;
 
@@ -43,6 +45,7 @@ public final class LoggingRuntime {
   private final PersistenceSanitizer sanitizer;
   private final Map<LogStream, StreamState> streams = new EnumMap<>(LogStream.class);
   private final Map<LogStream, BoundedAsyncAppender> appenders = new EnumMap<>(LogStream.class);
+  private final List<SanitizingEncoder> encoders = new ArrayList<>();
   private final Set<String> issuedEngineIds = ConcurrentHashMap.newKeySet();
   private final AtomicLong engineSequence = new AtomicLong();
   private final AtomicLong commandSequence = new AtomicLong();
@@ -74,16 +77,52 @@ public final class LoggingRuntime {
 
   public static LoggingRuntime initialize(
       WorkDirectoryResolution resolution, LoggingLimits limits) {
+    ILoggerFactory factory;
+    try {
+      factory = LoggerFactory.getILoggerFactory();
+    } catch (RuntimeException e) {
+      return degrade(
+          resolution, limits, e.getClass().getSimpleName() + ": " + e.getMessage());
+    }
+    return initialize(resolution, limits, factory);
+  }
+
+  static LoggingRuntime initialize(
+      WorkDirectoryResolution resolution, LoggingLimits limits, ILoggerFactory factory) {
     Objects.requireNonNull(resolution, "resolution");
     Objects.requireNonNull(limits, "limits");
     synchronized (LOCK) {
       if (instance != null && !instance.shutdown) {
         return instance;
       }
-      LoggerContext context = (LoggerContext) LoggerFactory.getILoggerFactory();
+      try {
+        if (!(factory instanceof LoggerContext)) {
+          String name = factory == null ? "null" : factory.getClass().getName();
+          return degrade(resolution, limits, "provider unavailable: " + name);
+        }
+        LoggingRuntime runtime =
+            new LoggingRuntime(
+                resolution.directory(), limits, (LoggerContext) factory, System.err);
+        runtime.bootstrap(resolution);
+        instance = runtime;
+        return runtime;
+      } catch (RuntimeException e) {
+        return degrade(
+            resolution, limits, e.getClass().getSimpleName() + ": " + e.getMessage());
+      }
+    }
+  }
+
+  private static LoggingRuntime degrade(
+      WorkDirectoryResolution resolution, LoggingLimits limits, String reason) {
+    synchronized (LOCK) {
+      if (instance != null && !instance.shutdown) {
+        return instance;
+      }
       LoggingRuntime runtime =
-          new LoggingRuntime(resolution.directory(), limits, context, System.err);
-      runtime.bootstrap(resolution);
+          new LoggingRuntime(resolution.directory(), limits, null, System.err);
+      runtime.persistenceEnabled.set(false);
+      runtime.notice("bootstrap", reason);
       instance = runtime;
       return runtime;
     }
@@ -127,6 +166,10 @@ public final class LoggingRuntime {
 
   public boolean fullTraceActive() {
     return traceSessionId != null;
+  }
+
+  boolean isShutdown() {
+    return shutdown;
   }
 
   public String newEngineIdentity() {
@@ -173,7 +216,7 @@ public final class LoggingRuntime {
   }
 
   public synchronized void startFullTrace(Set<TraceScope> scopes) {
-    if (shutdown) {
+    if (shutdown || context == null) {
       return;
     }
     Set<TraceScope> selected =
@@ -225,6 +268,9 @@ public final class LoggingRuntime {
         return new ShutdownReport(Map.of());
       }
       shutdown = true;
+      if (context == null) {
+        return new ShutdownReport(Map.of());
+      }
       long deadline = System.nanoTime() + LoggingLimits.SHUTDOWN_BUDGET_NANOS;
       for (TraceScope scope : activeTraceScopes) {
         BoundedAsyncAppender appender = appenders.get(scope.stream());
@@ -255,7 +301,7 @@ public final class LoggingRuntime {
         notice("shutdown", "unwritten events=" + remaining);
       }
       try {
-        context.stop();
+        Deadline.run(deadline, context::stop);
       } catch (RuntimeException ignored) {
       }
       CorrelationContext.clearAsync();
@@ -268,6 +314,7 @@ public final class LoggingRuntime {
     if (state != null) {
       state.recordDrop();
     }
+    notice(stream.name() + ":queue", "queue saturation");
   }
 
   void recordFailure(LogStream stream, String reason) {
@@ -275,7 +322,45 @@ public final class LoggingRuntime {
     if (state != null) {
       state.recordFailure(reason);
     }
-    notice(stream.name(), reason);
+    if (stream == LogStream.APP) {
+      persistenceEnabled.set(false);
+    }
+    notice(stream.name() + ":failure", reason);
+  }
+
+  void recordSuccess(LogStream stream) {
+    StreamState state = streams.get(stream);
+    if (state != null) {
+      state.recordSuccess();
+      if (stream == LogStream.APP && state.recovered) {
+        persistenceEnabled.set(true);
+      }
+    }
+  }
+
+  long failureGeneration(LogStream stream) {
+    StreamState state = streams.get(stream);
+    return state == null ? 0L : state.failureGeneration();
+  }
+
+  void failWritesForTests(LogStream stream, boolean fail) {
+    BoundedAsyncAppender appender = appenders.get(stream);
+    if (appender != null) {
+      appender.setFailWrites(fail);
+    }
+  }
+
+  void pauseNestedStopForTests(LogStream stream, long millis) {
+    BoundedAsyncAppender appender = appenders.get(stream);
+    if (appender != null) {
+      appender.setNestedStopPauseMillis(millis);
+    }
+  }
+
+  void replaceSanitizerForTests(PersistenceSanitizer sanitizer) {
+    for (SanitizingEncoder encoder : encoders) {
+      encoder.setSanitizer(sanitizer);
+    }
   }
 
   void blockPersistenceForTests(LogStream stream, CountDownLatch gate) {
@@ -318,13 +403,20 @@ public final class LoggingRuntime {
   private void bootstrap(WorkDirectoryResolution resolution) {
     try {
       context.reset();
+      context
+          .getStatusManager()
+          .add(
+              status -> {
+                if (status.getLevel() >= Status.ERROR) {
+                  recordFailure(streamOf(status), safeStatusMessage(status));
+                }
+              });
       Logger root = context.getLogger(Logger.ROOT_LOGGER_NAME);
       root.setLevel(Level.WARN);
       root.setAdditive(true);
       configureProjectLoggers();
       CorrelationContext.installAppSession(applicationLogSessionId);
       Files.createDirectories(logsDirectory.resolve("archive"));
-      persistenceEnabled.set(true);
       startFileStream(LogStream.APP, "app.log", true);
       startFileStream(LogStream.CRASH, "crash.log", true);
       attachCrashLogger();
@@ -370,6 +462,9 @@ public final class LoggingRuntime {
 
   private void applyPlan(LoggingSettings newSettings) {
     this.settings = newSettings;
+    if (context == null) {
+      return;
+    }
     for (DiagnosticModule module : DiagnosticModule.values()) {
       Level level =
           newSettings.diagnosticsEnabled() && newSettings.diagnosticModules().contains(module)
@@ -394,19 +489,27 @@ public final class LoggingRuntime {
   private void startFileStream(LogStream stream, String fileName, boolean dropInfoFirst) {
     try {
       RollingFileAppender<ILoggingEvent> file = rollingAppender(stream, fileName);
+      boolean fileStarted = file.isStarted();
       BoundedAsyncAppender async =
           new BoundedAsyncAppender(stream, limits.queueCapacity(stream), dropInfoFirst);
       async.setName(stream.name());
       async.setContext(context);
       async.setNested(file);
       async.setRuntime(this);
+      async.setActiveFile(logsDirectory.resolve(fileName));
       async.start();
       appenders.put(stream, async);
       if (stream == LogStream.APP) {
         context.getLogger(Logger.ROOT_LOGGER_NAME).addAppender(async);
+        persistenceEnabled.set(fileStarted);
+      }
+      if (!fileStarted) {
+        recordFailure(stream, "file appender failed to start");
       }
     } catch (RuntimeException e) {
-      persistenceEnabled.set(stream != LogStream.APP && persistenceEnabled.get());
+      if (stream == LogStream.APP) {
+        persistenceEnabled.set(false);
+      }
       recordFailure(stream, e.getClass().getSimpleName() + ": " + e.getMessage());
     }
   }
@@ -448,7 +551,9 @@ public final class LoggingRuntime {
     encoder.setContext(context);
     encoder.setPattern(PATTERN);
     encoder.setSanitizer(sanitizer);
+    encoder.setLogStream(stream);
     encoder.start();
+    encoders.add(encoder);
     file.setEncoder(encoder);
     SizeAndTimeBasedRollingPolicy<ILoggingEvent> policy = new SizeAndTimeBasedRollingPolicy<>();
     policy.setContext(context);
@@ -472,9 +577,53 @@ public final class LoggingRuntime {
     stderr.println(STDERR_PREFIX + key + " " + message);
   }
 
+  private LogStream streamOf(Status status) {
+    Object origin = status.getOrigin();
+    if (origin instanceof SanitizingEncoder encoder && encoder.logStream() != null) {
+      return encoder.logStream();
+    }
+    String name = "";
+    if (origin instanceof ch.qos.logback.core.Appender<?> appender) {
+      name = appender.getName() == null ? "" : appender.getName();
+    }
+    LogStream fromName = streamFromToken(name);
+    if (fromName != LogStream.APP) {
+      return fromName;
+    }
+    String text =
+        (status.getMessage() == null ? "" : status.getMessage()) + " " + String.valueOf(origin);
+    return streamFromToken(text);
+  }
+
+  private static LogStream streamFromToken(String text) {
+    if (text == null) {
+      return LogStream.APP;
+    }
+    if (text.contains("engine-trace.log") || text.startsWith(LogStream.ENGINE_TRACE.name())) {
+      return LogStream.ENGINE_TRACE;
+    }
+    if (text.contains("readboard-trace.log")
+        || text.startsWith(LogStream.READBOARD_TRACE.name())) {
+      return LogStream.READBOARD_TRACE;
+    }
+    if (text.contains("network-trace.log") || text.startsWith(LogStream.NETWORK_TRACE.name())) {
+      return LogStream.NETWORK_TRACE;
+    }
+    if (text.contains("crash.log") || text.startsWith(LogStream.CRASH.name())) {
+      return LogStream.CRASH;
+    }
+    return LogStream.APP;
+  }
+
+  private static String safeStatusMessage(Status status) {
+    String message = status.getMessage();
+    return message == null || message.isEmpty() ? "file failure" : message;
+  }
+
   private static final class StreamState {
     private final LogStream stream;
     private final AtomicLong dropped = new AtomicLong();
+    private final AtomicLong failures = new AtomicLong();
     private volatile String reason;
     private volatile Instant firstOccurrence;
     private volatile Instant lastOccurrence;
@@ -489,6 +638,8 @@ public final class LoggingRuntime {
       Instant now = Instant.now();
       if (firstOccurrence == null) {
         firstOccurrence = now;
+      }
+      if (reason == null) {
         reason = "queue saturation";
       }
       lastOccurrence = now;
@@ -496,6 +647,7 @@ public final class LoggingRuntime {
     }
 
     private void recordFailure(String failureReason) {
+      failures.incrementAndGet();
       Instant now = Instant.now();
       if (firstOccurrence == null) {
         firstOccurrence = now;
@@ -503,6 +655,16 @@ public final class LoggingRuntime {
       lastOccurrence = now;
       reason = failureReason;
       recovered = false;
+    }
+
+    private long failureGeneration() {
+      return failures.get();
+    }
+
+    private void recordSuccess() {
+      if (reason != null || dropped.get() > 0) {
+        recovered = true;
+      }
     }
 
     private LoggingStatus.StreamStatus snapshot() {

--- a/src/main/java/featurecat/lizzie/logging/LoggingRuntime.java
+++ b/src/main/java/featurecat/lizzie/logging/LoggingRuntime.java
@@ -1,0 +1,513 @@
+package featurecat.lizzie.logging;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.rolling.RollingFileAppender;
+import ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy;
+import ch.qos.logback.core.util.FileSize;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.EnumMap;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+import org.slf4j.LoggerFactory;
+
+public final class LoggingRuntime {
+  private static final String PATTERN =
+      "%d{yyyy-MM-dd HH:mm:ss.SSS} %-5level [%logger] session=%X{lizzie.appSession} %msg%n%ex";
+  private static final String STDERR_PREFIX = "LizzieYzy logging: ";
+  private static final Object LOCK = new Object();
+  private static LoggingRuntime instance;
+
+  private final Path workDirectory;
+  private final Path logsDirectory;
+  private final LoggingLimits limits;
+  private final String applicationLogSessionId;
+  private final LoggerContext context;
+  private final PersistenceSanitizer sanitizer;
+  private final Map<LogStream, StreamState> streams = new EnumMap<>(LogStream.class);
+  private final Map<LogStream, BoundedAsyncAppender> appenders = new EnumMap<>(LogStream.class);
+  private final Set<String> issuedEngineIds = ConcurrentHashMap.newKeySet();
+  private final AtomicLong engineSequence = new AtomicLong();
+  private final AtomicLong commandSequence = new AtomicLong();
+  private final AtomicBoolean persistenceEnabled = new AtomicBoolean();
+  private final Set<String> stderrNotices = ConcurrentHashMap.newKeySet();
+  private final PrintStream stderr;
+  private volatile LoggingSettings settings = LoggingSettings.defaults();
+  private volatile String traceSessionId;
+  private volatile Set<TraceScope> activeTraceScopes = EnumSet.noneOf(TraceScope.class);
+  private volatile boolean shutdown;
+
+  private LoggingRuntime(
+      Path workDirectory, LoggingLimits limits, LoggerContext context, PrintStream stderr) {
+    this.workDirectory = workDirectory;
+    this.logsDirectory = workDirectory.resolve("logs");
+    this.limits = limits;
+    this.context = context;
+    this.stderr = stderr;
+    this.applicationLogSessionId = UUID.randomUUID().toString();
+    this.sanitizer = new PersistenceSanitizer();
+    for (LogStream stream : LogStream.values()) {
+      streams.put(stream, new StreamState(stream));
+    }
+  }
+
+  public static LoggingRuntime initialize(WorkDirectoryResolution resolution) {
+    return initialize(resolution, LoggingLimits.production());
+  }
+
+  public static LoggingRuntime initialize(
+      WorkDirectoryResolution resolution, LoggingLimits limits) {
+    Objects.requireNonNull(resolution, "resolution");
+    Objects.requireNonNull(limits, "limits");
+    synchronized (LOCK) {
+      if (instance != null && !instance.shutdown) {
+        return instance;
+      }
+      LoggerContext context = (LoggerContext) LoggerFactory.getILoggerFactory();
+      LoggingRuntime runtime =
+          new LoggingRuntime(resolution.directory(), limits, context, System.err);
+      runtime.bootstrap(resolution);
+      instance = runtime;
+      return runtime;
+    }
+  }
+
+  public static Optional<LoggingRuntime> current() {
+    synchronized (LOCK) {
+      return Optional.ofNullable(instance);
+    }
+  }
+
+  static void resetForTests() {
+    synchronized (LOCK) {
+      if (instance != null) {
+        instance.shutdown();
+        instance = null;
+      }
+      LoggerContext context = (LoggerContext) LoggerFactory.getILoggerFactory();
+      context.reset();
+      if (!context.isStarted()) {
+        context.start();
+      }
+    }
+  }
+
+  public String applicationLogSessionId() {
+    return applicationLogSessionId;
+  }
+
+  public Path logsDirectory() {
+    return logsDirectory;
+  }
+
+  public LoggingSettings settings() {
+    return settings;
+  }
+
+  public String currentTraceSessionId() {
+    return traceSessionId;
+  }
+
+  public boolean fullTraceActive() {
+    return traceSessionId != null;
+  }
+
+  public String newEngineIdentity() {
+    String identity;
+    do {
+      identity =
+          "eng-"
+              + Long.toUnsignedString(engineSequence.incrementAndGet(), 16)
+              + "-"
+              + Long.toUnsignedString(ThreadLocalRandom.current().nextLong(), 16);
+    } while (!issuedEngineIds.add(identity));
+    return identity;
+  }
+
+  public String newCommandIdentity() {
+    return "cmd-" + Long.toUnsignedString(commandSequence.incrementAndGet(), 16);
+  }
+
+  public void applySettings(LoggingSettings newSettings) {
+    applySettings(newSettings, null);
+  }
+
+  public void applySettings(LoggingSettings newSettings, LoggingSettingsPersister persister) {
+    Objects.requireNonNull(newSettings, "newSettings");
+    LoggingSettings previous = settings;
+    synchronized (this) {
+      try {
+        applyPlan(newSettings);
+        if (persister != null) {
+          persister.save(newSettings);
+        }
+      } catch (RuntimeException | IOException e) {
+        applyPlan(previous);
+        if (e instanceof RuntimeException) {
+          throw (RuntimeException) e;
+        }
+        throw new IllegalStateException("Failed to persist logging settings", e);
+      }
+    }
+  }
+
+  public void startFullTrace() {
+    startFullTrace(settings.preferredTraceScopes());
+  }
+
+  public synchronized void startFullTrace(Set<TraceScope> scopes) {
+    if (shutdown) {
+      return;
+    }
+    Set<TraceScope> selected =
+        scopes == null || scopes.isEmpty()
+            ? EnumSet.noneOf(TraceScope.class)
+            : EnumSet.copyOf(scopes);
+    if (traceSessionId != null) {
+      stopFullTrace();
+    }
+    traceSessionId = "trace-" + UUID.randomUUID();
+    activeTraceScopes = selected;
+    CorrelationContext.installTraceSession(traceSessionId);
+    for (TraceScope scope : selected) {
+      startTraceStream(scope);
+      org.slf4j.LoggerFactory.getLogger(scope.loggerName())
+          .info("Full Trace session started session={} scope={}", traceSessionId, scope.wireName());
+    }
+  }
+
+  public synchronized void stopFullTrace() {
+    String session = traceSessionId;
+    if (session == null) {
+      return;
+    }
+    for (TraceScope scope : activeTraceScopes) {
+      org.slf4j.LoggerFactory.getLogger(scope.loggerName())
+          .info("Full Trace session stopped session={} scope={}", session, scope.wireName());
+    }
+    awaitIdle(50);
+    for (TraceScope scope : activeTraceScopes) {
+      stopTraceStream(scope);
+    }
+    activeTraceScopes = EnumSet.noneOf(TraceScope.class);
+    traceSessionId = null;
+    CorrelationContext.clearTraceSession();
+  }
+
+  public LoggingStatus status() {
+    List<LoggingStatus.StreamStatus> snapshot = new ArrayList<>();
+    for (StreamState state : streams.values()) {
+      snapshot.add(state.snapshot());
+    }
+    return new LoggingStatus(persistenceEnabled.get(), snapshot);
+  }
+
+  public ShutdownReport shutdown() {
+    synchronized (this) {
+      if (shutdown) {
+        return new ShutdownReport(Map.of());
+      }
+      shutdown = true;
+      long deadline = System.nanoTime() + LoggingLimits.SHUTDOWN_BUDGET_NANOS;
+      for (TraceScope scope : activeTraceScopes) {
+        BoundedAsyncAppender appender = appenders.get(scope.stream());
+        if (appender != null) {
+          appender.stopAccepting();
+        }
+      }
+      Map<LogStream, Long> unwritten = new EnumMap<>(LogStream.class);
+      BoundedAsyncAppender app = appenders.get(LogStream.APP);
+      BoundedAsyncAppender crash = appenders.get(LogStream.CRASH);
+      if (app != null) {
+        unwritten.put(LogStream.APP, app.shutdown(deadline));
+      }
+      if (crash != null) {
+        unwritten.put(LogStream.CRASH, crash.shutdown(deadline));
+      }
+      for (TraceScope scope : TraceScope.values()) {
+        BoundedAsyncAppender appender = appenders.get(scope.stream());
+        if (appender != null) {
+          unwritten.put(scope.stream(), appender.shutdown(deadline));
+        }
+      }
+      long remaining = 0;
+      for (Long count : unwritten.values()) {
+        remaining += count;
+      }
+      if (remaining > 0) {
+        notice("shutdown", "unwritten events=" + remaining);
+      }
+      try {
+        context.stop();
+      } catch (RuntimeException ignored) {
+      }
+      CorrelationContext.clearAsync();
+      return new ShutdownReport(unwritten);
+    }
+  }
+
+  void recordDrop(LogStream stream) {
+    StreamState state = streams.get(stream);
+    if (state != null) {
+      state.recordDrop();
+    }
+  }
+
+  void recordFailure(LogStream stream, String reason) {
+    StreamState state = streams.get(stream);
+    if (state != null) {
+      state.recordFailure(reason);
+    }
+    notice(stream.name(), reason);
+  }
+
+  void blockPersistenceForTests(LogStream stream, CountDownLatch gate) {
+    BoundedAsyncAppender appender = appenders.get(stream);
+    if (appender != null) {
+      appender.setGate(gate);
+    }
+  }
+
+  void awaitIdle() {
+    awaitIdle(40);
+  }
+
+  void awaitIdle(int spins) {
+    for (int i = 0; i < spins; i++) {
+      boolean idle = true;
+      for (BoundedAsyncAppender appender : appenders.values()) {
+        if (appender != null && appender.queuedCount() > 0) {
+          idle = false;
+          break;
+        }
+      }
+      if (idle) {
+        try {
+          Thread.sleep(20);
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+        }
+        return;
+      }
+      try {
+        Thread.sleep(10);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        return;
+      }
+    }
+  }
+
+  private void bootstrap(WorkDirectoryResolution resolution) {
+    try {
+      context.reset();
+      Logger root = context.getLogger(Logger.ROOT_LOGGER_NAME);
+      root.setLevel(Level.WARN);
+      root.setAdditive(true);
+      configureProjectLoggers();
+      CorrelationContext.installAppSession(applicationLogSessionId);
+      Files.createDirectories(logsDirectory.resolve("archive"));
+      persistenceEnabled.set(true);
+      startFileStream(LogStream.APP, "app.log", true);
+      startFileStream(LogStream.CRASH, "crash.log", true);
+      attachCrashLogger();
+      applyPlan(LoggingSettings.defaults());
+      org.slf4j.Logger app = LoggerFactory.getLogger(LogCategories.APP);
+      app.info(
+          "application log session started id={} workDir={}",
+          applicationLogSessionId,
+          workDirectory);
+      for (WorkDirectoryDiagnostic diagnostic : resolution.diagnostics()) {
+        app.info("work-directory {}: {}", diagnostic.code(), diagnostic.message());
+      }
+    } catch (RuntimeException | IOException e) {
+      persistenceEnabled.set(false);
+      notice("bootstrap", e.getClass().getSimpleName() + ": " + e.getMessage());
+    }
+  }
+
+  private void configureProjectLoggers() {
+    for (String name :
+        List.of(
+            LogCategories.APP,
+            LogCategories.CONFIG,
+            LogCategories.ENGINE,
+            LogCategories.GTP,
+            LogCategories.READBOARD,
+            LogCategories.NETWORK,
+            LogCategories.REMOTE,
+            LogCategories.SGF,
+            LogCategories.UI,
+            LogCategories.CRASH,
+            LogCategories.DIAGNOSTICS)) {
+      Logger logger = context.getLogger(name);
+      logger.setLevel(Level.INFO);
+      logger.setAdditive(true);
+    }
+    for (TraceScope scope : TraceScope.values()) {
+      Logger logger = context.getLogger(scope.loggerName());
+      logger.setLevel(Level.OFF);
+      logger.setAdditive(false);
+    }
+  }
+
+  private void applyPlan(LoggingSettings newSettings) {
+    this.settings = newSettings;
+    for (DiagnosticModule module : DiagnosticModule.values()) {
+      Level level =
+          newSettings.diagnosticsEnabled() && newSettings.diagnosticModules().contains(module)
+              ? Level.DEBUG
+              : Level.INFO;
+      context.getLogger(module.loggerName()).setLevel(level);
+      if (module == DiagnosticModule.NETWORK_REMOTE) {
+        context.getLogger(LogCategories.REMOTE).setLevel(level);
+      }
+    }
+  }
+
+  private void attachCrashLogger() {
+    Logger crash = context.getLogger(LogCategories.CRASH);
+    BoundedAsyncAppender crashAppender = appenders.get(LogStream.CRASH);
+    if (crashAppender != null) {
+      crash.addAppender(crashAppender);
+      crash.setAdditive(true);
+    }
+  }
+
+  private void startFileStream(LogStream stream, String fileName, boolean dropInfoFirst) {
+    try {
+      RollingFileAppender<ILoggingEvent> file = rollingAppender(stream, fileName);
+      BoundedAsyncAppender async =
+          new BoundedAsyncAppender(stream, limits.queueCapacity(stream), dropInfoFirst);
+      async.setName(stream.name());
+      async.setContext(context);
+      async.setNested(file);
+      async.setRuntime(this);
+      async.start();
+      appenders.put(stream, async);
+      if (stream == LogStream.APP) {
+        context.getLogger(Logger.ROOT_LOGGER_NAME).addAppender(async);
+      }
+    } catch (RuntimeException e) {
+      persistenceEnabled.set(stream != LogStream.APP && persistenceEnabled.get());
+      recordFailure(stream, e.getClass().getSimpleName() + ": " + e.getMessage());
+    }
+  }
+
+  private void startTraceStream(TraceScope scope) {
+    if (!appenders.containsKey(scope.stream())) {
+      startFileStream(scope.stream(), scope.fileName(), false);
+    }
+    Logger logger = context.getLogger(scope.loggerName());
+    BoundedAsyncAppender appender = appenders.get(scope.stream());
+    if (appender != null) {
+      if (!logger.isAttached(appender)) {
+        logger.addAppender(appender);
+      }
+      logger.setLevel(Level.INFO);
+      logger.setAdditive(false);
+    }
+  }
+
+  private void stopTraceStream(TraceScope scope) {
+    Logger logger = context.getLogger(scope.loggerName());
+    logger.setLevel(Level.OFF);
+    BoundedAsyncAppender appender = appenders.get(scope.stream());
+    if (appender != null) {
+      logger.detachAppender(appender);
+    }
+  }
+
+  private RollingFileAppender<ILoggingEvent> rollingAppender(LogStream stream, String fileName) {
+    Path active = logsDirectory.resolve(fileName);
+    Path archive = logsDirectory.resolve("archive");
+    RollingFileAppender<ILoggingEvent> file = new RollingFileAppender<>();
+    file.setName(stream.name() + "-file");
+    file.setContext(context);
+    file.setFile(active.toString());
+    file.setAppend(true);
+    file.setImmediateFlush(true);
+    SanitizingEncoder encoder = new SanitizingEncoder();
+    encoder.setContext(context);
+    encoder.setPattern(PATTERN);
+    encoder.setSanitizer(sanitizer);
+    encoder.start();
+    file.setEncoder(encoder);
+    SizeAndTimeBasedRollingPolicy<ILoggingEvent> policy = new SizeAndTimeBasedRollingPolicy<>();
+    policy.setContext(context);
+    policy.setParent(file);
+    String stem =
+        fileName.endsWith(".log") ? fileName.substring(0, fileName.length() - 4) : fileName;
+    policy.setFileNamePattern(archive.resolve(stem + ".%d{yyyy-MM-dd}.%i.log.gz").toString());
+    policy.setMaxHistory(limits.retentionDays());
+    policy.setTotalSizeCap(new FileSize(limits.totalSizeCapBytes()));
+    policy.setMaxFileSize(new FileSize(limits.activeFileSizeBytes()));
+    policy.start();
+    file.setRollingPolicy(policy);
+    file.start();
+    return file;
+  }
+
+  private void notice(String key, String message) {
+    if (!stderrNotices.add(key)) {
+      return;
+    }
+    stderr.println(STDERR_PREFIX + key + " " + message);
+  }
+
+  private static final class StreamState {
+    private final LogStream stream;
+    private final AtomicLong dropped = new AtomicLong();
+    private volatile String reason;
+    private volatile Instant firstOccurrence;
+    private volatile Instant lastOccurrence;
+    private volatile boolean recovered;
+
+    private StreamState(LogStream stream) {
+      this.stream = stream;
+    }
+
+    private void recordDrop() {
+      dropped.incrementAndGet();
+      Instant now = Instant.now();
+      if (firstOccurrence == null) {
+        firstOccurrence = now;
+        reason = "queue saturation";
+      }
+      lastOccurrence = now;
+      recovered = false;
+    }
+
+    private void recordFailure(String failureReason) {
+      Instant now = Instant.now();
+      if (firstOccurrence == null) {
+        firstOccurrence = now;
+      }
+      lastOccurrence = now;
+      reason = failureReason;
+      recovered = false;
+    }
+
+    private LoggingStatus.StreamStatus snapshot() {
+      return new LoggingStatus.StreamStatus(
+          stream, reason, firstOccurrence, lastOccurrence, dropped.get(), recovered);
+    }
+  }
+}

--- a/src/main/java/featurecat/lizzie/logging/LoggingSettings.java
+++ b/src/main/java/featurecat/lizzie/logging/LoggingSettings.java
@@ -1,0 +1,106 @@
+package featurecat.lizzie.logging;
+
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.Objects;
+import java.util.Set;
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+public final class LoggingSettings {
+  public static final String CONFIG_KEY = "logging";
+  public static final String DIAGNOSTICS_ENABLED_KEY = "diagnostics-enabled";
+  public static final String DIAGNOSTIC_MODULES_KEY = "diagnostic-modules";
+  public static final String PREFERRED_FULL_TRACE_SCOPES_KEY = "preferred-full-trace-scopes";
+
+  private final boolean diagnosticsEnabled;
+  private final Set<DiagnosticModule> diagnosticModules;
+  private final Set<TraceScope> preferredTraceScopes;
+
+  public LoggingSettings(
+      boolean diagnosticsEnabled,
+      Set<DiagnosticModule> diagnosticModules,
+      Set<TraceScope> preferredTraceScopes) {
+    this.diagnosticsEnabled = diagnosticsEnabled;
+    this.diagnosticModules =
+        Collections.unmodifiableSet(
+            EnumSet.copyOf(requireSet(diagnosticModules, "diagnosticModules")));
+    this.preferredTraceScopes =
+        Collections.unmodifiableSet(
+            EnumSet.copyOf(requireSet(preferredTraceScopes, "preferredTraceScopes")));
+  }
+
+  public static LoggingSettings defaults() {
+    return new LoggingSettings(
+        false, EnumSet.allOf(DiagnosticModule.class), EnumSet.allOf(TraceScope.class));
+  }
+
+  public static LoggingSettings fromJson(JSONObject json) {
+    if (json == null) {
+      return defaults();
+    }
+    EnumSet<DiagnosticModule> modules = EnumSet.noneOf(DiagnosticModule.class);
+    JSONArray moduleNames = json.optJSONArray(DIAGNOSTIC_MODULES_KEY);
+    if (moduleNames == null) {
+      modules = EnumSet.allOf(DiagnosticModule.class);
+    } else {
+      for (int i = 0; i < moduleNames.length(); i++) {
+        modules.add(DiagnosticModule.fromWireName(moduleNames.getString(i)));
+      }
+    }
+    EnumSet<TraceScope> scopes = EnumSet.noneOf(TraceScope.class);
+    JSONArray scopeNames = json.optJSONArray(PREFERRED_FULL_TRACE_SCOPES_KEY);
+    if (scopeNames == null) {
+      scopes = EnumSet.allOf(TraceScope.class);
+    } else {
+      for (int i = 0; i < scopeNames.length(); i++) {
+        scopes.add(TraceScope.fromWireName(scopeNames.getString(i)));
+      }
+    }
+    return new LoggingSettings(json.optBoolean(DIAGNOSTICS_ENABLED_KEY, false), modules, scopes);
+  }
+
+  public boolean diagnosticsEnabled() {
+    return diagnosticsEnabled;
+  }
+
+  public Set<DiagnosticModule> diagnosticModules() {
+    return diagnosticModules;
+  }
+
+  public Set<TraceScope> preferredTraceScopes() {
+    return preferredTraceScopes;
+  }
+
+  public JSONObject toJson() {
+    JSONObject json = new JSONObject();
+    json.put(DIAGNOSTICS_ENABLED_KEY, diagnosticsEnabled);
+    JSONArray modules = new JSONArray();
+    for (DiagnosticModule module : diagnosticModules) {
+      modules.put(module.wireName());
+    }
+    json.put(DIAGNOSTIC_MODULES_KEY, modules);
+    JSONArray scopes = new JSONArray();
+    for (TraceScope scope : preferredTraceScopes) {
+      scopes.put(scope.wireName());
+    }
+    json.put(PREFERRED_FULL_TRACE_SCOPES_KEY, scopes);
+    return json;
+  }
+
+  public LoggingSettings withDiagnosticsEnabled(boolean enabled) {
+    return new LoggingSettings(enabled, diagnosticModules, preferredTraceScopes);
+  }
+
+  public LoggingSettings withDiagnosticModules(Set<DiagnosticModule> modules) {
+    return new LoggingSettings(diagnosticsEnabled, modules, preferredTraceScopes);
+  }
+
+  public LoggingSettings withPreferredTraceScopes(Set<TraceScope> scopes) {
+    return new LoggingSettings(diagnosticsEnabled, diagnosticModules, scopes);
+  }
+
+  private static <T extends Enum<T>> Set<T> requireSet(Set<T> values, String name) {
+    return Objects.requireNonNull(values, name);
+  }
+}

--- a/src/main/java/featurecat/lizzie/logging/LoggingSettingsPersister.java
+++ b/src/main/java/featurecat/lizzie/logging/LoggingSettingsPersister.java
@@ -1,0 +1,8 @@
+package featurecat.lizzie.logging;
+
+import java.io.IOException;
+
+@FunctionalInterface
+public interface LoggingSettingsPersister {
+  void save(LoggingSettings settings) throws IOException;
+}

--- a/src/main/java/featurecat/lizzie/logging/LoggingStatus.java
+++ b/src/main/java/featurecat/lizzie/logging/LoggingStatus.java
@@ -1,0 +1,81 @@
+package featurecat.lizzie.logging;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+public final class LoggingStatus {
+  private final boolean persistenceEnabled;
+  private final List<StreamStatus> streams;
+
+  public LoggingStatus(boolean persistenceEnabled, List<StreamStatus> streams) {
+    this.persistenceEnabled = persistenceEnabled;
+    this.streams = List.copyOf(Objects.requireNonNull(streams, "streams"));
+  }
+
+  public boolean persistenceEnabled() {
+    return persistenceEnabled;
+  }
+
+  public List<StreamStatus> streams() {
+    return streams;
+  }
+
+  public Optional<StreamStatus> stream(LogStream stream) {
+    for (StreamStatus status : streams) {
+      if (status.stream() == stream) {
+        return Optional.of(status);
+      }
+    }
+    return Optional.empty();
+  }
+
+  public static final class StreamStatus {
+    private final LogStream stream;
+    private final String reason;
+    private final Instant firstOccurrence;
+    private final Instant lastOccurrence;
+    private final long droppedCount;
+    private final boolean recovered;
+
+    public StreamStatus(
+        LogStream stream,
+        String reason,
+        Instant firstOccurrence,
+        Instant lastOccurrence,
+        long droppedCount,
+        boolean recovered) {
+      this.stream = Objects.requireNonNull(stream, "stream");
+      this.reason = reason;
+      this.firstOccurrence = firstOccurrence;
+      this.lastOccurrence = lastOccurrence;
+      this.droppedCount = droppedCount;
+      this.recovered = recovered;
+    }
+
+    public LogStream stream() {
+      return stream;
+    }
+
+    public String reason() {
+      return reason;
+    }
+
+    public Instant firstOccurrence() {
+      return firstOccurrence;
+    }
+
+    public Instant lastOccurrence() {
+      return lastOccurrence;
+    }
+
+    public long droppedCount() {
+      return droppedCount;
+    }
+
+    public boolean recovered() {
+      return recovered;
+    }
+  }
+}

--- a/src/main/java/featurecat/lizzie/logging/PersistenceSanitizer.java
+++ b/src/main/java/featurecat/lizzie/logging/PersistenceSanitizer.java
@@ -10,6 +10,8 @@ public class PersistenceSanitizer {
           "(?i)([\\\"']?(?:password|passwd|token|secret|authorization|cookie|set-cookie|connectPassword|zhizi-account-token|zz-socketio-token)[\\\"']?\\s*(?:[=:]\\s*|\\s+)[\\\"']?)([^\\\"'\\s,;}&]+)([\\\"']?)");
   private static final Pattern BEARER_CREDENTIAL =
       Pattern.compile("(?i)\\bBearer\\s+[A-Za-z0-9._~+\\-/]+=*");
+  private static final Pattern BASIC_CREDENTIAL =
+      Pattern.compile("(?i)\\bBasic\\s+[A-Za-z0-9+/=_-]+");
   private static final Pattern URL_SECRET =
       Pattern.compile("(?i)([?&](?:token|key|secret|password)=)[^&\\s]+");
 
@@ -17,8 +19,9 @@ public class PersistenceSanitizer {
     if (text == null || text.isEmpty()) {
       return "";
     }
-    String safe = CREDENTIAL_PARAMETER.matcher(text).replaceAll("$1<redacted>$3");
+    String safe = BASIC_CREDENTIAL.matcher(text).replaceAll("Basic <redacted>");
     safe = BEARER_CREDENTIAL.matcher(safe).replaceAll("Bearer <redacted>");
+    safe = CREDENTIAL_PARAMETER.matcher(safe).replaceAll("$1<redacted>$3");
     return URL_SECRET.matcher(safe).replaceAll("$1<redacted>");
   }
 }

--- a/src/main/java/featurecat/lizzie/logging/PersistenceSanitizer.java
+++ b/src/main/java/featurecat/lizzie/logging/PersistenceSanitizer.java
@@ -1,0 +1,24 @@
+package featurecat.lizzie.logging;
+
+import java.util.regex.Pattern;
+
+public class PersistenceSanitizer {
+  public static final String FAILURE_MARKER = "[redaction-failed]";
+
+  private static final Pattern CREDENTIAL_PARAMETER =
+      Pattern.compile(
+          "(?i)([\\\"']?(?:password|passwd|token|secret|authorization|cookie|set-cookie|connectPassword|zhizi-account-token|zz-socketio-token)[\\\"']?\\s*(?:[=:]\\s*|\\s+)[\\\"']?)([^\\\"'\\s,;}&]+)([\\\"']?)");
+  private static final Pattern BEARER_CREDENTIAL =
+      Pattern.compile("(?i)\\bBearer\\s+[A-Za-z0-9._~+\\-/]+=*");
+  private static final Pattern URL_SECRET =
+      Pattern.compile("(?i)([?&](?:token|key|secret|password)=)[^&\\s]+");
+
+  public String sanitize(String text) {
+    if (text == null || text.isEmpty()) {
+      return "";
+    }
+    String safe = CREDENTIAL_PARAMETER.matcher(text).replaceAll("$1<redacted>$3");
+    safe = BEARER_CREDENTIAL.matcher(safe).replaceAll("Bearer <redacted>");
+    return URL_SECRET.matcher(safe).replaceAll("$1<redacted>");
+  }
+}

--- a/src/main/java/featurecat/lizzie/logging/SanitizingEncoder.java
+++ b/src/main/java/featurecat/lizzie/logging/SanitizingEncoder.java
@@ -1,53 +1,65 @@
 package featurecat.lizzie.logging;
 
-import ch.qos.logback.classic.encoder.PatternLayoutEncoder;
+import ch.qos.logback.classic.PatternLayout;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.encoder.EncoderBase;
 import java.nio.charset.StandardCharsets;
 
 final class SanitizingEncoder extends EncoderBase<ILoggingEvent> {
-  private final PatternLayoutEncoder delegate = new PatternLayoutEncoder();
+  private final PatternLayout layout = new PatternLayout();
   private PersistenceSanitizer sanitizer = new PersistenceSanitizer();
+  private LogStream stream = LogStream.APP;
+  private String pattern =
+      "%d{yyyy-MM-dd HH:mm:ss.SSS} %-5level [%logger] %corr %msg%n%ex";
 
   void setPattern(String pattern) {
-    delegate.setPattern(pattern);
+    this.pattern = pattern;
   }
 
   void setSanitizer(PersistenceSanitizer sanitizer) {
     this.sanitizer = sanitizer == null ? new PersistenceSanitizer() : sanitizer;
   }
 
+  void setLogStream(LogStream stream) {
+    this.stream = stream == null ? LogStream.APP : stream;
+  }
+
+  LogStream logStream() {
+    return stream;
+  }
+
   @Override
   public void start() {
-    delegate.setContext(context);
-    delegate.setCharset(StandardCharsets.UTF_8);
-    delegate.start();
+    layout.setContext(context);
+    layout.getInstanceConverterMap().put("corr", CorrelationConverter::new);
+    layout.setPattern(pattern);
+    layout.start();
     super.start();
   }
 
   @Override
   public void stop() {
     super.stop();
-    delegate.stop();
+    layout.stop();
   }
 
   @Override
   public byte[] headerBytes() {
-    return delegate.headerBytes();
+    return new byte[0];
   }
 
   @Override
   public byte[] footerBytes() {
-    return delegate.footerBytes();
+    return new byte[0];
   }
 
   @Override
   public byte[] encode(ILoggingEvent event) {
     try {
-      byte[] encoded = delegate.encode(event);
-      String formatted = new String(encoded, StandardCharsets.UTF_8);
+      String formatted = layout.doLayout(event);
       return sanitizer.sanitize(formatted).getBytes(StandardCharsets.UTF_8);
     } catch (RuntimeException e) {
+      addError("encoder redaction failed", e);
       return (PersistenceSanitizer.FAILURE_MARKER + System.lineSeparator())
           .getBytes(StandardCharsets.UTF_8);
     }

--- a/src/main/java/featurecat/lizzie/logging/SanitizingEncoder.java
+++ b/src/main/java/featurecat/lizzie/logging/SanitizingEncoder.java
@@ -1,0 +1,55 @@
+package featurecat.lizzie.logging;
+
+import ch.qos.logback.classic.encoder.PatternLayoutEncoder;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.encoder.EncoderBase;
+import java.nio.charset.StandardCharsets;
+
+final class SanitizingEncoder extends EncoderBase<ILoggingEvent> {
+  private final PatternLayoutEncoder delegate = new PatternLayoutEncoder();
+  private PersistenceSanitizer sanitizer = new PersistenceSanitizer();
+
+  void setPattern(String pattern) {
+    delegate.setPattern(pattern);
+  }
+
+  void setSanitizer(PersistenceSanitizer sanitizer) {
+    this.sanitizer = sanitizer == null ? new PersistenceSanitizer() : sanitizer;
+  }
+
+  @Override
+  public void start() {
+    delegate.setContext(context);
+    delegate.setCharset(StandardCharsets.UTF_8);
+    delegate.start();
+    super.start();
+  }
+
+  @Override
+  public void stop() {
+    super.stop();
+    delegate.stop();
+  }
+
+  @Override
+  public byte[] headerBytes() {
+    return delegate.headerBytes();
+  }
+
+  @Override
+  public byte[] footerBytes() {
+    return delegate.footerBytes();
+  }
+
+  @Override
+  public byte[] encode(ILoggingEvent event) {
+    try {
+      byte[] encoded = delegate.encode(event);
+      String formatted = new String(encoded, StandardCharsets.UTF_8);
+      return sanitizer.sanitize(formatted).getBytes(StandardCharsets.UTF_8);
+    } catch (RuntimeException e) {
+      return (PersistenceSanitizer.FAILURE_MARKER + System.lineSeparator())
+          .getBytes(StandardCharsets.UTF_8);
+    }
+  }
+}

--- a/src/main/java/featurecat/lizzie/logging/ShutdownReport.java
+++ b/src/main/java/featurecat/lizzie/logging/ShutdownReport.java
@@ -1,0 +1,21 @@
+package featurecat.lizzie.logging;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Objects;
+
+public final class ShutdownReport {
+  private final Map<LogStream, Long> unwrittenCounts;
+
+  public ShutdownReport(Map<LogStream, Long> unwrittenCounts) {
+    this.unwrittenCounts = Collections.unmodifiableMap(Objects.requireNonNull(unwrittenCounts));
+  }
+
+  public Map<LogStream, Long> unwrittenCounts() {
+    return unwrittenCounts;
+  }
+
+  public long unwritten(LogStream stream) {
+    return unwrittenCounts.getOrDefault(stream, 0L);
+  }
+}

--- a/src/main/java/featurecat/lizzie/logging/TraceScope.java
+++ b/src/main/java/featurecat/lizzie/logging/TraceScope.java
@@ -1,0 +1,52 @@
+package featurecat.lizzie.logging;
+
+public enum TraceScope {
+  ENGINE_GTP("engine-gtp", LogCategories.ENGINE_TRACE, LogStream.ENGINE_TRACE, "engine-trace.log"),
+  READBOARD_YIKE(
+      "readboard-yike",
+      LogCategories.READBOARD_TRACE,
+      LogStream.READBOARD_TRACE,
+      "readboard-trace.log"),
+  NETWORK_WEBSOCKET(
+      "network-websocket",
+      LogCategories.NETWORK_TRACE,
+      LogStream.NETWORK_TRACE,
+      "network-trace.log");
+
+  private final String wireName;
+  private final String loggerName;
+  private final LogStream stream;
+  private final String fileName;
+
+  TraceScope(String wireName, String loggerName, LogStream stream, String fileName) {
+    this.wireName = wireName;
+    this.loggerName = loggerName;
+    this.stream = stream;
+    this.fileName = fileName;
+  }
+
+  public String wireName() {
+    return wireName;
+  }
+
+  public String loggerName() {
+    return loggerName;
+  }
+
+  public LogStream stream() {
+    return stream;
+  }
+
+  public String fileName() {
+    return fileName;
+  }
+
+  public static TraceScope fromWireName(String wireName) {
+    for (TraceScope scope : values()) {
+      if (scope.wireName.equals(wireName)) {
+        return scope;
+      }
+    }
+    throw new IllegalArgumentException("Unknown Full Trace scope: " + wireName);
+  }
+}

--- a/src/main/java/featurecat/lizzie/logging/WorkDirectoryDiagnostic.java
+++ b/src/main/java/featurecat/lizzie/logging/WorkDirectoryDiagnostic.java
@@ -1,0 +1,33 @@
+package featurecat.lizzie.logging;
+
+import java.util.Objects;
+
+public final class WorkDirectoryDiagnostic {
+  public enum Kind {
+    INFO,
+    WARNING,
+    ERROR
+  }
+
+  private final Kind kind;
+  private final String code;
+  private final String message;
+
+  public WorkDirectoryDiagnostic(Kind kind, String code, String message) {
+    this.kind = Objects.requireNonNull(kind, "kind");
+    this.code = Objects.requireNonNull(code, "code");
+    this.message = Objects.requireNonNull(message, "message");
+  }
+
+  public Kind kind() {
+    return kind;
+  }
+
+  public String code() {
+    return code;
+  }
+
+  public String message() {
+    return message;
+  }
+}

--- a/src/main/java/featurecat/lizzie/logging/WorkDirectoryEnvironment.java
+++ b/src/main/java/featurecat/lizzie/logging/WorkDirectoryEnvironment.java
@@ -1,0 +1,98 @@
+package featurecat.lizzie.logging;
+
+import java.io.File;
+import java.net.URI;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import org.jdesktop.swingx.util.OS;
+
+public final class WorkDirectoryEnvironment {
+  public static final String WORK_DIR_PROPERTY = "lizzie.work.dir";
+
+  private final boolean windows;
+  private final String userHome;
+  private final String userDir;
+  private final String explicitWorkDir;
+  private final String publicDirectory;
+  private final String programDataDirectory;
+  private final List<Path> portableSeedPaths;
+
+  public WorkDirectoryEnvironment(
+      boolean windows,
+      String userHome,
+      String userDir,
+      String explicitWorkDir,
+      String publicDirectory,
+      String programDataDirectory,
+      List<Path> portableSeedPaths) {
+    this.windows = windows;
+    this.userHome = userHome == null ? "" : userHome;
+    this.userDir = userDir == null ? "" : userDir;
+    this.explicitWorkDir = explicitWorkDir == null ? "" : explicitWorkDir;
+    this.publicDirectory = publicDirectory;
+    this.programDataDirectory = programDataDirectory;
+    this.portableSeedPaths =
+        List.copyOf(Objects.requireNonNull(portableSeedPaths, "portableSeedPaths"));
+  }
+
+  public static WorkDirectoryEnvironment system() {
+    List<Path> seeds = new ArrayList<>();
+    try {
+      URI location =
+          WorkDirectoryEnvironment.class
+              .getProtectionDomain()
+              .getCodeSource()
+              .getLocation()
+              .toURI();
+      File codeSource = new File(location);
+      seeds.add(codeSource.isFile() ? codeSource.toPath().getParent() : codeSource.toPath());
+    } catch (Exception ignored) {
+    }
+    try {
+      seeds.add(Path.of("").toAbsolutePath().normalize());
+    } catch (Exception ignored) {
+    }
+    try {
+      seeds.add(Path.of(System.getProperty("user.dir")).toAbsolutePath().normalize());
+    } catch (Exception ignored) {
+    }
+    return new WorkDirectoryEnvironment(
+        OS.isWindows(),
+        System.getProperty("user.home", ""),
+        System.getProperty("user.dir", ""),
+        System.getProperty(WORK_DIR_PROPERTY, ""),
+        System.getenv("PUBLIC"),
+        System.getenv("PROGRAMDATA"),
+        seeds);
+  }
+
+  public boolean windows() {
+    return windows;
+  }
+
+  public String userHome() {
+    return userHome;
+  }
+
+  public String userDir() {
+    return userDir;
+  }
+
+  public String explicitWorkDir() {
+    return explicitWorkDir;
+  }
+
+  public String publicDirectory() {
+    return publicDirectory;
+  }
+
+  public String programDataDirectory() {
+    return programDataDirectory;
+  }
+
+  public List<Path> portableSeedPaths() {
+    return portableSeedPaths;
+  }
+}

--- a/src/main/java/featurecat/lizzie/logging/WorkDirectoryResolution.java
+++ b/src/main/java/featurecat/lizzie/logging/WorkDirectoryResolution.java
@@ -1,0 +1,23 @@
+package featurecat.lizzie.logging;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Objects;
+
+public final class WorkDirectoryResolution {
+  private final Path directory;
+  private final List<WorkDirectoryDiagnostic> diagnostics;
+
+  public WorkDirectoryResolution(Path directory, List<WorkDirectoryDiagnostic> diagnostics) {
+    this.directory = Objects.requireNonNull(directory, "directory").toAbsolutePath().normalize();
+    this.diagnostics = List.copyOf(Objects.requireNonNull(diagnostics, "diagnostics"));
+  }
+
+  public Path directory() {
+    return directory;
+  }
+
+  public List<WorkDirectoryDiagnostic> diagnostics() {
+    return diagnostics;
+  }
+}

--- a/src/main/java/featurecat/lizzie/logging/WorkDirectoryResolver.java
+++ b/src/main/java/featurecat/lizzie/logging/WorkDirectoryResolver.java
@@ -1,0 +1,829 @@
+package featurecat.lizzie.logging;
+
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.PushbackReader;
+import java.io.Reader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.AtomicMoveNotSupportedException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Stream;
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.json.JSONTokener;
+
+public final class WorkDirectoryResolver {
+  static final String USER_WORK_DIR_NAME = ".lizzieyzy-next";
+  static final String LEGACY_USER_WORK_DIR_NAME = ".lizzieyzy-next-foxuid";
+  static final String WINDOWS_SHARED_WORK_DIR_NAME = "LizzieYzyNext";
+  static final String WINDOWS_PORTABLE_MARKER_NAME = ".lizzie-portable";
+  static final String WINDOWS_PORTABLE_WORK_DIR_NAME = "user-data";
+  static final String WINDOWS_PORTABLE_STATE_MIGRATION_KEY =
+      "migrated-windows-portable-user-state-v2";
+  static final String WINDOWS_PORTABLE_RECOVERY_BACKUP_NAME = "config.before-portable-recovery.txt";
+  private static final String BUNDLED_ENGINE_NAME = "KataGo Bundled";
+  private static final String BUNDLED_ENGINE_ROOT = "engines";
+  private static final String BUNDLED_WEIGHT_ROOT = "weights";
+
+  private static final Object LOCK = new Object();
+  private static WorkDirectoryResolution cached;
+
+  private WorkDirectoryResolver() {}
+
+  public static WorkDirectoryResolution resolve() {
+    synchronized (LOCK) {
+      if (cached == null) {
+        cached = resolve(WorkDirectoryEnvironment.system());
+      }
+      return cached;
+    }
+  }
+
+  public static WorkDirectoryResolution resolve(WorkDirectoryEnvironment environment) {
+    List<WorkDirectoryDiagnostic> diagnostics = new ArrayList<>();
+    Path directory = resolveDirectory(environment, diagnostics);
+    return new WorkDirectoryResolution(directory, diagnostics);
+  }
+
+  static void resetCacheForTests() {
+    synchronized (LOCK) {
+      cached = null;
+    }
+  }
+
+  public static Path resolveWritableFallbackDir() throws IOException {
+    List<WorkDirectoryDiagnostic> diagnostics = new ArrayList<>();
+    return resolveWritableFallbackDir(WorkDirectoryEnvironment.system(), diagnostics);
+  }
+
+  public static Optional<Path> findWindowsPortablePackageRootForTests(Path seedPath) {
+    if (seedPath == null) {
+      return Optional.empty();
+    }
+    return findWindowsPortablePackageRoot(Collections.singleton(seedPath), new ArrayList<>());
+  }
+
+  public static Path prepareWindowsPortableWorkDirForTests(Path portableRoot) throws IOException {
+    return prepareWindowsPortableWorkDir(
+        portableRoot, Collections.singletonList(portableRoot), new ArrayList<>());
+  }
+
+  public static Path prepareWindowsPortableWorkDirWithSourcesForTests(
+      Path portableRoot, Path... migrationSources) throws IOException {
+    return prepareWindowsPortableWorkDir(
+        portableRoot, Arrays.asList(migrationSources), new ArrayList<>());
+  }
+
+  public static List<Path> windowsPortableMigrationSourcesForTests(Path portableRoot) {
+    return windowsPortableMigrationSources(
+        portableRoot, WorkDirectoryEnvironment.system(), new ArrayList<>());
+  }
+
+  public static List<Path> windowsPortableCredentialDirectoriesForTests(Path portableRoot) {
+    return windowsPortableCredentialDirectories(
+        portableRoot, WorkDirectoryEnvironment.system(), new ArrayList<>());
+  }
+
+  public static List<Path> legacyWindowsCredentialDirectories() {
+    WorkDirectoryEnvironment environment = WorkDirectoryEnvironment.system();
+    List<WorkDirectoryDiagnostic> diagnostics = new ArrayList<>();
+    Optional<Path> portableRoot =
+        findWindowsPortablePackageRoot(environment.portableSeedPaths(), diagnostics);
+    if (portableRoot.isPresent()) {
+      return windowsPortableCredentialDirectories(portableRoot.get(), environment, diagnostics);
+    }
+    Path credentials =
+        resolve().directory().resolve("secure-credentials").toAbsolutePath().normalize();
+    return Files.isDirectory(credentials)
+        ? Collections.singletonList(credentials)
+        : Collections.emptyList();
+  }
+
+  private static Path resolveDirectory(
+      WorkDirectoryEnvironment environment, List<WorkDirectoryDiagnostic> diagnostics) {
+    try {
+      Path explicitWorkDir = resolveExplicitWorkDir(environment);
+      if (explicitWorkDir != null) {
+        return explicitWorkDir;
+      }
+    } catch (Exception e) {
+      addError(diagnostics, "explicit-work-dir", e);
+    }
+
+    if (environment.windows()) {
+      try {
+        Optional<Path> portableRoot =
+            findWindowsPortablePackageRoot(environment.portableSeedPaths(), diagnostics);
+        if (portableRoot.isPresent()) {
+          Path portableWorkDir =
+              prepareWindowsPortableWorkDir(
+                  portableRoot.get(),
+                  windowsPortableMigrationSources(portableRoot.get(), environment, diagnostics),
+                  diagnostics);
+          if (portableWorkDir != null) {
+            return portableWorkDir;
+          }
+        }
+      } catch (Exception e) {
+        addError(diagnostics, "windows-portable", e);
+      }
+      try {
+        Path cwd = Path.of(environment.userDir()).toAbsolutePath().normalize();
+        if (shouldUsePortableWindowsWorkDir(cwd)) {
+          return cwd;
+        }
+      } catch (Exception e) {
+        addError(diagnostics, "windows-cwd", e);
+      }
+      try {
+        Path fallback = resolveWritableFallbackDir(environment, diagnostics);
+        diagnostics.add(
+            new WorkDirectoryDiagnostic(
+                WorkDirectoryDiagnostic.Kind.INFO, "fallback", "Config dir fallback: " + fallback));
+        return fallback;
+      } catch (Exception e) {
+        addError(diagnostics, "windows-fallback", e);
+      }
+    }
+
+    try {
+      Path cwd = Path.of(environment.userDir()).toAbsolutePath();
+      if (Files.isWritable(cwd)) {
+        return cwd;
+      }
+    } catch (Exception e) {
+      addError(diagnostics, "cwd", e);
+    }
+
+    try {
+      Path fallback = resolveWritableFallbackDir(environment, diagnostics);
+      diagnostics.add(
+          new WorkDirectoryDiagnostic(
+              WorkDirectoryDiagnostic.Kind.INFO, "fallback", "Config dir fallback: " + fallback));
+      return fallback;
+    } catch (Exception e) {
+      addError(diagnostics, "fallback", e);
+      return Path.of(environment.userHome());
+    }
+  }
+
+  private static Path resolveExplicitWorkDir(WorkDirectoryEnvironment environment)
+      throws IOException {
+    String configured = environment.explicitWorkDir().trim();
+    if (configured.isEmpty()) {
+      return null;
+    }
+    Path path = Path.of(configured).toAbsolutePath().normalize();
+    Files.createDirectories(path.resolve("save"));
+    return path;
+  }
+
+  private static Path resolveWritableFallbackDir(
+      WorkDirectoryEnvironment environment, List<WorkDirectoryDiagnostic> diagnostics)
+      throws IOException {
+    if (environment.windows()) {
+      return resolveWindowsWorkDir(environment, diagnostics);
+    }
+
+    Path preferred = Path.of(environment.userHome(), USER_WORK_DIR_NAME);
+    Path legacy = Path.of(environment.userHome(), LEGACY_USER_WORK_DIR_NAME);
+
+    if (!Files.exists(preferred) && Files.isDirectory(legacy)) {
+      try {
+        Files.move(legacy, preferred);
+        diagnostics.add(
+            new WorkDirectoryDiagnostic(
+                WorkDirectoryDiagnostic.Kind.INFO,
+                "migrated",
+                "Migrated config dir to " + preferred));
+      } catch (Exception moveError) {
+        diagnostics.add(
+            new WorkDirectoryDiagnostic(
+                WorkDirectoryDiagnostic.Kind.WARNING,
+                "migration-skipped",
+                "Config dir migration skipped: " + moveError.getMessage()));
+        Files.createDirectories(legacy.resolve("save"));
+        return legacy;
+      }
+    }
+
+    Files.createDirectories(preferred.resolve("save"));
+    return preferred;
+  }
+
+  private static Path resolveWindowsWorkDir(
+      WorkDirectoryEnvironment environment, List<WorkDirectoryDiagnostic> diagnostics)
+      throws IOException {
+    Path preferred = Path.of(environment.userHome(), USER_WORK_DIR_NAME);
+    Path legacy = Path.of(environment.userHome(), LEGACY_USER_WORK_DIR_NAME);
+    Path target = resolveWindowsSharedWorkDirCandidate(environment, diagnostics);
+
+    migrateWorkDirIfNeeded(target, diagnostics, preferred, legacy);
+
+    try {
+      Path cwd = Path.of(environment.userDir()).toAbsolutePath().normalize();
+      if (!target.equals(cwd)) {
+        migrateWorkDirIfNeeded(target, diagnostics, cwd);
+      }
+    } catch (Exception e) {
+      addError(diagnostics, "windows-cwd-migrate", e);
+    }
+
+    Files.createDirectories(target.resolve("save"));
+    return target;
+  }
+
+  private static Path resolveWindowsSharedWorkDirCandidate(
+      WorkDirectoryEnvironment environment, List<WorkDirectoryDiagnostic> diagnostics)
+      throws IOException {
+    for (Path candidate : windowsSharedWorkDirCandidates(environment)) {
+      if (candidate == null || !isAsciiSafePath(candidate)) {
+        continue;
+      }
+      try {
+        Files.createDirectories(candidate.resolve("save"));
+        if (Files.isWritable(candidate)) {
+          return candidate;
+        }
+      } catch (IOException e) {
+        addError(diagnostics, "windows-shared-candidate", e);
+      }
+    }
+
+    Path preferred = Path.of(environment.userHome(), USER_WORK_DIR_NAME);
+    Files.createDirectories(preferred.resolve("save"));
+    return preferred;
+  }
+
+  private static List<Path> windowsSharedWorkDirCandidates(WorkDirectoryEnvironment environment) {
+    List<Path> candidates = new ArrayList<>();
+    addWindowsWorkDirCandidate(
+        candidates, environment.publicDirectory(), "Documents", WINDOWS_SHARED_WORK_DIR_NAME);
+    addWindowsWorkDirCandidate(
+        candidates, environment.publicDirectory(), WINDOWS_SHARED_WORK_DIR_NAME);
+    addWindowsWorkDirCandidate(
+        candidates, environment.programDataDirectory(), WINDOWS_SHARED_WORK_DIR_NAME);
+    return candidates;
+  }
+
+  private static void addWindowsWorkDirCandidate(
+      List<Path> candidates, String root, String... children) {
+    if (root == null || root.trim().isEmpty()) {
+      return;
+    }
+    try {
+      candidates.add(Path.of(root, children).toAbsolutePath().normalize());
+    } catch (Exception ignored) {
+    }
+  }
+
+  private static Optional<Path> findWindowsPortablePackageRoot(
+      Collection<Path> seedPaths, List<WorkDirectoryDiagnostic> diagnostics) {
+    if (seedPaths == null) {
+      return Optional.empty();
+    }
+    for (Path seedPath : seedPaths) {
+      if (seedPath == null) {
+        continue;
+      }
+      Path current = seedPath.toAbsolutePath().normalize();
+      for (int depth = 0; current != null && depth < 8; depth++) {
+        if (Files.isRegularFile(current.resolve(WINDOWS_PORTABLE_MARKER_NAME))) {
+          return Optional.of(current);
+        }
+        current = current.getParent();
+      }
+    }
+    return Optional.empty();
+  }
+
+  private static Path prepareWindowsPortableWorkDir(
+      Path portableRoot,
+      Collection<Path> migrationSources,
+      List<WorkDirectoryDiagnostic> diagnostics)
+      throws IOException {
+    if (portableRoot == null || !Files.isDirectory(portableRoot)) {
+      return null;
+    }
+    Path workDir =
+        portableRoot.resolve(WINDOWS_PORTABLE_WORK_DIR_NAME).toAbsolutePath().normalize();
+    Files.createDirectories(workDir.resolve("save"));
+    if (!Files.isWritable(workDir)) {
+      return null;
+    }
+    Collection<Path> safeSources =
+        migrationSources == null ? Collections.emptyList() : migrationSources;
+    migrateWorkDirIfNeeded(workDir, diagnostics, safeSources.toArray(new Path[0]));
+    return workDir;
+  }
+
+  private static List<Path> windowsPortableMigrationSources(
+      Path portableRoot,
+      WorkDirectoryEnvironment environment,
+      List<WorkDirectoryDiagnostic> diagnostics) {
+    LinkedHashSet<Path> sources = new LinkedHashSet<>();
+    addMigrationSource(sources, portableRoot);
+    addMigrationSource(sources, portableRoot.resolve("app"));
+
+    Path parent = portableRoot.getParent();
+    if (parent != null && Files.isDirectory(parent)) {
+      try (Stream<Path> stream = Files.list(parent)) {
+        for (Path sibling : (Iterable<Path>) stream::iterator) {
+          if (!Files.isDirectory(sibling)
+              || sibling.toAbsolutePath().normalize().equals(portableRoot)) {
+            continue;
+          }
+          if (hasAppRootMarker(sibling)) {
+            addMigrationSource(sources, sibling.resolve(WINDOWS_PORTABLE_WORK_DIR_NAME));
+            addMigrationSource(sources, sibling);
+            addMigrationSource(
+                sources, sibling.resolve("app").resolve(WINDOWS_PORTABLE_WORK_DIR_NAME));
+            addMigrationSource(sources, sibling.resolve("app"));
+          }
+        }
+      } catch (IOException e) {
+        diagnostics.add(
+            new WorkDirectoryDiagnostic(
+                WorkDirectoryDiagnostic.Kind.WARNING,
+                "portable-sibling-scan",
+                "Portable sibling scan skipped: " + e.getMessage()));
+      }
+    }
+
+    for (Path shared : windowsSharedWorkDirCandidates(environment)) {
+      addMigrationSource(sources, shared);
+    }
+    String userHome = environment.userHome().trim();
+    if (!userHome.isEmpty()) {
+      addMigrationSource(sources, Path.of(userHome, USER_WORK_DIR_NAME));
+      addMigrationSource(sources, Path.of(userHome, LEGACY_USER_WORK_DIR_NAME));
+    }
+    return new ArrayList<>(sources);
+  }
+
+  private static List<Path> windowsPortableCredentialDirectories(
+      Path portableRoot,
+      WorkDirectoryEnvironment environment,
+      List<WorkDirectoryDiagnostic> diagnostics) {
+    LinkedHashSet<Path> directories = new LinkedHashSet<>();
+    addExistingCredentialDirectory(
+        directories, portableRoot.resolve(WINDOWS_PORTABLE_WORK_DIR_NAME));
+    for (Path source : windowsPortableMigrationSources(portableRoot, environment, diagnostics)) {
+      addExistingCredentialDirectory(directories, source);
+    }
+    return new ArrayList<>(directories);
+  }
+
+  private static void addExistingCredentialDirectory(Collection<Path> directories, Path source) {
+    if (directories == null || source == null) {
+      return;
+    }
+    try {
+      Path credentialDirectory = source.resolve("secure-credentials").toAbsolutePath().normalize();
+      if (Files.isDirectory(credentialDirectory)) {
+        directories.add(credentialDirectory);
+      }
+    } catch (Exception ignored) {
+    }
+  }
+
+  private static void addMigrationSource(Collection<Path> sources, Path source) {
+    if (sources == null || source == null) {
+      return;
+    }
+    try {
+      sources.add(source.toAbsolutePath().normalize());
+    } catch (Exception ignored) {
+    }
+  }
+
+  private static boolean shouldUsePortableWindowsWorkDir(Path cwd) {
+    if (cwd == null || !Files.isDirectory(cwd) || !Files.isWritable(cwd) || !isAsciiSafePath(cwd)) {
+      return false;
+    }
+    return hasBundledAssets(cwd) || hasExistingWorkDirData(cwd);
+  }
+
+  private static boolean hasBundledAssets(Path dir) {
+    return dir != null
+        && Files.isDirectory(dir.resolve(BUNDLED_ENGINE_ROOT))
+        && Files.isDirectory(dir.resolve(BUNDLED_WEIGHT_ROOT));
+  }
+
+  private static boolean hasExistingWorkDirData(Path dir) {
+    if (dir == null) {
+      return false;
+    }
+    if (Files.isRegularFile(dir.resolve("config.txt"))
+        || Files.isRegularFile(dir.resolve("persist"))) {
+      return true;
+    }
+    Path saveDir = dir.resolve("save");
+    if (!Files.isDirectory(saveDir)) {
+      return false;
+    }
+    try (Stream<Path> stream = Files.list(saveDir)) {
+      return stream.findFirst().isPresent();
+    } catch (IOException e) {
+      return false;
+    }
+  }
+
+  private static void migrateWorkDirIfNeeded(
+      Path target, List<WorkDirectoryDiagnostic> diagnostics, Path... sources) throws IOException {
+    if (target == null) {
+      return;
+    }
+    Path normalizedTarget = target.toAbsolutePath().normalize();
+    Files.createDirectories(normalizedTarget);
+    List<Path> candidates = normalizedMigrationSources(normalizedTarget, sources);
+    Path configSource = selectBestConfigSource(candidates);
+    Path targetConfigFile = normalizedTarget.resolve("config.txt");
+    boolean targetHadConfig = hasUsableConfig(targetConfigFile);
+    boolean recovered = false;
+
+    if (targetHadConfig && configSource != null) {
+      recovered = recoverPortableUserStateIfNeeded(normalizedTarget, configSource);
+    } else if (!targetHadConfig && configSource != null) {
+      backupUnreadableConfig(targetConfigFile, diagnostics);
+      copyIfExists(configSource.resolve("config.txt"), targetConfigFile, true);
+    }
+
+    Path primarySource =
+        configSource != null ? configSource : candidates.stream().findFirst().orElse(null);
+    if (primarySource != null) {
+      copyIfExists(primarySource.resolve("persist"), normalizedTarget.resolve("persist"), false);
+      Path sourceSave = primarySource.resolve("save");
+      if (Files.isDirectory(sourceSave)) {
+        copyDirectoryContents(sourceSave, normalizedTarget.resolve("save"), false);
+      }
+    }
+
+    if (configSource != null && (!targetHadConfig || recovered)) {
+      diagnostics.add(
+          new WorkDirectoryDiagnostic(
+              WorkDirectoryDiagnostic.Kind.INFO,
+              "migrated",
+              "Migrated config dir to " + normalizedTarget + " from " + configSource));
+    }
+  }
+
+  private static List<Path> normalizedMigrationSources(Path target, Path... sources) {
+    LinkedHashSet<Path> candidates = new LinkedHashSet<>();
+    if (sources == null) {
+      return new ArrayList<>();
+    }
+    for (Path source : sources) {
+      if (source == null) {
+        continue;
+      }
+      try {
+        Path normalized = source.toAbsolutePath().normalize();
+        if (!normalized.equals(target) && hasMigratableWorkDirData(normalized)) {
+          candidates.add(normalized);
+        }
+      } catch (Exception ignored) {
+      }
+    }
+    return new ArrayList<>(candidates);
+  }
+
+  private static boolean hasMigratableWorkDirData(Path directory) {
+    return hasExistingWorkDirData(directory);
+  }
+
+  private static Path selectBestConfigSource(List<Path> candidates) {
+    Path selected = null;
+    int selectedTier = Integer.MIN_VALUE;
+    long selectedModified = Long.MIN_VALUE;
+    for (Path candidate : candidates) {
+      Path configFile = candidate.resolve("config.txt");
+      if (!hasUsableConfig(configFile)) {
+        continue;
+      }
+      int tier;
+      try {
+        tier = configUserStateTier(readJsonObject(configFile));
+      } catch (Exception e) {
+        continue;
+      }
+      long modified = Long.MIN_VALUE;
+      try {
+        modified = Files.getLastModifiedTime(configFile).toMillis();
+      } catch (IOException ignored) {
+      }
+      if (selected == null
+          || tier > selectedTier
+          || (tier == selectedTier && modified > selectedModified)) {
+        selected = candidate;
+        selectedTier = tier;
+        selectedModified = modified;
+      }
+    }
+    return selected;
+  }
+
+  private static int configUserStateTier(JSONObject root) {
+    JSONObject leelaz = root.optJSONObject("leelaz");
+    if (leelaz == null) {
+      return 0;
+    }
+    if (hasConfiguredRemoteProvider(leelaz)) {
+      return 2;
+    }
+    JSONArray engines = leelaz.optJSONArray("engine-settings-list");
+    if (engines != null) {
+      for (int i = 0; i < engines.length(); i++) {
+        JSONObject engine = engines.optJSONObject(i);
+        if (engine != null && !looksLikeManagedBundledEngine(engine)) {
+          return 2;
+        }
+      }
+    }
+    JSONArray legacyCommands = leelaz.optJSONArray("engine-command-list");
+    if (legacyCommands != null && legacyCommands.length() > 0) {
+      return 2;
+    }
+    return engines != null && engines.length() > 0 ? 1 : 0;
+  }
+
+  private static boolean hasUsableConfig(Path configFile) {
+    if (!Files.isRegularFile(configFile)) {
+      return false;
+    }
+    try {
+      JSONObject parsed = readJsonObject(configFile);
+      return parsed.optJSONObject("ui") != null || parsed.optJSONObject("leelaz") != null;
+    } catch (Exception e) {
+      return false;
+    }
+  }
+
+  private static boolean recoverPortableUserStateIfNeeded(Path target, Path source)
+      throws IOException {
+    Path targetConfigFile = target.resolve("config.txt");
+    Path sourceConfigFile = source.resolve("config.txt");
+    try {
+      JSONObject targetConfig = readJsonObject(targetConfigFile);
+      JSONObject sourceConfig = readJsonObject(sourceConfigFile);
+      JSONObject targetUi = targetConfig.optJSONObject("ui");
+      if (targetUi != null && targetUi.optBoolean(WINDOWS_PORTABLE_STATE_MIGRATION_KEY, false)) {
+        return false;
+      }
+      if (!looksLikeFreshPortableConfig(targetConfig)
+          || !containsRecoverableUserState(sourceConfig, targetConfig)) {
+        return false;
+      }
+
+      Path backup = target.resolve(WINDOWS_PORTABLE_RECOVERY_BACKUP_NAME);
+      copyIfExists(targetConfigFile, backup, false);
+      JSONObject recovered = new JSONObject(sourceConfig.toString());
+      mergeMissingJsonValues(recovered, targetConfig);
+      JSONObject recoveredUi = recovered.optJSONObject("ui");
+      if (recoveredUi == null) {
+        recoveredUi = new JSONObject();
+        recovered.put("ui", recoveredUi);
+      }
+      recoveredUi.put(WINDOWS_PORTABLE_STATE_MIGRATION_KEY, true);
+      writeJsonAtomically(targetConfigFile, recovered);
+      return true;
+    } catch (JSONException e) {
+      return false;
+    }
+  }
+
+  private static boolean looksLikeFreshPortableConfig(JSONObject root) {
+    JSONObject leelaz = root.optJSONObject("leelaz");
+    if (leelaz == null || hasConfiguredRemoteProvider(leelaz)) {
+      return false;
+    }
+    JSONArray engines = leelaz.optJSONArray("engine-settings-list");
+    if (engines == null || engines.length() == 0) {
+      return true;
+    }
+    if (engines.length() != 1) {
+      return false;
+    }
+    JSONObject engine = engines.optJSONObject(0);
+    if (engine == null) {
+      return true;
+    }
+    return looksLikeManagedBundledEngine(engine);
+  }
+
+  private static boolean looksLikeManagedBundledEngine(JSONObject engine) {
+    String name = engine.optString("name", "").trim();
+    String command = engine.optString("command", "").replace('\\', '/').toLowerCase(Locale.ROOT);
+    return (BUNDLED_ENGINE_NAME.equals(name) || "KataGo Auto Setup".equals(name))
+        && (command.isEmpty()
+            || command.contains("weights/default.bin.gz")
+            || command.contains("engines/katago/"));
+  }
+
+  private static boolean containsRecoverableUserState(JSONObject source, JSONObject target) {
+    JSONObject sourceLeelaz = source.optJSONObject("leelaz");
+    JSONObject targetLeelaz = target.optJSONObject("leelaz");
+    if (sourceLeelaz == null) {
+      return false;
+    }
+    if (hasConfiguredRemoteProvider(sourceLeelaz)
+        && (targetLeelaz == null || !hasConfiguredRemoteProvider(targetLeelaz))) {
+      return true;
+    }
+    Set<String> targetEngines = engineIdentities(targetLeelaz);
+    for (String sourceEngine : engineIdentities(sourceLeelaz)) {
+      if (!targetEngines.contains(sourceEngine)) {
+        return true;
+      }
+    }
+    JSONArray legacyCommands = sourceLeelaz.optJSONArray("engine-command-list");
+    return legacyCommands != null && legacyCommands.length() > 0;
+  }
+
+  private static boolean hasConfiguredRemoteProvider(JSONObject leelaz) {
+    if (leelaz == null) {
+      return false;
+    }
+    JSONObject remote = leelaz.optJSONObject("remote-compute");
+    if (remote == null) {
+      return false;
+    }
+    return !"local".equalsIgnoreCase(remote.optString("provider", "local"))
+        || !remote.optString("zhizi-identifier", "").isBlank()
+        || !remote.optString("custom-remote-code", "").isBlank();
+  }
+
+  private static Set<String> engineIdentities(JSONObject leelaz) {
+    LinkedHashSet<String> identities = new LinkedHashSet<>();
+    if (leelaz == null) {
+      return identities;
+    }
+    JSONArray engines = leelaz.optJSONArray("engine-settings-list");
+    if (engines == null) {
+      return identities;
+    }
+    for (int i = 0; i < engines.length(); i++) {
+      JSONObject engine = engines.optJSONObject(i);
+      if (engine == null) {
+        continue;
+      }
+      String command = engine.optString("command", "").trim().toLowerCase(Locale.ROOT);
+      String name = engine.optString("name", "").trim().toLowerCase(Locale.ROOT);
+      identities.add(command.isEmpty() ? "name:" + name : "command:" + command);
+    }
+    return identities;
+  }
+
+  private static void mergeMissingJsonValues(JSONObject target, JSONObject fallback) {
+    for (String key : fallback.keySet()) {
+      Object fallbackValue = fallback.get(key);
+      if (!target.has(key)) {
+        target.put(key, fallbackValue);
+      } else if (target.opt(key) instanceof JSONObject && fallbackValue instanceof JSONObject) {
+        mergeMissingJsonValues(target.getJSONObject(key), (JSONObject) fallbackValue);
+      }
+    }
+  }
+
+  private static void writeJsonAtomically(Path target, JSONObject value) throws IOException {
+    Files.createDirectories(target.getParent());
+    Path temporary = Files.createTempFile(target.getParent(), ".config-recovery-", ".tmp");
+    try {
+      Files.writeString(temporary, value.toString(2));
+      try {
+        Files.move(
+            temporary, target, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);
+      } catch (AtomicMoveNotSupportedException e) {
+        Files.move(temporary, target, StandardCopyOption.REPLACE_EXISTING);
+      }
+    } finally {
+      Files.deleteIfExists(temporary);
+    }
+  }
+
+  private static void copyDirectoryContents(Path source, Path target, boolean replace)
+      throws IOException {
+    Files.createDirectories(target);
+    try (Stream<Path> stream = Files.list(source)) {
+      for (Path child : (Iterable<Path>) stream::iterator) {
+        Path destination = target.resolve(child.getFileName().toString());
+        if (Files.isDirectory(child)) {
+          copyDirectoryContents(child, destination, replace);
+        } else {
+          copyIfExists(child, destination, replace);
+        }
+      }
+    }
+  }
+
+  private static void copyIfExists(Path source, Path destination, boolean replace)
+      throws IOException {
+    if (!Files.exists(source) || Files.isDirectory(source)) {
+      return;
+    }
+    if (!replace && Files.exists(destination)) {
+      return;
+    }
+    Files.createDirectories(destination.getParent());
+    if (replace) {
+      Files.copy(source, destination, StandardCopyOption.REPLACE_EXISTING);
+    } else {
+      Files.copy(source, destination);
+    }
+  }
+
+  private static boolean isAsciiSafePath(Path path) {
+    if (path == null) {
+      return false;
+    }
+    String text = path.toAbsolutePath().normalize().toString();
+    for (int i = 0; i < text.length(); i++) {
+      if (text.charAt(i) > 127) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  static boolean hasAppRootMarker(Path directory) {
+    return directory != null
+        && (Files.isRegularFile(directory.resolve(WINDOWS_PORTABLE_MARKER_NAME))
+            || Files.isRegularFile(directory.resolve("PROJECT_INFO.txt"))
+            || Files.isRegularFile(directory.resolve("lizzieyzy-next-installed-manifest.json"))
+            || Files.isRegularFile(directory.resolve("app").resolve("PROJECT_INFO.txt"))
+            || Files.isRegularFile(
+                directory.resolve("app").resolve("lizzieyzy-next-installed-manifest.json")));
+  }
+
+  private static void backupUnreadableConfig(
+      Path configFile, List<WorkDirectoryDiagnostic> diagnostics) {
+    if (configFile == null || !Files.isRegularFile(configFile)) {
+      return;
+    }
+    Path source = configFile.toAbsolutePath().normalize();
+    Path parent = source.getParent();
+    if (parent == null) {
+      return;
+    }
+    String fileName = configFile.getFileName() + ".unreadable-backup";
+    Path backup = parent.resolve(fileName);
+    for (int suffix = 1; Files.exists(backup); suffix++) {
+      backup = parent.resolve(fileName + "." + suffix);
+    }
+    try {
+      Files.copy(source, backup);
+      diagnostics.add(
+          new WorkDirectoryDiagnostic(
+              WorkDirectoryDiagnostic.Kind.INFO,
+              "unreadable-backup",
+              "Saved unreadable config backup to " + backup));
+    } catch (IOException backupError) {
+      addError(diagnostics, "unreadable-backup", backupError);
+    }
+  }
+
+  private static JSONObject readJsonObject(Path file) throws IOException {
+    try (Reader reader = openUtf8JsonReader(file)) {
+      return new JSONObject(new JSONTokener(reader));
+    }
+  }
+
+  private static Reader openUtf8JsonReader(Path file) throws IOException {
+    PushbackReader reader =
+        new PushbackReader(
+            new InputStreamReader(Files.newInputStream(file), StandardCharsets.UTF_8), 1);
+    try {
+      int first = reader.read();
+      if (first != -1 && first != '\uFEFF') {
+        reader.unread(first);
+      }
+      return reader;
+    } catch (IOException | RuntimeException e) {
+      reader.close();
+      throw e;
+    }
+  }
+
+  private static void addError(
+      List<WorkDirectoryDiagnostic> diagnostics, String code, Exception error) {
+    diagnostics.add(
+        new WorkDirectoryDiagnostic(
+            WorkDirectoryDiagnostic.Kind.ERROR,
+            code,
+            error.getClass().getSimpleName()
+                + ": "
+                + (error.getMessage() == null ? "" : error.getMessage())));
+  }
+}

--- a/src/test/java/featurecat/lizzie/logging/LizzieLoggingShutdownTest.java
+++ b/src/test/java/featurecat/lizzie/logging/LizzieLoggingShutdownTest.java
@@ -1,0 +1,52 @@
+package featurecat.lizzie.logging;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import featurecat.lizzie.Lizzie;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class LizzieLoggingShutdownTest {
+  @TempDir Path tempDir;
+
+  @AfterEach
+  void tearDown() {
+    LoggingRuntime.resetForTests();
+  }
+
+  @Test
+  void loggingShutdownRunsOnceBeforeExit() {
+    LoggingRuntime runtime =
+        LoggingRuntime.initialize(
+            new WorkDirectoryResolution(tempDir, List.of()),
+            new LoggingLimits(64, 32, 32, 32, 7, 1_000_000, 256_000));
+    AtomicInteger exits = new AtomicInteger();
+    List<String> order = new ArrayList<>();
+    Lizzie.shutdownLoggingThenExit(
+        code -> {
+          assertEquals(0, code);
+          assertTrue(runtime.isShutdown());
+          order.add("exit");
+          exits.incrementAndGet();
+        });
+    assertEquals(List.of("exit"), order);
+    assertEquals(1, exits.get());
+    Lizzie.shutdownLoggingThenExit(code -> exits.incrementAndGet());
+    assertEquals(2, exits.get());
+    assertTrue(runtime.isShutdown());
+  }
+
+  @Test
+  void exitStillRunsWhenLoggingWasNeverInitialized() {
+    LoggingRuntime.resetForTests();
+    AtomicInteger code = new AtomicInteger(-1);
+    Lizzie.shutdownLoggingThenExit(code::set);
+    assertEquals(0, code.get());
+  }
+}

--- a/src/test/java/featurecat/lizzie/logging/LoadEngineNormalExitProbe.java
+++ b/src/test/java/featurecat/lizzie/logging/LoadEngineNormalExitProbe.java
@@ -1,0 +1,47 @@
+package featurecat.lizzie.logging;
+
+import featurecat.lizzie.gui.LoadEngine;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+public final class LoadEngineNormalExitProbe {
+  public static void main(String[] args) throws Exception {
+    Path work = Path.of(args[0]);
+    Path marker = Path.of(args[1]);
+    LoggingRuntime.initialize(new WorkDirectoryResolution(work, List.of()));
+    int[] calls = {0};
+    LoadEngine.requestNormalExit(
+        code -> {
+          calls[0]++;
+          try {
+            Files.writeString(
+                marker,
+                "calls="
+                    + calls[0]
+                    + "\ncode="
+                    + code
+                    + "\nshutdown="
+                    + LoggingRuntime.current().orElseThrow().isShutdown());
+          } catch (Exception e) {
+            throw new RuntimeException(e);
+          }
+        });
+    LoadEngine.requestNormalExit(
+        code -> {
+          calls[0]++;
+          try {
+            Files.writeString(
+                marker,
+                "calls="
+                    + calls[0]
+                    + "\ncode="
+                    + code
+                    + "\nshutdown="
+                    + LoggingRuntime.current().orElseThrow().isShutdown());
+          } catch (Exception e) {
+            throw new RuntimeException(e);
+          }
+        });
+  }
+}

--- a/src/test/java/featurecat/lizzie/logging/LoadEngineNormalExitProcessTest.java
+++ b/src/test/java/featurecat/lizzie/logging/LoadEngineNormalExitProcessTest.java
@@ -1,0 +1,45 @@
+package featurecat.lizzie.logging;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class LoadEngineNormalExitProcessTest {
+  @TempDir Path tempDir;
+
+  @Test
+  void engineSelectionExitShutsDownLoggingOnceWithZeroCode() throws Exception {
+    Path work = Files.createTempDirectory(tempDir, "exit-work");
+    Path marker = tempDir.resolve("exit-marker.txt");
+    String java =
+        Path.of(
+                System.getProperty("java.home"),
+                "bin",
+                System.getProperty("os.name", "").startsWith("Windows") ? "java.exe" : "java")
+            .toString();
+    String classPath =
+        System.getProperty("surefire.test.class.path", System.getProperty("java.class.path", ""));
+    Process process =
+        new ProcessBuilder(
+                java,
+                "-Djava.awt.headless=true",
+                "-cp",
+                classPath,
+                LoadEngineNormalExitProbe.class.getName(),
+                work.toAbsolutePath().toString(),
+                marker.toAbsolutePath().toString())
+            .redirectErrorStream(true)
+            .start();
+    String output = new String(process.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+    assertEquals(0, process.waitFor(), output);
+    String recorded = Files.readString(marker);
+    assertTrue(recorded.contains("calls=2"), recorded);
+    assertTrue(recorded.contains("code=0"), recorded);
+    assertTrue(recorded.contains("shutdown=true"), recorded);
+  }
+}

--- a/src/test/java/featurecat/lizzie/logging/LoggingProviderFailureProbe.java
+++ b/src/test/java/featurecat/lizzie/logging/LoggingProviderFailureProbe.java
@@ -1,0 +1,20 @@
+package featurecat.lizzie.logging;
+
+import java.nio.file.Path;
+import java.util.List;
+import org.slf4j.helpers.NOPLoggerFactory;
+
+public final class LoggingProviderFailureProbe {
+  public static void main(String[] args) {
+    try {
+      LoggingRuntime.initialize(
+          new WorkDirectoryResolution(Path.of(args[0]), List.of()),
+          LoggingLimits.production(),
+          new NOPLoggerFactory());
+      System.out.println("CONTINUED");
+    } catch (Throwable t) {
+      t.printStackTrace();
+      System.exit(2);
+    }
+  }
+}

--- a/src/test/java/featurecat/lizzie/logging/LoggingProviderFailureProcessTest.java
+++ b/src/test/java/featurecat/lizzie/logging/LoggingProviderFailureProcessTest.java
@@ -1,0 +1,40 @@
+package featurecat.lizzie.logging;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class LoggingProviderFailureProcessTest {
+  @TempDir Path tempDir;
+
+  @Test
+  void isolatedJvmContinuesWhenProviderIsNop() throws Exception {
+    Path work = Files.createTempDirectory(tempDir, "nop-work");
+    String java =
+        Path.of(
+                System.getProperty("java.home"),
+                "bin",
+                System.getProperty("os.name", "").startsWith("Windows") ? "java.exe" : "java")
+            .toString();
+    String classPath =
+        System.getProperty("surefire.test.class.path", System.getProperty("java.class.path", ""));
+    Process process =
+        new ProcessBuilder(
+                java,
+                "-cp",
+                classPath,
+                LoggingProviderFailureProbe.class.getName(),
+                work.toAbsolutePath().toString())
+            .redirectErrorStream(true)
+            .start();
+    String output = new String(process.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+    assertEquals(0, process.waitFor(), output);
+    assertTrue(output.contains("CONTINUED"), output);
+    assertTrue(output.contains(LoggingRuntime.STDERR_PREFIX), output);
+  }
+}

--- a/src/test/java/featurecat/lizzie/logging/LoggingProviderSmokeIT.java
+++ b/src/test/java/featurecat/lizzie/logging/LoggingProviderSmokeIT.java
@@ -1,0 +1,57 @@
+package featurecat.lizzie.logging;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class LoggingProviderSmokeIT {
+  @TempDir Path tempDir;
+
+  @Test
+  void shadedArtifactWritesOneProviderEvent() throws Exception {
+    String configured = System.getProperty("lizzie.shaded.jar", "");
+    assertFalse(configured.isBlank(), "lizzie.shaded.jar must be set by failsafe");
+    Path shaded = Path.of(configured);
+    assertTrue(Files.isRegularFile(shaded), "shaded artifact missing: " + shaded.toAbsolutePath());
+
+    Path work = Files.createTempDirectory(tempDir, "shaded-smoke");
+    String java =
+        Path.of(
+                System.getProperty("java.home"),
+                "bin",
+                System.getProperty("os.name", "").startsWith("Windows") ? "java.exe" : "java")
+            .toString();
+    Process process =
+        new ProcessBuilder(
+                java,
+                "-cp",
+                shaded.toAbsolutePath().toString(),
+                LoggingProviderSmoke.class.getName(),
+                work.toAbsolutePath().toString())
+            .redirectErrorStream(true)
+            .start();
+    String output = new String(process.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+    assertEquals(0, process.waitFor(), output + "\njar=" + shaded.toAbsolutePath());
+    String appLog = Files.readString(work.resolve("logs/app.log"));
+    assertTrue(appLog.contains("provider-smoke"), appLog);
+    assertEquals(1, count(appLog, "provider-smoke"));
+    assertEquals(1, count(appLog, "application log session started"));
+    System.out.println("shaded-smoke-jar=" + shaded.toAbsolutePath());
+  }
+
+  private static int count(String text, String token) {
+    int count = 0;
+    int index = 0;
+    while ((index = text.indexOf(token, index)) >= 0) {
+      count++;
+      index += token.length();
+    }
+    return count;
+  }
+}

--- a/src/test/java/featurecat/lizzie/logging/LoggingRuntimeTest.java
+++ b/src/test/java/featurecat/lizzie/logging/LoggingRuntimeTest.java
@@ -1,0 +1,320 @@
+package featurecat.lizzie.logging;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.spi.LoggingEvent;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.ServiceLoader;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.slf4j.LoggerFactory;
+import org.slf4j.spi.SLF4JServiceProvider;
+
+class LoggingRuntimeTest {
+  @TempDir Path tempDir;
+
+  @AfterEach
+  void tearDown() {
+    LoggingRuntime.resetForTests();
+  }
+
+  @Test
+  void bootstrapWritesStartupEventToAppLog() throws Exception {
+    LoggingRuntime runtime = start();
+
+    runtime.awaitIdle();
+    String appLog = read("logs/app.log");
+    assertTrue(appLog.contains("application log session started"));
+    assertTrue(appLog.contains(runtime.applicationLogSessionId()));
+    assertTrue(Files.isRegularFile(tempDir.resolve("logs/crash.log")));
+    assertFalse(Files.exists(tempDir.resolve("logs/engine-trace.log")));
+  }
+
+  @Test
+  void repeatedInitializeReusesRuntimeWithoutDuplicateStartupEvents() throws Exception {
+    LoggingRuntime first = start();
+    LoggingRuntime second =
+        LoggingRuntime.initialize(new WorkDirectoryResolution(tempDir, List.of()), testLimits());
+    first.awaitIdle();
+
+    assertEquals(first, second);
+    String appLog = read("logs/app.log");
+    assertEquals(1, count(appLog, "application log session started"));
+  }
+
+  @Test
+  void discoversExactlyOneSlf4jProvider() {
+    AtomicInteger providers = new AtomicInteger();
+    ServiceLoader.load(SLF4JServiceProvider.class).forEach(provider -> providers.incrementAndGet());
+    assertEquals(1, providers.get());
+  }
+
+  @Test
+  void diagnosticsEnableSelectedModuleImmediately() throws Exception {
+    LoggingRuntime runtime = start();
+    org.slf4j.Logger engine = LoggerFactory.getLogger(LogCategories.ENGINE);
+    engine.debug("hidden-before-diagnostics");
+    runtime.applySettings(LoggingSettings.defaults().withDiagnosticsEnabled(true));
+    engine.debug("visible-after-diagnostics");
+    runtime.awaitIdle();
+
+    String appLog = read("logs/app.log");
+    assertFalse(appLog.contains("hidden-before-diagnostics"));
+    assertTrue(appLog.contains("visible-after-diagnostics"));
+  }
+
+  @Test
+  void persistFailureRestoresPreviousRuntimePlan() throws Exception {
+    LoggingRuntime runtime = start();
+    LoggingSettings enabled = LoggingSettings.defaults().withDiagnosticsEnabled(true);
+    assertThrows(
+        IllegalStateException.class,
+        () ->
+            runtime.applySettings(
+                enabled,
+                settings -> {
+                  throw new IOException("disk full");
+                }));
+    assertFalse(runtime.settings().diagnosticsEnabled());
+    LoggerFactory.getLogger(LogCategories.ENGINE).debug("should-remain-hidden");
+    runtime.awaitIdle();
+    assertFalse(read("logs/app.log").contains("should-remain-hidden"));
+  }
+
+  @Test
+  void fullTraceStartStopWritesDistinctSessionsToSelectedStreamsOnly() throws Exception {
+    LoggingRuntime runtime = start();
+    runtime.applySettings(
+        LoggingSettings.defaults().withPreferredTraceScopes(EnumSet.of(TraceScope.ENGINE_GTP)));
+    runtime.startFullTrace();
+    String first = runtime.currentTraceSessionId();
+    LoggerFactory.getLogger(LogCategories.ENGINE_TRACE).info("raw-gtp-1");
+    runtime.stopFullTrace();
+    runtime.startFullTrace();
+    String second = runtime.currentTraceSessionId();
+    LoggerFactory.getLogger(LogCategories.ENGINE_TRACE).info("raw-gtp-2");
+    runtime.awaitIdle();
+    runtime.stopFullTrace();
+    runtime.awaitIdle();
+
+    assertNotEquals(first, second);
+    String trace = read("logs/engine-trace.log");
+    assertTrue(trace.contains("Full Trace session started"), trace);
+    assertTrue(trace.contains("Full Trace session stopped"), trace);
+    assertTrue(trace.contains(first), "missing first=" + first + " in " + trace);
+    assertTrue(trace.contains(second), "missing second=" + second + " in " + trace);
+    assertTrue(trace.contains("raw-gtp-1"));
+    assertFalse(Files.exists(tempDir.resolve("logs/readboard-trace.log")));
+    assertFalse(read("logs/app.log").contains("raw-gtp-1"));
+  }
+
+  @Test
+  void restartDoesNotActivatePersistedTracePreference() throws Exception {
+    Path work = tempDir;
+    LoggingRuntime runtime = start();
+    runtime.applySettings(
+        LoggingSettings.defaults()
+            .withPreferredTraceScopes(EnumSet.of(TraceScope.NETWORK_WEBSOCKET)));
+    runtime.shutdown();
+    LoggingRuntime.resetForTests();
+    LoggingRuntime restarted =
+        LoggingRuntime.initialize(new WorkDirectoryResolution(work, List.of()), testLimits());
+    restarted.applySettings(
+        LoggingSettings.defaults()
+            .withPreferredTraceScopes(EnumSet.of(TraceScope.NETWORK_WEBSOCKET)));
+
+    assertFalse(restarted.fullTraceActive());
+    assertFalse(Files.exists(work.resolve("logs/network-trace.log")));
+  }
+
+  @Test
+  void rollingCreatesArchiveSegmentsAndKeepsActiveName() throws Exception {
+    LoggingRuntime.resetForTests();
+    LoggingRuntime runtime =
+        LoggingRuntime.initialize(
+            new WorkDirectoryResolution(tempDir, List.of()),
+            new LoggingLimits(64, 32, 32, 32, 7, 4000, 400));
+    org.slf4j.Logger app = LoggerFactory.getLogger(LogCategories.APP);
+    for (int i = 0; i < 40; i++) {
+      app.info("rolling-payload-{}", "x".repeat(80) + i);
+    }
+    runtime.awaitIdle(80);
+    assertTrue(Files.isRegularFile(tempDir.resolve("logs/app.log")));
+    try (var stream = Files.list(tempDir.resolve("logs/archive"))) {
+      assertTrue(stream.anyMatch(path -> path.getFileName().toString().startsWith("app.")));
+    }
+  }
+
+  @Test
+  void saturatedTraceQueueDoesNotBlockAppOrProducer() throws Exception {
+    LoggingRuntime runtime =
+        LoggingRuntime.initialize(
+            new WorkDirectoryResolution(tempDir, List.of()),
+            new LoggingLimits(32, 4, 4, 4, 7, 10000, 1000));
+    runtime.startFullTrace(EnumSet.of(TraceScope.ENGINE_GTP));
+    CountDownLatch gate = new CountDownLatch(1);
+    runtime.blockPersistenceForTests(LogStream.ENGINE_TRACE, gate);
+    org.slf4j.Logger trace = LoggerFactory.getLogger(LogCategories.ENGINE_TRACE);
+    long started = System.nanoTime();
+    for (int i = 0; i < 64; i++) {
+      trace.info("flood-{}", i);
+    }
+    long elapsedNanos = System.nanoTime() - started;
+    LoggerFactory.getLogger(LogCategories.APP).error("app-while-trace-blocked");
+    runtime.awaitIdle();
+    gate.countDown();
+
+    assertTrue(elapsedNanos < TimeUnit.SECONDS.toNanos(1));
+    assertTrue(read("logs/app.log").contains("app-while-trace-blocked"));
+    assertTrue(runtime.status().stream(LogStream.ENGINE_TRACE).orElseThrow().droppedCount() > 0);
+  }
+
+  @Test
+  void sanitizerRemovesCredentialCanariesAndKeepsOrdinaryPaths() throws Exception {
+    LoggingRuntime runtime = start();
+    LoggerFactory.getLogger(LogCategories.APP)
+        .error(
+            "login password={} path={} url={}",
+            "CANARY_PASSWORD_7f3a",
+            "/home/dev/lizzieyzy-next/config.txt",
+            "https://example.test/status");
+    runtime.awaitIdle();
+
+    String appLog = read("logs/app.log");
+    assertFalse(appLog.contains("CANARY_PASSWORD_7f3a"));
+    assertTrue(appLog.contains("/home/dev/lizzieyzy-next/config.txt"));
+    assertTrue(appLog.contains("https://example.test/status"));
+  }
+
+  @Test
+  void sanitizerFailureOmitsOriginalEvent() {
+    SanitizingEncoder encoder = new SanitizingEncoder();
+    LoggerContext context = new LoggerContext();
+    encoder.setContext(context);
+    encoder.setPattern("%msg%n");
+    encoder.setSanitizer(
+        new PersistenceSanitizer() {
+          @Override
+          public String sanitize(String text) {
+            throw new IllegalStateException("boom");
+          }
+        });
+    encoder.start();
+    LoggingEvent event = new LoggingEvent();
+    event.setLoggerName(LogCategories.APP);
+    event.setLevel(Level.INFO);
+    event.setMessage("secret CANARY_SHOULD_NOT_APPEAR");
+    String encoded = new String(encoder.encode(event), StandardCharsets.UTF_8);
+    assertEquals(PersistenceSanitizer.FAILURE_MARKER + System.lineSeparator(), encoded);
+  }
+
+  @Test
+  void engineAndCommandIdentitiesAreNotReused() {
+    LoggingRuntime runtime = start();
+    String firstEngine = runtime.newEngineIdentity();
+    String secondEngine = runtime.newEngineIdentity();
+    assertNotEquals(firstEngine, secondEngine);
+    assertNotEquals(runtime.newCommandIdentity(), runtime.newCommandIdentity());
+  }
+
+  @Test
+  void idleShutdownDoesNotBurnThreeSecondBudget() {
+    LoggingRuntime runtime = start();
+    runtime.awaitIdle();
+    long started = System.nanoTime();
+    runtime.shutdown();
+    assertTrue(System.nanoTime() - started < TimeUnit.SECONDS.toNanos(1));
+  }
+
+  @Test
+  void shutdownFlushesAppAndReportsUnwrittenWhenBlocked() throws Exception {
+    LoggingRuntime runtime = start();
+    CountDownLatch gate = new CountDownLatch(1);
+    runtime.blockPersistenceForTests(LogStream.APP, gate);
+    LoggerFactory.getLogger(LogCategories.APP).error("late-event");
+    ShutdownReport report = runtime.shutdown();
+    gate.countDown();
+    assertTrue(report.unwritten(LogStream.APP) >= 0);
+  }
+
+  @Test
+  void isolatedJvmProviderSmokeWritesAppLog() throws Exception {
+    Path shaded = findShadedJar();
+    Assumptions.assumeTrue(shaded != null, "shaded artifact is required for provider smoke");
+    Path work = Files.createTempDirectory(tempDir, "smoke");
+    String java =
+        Path.of(
+                System.getProperty("java.home"),
+                "bin",
+                System.getProperty("os.name", "").startsWith("Windows") ? "java.exe" : "java")
+            .toString();
+    Process process =
+        new ProcessBuilder(
+                java,
+                "-cp",
+                shaded.toString(),
+                LoggingProviderSmoke.class.getName(),
+                work.toString())
+            .redirectErrorStream(true)
+            .start();
+    String output = new String(process.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+    assertEquals(0, process.waitFor(), output);
+    assertTrue(Files.readString(work.resolve("logs/app.log")).contains("provider-smoke"));
+  }
+
+  private LoggingRuntime start() {
+    LoggingRuntime.resetForTests();
+    return LoggingRuntime.initialize(new WorkDirectoryResolution(tempDir, List.of()), testLimits());
+  }
+
+  private static LoggingLimits testLimits() {
+    return new LoggingLimits(64, 32, 32, 32, 7, 1_000_000, 256_000);
+  }
+
+  private String read(String relative) throws IOException {
+    return Files.readString(tempDir.resolve(relative));
+  }
+
+  private static int count(String text, String token) {
+    int count = 0;
+    int index = 0;
+    while ((index = text.indexOf(token, index)) >= 0) {
+      count++;
+      index += token.length();
+    }
+    return count;
+  }
+
+  private static Path findShadedJar() {
+    Path target = Path.of("target");
+    if (!Files.isDirectory(target)) {
+      return null;
+    }
+    try (var stream = Files.list(target)) {
+      return stream
+          .filter(path -> path.getFileName().toString().endsWith("-shaded.jar"))
+          .findFirst()
+          .orElse(null);
+    } catch (IOException e) {
+      return null;
+    }
+  }
+}

--- a/src/test/java/featurecat/lizzie/logging/LoggingRuntimeTest.java
+++ b/src/test/java/featurecat/lizzie/logging/LoggingRuntimeTest.java
@@ -379,7 +379,7 @@ class LoggingRuntimeTest {
   }
 
   @Test
-  void shutdownHonorsThreeSecondBudgetWhenNestedStopIsSlow() {
+  void shutdownHonorsThreeSecondBudgetWhenNestedStopIsSlow() throws Exception {
     LoggingRuntime runtime = start();
     runtime.pauseNestedStopForTests(LogStream.APP, 5_000);
     long started = System.nanoTime();
@@ -388,6 +388,10 @@ class LoggingRuntimeTest {
     assertTrue(
         elapsed <= LoggingLimits.SHUTDOWN_BUDGET_NANOS + TimeUnit.MILLISECONDS.toNanos(100),
         "elapsedNanos=" + elapsed);
+    assertFalse(runtime.isNestedStartedForTests(LogStream.APP));
+    assertFalse(runtime.isNestedStartedForTests(LogStream.CRASH));
+    Files.delete(tempDir.resolve("logs/app.log"));
+    Files.delete(tempDir.resolve("logs/crash.log"));
   }
 
   @Test

--- a/src/test/java/featurecat/lizzie/logging/LoggingRuntimeTest.java
+++ b/src/test/java/featurecat/lizzie/logging/LoggingRuntimeTest.java
@@ -3,6 +3,7 @@ package featurecat.lizzie.logging;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -21,11 +22,12 @@ import java.util.ServiceLoader;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.slf4j.LoggerFactory;
+import org.slf4j.helpers.NOPLoggerFactory;
 import org.slf4j.spi.SLF4JServiceProvider;
 
 class LoggingRuntimeTest {
@@ -158,7 +160,7 @@ class LoggingRuntimeTest {
     }
     runtime.awaitIdle(80);
     assertTrue(Files.isRegularFile(tempDir.resolve("logs/app.log")));
-    try (var stream = Files.list(tempDir.resolve("logs/archive"))) {
+    try (Stream<Path> stream = Files.list(tempDir.resolve("logs/archive"))) {
       assertTrue(stream.anyMatch(path -> path.getFileName().toString().startsWith("app.")));
     }
   }
@@ -185,6 +187,9 @@ class LoggingRuntimeTest {
     assertTrue(elapsedNanos < TimeUnit.SECONDS.toNanos(1));
     assertTrue(read("logs/app.log").contains("app-while-trace-blocked"));
     assertTrue(runtime.status().stream(LogStream.ENGINE_TRACE).orElseThrow().droppedCount() > 0);
+    assertEquals(
+        "queue saturation",
+        runtime.status().stream(LogStream.ENGINE_TRACE).orElseThrow().reason());
   }
 
   @Test
@@ -192,16 +197,126 @@ class LoggingRuntimeTest {
     LoggingRuntime runtime = start();
     LoggerFactory.getLogger(LogCategories.APP)
         .error(
-            "login password={} path={} url={}",
+            "login password={} authorization=Basic {} path={} url={} token=Bearer {}",
             "CANARY_PASSWORD_7f3a",
+            "CANARY_BASIC_9c2e",
             "/home/dev/lizzieyzy-next/config.txt",
-            "https://example.test/status");
+            "https://example.test/status",
+            "CANARY_BEARER_aa11");
+    LoggerFactory.getLogger(LogCategories.APP)
+        .error("header", new IllegalStateException("Authorization: Basic CANARY_BASIC_THROW"));
+    runtime.awaitIdle();
+
+    String scanned = scanLogFiles();
+    assertFalse(scanned.contains("CANARY_PASSWORD_7f3a"), scanned);
+    assertFalse(scanned.contains("CANARY_BASIC_9c2e"), scanned);
+    assertFalse(scanned.contains("CANARY_BASIC_THROW"), scanned);
+    assertFalse(scanned.contains("CANARY_BEARER_aa11"), scanned);
+    assertTrue(scanned.contains("/home/dev/lizzieyzy-next/config.txt"));
+    assertTrue(scanned.contains("https://example.test/status"));
+  }
+
+  @Test
+  void nopProviderDoesNotAbortInitialize() {
+    PrintStream original = System.err;
+    ByteArrayOutputStream captured = new ByteArrayOutputStream();
+    System.setErr(new PrintStream(captured, true, StandardCharsets.UTF_8));
+    try {
+      LoggingRuntime.resetForTests();
+      LoggingRuntime runtime =
+          LoggingRuntime.initialize(
+              new WorkDirectoryResolution(tempDir, List.of()),
+              testLimits(),
+              new NOPLoggerFactory());
+      assertFalse(runtime.status().persistenceEnabled());
+      LoggerFactory.getLogger(LogCategories.APP).error("must-not-throw");
+    } finally {
+      System.setErr(original);
+    }
+    String err = captured.toString(StandardCharsets.UTF_8);
+    assertTrue(err.contains(LoggingRuntime.STDERR_PREFIX), err);
+    assertEquals(1, count(err, LoggingRuntime.STDERR_PREFIX));
+    assertFalse(Files.exists(tempDir.resolve("logs/app.log")));
+  }
+
+  @Test
+  void illegalAppLogPathRecordsFailureAndContinues() throws Exception {
+    Files.createDirectories(tempDir.resolve("logs").resolve("app.log"));
+    PrintStream original = System.err;
+    ByteArrayOutputStream captured = new ByteArrayOutputStream();
+    System.setErr(new PrintStream(captured, true, StandardCharsets.UTF_8));
+    LoggingRuntime runtime;
+    try {
+      runtime = start();
+      LoggerFactory.getLogger(LogCategories.APP).error("after-failure");
+      LoggerFactory.getLogger(LogCategories.APP).error("after-failure-again");
+      runtime.awaitIdle();
+    } finally {
+      System.setErr(original);
+    }
+    LoggingStatus.StreamStatus app = runtime.status().stream(LogStream.APP).orElseThrow();
+    assertNotNull(app.reason());
+    assertNotNull(app.firstOccurrence());
+    assertNotNull(app.lastOccurrence());
+    assertFalse(runtime.status().persistenceEnabled());
+    String err = captured.toString(StandardCharsets.UTF_8);
+    assertTrue(count(err, LoggingRuntime.STDERR_PREFIX) >= 1, err);
+    assertEquals(1, count(err, "APP:failure"));
+  }
+
+  @Test
+  void queueSaturationThenSuccessfulWriteMarksRecovered() throws Exception {
+    LoggingRuntime runtime =
+        LoggingRuntime.initialize(
+            new WorkDirectoryResolution(tempDir, List.of()),
+            new LoggingLimits(32, 4, 4, 4, 7, 10000, 1000));
+    runtime.startFullTrace(EnumSet.of(TraceScope.ENGINE_GTP));
+    CountDownLatch gate = new CountDownLatch(1);
+    runtime.blockPersistenceForTests(LogStream.ENGINE_TRACE, gate);
+    org.slf4j.Logger trace = LoggerFactory.getLogger(LogCategories.ENGINE_TRACE);
+    for (int i = 0; i < 64; i++) {
+      trace.info("flood-{}", i);
+    }
+    LoggingStatus.StreamStatus blocked =
+        runtime.status().stream(LogStream.ENGINE_TRACE).orElseThrow();
+    assertTrue(blocked.droppedCount() > 0);
+    assertEquals("queue saturation", blocked.reason());
+    assertFalse(blocked.recovered());
+    gate.countDown();
+    trace.info("after-drain");
+    runtime.awaitIdle();
+    LoggingStatus.StreamStatus recovered =
+        runtime.status().stream(LogStream.ENGINE_TRACE).orElseThrow();
+    assertTrue(recovered.recovered());
+    assertTrue(recovered.droppedCount() > 0);
+    assertEquals("queue saturation", recovered.reason());
+    assertNotNull(recovered.firstOccurrence());
+  }
+
+  @Test
+  void persistedEventsIncludeInstalledCorrelationIdentities() throws Exception {
+    LoggingRuntime runtime = start();
+    String engine = runtime.newEngineIdentity();
+    String command = runtime.newCommandIdentity();
+    CorrelationContext.installEngine(engine);
+    CorrelationContext.installCommand(command);
+    LoggerFactory.getLogger(LogCategories.APP).error("correlated-event");
+    runtime.startFullTrace(EnumSet.of(TraceScope.ENGINE_GTP));
+    String traceSession = runtime.currentTraceSessionId();
+    LoggerFactory.getLogger(LogCategories.ENGINE_TRACE).info("trace-payload");
+    runtime.awaitIdle();
+    runtime.stopFullTrace();
     runtime.awaitIdle();
 
     String appLog = read("logs/app.log");
-    assertFalse(appLog.contains("CANARY_PASSWORD_7f3a"));
-    assertTrue(appLog.contains("/home/dev/lizzieyzy-next/config.txt"));
-    assertTrue(appLog.contains("https://example.test/status"));
+    assertTrue(appLog.contains("session=" + runtime.applicationLogSessionId()), appLog);
+    assertTrue(appLog.contains("engine=" + engine), appLog);
+    assertTrue(appLog.contains("command=" + command), appLog);
+    String traceLog = read("logs/engine-trace.log");
+    assertTrue(traceLog.contains("trace=" + traceSession), traceLog);
+    assertTrue(traceLog.contains("Full Trace session started"), traceLog);
+    CorrelationContext.clearEngine();
+    CorrelationContext.clearCommand();
   }
 
   @Test
@@ -245,39 +360,94 @@ class LoggingRuntimeTest {
   }
 
   @Test
-  void shutdownFlushesAppAndReportsUnwrittenWhenBlocked() throws Exception {
+  void shutdownCountsInterruptedInFlightExactlyOnce() throws Exception {
     LoggingRuntime runtime = start();
+    runtime.awaitIdle();
     CountDownLatch gate = new CountDownLatch(1);
     runtime.blockPersistenceForTests(LogStream.APP, gate);
     LoggerFactory.getLogger(LogCategories.APP).error("late-event");
+    Thread.sleep(80);
+    long started = System.nanoTime();
     ShutdownReport report = runtime.shutdown();
-    gate.countDown();
-    assertTrue(report.unwritten(LogStream.APP) >= 0);
+    long elapsed = System.nanoTime() - started;
+    assertEquals(1L, report.unwritten(LogStream.APP), "unwritten=" + report.unwritten(LogStream.APP));
+    assertTrue(elapsed <= LoggingLimits.SHUTDOWN_BUDGET_NANOS + TimeUnit.MILLISECONDS.toNanos(100));
+    Path appLog = tempDir.resolve("logs/app.log");
+    if (Files.isRegularFile(appLog)) {
+      assertFalse(Files.readString(appLog).contains("late-event"));
+    }
   }
 
   @Test
-  void isolatedJvmProviderSmokeWritesAppLog() throws Exception {
-    Path shaded = findShadedJar();
-    Assumptions.assumeTrue(shaded != null, "shaded artifact is required for provider smoke");
-    Path work = Files.createTempDirectory(tempDir, "smoke");
-    String java =
-        Path.of(
-                System.getProperty("java.home"),
-                "bin",
-                System.getProperty("os.name", "").startsWith("Windows") ? "java.exe" : "java")
-            .toString();
-    Process process =
-        new ProcessBuilder(
-                java,
-                "-cp",
-                shaded.toString(),
-                LoggingProviderSmoke.class.getName(),
-                work.toString())
-            .redirectErrorStream(true)
-            .start();
-    String output = new String(process.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
-    assertEquals(0, process.waitFor(), output);
-    assertTrue(Files.readString(work.resolve("logs/app.log")).contains("provider-smoke"));
+  void shutdownHonorsThreeSecondBudgetWhenNestedStopIsSlow() {
+    LoggingRuntime runtime = start();
+    runtime.pauseNestedStopForTests(LogStream.APP, 5_000);
+    long started = System.nanoTime();
+    runtime.shutdown();
+    long elapsed = System.nanoTime() - started;
+    assertTrue(
+        elapsed <= LoggingLimits.SHUTDOWN_BUDGET_NANOS + TimeUnit.MILLISECONDS.toNanos(100),
+        "elapsedNanos=" + elapsed);
+  }
+
+  @Test
+  void failedAppendDoesNotMarkRecoveredUntilLaterSuccess() throws Exception {
+    LoggingRuntime runtime = start();
+    assertTrue(runtime.status().persistenceEnabled());
+    runtime.failWritesForTests(LogStream.APP, true);
+    LoggerFactory.getLogger(LogCategories.APP).error("controlled-fail");
+    runtime.awaitIdle();
+    LoggingStatus.StreamStatus failed = runtime.status().stream(LogStream.APP).orElseThrow();
+    assertFalse(failed.recovered());
+    assertNotNull(failed.reason());
+    assertFalse(runtime.status().persistenceEnabled());
+    runtime.failWritesForTests(LogStream.APP, false);
+    LoggerFactory.getLogger(LogCategories.APP).error("after-recovery");
+    runtime.awaitIdle();
+    LoggingStatus.StreamStatus recovered = runtime.status().stream(LogStream.APP).orElseThrow();
+    assertTrue(recovered.recovered());
+    assertTrue(runtime.status().persistenceEnabled());
+    assertTrue(read("logs/app.log").contains("after-recovery"));
+  }
+
+  @Test
+  void engineTraceWriteFailureDoesNotAttachToAppStream() throws Exception {
+    LoggingRuntime runtime = start();
+    runtime.startFullTrace(EnumSet.of(TraceScope.ENGINE_GTP));
+    runtime.failWritesForTests(LogStream.ENGINE_TRACE, true);
+    LoggerFactory.getLogger(LogCategories.ENGINE_TRACE).info("trace-fail");
+    runtime.awaitIdle();
+    LoggingStatus.StreamStatus trace =
+        runtime.status().stream(LogStream.ENGINE_TRACE).orElseThrow();
+    assertNotNull(trace.reason());
+    assertFalse(trace.recovered());
+    LoggingStatus.StreamStatus app = runtime.status().stream(LogStream.APP).orElseThrow();
+    assertTrue(app.reason() == null || !app.reason().contains("engine-trace"));
+  }
+
+  @Test
+  void encoderFailureWritesMarkerAndUpdatesStatus() throws Exception {
+    LoggingRuntime runtime = start();
+    runtime.replaceSanitizerForTests(
+        new PersistenceSanitizer() {
+          @Override
+          public String sanitize(String text) {
+            if (text.contains("BLOW_UP")) {
+              throw new IllegalStateException("boom");
+            }
+            return super.sanitize(text);
+          }
+        });
+    LoggerFactory.getLogger(LogCategories.APP).error("BLOW_UP");
+    runtime.awaitIdle();
+    LoggingStatus.StreamStatus app = runtime.status().stream(LogStream.APP).orElseThrow();
+    assertNotNull(app.reason());
+    assertTrue(app.reason().toLowerCase().contains("encoder") || app.reason().contains("redaction"), app.reason());
+    assertFalse(app.recovered());
+    assertFalse(runtime.status().persistenceEnabled());
+    String scanned = scanLogFiles();
+    assertTrue(scanned.contains(PersistenceSanitizer.FAILURE_MARKER), scanned);
+    assertFalse(scanned.contains("BLOW_UP"), scanned);
   }
 
   private LoggingRuntime start() {
@@ -293,6 +463,27 @@ class LoggingRuntimeTest {
     return Files.readString(tempDir.resolve(relative));
   }
 
+  private String scanLogFiles() throws IOException {
+    Path logs = tempDir.resolve("logs");
+    if (!Files.exists(logs)) {
+      return "";
+    }
+    StringBuilder scanned = new StringBuilder();
+    try (Stream<Path> stream = Files.walk(logs)) {
+      stream
+          .filter(Files::isRegularFile)
+          .forEach(
+              path -> {
+                try {
+                  scanned.append(Files.readString(path));
+                } catch (IOException e) {
+                  throw new RuntimeException(e);
+                }
+              });
+    }
+    return scanned.toString();
+  }
+
   private static int count(String text, String token) {
     int count = 0;
     int index = 0;
@@ -301,20 +492,5 @@ class LoggingRuntimeTest {
       index += token.length();
     }
     return count;
-  }
-
-  private static Path findShadedJar() {
-    Path target = Path.of("target");
-    if (!Files.isDirectory(target)) {
-      return null;
-    }
-    try (var stream = Files.list(target)) {
-      return stream
-          .filter(path -> path.getFileName().toString().endsWith("-shaded.jar"))
-          .findFirst()
-          .orElse(null);
-    } catch (IOException e) {
-      return null;
-    }
   }
 }

--- a/src/test/java/featurecat/lizzie/logging/LoggingSettingsConfigTest.java
+++ b/src/test/java/featurecat/lizzie/logging/LoggingSettingsConfigTest.java
@@ -1,0 +1,89 @@
+package featurecat.lizzie.logging;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import featurecat.lizzie.Config;
+import featurecat.lizzie.ConfigTestHelper;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.EnumSet;
+import org.json.JSONObject;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class LoggingSettingsConfigTest {
+  @TempDir Path tempDir;
+
+  @Test
+  void defaultsSelectEveryModuleAndScopeWithoutEnablingDiagnostics() throws Exception {
+    Path workDirectory = Files.createTempDirectory(tempDir, "config");
+    Config config = ConfigTestHelper.createForTests(workDirectory);
+    initializeConfig(config);
+
+    LoggingSettings settings = LoggingSettings.fromJson(config.config.optJSONObject("logging"));
+    if (settings == LoggingSettings.defaults() && config.config.optJSONObject("logging") == null) {
+      settings = LoggingSettings.defaults();
+    }
+    JSONObject logging = LoggingSettings.defaults().toJson();
+    config.config.put(LoggingSettings.CONFIG_KEY, logging);
+    config.loggingSettings = LoggingSettings.fromJson(logging);
+    config.save();
+
+    JSONObject saved = new JSONObject(Files.readString(Path.of(config.getConfigFilePath())));
+    LoggingSettings persisted = LoggingSettings.fromJson(saved.getJSONObject("logging"));
+    assertFalse(persisted.diagnosticsEnabled());
+    assertEquals(EnumSet.allOf(DiagnosticModule.class), persisted.diagnosticModules());
+    assertEquals(EnumSet.allOf(TraceScope.class), persisted.preferredTraceScopes());
+    assertFalse(saved.getJSONObject("logging").has("full-trace-active"));
+    assertFalse(saved.getJSONObject("logging").has("trace-session"));
+  }
+
+  @Test
+  void saveLoggingSettingsPersistsPreferredScopesNotActiveTrace() throws Exception {
+    Path workDirectory = Files.createTempDirectory(tempDir, "config-save");
+    Config config = ConfigTestHelper.createForTests(workDirectory);
+    initializeConfig(config);
+    LoggingSettings settings =
+        LoggingSettings.defaults()
+            .withDiagnosticsEnabled(true)
+            .withPreferredTraceScopes(EnumSet.of(TraceScope.ENGINE_GTP));
+    config.saveLoggingSettings(settings);
+
+    JSONObject saved = new JSONObject(Files.readString(Path.of(config.getConfigFilePath())));
+    LoggingSettings persisted = LoggingSettings.fromJson(saved.getJSONObject("logging"));
+    assertTrue(persisted.diagnosticsEnabled());
+    assertEquals(EnumSet.of(TraceScope.ENGINE_GTP), persisted.preferredTraceScopes());
+    assertFalse(saved.getJSONObject("logging").has("full-trace-active"));
+  }
+
+  @Test
+  void failedLoggingSaveKeepsPreviousSettings() throws Exception {
+    Path workDirectory = Files.createTempDirectory(tempDir, "config-fail");
+    Config config = ConfigTestHelper.createForTests(workDirectory);
+    initializeConfig(config);
+    Path configFile = Path.of(config.getConfigFilePath());
+    Files.delete(configFile);
+    Files.createDirectory(configFile);
+    LoggingSettings previous = config.loggingSettings;
+
+    assertThrows(
+        Exception.class,
+        () -> config.saveLoggingSettings(LoggingSettings.defaults().withDiagnosticsEnabled(true)));
+    assertEquals(previous, config.loggingSettings);
+  }
+
+  private static void initializeConfig(Config config) throws Exception {
+    JSONObject root = new JSONObject();
+    root.put("ui", new JSONObject());
+    root.put("leelaz", new JSONObject());
+    root.put(LoggingSettings.CONFIG_KEY, LoggingSettings.defaults().toJson());
+    config.config = root;
+    config.uiConfig = root.getJSONObject("ui");
+    config.leelazConfig = root.getJSONObject("leelaz");
+    config.loggingSettings = LoggingSettings.defaults();
+    config.save();
+  }
+}

--- a/src/test/java/featurecat/lizzie/logging/WorkDirectoryResolverTest.java
+++ b/src/test/java/featurecat/lizzie/logging/WorkDirectoryResolverTest.java
@@ -1,0 +1,225 @@
+package featurecat.lizzie.logging;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.util.List;
+import org.json.JSONObject;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+
+class WorkDirectoryResolverTest {
+
+  @Test
+  void explicitWorkDirIsUsedAndCreatesSave() throws Exception {
+    Path workDir = Files.createTempDirectory("lizzie-explicit-work");
+    WorkDirectoryEnvironment environment =
+        environment(false, workDir.getParent(), workDir.getParent(), workDir.toString());
+
+    WorkDirectoryResolution resolution = WorkDirectoryResolver.resolve(environment);
+
+    assertEquals(workDir.toAbsolutePath().normalize(), resolution.directory());
+    assertTrue(Files.isDirectory(workDir.resolve("save")));
+  }
+
+  @Test
+  void writableCwdIsUsedOnNonWindows() throws Exception {
+    Path cwd = Files.createTempDirectory("lizzie-writable-cwd");
+    WorkDirectoryEnvironment environment = environment(false, cwd.getParent(), cwd, "");
+
+    WorkDirectoryResolution resolution = WorkDirectoryResolver.resolve(environment);
+
+    assertEquals(cwd.toAbsolutePath().normalize(), resolution.directory());
+    assertTrue(resolution.diagnostics().isEmpty());
+  }
+
+  @Test
+  @DisabledOnOs(OS.WINDOWS)
+  void nonWritableInstalledLocationFallsBackWithoutUsingCwd() throws Exception {
+    Assumptions.assumeTrue(Files.getFileStore(Path.of("/tmp")).supportsFileAttributeView("posix"));
+    Path home = Files.createTempDirectory("lizzie-home");
+    Path installed = Files.createTempDirectory("lizzie-installed");
+    Files.setPosixFilePermissions(installed, PosixFilePermissions.fromString("r-xr-xr-x"));
+    try {
+      WorkDirectoryEnvironment environment = environment(false, home, installed, "");
+
+      WorkDirectoryResolution resolution = WorkDirectoryResolver.resolve(environment);
+
+      Path expected = home.resolve(WorkDirectoryResolver.USER_WORK_DIR_NAME);
+      assertEquals(expected.toAbsolutePath().normalize(), resolution.directory());
+      assertTrue(Files.isDirectory(expected.resolve("save")));
+      assertFalse(resolution.directory().equals(installed.toAbsolutePath().normalize()));
+      assertTrue(
+          resolution.diagnostics().stream()
+              .anyMatch(diagnostic -> "fallback".equals(diagnostic.code())));
+    } finally {
+      Files.setPosixFilePermissions(installed, PosixFilePermissions.fromString("rwxrwxrwx"));
+    }
+  }
+
+  @Test
+  void windowsPortableLayoutUsesUserData() throws Exception {
+    Path portableRoot = Files.createTempDirectory("lizzie-portable");
+    Files.writeString(portableRoot.resolve(".lizzie-portable"), "portable");
+    WorkDirectoryEnvironment environment =
+        new WorkDirectoryEnvironment(
+            true,
+            portableRoot.resolve("home").toString(),
+            portableRoot.resolve("app").toString(),
+            "",
+            null,
+            null,
+            List.of(portableRoot.resolve("app")));
+
+    WorkDirectoryResolution resolution = WorkDirectoryResolver.resolve(environment);
+
+    assertEquals(
+        portableRoot.resolve("user-data").toAbsolutePath().normalize(), resolution.directory());
+    assertTrue(Files.isDirectory(resolution.directory().resolve("save")));
+  }
+
+  @Test
+  void windowsFallbackUsesSharedPublicDocuments() throws Exception {
+    Path home = Files.createTempDirectory("lizzie-win-home");
+    Path cwd = Files.createTempDirectory("lizzie-win-cwd");
+    Path publicRoot = Files.createTempDirectory("lizzie-public");
+    WorkDirectoryEnvironment environment =
+        new WorkDirectoryEnvironment(
+            true, home.toString(), cwd.toString(), "", publicRoot.toString(), null, List.of(cwd));
+
+    WorkDirectoryResolution resolution = WorkDirectoryResolver.resolve(environment);
+
+    Path expected = publicRoot.resolve("Documents").resolve("LizzieYzyNext");
+    assertEquals(expected.toAbsolutePath().normalize(), resolution.directory());
+    assertTrue(
+        resolution.diagnostics().stream()
+            .anyMatch(diagnostic -> "fallback".equals(diagnostic.code())));
+  }
+
+  @Test
+  void migratedLegacyConfigMovesToPreferredHomeDirectory() throws Exception {
+    Path home = Files.createTempDirectory("lizzie-migrate-home");
+    Path installed = Files.createTempDirectory("lizzie-migrate-installed");
+    Files.setPosixFilePermissions(installed, PosixFilePermissions.fromString("r-xr-xr-x"));
+    Path legacy = home.resolve(WorkDirectoryResolver.LEGACY_USER_WORK_DIR_NAME);
+    Files.createDirectories(legacy.resolve("save"));
+    Files.writeString(legacy.resolve("config.txt"), "{\"ui\":{}}");
+    try {
+      WorkDirectoryEnvironment environment = environment(false, home, installed, "");
+
+      WorkDirectoryResolution resolution = WorkDirectoryResolver.resolve(environment);
+
+      Path expected = home.resolve(WorkDirectoryResolver.USER_WORK_DIR_NAME);
+      assertEquals(expected.toAbsolutePath().normalize(), resolution.directory());
+      assertTrue(Files.isRegularFile(expected.resolve("config.txt")));
+      assertFalse(Files.exists(legacy));
+      assertTrue(
+          resolution.diagnostics().stream()
+              .anyMatch(diagnostic -> "migrated".equals(diagnostic.code())));
+    } finally {
+      Files.setPosixFilePermissions(installed, PosixFilePermissions.fromString("rwxrwxrwx"));
+    }
+  }
+
+  @Test
+  void bundledEngineWindowsCwdStaysPortable() throws Exception {
+    Path cwd = Files.createTempDirectory("lizzie-bundled");
+    Files.createDirectories(cwd.resolve("engines"));
+    Files.createDirectories(cwd.resolve("weights"));
+    WorkDirectoryEnvironment environment =
+        new WorkDirectoryEnvironment(
+            true,
+            cwd.resolve("home").toString(),
+            cwd.toString(),
+            "",
+            cwd.resolve("public").toString(),
+            null,
+            List.of(cwd));
+
+    WorkDirectoryResolution resolution = WorkDirectoryResolver.resolve(environment);
+
+    assertEquals(cwd.toAbsolutePath().normalize(), resolution.directory());
+  }
+
+  @Test
+  void repeatedResolutionReturnsTheCachedResult() {
+    WorkDirectoryResolution first = WorkDirectoryResolver.resolve();
+    WorkDirectoryResolution second = WorkDirectoryResolver.resolve();
+    assertSame(first, second);
+    assertEquals(first.directory(), second.directory());
+  }
+
+  @Test
+  void resolverDoesNotPrintDiagnostics() throws Exception {
+    Path workDir = Files.createTempDirectory("lizzie-silent-work");
+    PrintStream original = System.out;
+    ByteArrayOutputStream captured = new ByteArrayOutputStream();
+    System.setOut(new PrintStream(captured, true, StandardCharsets.UTF_8));
+    try {
+      WorkDirectoryResolver.resolve(
+          environment(false, workDir.getParent(), workDir.getParent(), workDir.toString()));
+    } finally {
+      System.setOut(original);
+    }
+    assertEquals("", captured.toString(StandardCharsets.UTF_8));
+  }
+
+  @Test
+  void windowsPortableMarkerKeepsMutableDataInsideExtractedFolder() throws Exception {
+    Path tempRoot = Files.createTempDirectory("lizzie-portable-root");
+    Path portableRoot = Files.createDirectories(tempRoot.resolve("LizzieYzy Next 围棋"));
+    Files.writeString(portableRoot.resolve(".lizzie-portable"), "portable");
+    Files.createDirectories(portableRoot.resolve("app"));
+    Files.writeString(
+        portableRoot.resolve("config.txt"), "{\"ui\":{},\"leelaz\":{\"legacy\":true}}");
+
+    Path foundRoot =
+        WorkDirectoryResolver.findWindowsPortablePackageRootForTests(portableRoot.resolve("app"))
+            .orElseThrow();
+    Path workDir = WorkDirectoryResolver.prepareWindowsPortableWorkDirForTests(foundRoot);
+
+    assertEquals(portableRoot.toAbsolutePath().normalize(), foundRoot);
+    assertEquals(portableRoot.resolve("user-data").toAbsolutePath().normalize(), workDir);
+    assertTrue(Files.exists(workDir.resolve("save")));
+    assertTrue(Files.exists(workDir.resolve("config.txt")));
+    assertFalse(workDir.equals(portableRoot));
+  }
+
+  @Test
+  void migratedConfigIsCopiedIntoPortableUserData() throws Exception {
+    Path previous = Files.createTempDirectory("lizzie-prev-data");
+    Files.writeString(
+        previous.resolve("config.txt"),
+        new JSONObject()
+            .put("ui", new JSONObject())
+            .put("leelaz", new JSONObject().put("engine-command-list", List.of("katago")))
+            .toString(2));
+    Path currentRoot = Files.createTempDirectory("lizzie-current-portable");
+    Files.writeString(currentRoot.resolve(".lizzie-portable"), "portable");
+
+    Path workDir =
+        WorkDirectoryResolver.prepareWindowsPortableWorkDirWithSourcesForTests(
+            currentRoot, previous);
+
+    JSONObject migrated = new JSONObject(Files.readString(workDir.resolve("config.txt")));
+    assertEquals(
+        "katago",
+        migrated.getJSONObject("leelaz").getJSONArray("engine-command-list").getString(0));
+  }
+
+  private static WorkDirectoryEnvironment environment(
+      boolean windows, Path home, Path userDir, String explicit) {
+    return new WorkDirectoryEnvironment(
+        windows, home.toString(), userDir.toString(), explicit, null, null, List.of(userDir));
+  }
+}

--- a/src/test/java/featurecat/lizzie/logging/WorkDirectoryResolverTest.java
+++ b/src/test/java/featurecat/lizzie/logging/WorkDirectoryResolverTest.java
@@ -107,7 +107,9 @@ class WorkDirectoryResolverTest {
   }
 
   @Test
+  @DisabledOnOs(OS.WINDOWS)
   void migratedLegacyConfigMovesToPreferredHomeDirectory() throws Exception {
+    Assumptions.assumeTrue(Files.getFileStore(Path.of("/tmp")).supportsFileAttributeView("posix"));
     Path home = Files.createTempDirectory("lizzie-migrate-home");
     Path installed = Files.createTempDirectory("lizzie-migrate-installed");
     Files.setPosixFilePermissions(installed, PosixFilePermissions.fromString("r-xr-xr-x"));


### PR DESCRIPTION
## Why

LizzieYzy Next has no stable, bounded runtime log in the resolved work directory. Support evidence is scattered across stdout, optional `Last*Logs`, and module-specific files. Ticket 01 / PR1 of the unified logging spec establishes one logging runtime before Config loads.

## What

- Extract `WorkDirectoryResolver` as the single work-directory seam used by Config and logging.
- Pin SLF4J 2.0.16 and Logback Classic 1.6.3; merge `META-INF/services` in the shaded JAR.
- Add `LoggingRuntime`: semantic Diagnostics / Full Trace settings, non-blocking queues, rolling files, persistence sanitization, correlation identities, degradation status, and a 3s shutdown budget.
- Fail closed when the SLF4J provider is missing or is not Logback; never persist beside the application.
- Hook non-force zero-exit paths (`Lizzie.shutdown`, LoadEngine, FirstUseSettings) through logging shutdown. Menu force-exit is unchanged.
- Do **not** migrate or remove `log-console-to-file` / `log-gtp-to-file` (Tickets 02 and 03).

## How

Startup resolves the work directory once, bootstraps Normal logging, then loads Config and applies persisted product settings. File I/O stays on logging workers. Persistence sanitization removes credentials (including Basic) before bytes hit disk; ordinary local paths and URLs remain. Full Trace files stay inactive until an explicit session starts.

## Test Plan

- [x] Focused: `WorkDirectoryResolverTest`, `LoggingRuntimeTest`, `LoggingSettingsConfigTest`, shutdown/exit/provider-failure tests (40 tests, 0 fail, 0 skip)
- [x] Failsafe `LoggingProviderSmokeIT` against the current `*-shaded.jar` (not skipped)
- [ ] Hosted CI on this PR

## Related

- Ticket: `.scratch/unified-logging/issues/01-logging-foundation.md`
- Spec: `.scratch/unified-logging/spec.md` (PR1 — Logging Foundation)
- ADR 0003: resolve work directory before logging and Config