### PR TITLE
fix(engine): restore remote snapshot stones with in-band GTP

### DIFF
--- a/src/main/java/featurecat/lizzie/analysis/ExactSnapshotEngineRestore.java
+++ b/src/main/java/featurecat/lizzie/analysis/ExactSnapshotEngineRestore.java
@@ -123,21 +123,30 @@ public final class ExactSnapshotEngineRestore {
     if (plan.preclear) {
       clearCapturedTargets(plan);
     }
-    Path sgfFile = writeSnapshotSgf(plan);
-    RestoreLifecycle lifecycle = new RestoreLifecycle(sgfFile);
+    List<Leelaz> remoteTargets = new ArrayList<>();
+    List<Leelaz> localTargets = new ArrayList<>();
+    for (Leelaz target : plan.targetEngines) {
+      if (target.useRemoteCompute) {
+        remoteTargets.add(target);
+      } else {
+        localTargets.add(target);
+      }
+    }
+    RestoreLifecycle lifecycle = null;
     try {
       try {
-        plan.engine.withExactSnapshotRestoreAdmission(
-            plan.admission,
-            () ->
-                plan.engine.loadSgfForExactSnapshotRestore(
-                    sgfFile,
-                    plan.mirrorEngine,
-                    plan.admission,
-                    lifecycle::onLoadSgfConsumed,
-                    lifecycle::onLoadDispatchStarted));
+        if (!remoteTargets.isEmpty()) {
+          restoreRemoteSnapshotInBand(plan, remoteTargets);
+        }
+        if (!localTargets.isEmpty()) {
+          Path sgfFile = writeSnapshotSgf(plan);
+          lifecycle = new RestoreLifecycle(sgfFile);
+          restoreLocalSnapshotSgf(plan, localTargets, lifecycle);
+        }
       } catch (RuntimeException failure) {
-        lifecycle.failBeforeLoadDispatch();
+        if (lifecycle != null) {
+          lifecycle.failBeforeLoadDispatch();
+        }
         throw failure;
       }
       for (TailAction action : plan.tail) {
@@ -154,9 +163,73 @@ public final class ExactSnapshotEngineRestore {
       }
       return new Completion();
     } finally {
-      lifecycle.finishTailReplay();
+      if (lifecycle != null) {
+        lifecycle.finishTailReplay();
+      }
       plan.admission.completeBoardSync();
     }
+  }
+
+  private static void restoreRemoteSnapshotInBand(RestorePlan plan, List<Leelaz> remoteTargets) {
+    if (plan.komi != null) {
+      String komiCommand = "komi " + formatKomi(plan.komi);
+      for (Leelaz target : remoteTargets) {
+        sendCapturedRestoreCommand(plan, target, komiCommand, "komi");
+      }
+    }
+    String command = buildSetPositionCommand(plan);
+    Leelaz loadEngine = remoteTargets.get(0);
+    Leelaz loadMirror = remoteTargets.size() > 1 ? remoteTargets.get(1) : null;
+    loadEngine.withExactSnapshotRestoreAdmission(
+        plan.admission,
+        () ->
+            loadEngine.restoreInBandForExactSnapshotRestore(
+                command, loadMirror, plan.admission, () -> {}, null));
+  }
+
+  private static void restoreLocalSnapshotSgf(
+      RestorePlan plan, List<Leelaz> localTargets, RestoreLifecycle lifecycle) {
+    Leelaz loadEngine = localTargets.get(0);
+    Leelaz loadMirror = localTargets.size() > 1 ? localTargets.get(1) : null;
+    loadEngine.withExactSnapshotRestoreAdmission(
+        plan.admission,
+        () ->
+            loadEngine.loadSgfForExactSnapshotRestore(
+                lifecycle.sgfFile,
+                loadMirror,
+                plan.admission,
+                lifecycle::onLoadSgfConsumed,
+                lifecycle::onLoadDispatchStarted));
+  }
+
+  private static String buildSetPositionCommand(RestorePlan plan) {
+    StringBuilder command = new StringBuilder("set_position");
+    appendSetPositionStones(command, plan, Stone.BLACK, "B");
+    appendSetPositionStones(command, plan, Stone.WHITE, "W");
+    return command.toString();
+  }
+
+  private static void appendSetPositionStones(
+      StringBuilder command, RestorePlan plan, Stone targetColor, String gtpColor) {
+    Stone[] stones = plan.snapshotData.stones;
+    for (int index = 0; index < stones.length; index++) {
+      if (stones[index] != targetColor) {
+        continue;
+      }
+      int[] coord = toBoardCoord(index, plan.boardHeight);
+      command
+          .append(' ')
+          .append(gtpColor)
+          .append(' ')
+          .append(formatGtpCoord(coord[0], coord[1], plan.boardWidth, plan.boardHeight));
+    }
+  }
+
+  private static String formatGtpCoord(int x, int y, int boardWidth, int boardHeight) {
+    if (boardWidth > 25 || boardHeight > 25) {
+      return String.format(java.util.Locale.ENGLISH, "(%d,%d)", x, y);
+    }
+    return Board.coordsAsName(x) + (boardHeight - y);
   }
 
   private static void clearCapturedTargets(RestorePlan plan) {
@@ -581,10 +654,7 @@ public final class ExactSnapshotEngineRestore {
         return Optional.empty();
       }
       int[] move = data.lastMove.get();
-      String coordinate =
-          boardWidth > 25 || boardHeight > 25
-              ? String.format(java.util.Locale.ENGLISH, "(%d,%d)", move[0], move[1])
-              : Board.coordsAsName(move[0]) + (boardHeight - move[1]);
+      String coordinate = formatGtpCoord(move[0], move[1], boardWidth, boardHeight);
       return Optional.of(new TailAction("play " + color + " " + coordinate));
     }
   }

--- a/src/main/java/featurecat/lizzie/analysis/ExactSnapshotEngineRestore.java
+++ b/src/main/java/featurecat/lizzie/analysis/ExactSnapshotEngineRestore.java
@@ -185,14 +185,11 @@ public final class ExactSnapshotEngineRestore {
         () ->
             loadEngine.restoreInBandForExactSnapshotRestore(
                 command, loadMirror, plan.admission, () -> {}, null));
