### PR TITLE
fix(macos): extract CaptureTsumeGo jar under the app work dir

### DIFF
--- a/src/main/java/featurecat/lizzie/analysis/CaptureTsumeGo.java
+++ b/src/main/java/featurecat/lizzie/analysis/CaptureTsumeGo.java
@@ -17,6 +17,9 @@ import java.util.concurrent.ScheduledExecutorService;
 import javax.swing.JFrame;
 
 public class CaptureTsumeGo {
+  static final String HELPER_DIR_NAME = "captureTsumeGo";
+  static final String HELPER_JAR_NAME = "CaptureTsumeGo1.2.jar";
+
   private static boolean macPermissionHintShown = false;
 
   private Process process;
@@ -47,10 +50,31 @@ public class CaptureTsumeGo {
     }
   }
 
+  public static File helperJarFile(File workDirectory) {
+    if (workDirectory == null) {
+      throw new IllegalArgumentException("workDirectory");
+    }
+    return workDirectory
+        .toPath()
+        .toAbsolutePath()
+        .normalize()
+        .resolve(HELPER_DIR_NAME)
+        .resolve(HELPER_JAR_NAME)
+        .toFile();
+  }
+
   private boolean start() {
-    String jarName = "CaptureTsumeGo1.2.jar";
-    File jarFile = new File("captureTsumeGo" + File.separator + jarName);
-    if (!jarFile.exists()) Utils.copyCaptureTsumeGo();
+    File workDirectory = Lizzie.config.getWorkDirectory();
+    File jarFile = helperJarFile(workDirectory);
+    if (!jarFile.exists()) {
+      try {
+        Utils.copyCaptureTsumeGo(workDirectory);
+      } catch (IOException e) {
+        e.printStackTrace();
+        Utils.showMsg("无法提取抓死活棋辅助程序到 " + jarFile.getAbsolutePath() + "：" + e.getLocalizedMessage());
+        return false;
+      }
+    }
     if (!jarFile.exists()) {
       Utils.showMsg("找不到 " + jarFile.getAbsolutePath() + "，抓死活棋功能无法启动。");
       return false;

--- a/src/main/java/featurecat/lizzie/util/Utils.java
+++ b/src/main/java/featurecat/lizzie/util/Utils.java
@@ -4,6 +4,7 @@ import static java.lang.Math.round;
 
 import featurecat.lizzie.Config;
 import featurecat.lizzie.Lizzie;
+import featurecat.lizzie.analysis.CaptureTsumeGo;
 import featurecat.lizzie.analysis.MoveData;
 import featurecat.lizzie.gui.EngineData;
 import featurecat.lizzie.gui.HtmlMessage;
@@ -1380,13 +1381,31 @@ public class Utils {
     }
   }
 
-  public static void copyCaptureTsumeGo() {
-    // TODO Auto-generated method stub
-    try {
-      copy("/assets/captureTsumeGo/CaptureTsumeGo1.2.jar", "captureTsumeGo");
-    } catch (IOException e) {
-      // TODO Auto-generated catch block
-      e.printStackTrace();
+  public static void copyCaptureTsumeGo() throws IOException {
+    if (Lizzie.config == null) {
+      throw new IOException("App work directory is not available for CaptureTsumeGo extract");
+    }
+    copyCaptureTsumeGo(Lizzie.config.getWorkDirectory());
+  }
+
+  public static void copyCaptureTsumeGo(File workDirectory) throws IOException {
+    copyResourceToFile(
+        "/assets/captureTsumeGo/CaptureTsumeGo1.2.jar",
+        CaptureTsumeGo.helperJarFile(workDirectory));
+  }
+
+  private static void copyResourceToFile(String resource, File destFile) throws IOException {
+    try (InputStream in = Utils.class.getResourceAsStream(resource)) {
+      if (in == null) {
+        throw new IOException("Missing bundled resource: " + resource);
+      }
+      File parent = destFile.getParentFile();
+      if (parent != null) {
+        Files.createDirectories(parent.toPath());
+      }
+      Path dest = destFile.toPath();
+      Files.deleteIfExists(dest);
+      Files.copy(in, dest);
     }
   }
 

--- a/src/test/java/featurecat/lizzie/analysis/CaptureTsumeGoHelperJarTest.java
+++ b/src/test/java/featurecat/lizzie/analysis/CaptureTsumeGoHelperJarTest.java
@@ -1,0 +1,55 @@
+package featurecat.lizzie.analysis;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import featurecat.lizzie.util.Utils;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class CaptureTsumeGoHelperJarTest {
+  private static final String HELPER_DIR = "captureTsumeGo";
+  private static final String HELPER_JAR = "CaptureTsumeGo1.2.jar";
+
+  @Test
+  void neverLooksUnderFilesystemRootWhenCwdIsRoot(@TempDir Path workDir) throws Exception {
+    File workDirectory = workDir.toFile().getCanonicalFile();
+    Path expected = workDirectory.toPath().resolve(HELPER_DIR).resolve(HELPER_JAR);
+    File forbiddenRootLookup =
+        new File(new File(File.separator, HELPER_DIR), HELPER_JAR).getAbsoluteFile();
+
+    String previousUserDir = System.getProperty("user.dir");
+    System.setProperty("user.dir", File.separator);
+    try {
+      File resolved = CaptureTsumeGo.helperJarFile(workDirectory).getCanonicalFile();
+
+      assertEquals(expected, resolved.toPath());
+      assertNotEquals(forbiddenRootLookup.getAbsolutePath(), resolved.getAbsolutePath());
+      assertTrue(resolved.toPath().startsWith(workDirectory.toPath()), resolved.getAbsolutePath());
+
+      Utils.copyCaptureTsumeGo(workDirectory);
+
+      assertTrue(Files.isRegularFile(expected), expected.toString());
+      assertTrue(Files.size(expected) > 0);
+      assertFalse(
+          Files.exists(forbiddenRootLookup.toPath()), forbiddenRootLookup.getAbsolutePath());
+    } finally {
+      System.setProperty("user.dir", previousUserDir);
+    }
+  }
+
+  @Test
+  void extractFailureIsThrownInsteadOfSwallowed(@TempDir Path workDir) throws Exception {
+    Files.writeString(workDir.resolve(HELPER_DIR), "not-a-directory");
+    IOException thrown =
+        assertThrows(IOException.class, () -> Utils.copyCaptureTsumeGo(workDir.toFile()));
+    assertFalse(thrown.getMessage() == null || thrown.getMessage().isBlank());
+  }
+}


### PR DESCRIPTION
## Summary

- Resolve and extract `CaptureTsumeGo1.2.jar` under the writable app work directory (`Config.getWorkDirectory()`), not process CWD.
- Keep using the bundled resource `/assets/captureTsumeGo/CaptureTsumeGo1.2.jar`; the dmg does not need a loose folder at filesystem root.
- Surface extract `IOException` instead of swallowing it with `printStackTrace()` and then showing a `/captureTsumeGo/...` missing-file dialog.

Fixes #285.

## Type Of Change

- [x] Bug fix
- [ ] Feature
- [ ] Packaging / release update
- [ ] Docs / translation
- [ ] Refactor

## Testing

- [x] Tested locally
- [ ] Verified package contents if packaging changed
- [ ] Verified Fox sync flow if related
- [ ] Added screenshots if UI changed
- [ ] Updated README / docs if user-facing behavior changed
- [x] Noted affected platforms if the change is platform-specific
- [x] Verified there is no unrelated formatting or line-ending churn
- [x] Ran `python3 scripts/check_line_endings.py` (or equivalent `python` on Windows)

Unit/regression: `CaptureTsumeGoHelperJarTest` with `user.dir=/` asserts the helper path is never `/captureTsumeGo/CaptureTsumeGo1.2.jar` and extract lands under the temp work dir. Extract failure now throws instead of being swallowed. Did not boot the Lizzie Swing GUI.

## Notes

macOS `.app` / dmg launches often have CWD `/`, which made the old CWD-relative lookup and `getDistFile` extract target `/captureTsumeGo`. This change is local to Capture tsumego helper-jar resolve/extract. `getDistFile` is not retargeted globally (theme copies stay on CWD). `ConfigDialog2.java`, SNAPSHOT / MOVE / PASS, and packaging / Main-Class are untouched.