-    String setupPlayer = buildSetupPlayerCommand(plan.snapshotData.blackToPlay);
-    for (Leelaz target : remoteTargets) {
-      sendCapturedRestoreCommand(plan, target, setupPlayer, "side-to-play");
+    if (!plan.snapshotData.blackToPlay && plan.tail.isEmpty()) {
+      for (Leelaz target : remoteTargets) {
+        sendCapturedRestoreCommand(plan, target, "play B pass", "side-to-play");
+      }
     }
-  }
-
-  private static String buildSetupPlayerCommand(boolean blackToPlay) {
-    return "gogui-setup_player " + (blackToPlay ? "B" : "W");
   }
 
   private static void restoreLocalSnapshotSgf(

--- a/src/main/java/featurecat/lizzie/analysis/ExactSnapshotEngineRestore.java
+++ b/src/main/java/featurecat/lizzie/analysis/ExactSnapshotEngineRestore.java
@@ -185,6 +185,14 @@ public final class ExactSnapshotEngineRestore {
         () ->
             loadEngine.restoreInBandForExactSnapshotRestore(
                 command, loadMirror, plan.admission, () -> {}, null));
+    String setupPlayer = buildSetupPlayerCommand(plan.snapshotData.blackToPlay);
+    for (Leelaz target : remoteTargets) {
+      sendCapturedRestoreCommand(plan, target, setupPlayer, "side-to-play");
+    }
+  }
+
+  private static String buildSetupPlayerCommand(boolean blackToPlay) {
+    return "gogui-setup_player " + (blackToPlay ? "B" : "W");
   }
 
   private static void restoreLocalSnapshotSgf(

--- a/src/main/java/featurecat/lizzie/analysis/Leelaz.java
+++ b/src/main/java/featurecat/lizzie/analysis/Leelaz.java
@@ -5016,6 +5016,32 @@ public class Leelaz {
       ExactSnapshotRestoreAdmission admission,
       Runnable afterConsumed,
       Runnable onDispatchStarted) {
+    restoreExactSnapshotPosition(
+        "loadsgf " + sgfFile.toAbsolutePath(),
+        sgfFile,
+        mirroredEngine,
+        admission,
+        afterConsumed,
+        onDispatchStarted);
+  }
+
+  final void restoreInBandForExactSnapshotRestore(
+      String command,
+      Leelaz mirroredEngine,
+      ExactSnapshotRestoreAdmission admission,
+      Runnable afterConsumed,
+      Runnable onDispatchStarted) {
+    restoreExactSnapshotPosition(
+        command, null, mirroredEngine, admission, afterConsumed, onDispatchStarted);
+  }
+
+  private void restoreExactSnapshotPosition(
+      String command,
+      Path sgfFile,
+      Leelaz mirroredEngine,
+      ExactSnapshotRestoreAdmission admission,
+      Runnable afterConsumed,
+      Runnable onDispatchStarted) {
     if (afterConsumed == null) {
       throw new IllegalArgumentException("afterConsumed");
     }
@@ -5032,7 +5058,7 @@ public class Leelaz {
           if (onDispatchStarted != null) {
             onDispatchStarted.run();
           }
-          loadTrackedSgf(sgfFile, mirroredEngine, afterConsumed, admission);
+          loadTrackedSnapshotCommand(command, sgfFile, mirroredEngine, afterConsumed, admission);
         });
   }
 
@@ -5041,13 +5067,27 @@ public class Leelaz {
       Leelaz mirroredEngine,
       Runnable afterConsumed,
       ExactSnapshotRestoreAdmission admission) {
+    loadTrackedSnapshotCommand(
+        "loadsgf " + sgfFile.toAbsolutePath(),
+        sgfFile,
+        mirroredEngine,
+        afterConsumed,
+        admission);
+  }
+
+  private void loadTrackedSnapshotCommand(
+      String command,
+      Path sgfFile,
+      Leelaz mirroredEngine,
+      Runnable afterConsumed,
+      ExactSnapshotRestoreAdmission admission) {
     LoadSgfDispatch dispatch = new LoadSgfDispatch(afterConsumed);
     RuntimeException sendFailure =
-        sendTrackedLoadSgfCommand(this, sgfFile, dispatch, admission);
+        sendTrackedSnapshotCommand(this, command, sgfFile, dispatch, admission);
     RuntimeException mirroredSendFailure = null;
     if (mirroredEngine != null) {
       mirroredSendFailure =
-          sendTrackedLoadSgfCommand(mirroredEngine, sgfFile, dispatch, admission);
+          sendTrackedSnapshotCommand(mirroredEngine, command, sgfFile, dispatch, admission);
     }
     if (sendFailure == null) {
       sendFailure = mirroredSendFailure;
@@ -5091,47 +5131,46 @@ public class Leelaz {
       Path sgfFile,
       Runnable onResponse,
       CommandSendFailureHandler onSendFailure) {
-    sendLoadSgfCommand(targetEngine, sgfFile, onResponse, onSendFailure, null);
+    sendSnapshotRestoreCommand(
+        targetEngine,
+        "loadsgf " + sgfFile.toAbsolutePath(),
+        onResponse,
+        onSendFailure,
+        null);
   }
 
-  private void sendLoadSgfCommand(
+  private void sendSnapshotRestoreCommand(
       Leelaz targetEngine,
-      Path sgfFile,
+      String command,
       Runnable onResponse,
       CommandSendFailureHandler onSendFailure,
       ExactSnapshotRestoreAdmission admission) {
     if (admission != null) {
-      String command = "loadsgf " + sgfFile.toAbsolutePath();
       if (!targetEngine.sendExactSnapshotRestoreCommand(
           command, onResponse, onSendFailure, admission)) {
         throw new ExactSnapshotEngineRestore.Failure(
             ExactSnapshotEngineRestore.FailureCategory.SEND_FAILED,
-            "Exact snapshot restore loadsgf command was rejected: " + command);
+            "Exact snapshot restore command was rejected: " + command);
       }
       return;
     }
-    targetEngine.sendCommand(
-        "loadsgf " + sgfFile.toAbsolutePath(), onResponse, onSendFailure, true, false);
+    targetEngine.sendCommand(command, onResponse, onSendFailure, true, false);
   }
 
-  private RuntimeException sendTrackedLoadSgfCommand(
-      Leelaz targetEngine, Path sgfFile, LoadSgfDispatch dispatch) {
-    return sendTrackedLoadSgfCommand(targetEngine, sgfFile, dispatch, null);
-  }
-
-  private RuntimeException sendTrackedLoadSgfCommand(
+  private RuntimeException sendTrackedSnapshotCommand(
       Leelaz targetEngine,
+      String command,
       Path sgfFile,
       LoadSgfDispatch dispatch,
       ExactSnapshotRestoreAdmission admission) {
     TrackedLoadSgfConsumer trackedConsumer =
-        new TrackedLoadSgfConsumer(targetEngine, sgfFile, dispatch);
+        new TrackedLoadSgfConsumer(targetEngine, sgfFile, command, dispatch);
     try {
       Runnable send =
           () ->
-              sendLoadSgfCommand(
+              sendSnapshotRestoreCommand(
                   targetEngine,
-                  sgfFile,
+                  command,
                   trackedConsumer.responseHandler(),
                   trackedConsumer.sendFailureHandler(),
                   admission);
@@ -5147,13 +5186,18 @@ public class Leelaz {
     }
   }
 
-  private RuntimeException buildLoadSgfResponseFailure(Path sgfFile, String responseLine) {
+  private RuntimeException buildSnapshotRestoreResponseFailure(
+      String command, Path sgfFile, String responseLine) {
     String line = responseLine == null ? "" : responseLine.trim();
-    String detail = line.isEmpty() ? "? loadsgf failed" : line;
-    String message =
-        "GTP loadsgf failed for '" + sgfFile.toAbsolutePath() + "' with response: " + detail;
+    String detail = line.isEmpty() ? "? snapshot restore failed" : line;
+    if (sgfFile != null) {
+      return new ExactSnapshotEngineRestore.Failure(
+          ExactSnapshotEngineRestore.FailureCategory.GTP_ERROR,
+          "GTP loadsgf failed for '" + sgfFile.toAbsolutePath() + "' with response: " + detail);
+    }
     return new ExactSnapshotEngineRestore.Failure(
-        ExactSnapshotEngineRestore.FailureCategory.GTP_ERROR, message);
+        ExactSnapshotEngineRestore.FailureCategory.GTP_ERROR,
+        "GTP snapshot restore failed for '" + command + "' with response: " + detail);
   }
 
   private static Thread newLoadSgfCleanupThread(Runnable runnable) {
@@ -5755,9 +5799,15 @@ public class Leelaz {
   }
 
 
-  private boolean isExactSnapshotLoadSgf(String command, Runnable handler) {
+  private static boolean isExactSnapshotPositionCommand(String command) {
     return command != null
-        && command.startsWith("loadsgf ")
+        && (command.startsWith("loadsgf ")
+            || command.equals("set_position")
+            || command.startsWith("set_position "));
+  }
+
+  private boolean isExactSnapshotLoadSgf(String command, Runnable handler) {
+    return isExactSnapshotPositionCommand(command)
         && handler != NO_OP_RESPONSE_HANDLER
         && isExactSnapshotRestoreAdmissionContextActive();
   }
@@ -5774,6 +5824,9 @@ public class Leelaz {
 
   private int nextResponseCommandId(String command, Runnable handler) {
     if (command != null && command.startsWith("loadsgf ")) {
+      return loadSgfResponseCommandIds.getAndIncrement();
+    }
+    if (isExactSnapshotLoadSgf(command, handler)) {
       return loadSgfResponseCommandIds.getAndIncrement();
     }
     if (handler instanceof BoardSynchronizationResponseHandler) {
@@ -5887,7 +5940,7 @@ public class Leelaz {
         if (queuedCommand.onResponse != handler) {
           continue;
         }
-        if (queuedCommand.command == null || !queuedCommand.command.startsWith("loadsgf ")) {
+        if (!isExactSnapshotPositionCommand(queuedCommand.command)) {
           continue;
         }
         iterator.remove();
@@ -8809,7 +8862,7 @@ public class Leelaz {
     }
 
     private boolean isTrackedLoadSgf() {
-      return command != null && command.startsWith("loadsgf ") && queuedCommand.isTrackedLoadSgf();
+      return isExactSnapshotPositionCommand(command) && queuedCommand.isTrackedLoadSgf();
     }
 
     private boolean isOutstandingResponseRetired() {
@@ -10186,6 +10239,7 @@ public class Leelaz {
   private static final class TrackedLoadSgfConsumer {
     private final Leelaz targetEngine;
     private final Path sgfFile;
+    private final String command;
     private final LoadSgfDispatch dispatch;
     private final AtomicBoolean settled = new AtomicBoolean(false);
     private final Runnable responseHandler = this::onResponse;
@@ -10202,9 +10256,11 @@ public class Leelaz {
           }
         };
 
-    private TrackedLoadSgfConsumer(Leelaz targetEngine, Path sgfFile, LoadSgfDispatch dispatch) {
+    private TrackedLoadSgfConsumer(
+        Leelaz targetEngine, Path sgfFile, String command, LoadSgfDispatch dispatch) {
       this.targetEngine = targetEngine;
       this.sgfFile = sgfFile;
+      this.command = command;
       this.dispatch = dispatch;
       this.dispatch.registerPendingConsumer(this);
     }
@@ -10220,8 +10276,8 @@ public class Leelaz {
     private void onResponse() {
       if (targetEngine.isCurrentCommandResponseError()) {
         failFromResponse(
-            targetEngine.buildLoadSgfResponseFailure(
-                sgfFile, targetEngine.currentCommandResponseLine()));
+            targetEngine.buildSnapshotRestoreResponseFailure(
+                command, sgfFile, targetEngine.currentCommandResponseLine()));
         return;
       }
       complete();
@@ -10480,7 +10536,7 @@ public class Leelaz {
     }
 
     private boolean isTrackedLoadSgf() {
-      return command != null && command.startsWith("loadsgf ") && onSendFailure != null;
+      return isExactSnapshotPositionCommand(command) && onSendFailure != null;
     }
 
     private boolean requiresStateReset() {

--- a/src/main/java/featurecat/lizzie/analysis/remote/KataGoAnalysisWebSocketTransport.java
+++ b/src/main/java/featurecat/lizzie/analysis/remote/KataGoAnalysisWebSocketTransport.java
@@ -223,7 +223,7 @@ public class KataGoAnalysisWebSocketTransport implements EngineTransport {
             responseId,
             "protocol_version\nname\nversion\nlist_commands\nboardsize\nrectangular_boardsize\n"
                 + "komi\nkata-get-rules\nkata-get-param\nkata-set-param\nkata-set-rules\n"
-                + "clear_board\nset_position\ngogui-setup_player\nloadsgf\nplay\nundo\nkata-analyze\n"
+                + "clear_board\nset_position\nloadsgf\nplay\nundo\nkata-analyze\n"
                 + "kata-genmove_analyze\n"
                 + "genmove\nkata-list_time_settings\nkata-time_settings\nstop\nquit");
       } else if (lower.equals("kata-list_time_settings")) {
@@ -275,14 +275,6 @@ public class KataGoAnalysisWebSocketTransport implements EngineTransport {
         moves.clear();
         snapshotInitialPlayer = "";
         writeOk(responseId, "");
-      } else if (lower.equals("gogui-setup_player") || lower.startsWith("gogui-setup_player ")) {
-        String color = normalizeColor(token(line, 1, ""));
-        if (color.isEmpty()) {
-          writeError(responseId, "invalid gogui-setup_player command");
-        } else {
-          snapshotInitialPlayer = color;
-          writeOk(responseId, "");
-        }
       } else if (lower.startsWith("loadsgf ")) {
         loadSnapshotSgf(line.substring(line.indexOf(' ') + 1).trim());
         writeOk(responseId, "");

--- a/src/main/java/featurecat/lizzie/analysis/remote/KataGoAnalysisWebSocketTransport.java
+++ b/src/main/java/featurecat/lizzie/analysis/remote/KataGoAnalysisWebSocketTransport.java
@@ -223,7 +223,7 @@ public class KataGoAnalysisWebSocketTransport implements EngineTransport {
             responseId,
             "protocol_version\nname\nversion\nlist_commands\nboardsize\nrectangular_boardsize\n"
                 + "komi\nkata-get-rules\nkata-get-param\nkata-set-param\nkata-set-rules\n"
-                + "clear_board\nset_position\nloadsgf\nplay\nundo\nkata-analyze\n"
+                + "clear_board\nset_position\ngogui-setup_player\nloadsgf\nplay\nundo\nkata-analyze\n"
                 + "kata-genmove_analyze\n"
                 + "genmove\nkata-list_time_settings\nkata-time_settings\nstop\nquit");
       } else if (lower.equals("kata-list_time_settings")) {
@@ -275,6 +275,14 @@ public class KataGoAnalysisWebSocketTransport implements EngineTransport {
         moves.clear();
         snapshotInitialPlayer = "";
         writeOk(responseId, "");
+      } else if (lower.equals("gogui-setup_player") || lower.startsWith("gogui-setup_player ")) {
+        String color = normalizeColor(token(line, 1, ""));
+        if (color.isEmpty()) {
+          writeError(responseId, "invalid gogui-setup_player command");
+        } else {
+          snapshotInitialPlayer = color;
+          writeOk(responseId, "");
+        }
       } else if (lower.startsWith("loadsgf ")) {
         loadSnapshotSgf(line.substring(line.indexOf(' ') + 1).trim());
         writeOk(responseId, "");

--- a/src/test/java/featurecat/lizzie/analysis/ExactSnapshotEngineRestoreContractTest.java
+++ b/src/test/java/featurecat/lizzie/analysis/ExactSnapshotEngineRestoreContractTest.java
@@ -121,6 +121,16 @@ class ExactSnapshotEngineRestoreContractTest {
   }
 
   @Test
+  void remoteComputeEmptyTailWhiteToPlaySnapshotRestoreSetsEngineSideToPlay() throws Exception {
+    assertRemoteEmptyTailRestoreSideToPlay(false);
+  }
+
+  @Test
+  void remoteComputeEmptyTailBlackToPlaySnapshotRestoreSetsEngineSideToPlay() throws Exception {
+    assertRemoteEmptyTailRestoreSideToPlay(true);
+  }
+
+  @Test
   void emptyRootHistoryTargetDoesNotEnterExactRestore() throws Exception {
     try (TestHarness harness = TestHarness.open(false)) {
       BoardHistoryList history = new BoardHistoryList(BoardData.empty(BOARD_SIZE, BOARD_SIZE));
@@ -1430,6 +1440,81 @@ class ExactSnapshotEngineRestoreContractTest {
     return prepareCurrentPositionRestore(engine, positionData).execute();
   }
 
+  private static void assertRemoteEmptyTailRestoreSideToPlay(boolean blackToPlay) throws Exception {
+    try (TestHarness harness = TestHarness.open(false)) {
+      Board board = allocate(Board.class);
+      board.startStonelist = new ArrayList<>();
+      board.hasStartStone = false;
+      BoardHistoryList history = new BoardHistoryList(snapshotRoot(blackToPlay));
+      board.setHistory(history);
+      Lizzie.board = board;
+
+      Leelaz engine = new Leelaz("");
+      engine.useRemoteCompute = true;
+      ExactSnapshotRestoreProtocolFixture.Transport transport =
+          ExactSnapshotRestoreProtocolFixture.install(
+              engine, command -> ExactSnapshotRestoreProtocolFixture.Response.success());
+
+      board.resendMoveToEngine(engine, false);
+
+      List<String> commands = transport.commands();
+      assertTrue(
+          commands.stream().noneMatch(ExactSnapshotEngineRestoreContractTest::isHostLoadSgfCommand),
+          "remote snapshot-anchor restore must not emit a host-only loadsgf path: " + commands);
+      assertEquals(
+          List.of(),
+          collectPlayCommands(commands),
+          "empty-tail restore must not send play, including a bookkeeping pass: " + commands);
+
+      String setPosition =
+          commands.stream()
+              .filter(ExactSnapshotEngineRestoreContractTest::isSetPositionCommand)
+              .findFirst()
+              .orElseThrow(
+                  () ->
+                      new AssertionError(
+                          "remote snapshot restore must represent setup stones in-band: "
+                              + commands));
+      Set<String> placed = setPositionPlacements(setPosition);
+      assertTrue(
+          placed.contains("B " + Board.convertCoordinatesToName(0, 0)),
+          "black setup stone missing from in-band restore: " + setPosition);
+      assertTrue(
+          placed.contains("W " + Board.convertCoordinatesToName(1, 0)),
+          "white setup stone missing from in-band restore: " + setPosition);
+      assertEquals(
+          blackToPlay,
+          replayRemoteEngineBlackToPlay(commands),
+          "empty-tail remote restore must leave engine side-to-play matching snapshot PL: "
+              + commands);
+    }
+  }
+
+  private static boolean replayRemoteEngineBlackToPlay(List<String> commands) {
+    boolean engineBlackToPlay = true;
+    for (String command : commands) {
+      if (command == null) {
+        continue;
+      }
+      if (command.equals("clear_board")
+          || command.startsWith("boardsize ")
+          || command.startsWith("rectangular_boardsize ")) {
+        engineBlackToPlay = true;
+      } else if (isSetPositionCommand(command)) {
+        engineBlackToPlay = true;
+      } else if (command.startsWith("gogui-setup_player ")) {
+        engineBlackToPlay =
+            !"W".equalsIgnoreCase(command.substring("gogui-setup_player ".length()).trim());
+      } else if (command.startsWith("play ")) {
+        String[] parts = command.split("\\s+");
+        if (parts.length >= 2) {
+          engineBlackToPlay = "W".equalsIgnoreCase(parts[1]);
+        }
+      }
+    }
+    return engineBlackToPlay;
+  }
+
   private static List<Path> snapshotSgfFiles(Path tempDirectory) throws IOException {
     try (var files = Files.list(tempDirectory)) {
       return files
@@ -1440,6 +1525,10 @@ class ExactSnapshotEngineRestoreContractTest {
   }
 
   private static BoardData snapshotRoot() {
+    return snapshotRoot(false);
+  }
+
+  private static BoardData snapshotRoot(boolean blackToPlay) {
     Stone[] stones = emptyStones();
     stones[Board.getIndex(0, 0)] = Stone.BLACK;
     stones[Board.getIndex(1, 0)] = Stone.WHITE;
@@ -1450,7 +1539,7 @@ class ExactSnapshotEngineRestoreContractTest {
         stones,
         java.util.Optional.of(new int[] {1, 0}),
         Stone.WHITE,
-        false,
+        blackToPlay,
         zobrist(stones),
         3,
         moveNumberList,

--- a/src/test/java/featurecat/lizzie/analysis/ExactSnapshotEngineRestoreContractTest.java
+++ b/src/test/java/featurecat/lizzie/analysis/ExactSnapshotEngineRestoreContractTest.java
@@ -113,6 +113,10 @@ class ExactSnapshotEngineRestoreContractTest {
       assertTrue(
           placed.contains("W " + Board.convertCoordinatesToName(1, 0)),
           "white setup stone missing from in-band restore: " + setPosition);
+      assertTrue(
+          commands.stream()
+              .noneMatch(ExactSnapshotEngineRestoreContractTest::isGoguiSetupPlayerCommand),
+          "remote restore must not emit gogui-setup_player: " + commands);
       assertEquals(
           List.of("play B " + Board.convertCoordinatesToName(2, 2)),
           collectPlayCommands(commands),
@@ -1461,10 +1465,16 @@ class ExactSnapshotEngineRestoreContractTest {
       assertTrue(
           commands.stream().noneMatch(ExactSnapshotEngineRestoreContractTest::isHostLoadSgfCommand),
           "remote snapshot-anchor restore must not emit a host-only loadsgf path: " + commands);
+      assertTrue(
+          commands.stream()
+              .noneMatch(ExactSnapshotEngineRestoreContractTest::isGoguiSetupPlayerCommand),
+          "remote restore must not emit gogui-setup_player: " + commands);
       assertEquals(
-          List.of(),
+          blackToPlay ? List.of() : List.of("play B pass"),
           collectPlayCommands(commands),
-          "empty-tail restore must not send play, including a bookkeeping pass: " + commands);
+          blackToPlay
+              ? "B-to-play empty-tail must not send play B pass: " + commands
+              : "W-to-play empty-tail must send exactly one play B pass: " + commands);
 
       String setPosition =
           commands.stream()
@@ -1502,9 +1512,6 @@ class ExactSnapshotEngineRestoreContractTest {
         engineBlackToPlay = true;
       } else if (isSetPositionCommand(command)) {
         engineBlackToPlay = true;
-      } else if (command.startsWith("gogui-setup_player ")) {
-        engineBlackToPlay =
-            !"W".equalsIgnoreCase(command.substring("gogui-setup_player ".length()).trim());
       } else if (command.startsWith("play ")) {
         String[] parts = command.split("\\s+");
         if (parts.length >= 2) {
@@ -1627,6 +1634,11 @@ class ExactSnapshotEngineRestoreContractTest {
   private static boolean isSetPositionCommand(String command) {
     return command != null
         && (command.equals("set_position") || command.startsWith("set_position "));
+  }
+
+  private static boolean isGoguiSetupPlayerCommand(String command) {
+    return command != null
+        && (command.equals("gogui-setup_player") || command.startsWith("gogui-setup_player "));
   }
 
   private static Set<String> setPositionPlacements(String command) {

--- a/src/test/java/featurecat/lizzie/analysis/ExactSnapshotEngineRestoreContractTest.java
+++ b/src/test/java/featurecat/lizzie/analysis/ExactSnapshotEngineRestoreContractTest.java
@@ -25,7 +25,9 @@ import java.lang.reflect.Field;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
@@ -68,6 +70,53 @@ class ExactSnapshotEngineRestoreContractTest {
           List.of("play B " + Board.convertCoordinatesToName(2, 2), "play W pass"),
           collectPlayCommands(output.commands()),
           "history restore should replay only real MOVE/PASS nodes after the nearest snapshot.");
+    }
+  }
+
+  @Test
+  void remoteComputeSnapshotAnchorRestoreDoesNotEmitHostLoadSgf() throws Exception {
+    try (TestHarness harness = TestHarness.open(false)) {
+      Board board = allocate(Board.class);
+      board.startStonelist = new ArrayList<>();
+      board.hasStartStone = false;
+      BoardHistoryList history = new BoardHistoryList(snapshotRoot());
+      history.add(moveNode(2, 2, Stone.BLACK, true, 4));
+      board.setHistory(history);
+      Lizzie.board = board;
+
+      Leelaz engine = new Leelaz("");
+      engine.useRemoteCompute = true;
+      ExactSnapshotRestoreProtocolFixture.Transport transport =
+          ExactSnapshotRestoreProtocolFixture.install(
+              engine, command -> ExactSnapshotRestoreProtocolFixture.Response.success());
+
+      board.resendMoveToEngine(engine, false);
+
+      List<String> commands = transport.commands();
+      assertTrue(
+          commands.stream().noneMatch(ExactSnapshotEngineRestoreContractTest::isHostLoadSgfCommand),
+          "remote snapshot-anchor restore must not emit a host-only loadsgf path: " + commands);
+
+      String setPosition =
+          commands.stream()
+              .filter(ExactSnapshotEngineRestoreContractTest::isSetPositionCommand)
+              .findFirst()
+              .orElseThrow(
+                  () ->
+                      new AssertionError(
+                          "remote snapshot restore must represent setup stones in-band: "
+                              + commands));
+      Set<String> placed = setPositionPlacements(setPosition);
+      assertTrue(
+          placed.contains("B " + Board.convertCoordinatesToName(0, 0)),
+          "black setup stone missing from in-band restore: " + setPosition);
+      assertTrue(
+          placed.contains("W " + Board.convertCoordinatesToName(1, 0)),
+          "white setup stone missing from in-band restore: " + setPosition);
+      assertEquals(
+          List.of("play B " + Board.convertCoordinatesToName(2, 2)),
+          collectPlayCommands(commands),
+          "sequential tail after the snapshot must still be replayed with play");
     }
   }
 
@@ -1476,6 +1525,30 @@ class ExactSnapshotEngineRestoreContractTest {
 
   private static boolean isLoadSgfCommand(String command) {
     return command != null && command.contains("loadsgf ");
+  }
+
+  private static boolean isHostLoadSgfCommand(String command) {
+    if (!isLoadSgfCommand(command)) {
+      return false;
+    }
+    String argument = command.substring(command.indexOf("loadsgf ") + "loadsgf ".length()).trim();
+    return argument.contains("/") || argument.contains("\\") || argument.contains(":");
+  }
+
+  private static boolean isSetPositionCommand(String command) {
+    return command != null
+        && (command.equals("set_position") || command.startsWith("set_position "));
+  }
+
+  private static Set<String> setPositionPlacements(String command) {
+    String payload =
+        command.startsWith("set_position") ? command.substring("set_position".length()).trim() : "";
+    String[] tokens = payload.isEmpty() ? new String[0] : payload.split("\\s+");
+    Set<String> placements = new LinkedHashSet<>();
+    for (int index = 0; index + 1 < tokens.length; index += 2) {
+      placements.add(tokens[index] + " " + tokens[index + 1]);
+    }
+    return placements;
   }
 
   private static List<String> collectPlayCommands(List<String> commands) {

--- a/src/test/java/featurecat/lizzie/analysis/LeelazAutomaticRestartConvergenceTest.java
+++ b/src/test/java/featurecat/lizzie/analysis/LeelazAutomaticRestartConvergenceTest.java
@@ -1660,9 +1660,7 @@ class LeelazAutomaticRestartConvergenceTest {
     assertEquals(expectedHeight, engine.engineBoardHeight, "board height must match");
     assertEquals(
         board.getHistory().getGameInfo().getKomi(), engine.engineKomi, 0.0001, "komi must match");
-    if (!engine.usedSetPosition) {
-      assertEquals(application.blackToPlay, engine.engineBlackToPlay, "side-to-play must match");
-    }
+    assertEquals(application.blackToPlay, engine.engineBlackToPlay, "side-to-play must match");
     for (int x = 0; x < expectedWidth; x++) {
       for (int y = 0; y < expectedHeight; y++) {
         assertEquals(
@@ -1734,7 +1732,6 @@ class LeelazAutomaticRestartConvergenceTest {
     private int engineBoardHeight = 19;
     private double engineKomi = -1.0;
     private boolean engineBlackToPlay = true;
-    private boolean usedSetPosition;
 
     private ConvergingRestartLeelaz() throws Exception {
       super("controlled-engine");
@@ -1757,7 +1754,6 @@ class LeelazAutomaticRestartConvergenceTest {
                         "B".equalsIgnoreCase(parts[1]) ? Stone.BLACK : Stone.WHITE);
                   }
                   engineBlackToPlay = "W".equalsIgnoreCase(parts[1]);
-                  usedSetPosition = false;
                 } else if (command.equals("clear_board")) {
                   clearBoardCount.incrementAndGet();
                   engineStones.clear();
@@ -1776,6 +1772,10 @@ class LeelazAutomaticRestartConvergenceTest {
                   engineBlackToPlay = true;
                 } else if (command.startsWith("komi ")) {
                   engineKomi = Double.parseDouble(command.substring("komi ".length()).trim());
+                } else if (command.startsWith("gogui-setup_player ")) {
+                  engineBlackToPlay =
+                      !"W".equalsIgnoreCase(
+                          command.substring("gogui-setup_player ".length()).trim());
                 } else if (command.startsWith("loadsgf ")
                     || command.equals("set_position")
                     || command.startsWith("set_position ")) {
@@ -1788,10 +1788,8 @@ class LeelazAutomaticRestartConvergenceTest {
                     String sgfPath = command.substring("loadsgf ".length()).trim();
                     String sgf = Files.readString(Path.of(sgfPath));
                     applySnapshotSgf(sgf);
-                    usedSetPosition = false;
                   } else {
                     applySetPosition(command);
-                    usedSetPosition = true;
                   }
                   if (blockFirstLoadSgf && count == 1) {
                     // Hold the frozen route in flight so the test can navigate deterministically.
@@ -1903,6 +1901,7 @@ class LeelazAutomaticRestartConvergenceTest {
 
     private void applySetPosition(String command) {
       engineStones.clear();
+      engineBlackToPlay = true;
       String payload =
           command.startsWith("set_position")
               ? command.substring("set_position".length()).trim()

--- a/src/test/java/featurecat/lizzie/analysis/LeelazAutomaticRestartConvergenceTest.java
+++ b/src/test/java/featurecat/lizzie/analysis/LeelazAutomaticRestartConvergenceTest.java
@@ -1772,10 +1772,6 @@ class LeelazAutomaticRestartConvergenceTest {
                   engineBlackToPlay = true;
                 } else if (command.startsWith("komi ")) {
                   engineKomi = Double.parseDouble(command.substring("komi ".length()).trim());
-                } else if (command.startsWith("gogui-setup_player ")) {
-                  engineBlackToPlay =
-                      !"W".equalsIgnoreCase(
-                          command.substring("gogui-setup_player ".length()).trim());
                 } else if (command.startsWith("loadsgf ")
                     || command.equals("set_position")
                     || command.startsWith("set_position ")) {

--- a/src/test/java/featurecat/lizzie/analysis/LeelazAutomaticRestartConvergenceTest.java
+++ b/src/test/java/featurecat/lizzie/analysis/LeelazAutomaticRestartConvergenceTest.java
@@ -1384,7 +1384,12 @@ class LeelazAutomaticRestartConvergenceTest {
   }
 
   private static void invokeLoadSgfResponse(ConvergingRestartLeelaz engine) throws Exception {
-    String response = numberedResponseFor(engine.transport.rawCommands(), "loadsgf ");
+    String response;
+    try {
+      response = numberedResponseFor(engine.transport.rawCommands(), "loadsgf ");
+    } catch (IllegalArgumentException missingLoadSgf) {
+      response = numberedResponseFor(engine.transport.rawCommands(), "set_position");
+    }
     engine.processCommandResponseLineForTest(response);
   }
 
@@ -1651,11 +1656,13 @@ class LeelazAutomaticRestartConvergenceTest {
   private static void assertEngineMatchesBoard(
       ConvergingRestartLeelaz engine, Board board, int expectedWidth, int expectedHeight) {
     BoardData application = board.getHistory().getData();
-    assertEquals(application.blackToPlay, engine.engineBlackToPlay, "side-to-play must match");
     assertEquals(expectedWidth, engine.engineBoardWidth, "board width must match");
     assertEquals(expectedHeight, engine.engineBoardHeight, "board height must match");
     assertEquals(
         board.getHistory().getGameInfo().getKomi(), engine.engineKomi, 0.0001, "komi must match");
+    if (!engine.usedSetPosition) {
+      assertEquals(application.blackToPlay, engine.engineBlackToPlay, "side-to-play must match");
+    }
     for (int x = 0; x < expectedWidth; x++) {
       for (int y = 0; y < expectedHeight; y++) {
         assertEquals(
@@ -1727,6 +1734,7 @@ class LeelazAutomaticRestartConvergenceTest {
     private int engineBoardHeight = 19;
     private double engineKomi = -1.0;
     private boolean engineBlackToPlay = true;
+    private boolean usedSetPosition;
 
     private ConvergingRestartLeelaz() throws Exception {
       super("controlled-engine");
@@ -1749,6 +1757,7 @@ class LeelazAutomaticRestartConvergenceTest {
                         "B".equalsIgnoreCase(parts[1]) ? Stone.BLACK : Stone.WHITE);
                   }
                   engineBlackToPlay = "W".equalsIgnoreCase(parts[1]);
+                  usedSetPosition = false;
                 } else if (command.equals("clear_board")) {
                   clearBoardCount.incrementAndGet();
                   engineStones.clear();
@@ -1767,15 +1776,23 @@ class LeelazAutomaticRestartConvergenceTest {
                   engineBlackToPlay = true;
                 } else if (command.startsWith("komi ")) {
                   engineKomi = Double.parseDouble(command.substring("komi ".length()).trim());
-                } else if (command.startsWith("loadsgf ")) {
+                } else if (command.startsWith("loadsgf ")
+                    || command.equals("set_position")
+                    || command.startsWith("set_position ")) {
                   int count = loadSgfCount.incrementAndGet();
                   if (count >= failLoadSgfAt) {
                     return ExactSnapshotRestoreProtocolFixture.Response.error(
                         "controlled catch-up restore failure");
                   }
-                  String sgfPath = command.substring("loadsgf ".length()).trim();
-                  String sgf = Files.readString(Path.of(sgfPath));
-                  applySnapshotSgf(sgf);
+                  if (command.startsWith("loadsgf ")) {
+                    String sgfPath = command.substring("loadsgf ".length()).trim();
+                    String sgf = Files.readString(Path.of(sgfPath));
+                    applySnapshotSgf(sgf);
+                    usedSetPosition = false;
+                  } else {
+                    applySetPosition(command);
+                    usedSetPosition = true;
+                  }
                   if (blockFirstLoadSgf && count == 1) {
                     // Hold the frozen route in flight so the test can navigate deterministically.
                     return null;
@@ -1882,6 +1899,23 @@ class LeelazAutomaticRestartConvergenceTest {
     private Stone stoneAt(int x, int y) {
       return engineStones.getOrDefault(
           Board.convertCoordinatesToName(x, y).toUpperCase(Locale.ROOT), Stone.EMPTY);
+    }
+
+    private void applySetPosition(String command) {
+      engineStones.clear();
+      String payload =
+          command.startsWith("set_position")
+              ? command.substring("set_position".length()).trim()
+              : "";
+      if (payload.isEmpty()) {
+        return;
+      }
+      String[] tokens = payload.split("\\s+");
+      for (int index = 0; index + 1 < tokens.length; index += 2) {
+        engineStones.put(
+            tokens[index + 1].toUpperCase(Locale.ROOT),
+            "B".equalsIgnoreCase(tokens[index]) ? Stone.BLACK : Stone.WHITE);
+      }
     }
 
     private void applySnapshotSgf(String sgf) {

--- a/src/test/java/featurecat/lizzie/analysis/remote/KataGoAnalysisWebSocketTransportTest.java
+++ b/src/test/java/featurecat/lizzie/analysis/remote/KataGoAnalysisWebSocketTransportTest.java
@@ -515,6 +515,7 @@ public class KataGoAnalysisWebSocketTransportTest {
     assertTrue(commands.contains("kata-get-param"));
     assertTrue(commands.contains("kata-get-rules"));
     assertTrue(commands.contains("set_position"));
+    assertTrue(commands.contains("gogui-setup_player"));
     assertTrue(commands.contains("loadsgf"));
 
     assertEquals("= 0.0\n\n", sendGtp(transport, "kata-get-param playoutDoublingAdvantage"));
@@ -728,6 +729,27 @@ public class KataGoAnalysisWebSocketTransportTest {
         java.util.List.of(java.util.List.of("W", "pass")), query.getJSONArray("moves").toList());
     assertEquals(java.util.List.of(1), query.getJSONArray("analyzeTurns").toList());
     assertEquals("W", query.getString("initialPlayer"));
+  }
+
+  @Test
+  void setupPlayerAfterSetPositionSetsInitialPlayerWithoutAMove() throws Exception {
+    KataGoAnalysisWebSocketTransport transport =
+        new KataGoAnalysisWebSocketTransport("ws://127.0.0.1:1");
+
+    assertEquals("=\n\n", sendGtp(transport, "set_position B A3 W C3"));
+    assertEquals("=\n\n", sendGtp(transport, "gogui-setup_player W"));
+
+    JSONObject query = transport.buildAnalysisQuery("test", false, false, 50, "B");
+    assertEquals(
+        java.util.List.of(java.util.List.of("B", "A3"), java.util.List.of("W", "C3")),
+        query.getJSONArray("initialStones").toList());
+    assertEquals(java.util.List.of(), query.getJSONArray("moves").toList());
+    assertEquals("W", query.getString("initialPlayer"));
+
+    assertEquals("=\n\n", sendGtp(transport, "gogui-setup_player B"));
+    JSONObject blackToPlay = transport.buildAnalysisQuery("test", false, false, 50, "W");
+    assertEquals(java.util.List.of(), blackToPlay.getJSONArray("moves").toList());
+    assertEquals("B", blackToPlay.getString("initialPlayer"));
   }
 
   @Test

--- a/src/test/java/featurecat/lizzie/analysis/remote/KataGoAnalysisWebSocketTransportTest.java
+++ b/src/test/java/featurecat/lizzie/analysis/remote/KataGoAnalysisWebSocketTransportTest.java
@@ -515,8 +515,8 @@ public class KataGoAnalysisWebSocketTransportTest {
     assertTrue(commands.contains("kata-get-param"));
     assertTrue(commands.contains("kata-get-rules"));
     assertTrue(commands.contains("set_position"));
-    assertTrue(commands.contains("gogui-setup_player"));
     assertTrue(commands.contains("loadsgf"));
+    assertFalse(commands.contains("gogui-setup_player"));
 
     assertEquals("= 0.0\n\n", sendGtp(transport, "kata-get-param playoutDoublingAdvantage"));
     assertEquals("= 0.04\n\n", sendGtp(transport, "kata-get-param analysisWideRootNoise"));
@@ -732,24 +732,20 @@ public class KataGoAnalysisWebSocketTransportTest {
   }
 
   @Test
-  void setupPlayerAfterSetPositionSetsInitialPlayerWithoutAMove() throws Exception {
+  void playBlackPassAfterSetPositionLeavesWhiteToPlay() throws Exception {
     KataGoAnalysisWebSocketTransport transport =
         new KataGoAnalysisWebSocketTransport("ws://127.0.0.1:1");
 
     assertEquals("=\n\n", sendGtp(transport, "set_position B A3 W C3"));
-    assertEquals("=\n\n", sendGtp(transport, "gogui-setup_player W"));
+    assertEquals("=\n\n", sendGtp(transport, "play B pass"));
 
     JSONObject query = transport.buildAnalysisQuery("test", false, false, 50, "B");
     assertEquals(
         java.util.List.of(java.util.List.of("B", "A3"), java.util.List.of("W", "C3")),
         query.getJSONArray("initialStones").toList());
-    assertEquals(java.util.List.of(), query.getJSONArray("moves").toList());
-    assertEquals("W", query.getString("initialPlayer"));
-
-    assertEquals("=\n\n", sendGtp(transport, "gogui-setup_player B"));
-    JSONObject blackToPlay = transport.buildAnalysisQuery("test", false, false, 50, "W");
-    assertEquals(java.util.List.of(), blackToPlay.getJSONArray("moves").toList());
-    assertEquals("B", blackToPlay.getString("initialPlayer"));
+    assertEquals(
+        java.util.List.of(java.util.List.of("B", "pass")), query.getJSONArray("moves").toList());
+    assertEquals("B", query.getString("initialPlayer"));
   }
 
   @Test
@@ -809,6 +805,7 @@ public class KataGoAnalysisWebSocketTransportTest {
 
     assertTrue(response.startsWith("?42 unknown command"));
     assertTrue(sendGtp(transport, "time_warp 1").startsWith("? unknown command"));
+    assertTrue(sendGtp(transport, "gogui-setup_player W").startsWith("? unknown command"));
     assertTrue(
         sendGtp(transport, "kata-get-param unsupported").startsWith("? unknown parameter"));
   }


### PR DESCRIPTION
## Repro

1. Enable 智子 / remote compute (reporter: `./zz-ikatago --gpu-type vip-share --kata-weight fdx`).
2. Drag a normal sequential SGF — load and analyze work via `play`.
3. Drag the reporter tsumego `1.sgf` (root `AB`/`AW` setup stones, then a short variation).

Expected: setup stones match the SGF and analysis can run, same as a sequential SGF.

Actual: board is disordered. GTP shows `loadsgf C:\\Users\\zh_ch\\AppData\\Local\\Temp\\lizzie-snapshot-.sgf`, then `Could not load sgf: Could not open file ... does not exist or invalid permissions?`, and the “加载引擎失败” dialog.

## Cause

Root `AB`/`AW` is a usable snapshot anchor. `ExactSnapshotEngineRestore.writeSnapshotSgf` writes `Files.createTempFile("lizzie-snapshot-", ".sgf")` under `java.io.tmpdir`. `Leelaz.sendLoadSgfCommand` sends `loadsgf` plus that absolute host path. `ZhiziGtpTransport` forwards the command as-is. There is no upload and no in-band fallback, so the remote KataGo cannot open the host file.

Moving the temp file into `getWorkDirectory()` / `getRuntimeWorkDirectory()` would not help — the remote engine still cannot read the host disk.

## Fix

Remote / `useRemoteCompute` exact-snapshot restore uses in-band KataGo GTP instead of host-path `loadsgf`:

- `komi` (if present) + `set_position` for setup stones.
- Empty-tail W-to-play (`snapshotData.blackToPlay == false`): exactly one `play B pass` after `set_position` (KataGo `set_position` hardcodes B-to-play).
- Empty-tail B-to-play: nothing extra after `set_position`.
- Sequential tail still uses `play`.

`gogui-setup_player` is not KataGo/Zhizi and is not sent on the remote GTP stream or accepted by the in-repo websocket adapter. Local KataGo still uses temp-file `loadsgf` + `PL[]`. Empty default root is still not an exact-restore anchor. No Zhizi SGF upload protocol. #204 / PR #253 ReadBoard consume-after-use and dual-engine `loadsgf` are unchanged.

## SPEC-01 / STD-01

Empty-tail remote restore leaves engine side-to-play matching `plan.snapshotData.blackToPlay` using GTP a real KataGo accepts. The restart harness still asserts `engineBlackToPlay` (no skip).

## Verification

- Remote snapshot-anchor restore must not emit a host-only `loadsgf`; setup stones go through `set_position`.
- Empty-tail B-to-play: `set_position` only; no `gogui-setup_player`; no `play B pass`.
- Empty-tail W-to-play: `set_position` + exactly one `play B pass`; no `gogui-setup_player`; `engineBlackToPlay` is false after that pass.
- Focused: `ExactSnapshotEngineRestoreContractTest`, `LeelazAutomaticRestartConvergenceTest`, `EngineManagerInitialStartupSynchronizationTest`, `KataGoAnalysisWebSocketTransportTest`.
- Did not boot the Lizzie Swing GUI.

Fixes #290.
