### PR TITLE
Harden NVIDIA runtime tests and publish next-2026-08-24.1

### DIFF
--- a/.github/release-notes/next-2026-08-24.1.md
+++ b/.github/release-notes/next-2026-08-24.1.md
@@ -1,0 +1,335 @@
+# LizzieYzy Next next-2026-08-24.1
+
+## 中文
+
+这是 `next-2026-08-19.4` 之后的功能与稳定性预览更新，重点修复 Windows RTX 50 CUDA 包无法启动、TensorRT AI 陪练点击后长时间无响应，并全面加固引擎生命周期、远程同步与诊断能力。
+
+### 本版主要更新
+
+- 修复 RTX 5070/5080/5090 CUDA 完整包启动失败：补齐并锁定 CUDA 12.8 NVRTC 编译器与 builtins，应用内运行库检查、打包脚本和 Windows Release 审计使用同一份依赖契约。
+- 优化 TensorRT 包的 AI 陪练：主分析继续使用 TensorRT，HumanSL 使用包内经过校验的 CUDA companion；启动前暂停前台持续分析，失败、取消或结束后准确恢复，并显示模型加载、GPU 优化、缓存与原生退出诊断。
+- 新增统一“诊断”中心和隐私清理后的支持包导出，覆盖应用、配置、引擎/GTP、远程算力、SGF、弈客和 ReadBoard；日志有容量上限，敏感字段在导出前会被清理。
+- 系统加固引擎启动、切换、重启、双引擎对局和远程快照：旧进程输出不能污染新引擎，停止确认、隔离屏障与恢复状态更加确定，黑白双引擎状态保持同时成功或同时回滚。
+- 修复按住贴目加减时松开事件丢失导致持续变化；整理双层菜单中的 WRN/PDA 布局，并修复 ReadBoard 授权落子与结束同步时 WRN 状态错误恢复。
+- 修复 macOS CaptureTsumeGo 辅助程序的解压工作目录；ReadBoard、弈客、网络和远程算力也已接入统一诊断链路。
+- 本次合并的 14 个贡献 PR 经过整体冲突审查和跨模块复测。感谢 `qiyi71w` 的持续贡献，也感谢在 RTX 50 系列真机上参与验收的测试者。
+
+### 下载前先看这几句
+
+- RTX 50 CUDA 启动修复包含新的 CUDA 运行库，必须下载本版 `windows64.nvidia50.cuda` 完整包；`windows64.core-update.zip` 不会补齐 NVRTC 文件。
+- TensorRT AI 陪练修复包含 HumanSL CUDA companion，必须重新下载两个 TensorRT 分卷并从 `.001` 解压；只更新主程序不能得到该 companion。
+- 普通 Windows 用户优先选择 OpenCL 免安装版；20/30/40 系列 NVIDIA 用户选择 NVIDIA CUDA 版，RTX 50 系列选择 RTX 50 CUDA 版。
+- 这是预发布版。建议先解压到新目录测试，并备份现有 `user-data`、自定义权重和棋谱。
+
+### 下载建议
+
+| 你的电脑 | 直接下载这个 |
+| --- | --- |
+| Windows 64 位，OpenCL 版，推荐，免安装 | [`2026-08-24-windows64.opencl.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-24.1/2026-08-24-windows64.opencl.portable.zip) |
+| 已有 Windows 免安装版，只更新主程序 | [`2026-08-24-windows64.core-update.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-24.1/2026-08-24-windows64.core-update.zip) |
+| Windows 64 位，OpenCL 安装版 | [`2026-08-24-windows64.opencl.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-24.1/2026-08-24-windows64.opencl.installer.exe) |
+| Windows 64 位，CPU 兼容版，免安装 | [`2026-08-24-windows64.with-katago.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-24.1/2026-08-24-windows64.with-katago.portable.zip) |
+| Windows 64 位，CPU 兼容安装版 | [`2026-08-24-windows64.with-katago.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-24.1/2026-08-24-windows64.with-katago.installer.exe) |
+| Windows 64 位，NVIDIA CUDA 版，免安装 | [`2026-08-24-windows64.nvidia.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-24.1/2026-08-24-windows64.nvidia.portable.zip) |
+| Windows 64 位，NVIDIA CUDA 安装版 | [`2026-08-24-windows64.nvidia.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-24.1/2026-08-24-windows64.nvidia.installer.exe) |
+| Windows 64 位，RTX 5070/5080/5090，免安装 | [`2026-08-24-windows64.nvidia50.cuda.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-24.1/2026-08-24-windows64.nvidia50.cuda.portable.zip) |
+| 高级可选：TensorRT 预装分卷包，需下载全部分卷 | [`2026-08-24-windows64.nvidia.tensorrt.portable.7z.001`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-24.1/2026-08-24-windows64.nvidia.tensorrt.portable.7z.001)<br>[`2026-08-24-windows64.nvidia.tensorrt.portable.7z.002`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-24.1/2026-08-24-windows64.nvidia.tensorrt.portable.7z.002) |
+| Windows 64 位，RTX 50 CUDA 安装版 | [`2026-08-24-windows64.nvidia50.cuda.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-24.1/2026-08-24-windows64.nvidia50.cuda.installer.exe) |
+| Windows 64 位，自行配置引擎，免安装 | [`2026-08-24-windows64.without.engine.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-24.1/2026-08-24-windows64.without.engine.portable.zip) |
+| Windows 64 位，自行配置引擎，安装版 | [`2026-08-24-windows64.without.engine.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-24.1/2026-08-24-windows64.without.engine.installer.exe) |
+| macOS Apple Silicon | [`2026-08-24-mac-apple-silicon.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-24.1/2026-08-24-mac-apple-silicon.with-katago.dmg) |
+| macOS Intel | [`2026-08-24-mac-intel.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-24.1/2026-08-24-mac-intel.with-katago.dmg) |
+| Linux 64 位，CPU 兼容版 | [`2026-08-24-linux64.with-katago.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-24.1/2026-08-24-linux64.with-katago.zip) |
+| Linux 64 位，OpenCL 版 | [`2026-08-24-linux64.opencl.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-24.1/2026-08-24-linux64.opencl.zip) |
+| Linux 64 位，NVIDIA CUDA 版 | [`2026-08-24-linux64.nvidia.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-24.1/2026-08-24-linux64.nvidia.zip) |
+
+### 这一版为什么值得测试
+
+- 精确发布目标 `main` 已通过 Linux 与 Windows JDK 21 完整 CI：两端各运行 `3088` 项单元测试，`0` 失败、`0` 错误；Linux 跳过 `10` 项、Windows 跳过 `14` 项，随后两端各有 `1` 项集成 smoke test 通过。
+- RTX 3070 Windows 真机验证中，补齐 NVRTC 后 CUDA 引擎正常分析；TensorRT AI 陪练约 5.66 秒进入训练，实际完成 HumanSL 应手、复盘报告和前台 TensorRT 恢复。RTX 50 系列真机验收也已由维护者完成，本版继续以预发布扩大硬件样本。
+- 14 个 PR 的精确提交先整体集成，再修复跨 PR 的引擎 ownership、双引擎状态、诊断与异步清理竞争；不是简单拼接后直接发布。
+- 各平台构建会校验运行库、精确资产清单和版本，并生成绑定目标 commit、workflow run/attempt、大小与 SHA-256 的 provenance；公开前发布器还会逐项比对 GitHub Release 远端资产。
+
+### 交流
+
+- QQ 群：`299419120`
+
+---
+
+## 繁體中文
+
+這是 `next-2026-08-19.4` 之後的功能與穩定性預覽更新，重點修正 Windows RTX 50 CUDA package 無法啟動、TensorRT AI 教練點擊後長時間無回應，並全面強化 engine lifecycle、remote sync 與診斷能力。
+
+### 本版主要更新
+
+- 修正 RTX 5070/5080/5090 CUDA full package 啟動失敗：補齊並鎖定 CUDA 12.8 NVRTC compiler 與 builtins，app 內 runtime 檢查、packaging script 和 Windows Release audit 共用同一份 dependency contract。
+- 優化 TensorRT package 的 AI 教練：主要 analysis 繼續使用 TensorRT，HumanSL 使用 package 內已驗證的 CUDA companion；啟動前暫停 foreground analysis，失敗、取消或結束後精確恢復，並顯示 model loading、GPU optimization、cache 與 native exit diagnostics。
+- 新增統一「診斷」中心和隱私清理後的 support package export，涵蓋 app、config、engine/GTP、remote compute、SGF、弈客與 ReadBoard；log 有容量上限，敏感欄位會在 export 前清理。
+- 全面強化 engine start、switch、restart、dual-engine game 與 remote snapshot：舊 process output 不能污染新 engine，stop acknowledgement、quarantine barrier 與 recovery state 更確定，黑白雙 engine 狀態維持同時成功或同時 rollback。
+- 修正長按 komi +/- 時遺失 release event 導致持續變動；整理雙層 menu 的 WRN/PDA layout，並修正 ReadBoard 授權落子與結束 sync 時 WRN 狀態錯誤恢復。
+- 修正 macOS CaptureTsumeGo helper 的 extraction work directory；ReadBoard、弈客、network 與 remote compute 也已接入統一診斷鏈路。
+- 本次合併的 14 個 contribution PR 經過整體 conflict review 與 cross-module retest。感謝 `qiyi71w` 的持續貢獻，也感謝參與 RTX 50 真機驗收的測試者。
+
+### 下載前先看這幾句
+
+- RTX 50 CUDA 啟動修正包含新的 CUDA runtime，必須下載本版 `windows64.nvidia50.cuda` full package；`windows64.core-update.zip` 不會補上 NVRTC 檔案。
+- TensorRT AI 教練修正包含 HumanSL CUDA companion，必須重新下載兩個 TensorRT 分卷並從 `.001` 解壓；只更新 app 無法取得 companion。
+- 一般 Windows 使用者優先選 OpenCL portable；20/30/40 系列 NVIDIA 選 NVIDIA CUDA，RTX 50 系列選 RTX 50 CUDA。
+- 這是 pre-release，建議解壓到新目錄測試並備份 `user-data`、自訂 weight 與棋譜。
+
+### 下載建議
+
+| 你的電腦 | 直接下載這個 |
+| --- | --- |
+| Windows 64 位，OpenCL 推薦版，免安裝 | [`2026-08-24-windows64.opencl.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-24.1/2026-08-24-windows64.opencl.portable.zip) |
+| 既有 Windows portable，只更新主程式 | [`2026-08-24-windows64.core-update.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-24.1/2026-08-24-windows64.core-update.zip) |
+| Windows 64 位，OpenCL 安裝版 | [`2026-08-24-windows64.opencl.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-24.1/2026-08-24-windows64.opencl.installer.exe) |
+| Windows 64 位，CPU 相容版，免安裝 | [`2026-08-24-windows64.with-katago.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-24.1/2026-08-24-windows64.with-katago.portable.zip) |
+| Windows 64 位，CPU 相容安裝版 | [`2026-08-24-windows64.with-katago.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-24.1/2026-08-24-windows64.with-katago.installer.exe) |
+| Windows 64 位，NVIDIA CUDA，免安裝 | [`2026-08-24-windows64.nvidia.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-24.1/2026-08-24-windows64.nvidia.portable.zip) |
+| Windows 64 位，NVIDIA CUDA 安裝版 | [`2026-08-24-windows64.nvidia.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-24.1/2026-08-24-windows64.nvidia.installer.exe) |
+| Windows 64 位，RTX 5070/5080/5090，免安裝 | [`2026-08-24-windows64.nvidia50.cuda.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-24.1/2026-08-24-windows64.nvidia50.cuda.portable.zip) |
+| 進階可選：TensorRT 預裝分卷，需下載全部檔案 | [`2026-08-24-windows64.nvidia.tensorrt.portable.7z.001`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-24.1/2026-08-24-windows64.nvidia.tensorrt.portable.7z.001)<br>[`2026-08-24-windows64.nvidia.tensorrt.portable.7z.002`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-24.1/2026-08-24-windows64.nvidia.tensorrt.portable.7z.002) |
+| Windows 64 位，RTX 50 CUDA 安裝版 | [`2026-08-24-windows64.nvidia50.cuda.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-24.1/2026-08-24-windows64.nvidia50.cuda.installer.exe) |
+| Windows 64 位，自行設定 engine，免安裝 | [`2026-08-24-windows64.without.engine.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-24.1/2026-08-24-windows64.without.engine.portable.zip) |
+| Windows 64 位，自行設定 engine，安裝版 | [`2026-08-24-windows64.without.engine.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-24.1/2026-08-24-windows64.without.engine.installer.exe) |
+| macOS Apple Silicon | [`2026-08-24-mac-apple-silicon.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-24.1/2026-08-24-mac-apple-silicon.with-katago.dmg) |
+| macOS Intel | [`2026-08-24-mac-intel.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-24.1/2026-08-24-mac-intel.with-katago.dmg) |
+| Linux 64 位，CPU 相容版 | [`2026-08-24-linux64.with-katago.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-24.1/2026-08-24-linux64.with-katago.zip) |
+| Linux 64 位，OpenCL 版 | [`2026-08-24-linux64.opencl.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-24.1/2026-08-24-linux64.opencl.zip) |
+| Linux 64 位，NVIDIA CUDA 版 | [`2026-08-24-linux64.nvidia.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-24.1/2026-08-24-linux64.nvidia.zip) |
+
+### 這一版為什麼值得測試
+
+- 精確 release target `main` 已通過 Linux 與 Windows JDK 21 full CI：兩端各執行 `3088` 項 unit test，`0` failure、`0` error；Linux skipped `10` 項、Windows skipped `14` 項，之後兩端各有 `1` 項 integration smoke test 通過。
+- RTX 3070 Windows 實機驗證中，補齊 NVRTC 後 CUDA engine 正常 analysis；TensorRT AI 教練約 5.66 秒進入 training，實際完成 HumanSL 應手、review report 與 foreground TensorRT restore。RTX 50 系列實機驗收也已由 maintainer 完成，本版繼續以 pre-release 擴大硬體樣本。
+- 14 個 PR 的 exact commit 先整體 integration，再修正 cross-PR engine ownership、dual-engine state、diagnostics 與 async cleanup race；不是簡單拼接後直接發布。
+- 各平台 build 會檢查 runtime、exact asset inventory 與 version，並產生綁定 target commit、workflow run/attempt、size 和 SHA-256 的 provenance；公開前 publisher 會逐項核對 GitHub Release remote asset。
+
+### 交流
+
+- QQ 群：`299419120`
+
+---
+
+## English
+
+This feature and stability pre-release follows `next-2026-08-19.4`. It fixes Windows RTX 50 CUDA packages that could not start, long TensorRT AI Coach startup with no useful feedback, and broadly hardens engine lifecycle, remote synchronization, and diagnostics.
+
+### Release Highlights
+
+- Fixed RTX 5070/5080/5090 CUDA full-package startup by bundling and pinning the CUDA 12.8 NVRTC compiler and builtins. In-app runtime checks, packaging, and Windows Release audits now share the same dependency contract.
+- Improved AI Coach in the TensorRT package. Main analysis remains on TensorRT while HumanSL uses a verified bundled CUDA companion. Foreground pondering pauses before startup and is restored after failure, cancellation, or completion; loading, GPU optimization, cache, elapsed-time, and native-exit diagnostics are visible.
+- Added a unified Diagnostics center and privacy-sanitized support-bundle export covering the app, configuration, engines/GTP, remote compute, SGF, Yike, and ReadBoard. Logs are bounded and sensitive fields are removed before export.
+- Hardened startup, switching, restart, dual-engine games, and remote snapshots. Stale process output cannot contaminate a replacement engine; stop acknowledgements, quarantine barriers, and recovery are deterministic, and the two engine sides commit or roll back together.
+- Fixed runaway komi +/- changes when a release event is missed, aligned WRN/PDA controls in the double menu, and corrected ReadBoard WRN state across authorized play and end-sync transitions.
+- Fixed the macOS CaptureTsumeGo helper extraction directory. ReadBoard, Yike, network, and remote compute now participate in the unified diagnostic pipeline.
+- The 14 contributed PRs in this update were reviewed as one integrated system and retested across module boundaries. Thanks to `qiyi71w` for the sustained contributions and to everyone who performed RTX 50 hardware acceptance.
+
+### Read Before Downloading
+
+- The RTX 50 CUDA startup fix includes new CUDA runtime files. Download the complete `windows64.nvidia50.cuda` package; `windows64.core-update.zip` cannot add the missing NVRTC files.
+- The TensorRT AI Coach fix includes a HumanSL CUDA companion. Download both TensorRT parts again and extract from `.001`; an application-only update cannot provide the companion.
+- Most Windows users should choose OpenCL portable. NVIDIA 20/30/40-series users should choose NVIDIA CUDA, while RTX 50-series users should choose RTX 50 CUDA.
+- This is a pre-release. Test from a new directory first and back up `user-data`, custom weights, and kifu.
+
+### Download Guide
+
+| Your computer | Download this file |
+| --- | --- |
+| Windows 64-bit, OpenCL, recommended, portable | [`2026-08-24-windows64.opencl.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-24.1/2026-08-24-windows64.opencl.portable.zip) |
+| Existing Windows portable install, application-only update | [`2026-08-24-windows64.core-update.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-24.1/2026-08-24-windows64.core-update.zip) |
+| Windows 64-bit, OpenCL installer | [`2026-08-24-windows64.opencl.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-24.1/2026-08-24-windows64.opencl.installer.exe) |
+| Windows 64-bit, CPU fallback, portable | [`2026-08-24-windows64.with-katago.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-24.1/2026-08-24-windows64.with-katago.portable.zip) |
+| Windows 64-bit, CPU fallback installer | [`2026-08-24-windows64.with-katago.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-24.1/2026-08-24-windows64.with-katago.installer.exe) |
+| Windows 64-bit, NVIDIA CUDA, portable | [`2026-08-24-windows64.nvidia.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-24.1/2026-08-24-windows64.nvidia.portable.zip) |
+| Windows 64-bit, NVIDIA CUDA installer | [`2026-08-24-windows64.nvidia.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-24.1/2026-08-24-windows64.nvidia.installer.exe) |
+| Windows 64-bit, RTX 5070/5080/5090, portable | [`2026-08-24-windows64.nvidia50.cuda.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-24.1/2026-08-24-windows64.nvidia50.cuda.portable.zip) |
+| Advanced optional TensorRT split package; download every part | [`2026-08-24-windows64.nvidia.tensorrt.portable.7z.001`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-24.1/2026-08-24-windows64.nvidia.tensorrt.portable.7z.001)<br>[`2026-08-24-windows64.nvidia.tensorrt.portable.7z.002`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-24.1/2026-08-24-windows64.nvidia.tensorrt.portable.7z.002) |
+| Windows 64-bit, RTX 50 CUDA installer | [`2026-08-24-windows64.nvidia50.cuda.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-24.1/2026-08-24-windows64.nvidia50.cuda.installer.exe) |
+| Windows 64-bit, configure your own engine, portable | [`2026-08-24-windows64.without.engine.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-24.1/2026-08-24-windows64.without.engine.portable.zip) |
+| Windows 64-bit, configure your own engine, installer | [`2026-08-24-windows64.without.engine.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-24.1/2026-08-24-windows64.without.engine.installer.exe) |
+| macOS Apple Silicon | [`2026-08-24-mac-apple-silicon.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-24.1/2026-08-24-mac-apple-silicon.with-katago.dmg) |
+| macOS Intel | [`2026-08-24-mac-intel.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-24.1/2026-08-24-mac-intel.with-katago.dmg) |
+| Linux 64-bit, CPU fallback | [`2026-08-24-linux64.with-katago.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-24.1/2026-08-24-linux64.with-katago.zip) |
+| Linux 64-bit, OpenCL | [`2026-08-24-linux64.opencl.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-24.1/2026-08-24-linux64.opencl.zip) |
+| Linux 64-bit, NVIDIA CUDA | [`2026-08-24-linux64.nvidia.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-24.1/2026-08-24-linux64.nvidia.zip) |
+
+### Why Test This Release
+
+- The exact release target passed the complete JDK 21 CI on both Linux and Windows. Each platform ran `3088` unit tests with `0` failures and `0` errors; Linux skipped `10`, Windows skipped `14`, and each then passed `1` integration smoke test.
+- On a Windows RTX 3070, CUDA analysis worked after NVRTC was restored. TensorRT AI Coach entered training in about 5.66 seconds and completed a real HumanSL reply, review report, and foreground TensorRT restore. RTX 50-series hardware acceptance was also completed by the maintainer; this pre-release expands community coverage.
+- The exact heads of 14 PRs were integrated first, then cross-PR engine ownership, dual-engine state, diagnostics, and asynchronous-cleanup races were corrected. This is not an unreviewed concatenation of changes.
+- Every platform build validates runtime versions and an exact asset inventory, then emits provenance binding the target commit, workflow run/attempt, file size, and SHA-256. The publisher verifies every remote GitHub Release asset before making the pre-release public.
+
+### Contact
+
+- QQ group: `299419120`
+
+---
+
+## 日本語
+
+`next-2026-08-19.4` に続く機能・安定性プレリリースです。Windows RTX 50 CUDA package の起動失敗、TensorRT AI Coach が長時間応答しない問題を修正し、engine lifecycle、remote sync、diagnostics を全面的に強化しました。
+
+### 主な更新
+
+- RTX 5070/5080/5090 CUDA full package の起動を修正しました。CUDA 12.8 NVRTC compiler と builtins を同梱・固定し、in-app runtime check、packaging、Windows Release audit を同じ dependency contract に統一しました。
+- TensorRT package の AI Coach を改善しました。main analysis は TensorRT を維持し、HumanSL は検証済みの bundled CUDA companion を使います。起動前に foreground analysis を一時停止し、失敗・cancel・終了後に正確に復元します。model loading、GPU optimization、cache、elapsed time、native exit diagnostics も表示します。
+- 統合 Diagnostics center と privacy-sanitized support bundle export を追加しました。app、config、engine/GTP、remote compute、SGF、Yike、ReadBoard を対象にし、log size を制限して機密項目を export 前に除去します。
+- engine startup、switch、restart、dual-engine game、remote snapshot を強化しました。古い process output は replacement engine を汚染できず、stop acknowledgement、quarantine barrier、recovery が確定的になり、黒白 engine は同時に commit または rollback します。
+- komi +/- の release event が欠落した場合に値が変化し続ける問題を修正し、double menu の WRN/PDA layout と ReadBoard の WRN state transition を修正しました。
+- macOS CaptureTsumeGo helper の extraction work directory を修正しました。ReadBoard、Yike、network、remote compute も統合 diagnostics pipeline に接続しました。
+- 14 件の contribution PR は一つの system として conflict review と cross-module retest を行いました。継続的に貢献してくださった `qiyi71w` と RTX 50 hardware acceptance の参加者に感謝します。
+
+### ダウンロード前に
+
+- RTX 50 CUDA 起動修正には新しい CUDA runtime file が必要です。`windows64.nvidia50.cuda` full package をダウンロードしてください。`windows64.core-update.zip` では不足する NVRTC file を追加できません。
+- TensorRT AI Coach 修正には HumanSL CUDA companion が含まれます。TensorRT の両方の part を再ダウンロードし、`.001` から展開してください。app-only update では companion は追加されません。
+- 一般の Windows user は OpenCL portable、NVIDIA 20/30/40 series は NVIDIA CUDA、RTX 50 series は RTX 50 CUDA を選択してください。
+- これは pre-release です。まず新しい directory で試し、`user-data`、custom weight、棋譜を backup してください。
+
+### ダウンロード案内
+
+| 環境 | ダウンロードするファイル |
+| --- | --- |
+| Windows 64-bit、OpenCL 推奨 portable | [`2026-08-24-windows64.opencl.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-24.1/2026-08-24-windows64.opencl.portable.zip) |
+| 既存 Windows portable、アプリ本体のみ更新 | [`2026-08-24-windows64.core-update.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-24.1/2026-08-24-windows64.core-update.zip) |
+| Windows 64-bit、OpenCL installer | [`2026-08-24-windows64.opencl.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-24.1/2026-08-24-windows64.opencl.installer.exe) |
+| Windows 64-bit、CPU fallback portable | [`2026-08-24-windows64.with-katago.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-24.1/2026-08-24-windows64.with-katago.portable.zip) |
+| Windows 64-bit、CPU fallback installer | [`2026-08-24-windows64.with-katago.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-24.1/2026-08-24-windows64.with-katago.installer.exe) |
+| Windows 64-bit、NVIDIA CUDA portable | [`2026-08-24-windows64.nvidia.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-24.1/2026-08-24-windows64.nvidia.portable.zip) |
+| Windows 64-bit、NVIDIA CUDA installer | [`2026-08-24-windows64.nvidia.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-24.1/2026-08-24-windows64.nvidia.installer.exe) |
+| Windows 64-bit、RTX 5070/5080/5090 portable | [`2026-08-24-windows64.nvidia50.cuda.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-24.1/2026-08-24-windows64.nvidia50.cuda.portable.zip) |
+| 上級者向け TensorRT 分割 package、全 part が必要 | [`2026-08-24-windows64.nvidia.tensorrt.portable.7z.001`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-24.1/2026-08-24-windows64.nvidia.tensorrt.portable.7z.001)<br>[`2026-08-24-windows64.nvidia.tensorrt.portable.7z.002`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-24.1/2026-08-24-windows64.nvidia.tensorrt.portable.7z.002) |
+| Windows 64-bit、RTX 50 CUDA installer | [`2026-08-24-windows64.nvidia50.cuda.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-24.1/2026-08-24-windows64.nvidia50.cuda.installer.exe) |
+| Windows 64-bit、engine を自分で設定、portable | [`2026-08-24-windows64.without.engine.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-24.1/2026-08-24-windows64.without.engine.portable.zip) |
+| Windows 64-bit、engine を自分で設定、installer | [`2026-08-24-windows64.without.engine.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-24.1/2026-08-24-windows64.without.engine.installer.exe) |
+| macOS Apple Silicon | [`2026-08-24-mac-apple-silicon.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-24.1/2026-08-24-mac-apple-silicon.with-katago.dmg) |
+| macOS Intel | [`2026-08-24-mac-intel.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-24.1/2026-08-24-mac-intel.with-katago.dmg) |
+| Linux 64-bit、CPU fallback | [`2026-08-24-linux64.with-katago.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-24.1/2026-08-24-linux64.with-katago.zip) |
+| Linux 64-bit、OpenCL | [`2026-08-24-linux64.opencl.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-24.1/2026-08-24-linux64.opencl.zip) |
+| Linux 64-bit、NVIDIA CUDA | [`2026-08-24-linux64.nvidia.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-24.1/2026-08-24-linux64.nvidia.zip) |
+
+### このリリースを試す理由
+
+- exact release target は Linux と Windows の JDK 21 full CI に合格しました。各 platform で `3088` unit tests を実行し failure/error は `0`、Linux は `10`、Windows は `14` skipped、その後それぞれ `1` integration smoke test に合格しました。
+- Windows RTX 3070 では NVRTC 追加後に CUDA analysis が正常動作しました。TensorRT AI Coach は約 5.66 秒で training に入り、HumanSL 応手、review report、foreground TensorRT restore を完了しました。maintainer による RTX 50 series hardware acceptance も完了し、この pre-release で community coverage を拡大します。
+- 14 PR の exact head を統合した後、cross-PR engine ownership、dual-engine state、diagnostics、async cleanup race を修正しました。単純に変更を連結した release ではありません。
+- 各 platform build は runtime version と exact asset inventory を検証し、target commit、workflow run/attempt、file size、SHA-256 を結ぶ provenance を作成します。公開前に publisher が全 remote asset を照合します。
+
+### 連絡先
+
+- QQ グループ：`299419120`
+
+---
+
+## 한국어
+
+`next-2026-08-19.4` 이후의 기능 및 안정성 pre-release입니다. Windows RTX 50 CUDA package가 시작되지 않던 문제와 TensorRT AI Coach가 오랫동안 응답하지 않던 문제를 해결하고 engine lifecycle, remote sync, diagnostics를 전반적으로 강화했습니다.
+
+### 주요 업데이트
+
+- RTX 5070/5080/5090 CUDA full package 시작 실패를 수정했습니다. CUDA 12.8 NVRTC compiler와 builtins를 포함하고 pin했으며 in-app runtime check, packaging, Windows Release audit가 동일한 dependency contract를 사용합니다.
+- TensorRT package의 AI Coach를 개선했습니다. main analysis는 TensorRT를 유지하고 HumanSL은 검증된 bundled CUDA companion을 사용합니다. 시작 전에 foreground analysis를 일시 중지하고 실패, 취소, 종료 뒤 정확히 복구하며 model loading, GPU optimization, cache, elapsed time, native exit diagnostics를 표시합니다.
+- app, config, engine/GTP, remote compute, SGF, Yike, ReadBoard를 포함하는 통합 Diagnostics center와 privacy-sanitized support bundle export를 추가했습니다. log 용량은 제한되고 민감한 필드는 export 전에 제거됩니다.
+- engine startup, switch, restart, dual-engine game, remote snapshot을 강화했습니다. 오래된 process output이 replacement engine을 오염시키지 못하며 stop acknowledgement, quarantine barrier, recovery가 결정적으로 동작하고 흑백 engine state는 함께 commit 또는 rollback됩니다.
+- komi +/- release event가 누락될 때 값이 계속 바뀌는 문제를 수정하고 double menu WRN/PDA layout과 ReadBoard WRN state transition을 바로잡았습니다.
+- macOS CaptureTsumeGo helper extraction work directory를 수정했습니다. ReadBoard, Yike, network, remote compute도 통합 diagnostics pipeline에 연결했습니다.
+- 14개 contribution PR을 하나의 system으로 conflict review하고 cross-module retest했습니다. 꾸준히 기여한 `qiyi71w` 님과 RTX 50 hardware acceptance 참가자께 감사드립니다.
+
+### 다운로드 전 확인
+
+- RTX 50 CUDA 시작 수정에는 새 CUDA runtime file이 포함됩니다. `windows64.nvidia50.cuda` full package를 다운로드하세요. `windows64.core-update.zip`은 누락된 NVRTC file을 추가할 수 없습니다.
+- TensorRT AI Coach 수정에는 HumanSL CUDA companion이 포함됩니다. TensorRT part 두 개를 다시 다운로드하고 `.001`에서 압축을 푸세요. app-only update에는 companion이 포함되지 않습니다.
+- 일반 Windows 사용자는 OpenCL portable, NVIDIA 20/30/40 series는 NVIDIA CUDA, RTX 50 series는 RTX 50 CUDA를 선택하세요.
+- 이 버전은 pre-release입니다. 먼저 새 directory에서 테스트하고 `user-data`, custom weight, 기보를 backup하세요.
+
+### 다운로드 안내
+
+| 환경 | 다운로드할 파일 |
+| --- | --- |
+| Windows 64-bit, OpenCL 권장 portable | [`2026-08-24-windows64.opencl.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-24.1/2026-08-24-windows64.opencl.portable.zip) |
+| 기존 Windows portable, 앱만 업데이트 | [`2026-08-24-windows64.core-update.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-24.1/2026-08-24-windows64.core-update.zip) |
+| Windows 64-bit, OpenCL installer | [`2026-08-24-windows64.opencl.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-24.1/2026-08-24-windows64.opencl.installer.exe) |
+| Windows 64-bit, CPU portable | [`2026-08-24-windows64.with-katago.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-24.1/2026-08-24-windows64.with-katago.portable.zip) |
+| Windows 64-bit, CPU installer | [`2026-08-24-windows64.with-katago.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-24.1/2026-08-24-windows64.with-katago.installer.exe) |
+| Windows 64-bit, NVIDIA CUDA portable | [`2026-08-24-windows64.nvidia.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-24.1/2026-08-24-windows64.nvidia.portable.zip) |
+| Windows 64-bit, NVIDIA CUDA installer | [`2026-08-24-windows64.nvidia.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-24.1/2026-08-24-windows64.nvidia.installer.exe) |
+| Windows 64-bit, RTX 5070/5080/5090 portable | [`2026-08-24-windows64.nvidia50.cuda.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-24.1/2026-08-24-windows64.nvidia50.cuda.portable.zip) |
+| 고급 선택: TensorRT 분할 package, 모든 part 필요 | [`2026-08-24-windows64.nvidia.tensorrt.portable.7z.001`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-24.1/2026-08-24-windows64.nvidia.tensorrt.portable.7z.001)<br>[`2026-08-24-windows64.nvidia.tensorrt.portable.7z.002`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-24.1/2026-08-24-windows64.nvidia.tensorrt.portable.7z.002) |
+| Windows 64-bit, RTX 50 CUDA installer | [`2026-08-24-windows64.nvidia50.cuda.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-24.1/2026-08-24-windows64.nvidia50.cuda.installer.exe) |
+| Windows 64-bit, 직접 engine 설정, portable | [`2026-08-24-windows64.without.engine.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-24.1/2026-08-24-windows64.without.engine.portable.zip) |
+| Windows 64-bit, 직접 engine 설정, installer | [`2026-08-24-windows64.without.engine.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-24.1/2026-08-24-windows64.without.engine.installer.exe) |
+| macOS Apple Silicon | [`2026-08-24-mac-apple-silicon.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-24.1/2026-08-24-mac-apple-silicon.with-katago.dmg) |
+| macOS Intel | [`2026-08-24-mac-intel.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-24.1/2026-08-24-mac-intel.with-katago.dmg) |
+| Linux 64-bit, CPU | [`2026-08-24-linux64.with-katago.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-24.1/2026-08-24-linux64.with-katago.zip) |
+| Linux 64-bit, OpenCL | [`2026-08-24-linux64.opencl.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-24.1/2026-08-24-linux64.opencl.zip) |
+| Linux 64-bit, NVIDIA CUDA | [`2026-08-24-linux64.nvidia.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-24.1/2026-08-24-linux64.nvidia.zip) |
+
+### 이 릴리스를 테스트할 이유
+
+- exact release target은 Linux와 Windows JDK 21 full CI를 통과했습니다. 각 platform에서 `3088` unit tests를 실행해 failure/error는 `0`, Linux는 `10`, Windows는 `14` skipped였고 이후 각각 `1` integration smoke test를 통과했습니다.
+- Windows RTX 3070에서 NVRTC 추가 후 CUDA analysis가 정상 동작했습니다. TensorRT AI Coach는 약 5.66초 만에 training에 들어가 HumanSL 응수, review report, foreground TensorRT restore를 완료했습니다. maintainer의 RTX 50 series hardware acceptance도 완료했으며 이 pre-release로 community coverage를 확대합니다.
+- 14개 PR exact head를 통합한 뒤 cross-PR engine ownership, dual-engine state, diagnostics, async cleanup race를 수정했습니다. 변경을 단순히 합쳐 바로 배포한 버전이 아닙니다.
+- 각 platform build는 runtime version과 exact asset inventory를 검사하고 target commit, workflow run/attempt, file size, SHA-256을 연결한 provenance를 생성합니다. 공개 전 publisher가 모든 remote asset을 대조합니다.
+
+### 연락처
+
+- QQ 그룹：`299419120`
+
+---
+
+## ภาษาไทย
+
+นี่คือ feature และ stability pre-release หลัง `next-2026-08-19.4` แก้ package Windows RTX 50 CUDA ที่เริ่มไม่ได้ และ TensorRT AI Coach ที่รอนานโดยไม่มี feedback พร้อมเสริม engine lifecycle, remote sync และ diagnostics อย่างทั่วถึง
+
+### ไฮไลต์ของเวอร์ชันนี้
+
+- แก้การเริ่ม RTX 5070/5080/5090 CUDA full package โดยรวมและ pin CUDA 12.8 NVRTC compiler กับ builtins ให้ in-app runtime check, packaging และ Windows Release audit ใช้ dependency contract เดียวกัน
+- ปรับ AI Coach ใน TensorRT package โดย main analysis ยังใช้ TensorRT ส่วน HumanSL ใช้ bundled CUDA companion ที่ตรวจสอบแล้ว ระบบพัก foreground analysis ก่อนเริ่มและคืนค่าอย่างถูกต้องหลัง failure, cancel หรือจบ พร้อมแสดง model loading, GPU optimization, cache, elapsed time และ native exit diagnostics
+- เพิ่ม Diagnostics center แบบรวมและการ export support bundle ที่ล้างข้อมูลส่วนตัว ครอบคลุม app, config, engine/GTP, remote compute, SGF, Yike และ ReadBoard โดยจำกัดขนาด log และลบ field ที่อ่อนไหวก่อน export
+- เสริม engine startup, switch, restart, dual-engine game และ remote snapshot ไม่ให้ output จาก process เก่าปน replacement engine ทำให้ stop acknowledgement, quarantine barrier และ recovery แน่นอนขึ้น และ state ของ engine ดำ/ขาว commit หรือ rollback พร้อมกัน
+- แก้ komi +/- เปลี่ยนต่อเนื่องเมื่อ release event หาย ปรับ layout WRN/PDA ใน double menu และแก้ ReadBoard WRN state ระหว่าง authorized play กับ end sync
+- แก้ work directory สำหรับ extraction ของ macOS CaptureTsumeGo helper และเชื่อม ReadBoard, Yike, network, remote compute เข้ากับ diagnostics pipeline แบบรวม
+- contribution PR ทั้ง 14 รายการผ่าน conflict review และ cross-module retest เป็นระบบเดียว ขอบคุณ `qiyi71w` สำหรับการพัฒนาอย่างต่อเนื่อง และผู้ร่วมทดสอบ hardware RTX 50
+
+### ก่อนดาวน์โหลด
+
+- การแก้ RTX 50 CUDA ต้องใช้ CUDA runtime file ใหม่ โปรดดาวน์โหลด `windows64.nvidia50.cuda` full package เพราะ `windows64.core-update.zip` ไม่สามารถเพิ่ม NVRTC file ที่ขาดได้
+- การแก้ TensorRT AI Coach มี HumanSL CUDA companion โปรดดาวน์โหลด TensorRT ทั้งสอง part ใหม่และแตกจาก `.001`; app-only update ไม่มี companion นี้
+- ผู้ใช้ Windows ทั่วไปควรเลือก OpenCL portable, NVIDIA 20/30/40 series เลือก NVIDIA CUDA และ RTX 50 series เลือก RTX 50 CUDA
+- นี่คือ pre-release ควรทดสอบจาก directory ใหม่ก่อนและ backup `user-data`, custom weight และ kifu
+
+### คู่มือดาวน์โหลด
+
+| คอมพิวเตอร์ของคุณ | ดาวน์โหลดไฟล์นี้ |
+| --- | --- |
+| Windows 64-bit, OpenCL แนะนำ, portable | [`2026-08-24-windows64.opencl.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-24.1/2026-08-24-windows64.opencl.portable.zip) |
+| มี Windows portable แล้ว อัปเดตเฉพาะโปรแกรม | [`2026-08-24-windows64.core-update.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-24.1/2026-08-24-windows64.core-update.zip) |
+| Windows 64-bit, OpenCL installer | [`2026-08-24-windows64.opencl.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-24.1/2026-08-24-windows64.opencl.installer.exe) |
+| Windows 64-bit, CPU portable | [`2026-08-24-windows64.with-katago.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-24.1/2026-08-24-windows64.with-katago.portable.zip) |
+| Windows 64-bit, CPU installer | [`2026-08-24-windows64.with-katago.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-24.1/2026-08-24-windows64.with-katago.installer.exe) |
+| Windows 64-bit, NVIDIA CUDA portable | [`2026-08-24-windows64.nvidia.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-24.1/2026-08-24-windows64.nvidia.portable.zip) |
+| Windows 64-bit, NVIDIA CUDA installer | [`2026-08-24-windows64.nvidia.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-24.1/2026-08-24-windows64.nvidia.installer.exe) |
+| Windows 64-bit, RTX 5070/5080/5090 portable | [`2026-08-24-windows64.nvidia50.cuda.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-24.1/2026-08-24-windows64.nvidia50.cuda.portable.zip) |
+| ตัวเลือกขั้นสูง TensorRT แบบแบ่งส่วน ต้องดาวน์โหลดทุกส่วน | [`2026-08-24-windows64.nvidia.tensorrt.portable.7z.001`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-24.1/2026-08-24-windows64.nvidia.tensorrt.portable.7z.001)<br>[`2026-08-24-windows64.nvidia.tensorrt.portable.7z.002`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-24.1/2026-08-24-windows64.nvidia.tensorrt.portable.7z.002) |
+| Windows 64-bit, RTX 50 CUDA installer | [`2026-08-24-windows64.nvidia50.cuda.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-24.1/2026-08-24-windows64.nvidia50.cuda.installer.exe) |
+| Windows 64-bit, ตั้งค่า engine เอง, portable | [`2026-08-24-windows64.without.engine.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-24.1/2026-08-24-windows64.without.engine.portable.zip) |
+| Windows 64-bit, ตั้งค่า engine เอง, installer | [`2026-08-24-windows64.without.engine.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-24.1/2026-08-24-windows64.without.engine.installer.exe) |
+| macOS Apple Silicon | [`2026-08-24-mac-apple-silicon.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-24.1/2026-08-24-mac-apple-silicon.with-katago.dmg) |
+| macOS Intel | [`2026-08-24-mac-intel.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-24.1/2026-08-24-mac-intel.with-katago.dmg) |
+| Linux 64-bit, CPU | [`2026-08-24-linux64.with-katago.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-24.1/2026-08-24-linux64.with-katago.zip) |
+| Linux 64-bit, OpenCL | [`2026-08-24-linux64.opencl.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-24.1/2026-08-24-linux64.opencl.zip) |
+| Linux 64-bit, NVIDIA CUDA | [`2026-08-24-linux64.nvidia.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-24.1/2026-08-24-linux64.nvidia.zip) |
+
+### ทำไมควรทดสอบเวอร์ชันนี้
+
+- exact release target ผ่าน JDK 21 full CI บน Linux และ Windows แต่ละ platform รัน `3088` unit tests โดย failure/error เป็น `0`; Linux skipped `10`, Windows skipped `14` และต่อด้วย integration smoke test ผ่าน platform ละ `1`
+- บน Windows RTX 3070 CUDA analysis ทำงานหลังเพิ่ม NVRTC; TensorRT AI Coach เข้า training ในประมาณ 5.66 วินาทีและทำ HumanSL reply, review report, foreground TensorRT restore สำเร็จ maintainer ได้ทำ RTX 50 series hardware acceptance แล้ว และ pre-release นี้จะขยาย community coverage
+- หลังรวม exact head ของ 14 PR ได้แก้ cross-PR engine ownership, dual-engine state, diagnostics และ async cleanup race จึงไม่ใช่ release ที่เพียงนำ change มาต่อกันโดยไม่ review
+- build ทุก platform ตรวจ runtime version และ exact asset inventory พร้อมสร้าง provenance ที่ผูก target commit, workflow run/attempt, file size และ SHA-256 จากนั้น publisher ตรวจ remote asset ทุกไฟล์ก่อนเปิด pre-release
+
+### ติดต่อ
+
+- กลุ่ม QQ: `299419120`

--- a/.github/release-requests/next-2026-08-24.1.json
+++ b/.github/release-requests/next-2026-08-24.1.json
@@ -1,0 +1,7 @@
+{
+  "date_tag": "2026-08-24",
+  "release_tag": "next-2026-08-24.1",
+  "title": "LizzieYzy Next next-2026-08-24.1",
+  "prerelease": true,
+  "notes_file": ".github/release-notes/next-2026-08-24.1.md"
+}

--- a/scripts/test_macos_signing_security.py
+++ b/scripts/test_macos_signing_security.py
@@ -21,6 +21,11 @@ SIGN_SCRIPT = ROOT / "scripts" / "sign_macos_release.sh"
 
 
 def find_bash() -> str | None:
+    # Windows may expose the WSL launcher as bash.exe even when no usable Linux
+    # distribution exists. Keep the executable macOS cleanup fixture on POSIX;
+    # the static signing-security checks remain fully Windows-runnable.
+    if os.name == "nt":
+        return None
     discovered = shutil.which("bash")
     if discovered:
         return discovered
@@ -329,6 +334,13 @@ class MacOSSigningSecurityTest(unittest.TestCase):
 
             self.assertNotEqual(completed.returncode, 0, completed.stderr)
             self.assertNotIn("unbound variable", completed.stderr.lower())
+            self.assertTrue(
+                security_log.is_file(),
+                "fake security command was not reached\n"
+                f"return code: {completed.returncode}\n"
+                f"stdout:\n{completed.stdout}\n"
+                f"stderr:\n{completed.stderr}",
+            )
 
             records = [
                 json.loads(line)

--- a/src/main/java/featurecat/lizzie/util/KataGoRuntimeHelper.java
+++ b/src/main/java/featurecat/lizzie/util/KataGoRuntimeHelper.java
@@ -1136,6 +1136,10 @@ public final class KataGoRuntimeHelper {
   }
 
   public static NvidiaRuntimeStatus inspectNvidiaRuntime(Path enginePath) {
+    return inspectNvidiaRuntime(enginePath, System.getenv("PATH"));
+  }
+
+  static NvidiaRuntimeStatus inspectNvidiaRuntime(Path enginePath, String runtimeSearchPath) {
     Path runtimeDir = getNvidiaRuntimeDir();
     String backend = resolveNvidiaBackend(enginePath);
     if (!isWindowsPlatform() || backend == null) {
@@ -1151,7 +1155,8 @@ public final class KataGoRuntimeHelper {
               "Current engine does not need the NVIDIA runtime."));
     }
 
-    List<Path> searchDirs = collectRuntimeSearchDirs(enginePath, runtimeDir);
+    List<Path> searchDirs =
+        collectRuntimeSearchDirs(enginePath, runtimeDir, runtimeSearchPath);
     List<List<String>> requiredDllGroups = requiredRuntimeDllGroups(enginePath, backend);
     List<String> missing = collectMissingRuntimeGroups(searchDirs, requiredDllGroups);
     if ((NVIDIA50_CUDA_BACKEND.equalsIgnoreCase(backend) || isTensorRtBackend(backend))
@@ -4317,7 +4322,8 @@ public final class KataGoRuntimeHelper {
         });
   }
 
-  private static List<Path> collectRuntimeSearchDirs(Path enginePath, Path runtimeDir) {
+  private static List<Path> collectRuntimeSearchDirs(
+      Path enginePath, Path runtimeDir, String runtimeSearchPath) {
     LinkedHashSet<Path> paths = new LinkedHashSet<Path>();
     if (enginePath != null && enginePath.getParent() != null) {
       paths.add(enginePath.getParent().toAbsolutePath().normalize());
@@ -4325,10 +4331,9 @@ public final class KataGoRuntimeHelper {
     if (runtimeDir != null) {
       paths.add(runtimeDir.toAbsolutePath().normalize());
     }
-    String pathEnv = System.getenv("PATH");
-    if (pathEnv != null && !pathEnv.trim().isEmpty()) {
+    if (runtimeSearchPath != null && !runtimeSearchPath.trim().isEmpty()) {
       String separator = System.getProperty("path.separator", ";");
-      for (String entry : pathEnv.split(Pattern.quote(separator))) {
+      for (String entry : runtimeSearchPath.split(Pattern.quote(separator))) {
         if (entry == null || entry.trim().isEmpty()) {
           continue;
         }

--- a/src/test/java/featurecat/lizzie/util/KataGoRuntimeHelperTest.java
+++ b/src/test/java/featurecat/lizzie/util/KataGoRuntimeHelperTest.java
@@ -579,7 +579,7 @@ public class KataGoRuntimeHelperTest {
               runtimeWorkDirectory,
               () -> {
                 KataGoRuntimeHelper.NvidiaRuntimeStatus status =
-                    KataGoRuntimeHelper.inspectNvidiaRuntime(enginePath);
+                    KataGoRuntimeHelper.inspectNvidiaRuntime(enginePath, "");
                 KataGoRuntimeHelper.configureBundledProcessBuilder(processBuilder, enginePath);
 
                 assertTrue(
@@ -627,7 +627,7 @@ public class KataGoRuntimeHelperTest {
               runtimeWorkDirectory,
               () -> {
                 KataGoRuntimeHelper.NvidiaRuntimeStatus status =
-                    KataGoRuntimeHelper.inspectNvidiaRuntime(enginePath);
+                    KataGoRuntimeHelper.inspectNvidiaRuntime(enginePath, "");
 
                 assertTrue(status.applicable);
                 assertFalse(status.ready);
@@ -659,7 +659,7 @@ public class KataGoRuntimeHelperTest {
               runtimeWorkDirectory,
               () -> {
                 KataGoRuntimeHelper.NvidiaRuntimeStatus status =
-                    KataGoRuntimeHelper.inspectNvidiaRuntime(enginePath);
+                    KataGoRuntimeHelper.inspectNvidiaRuntime(enginePath, "");
 
                 assertTrue(status.applicable);
                 assertTrue(
@@ -692,7 +692,7 @@ public class KataGoRuntimeHelperTest {
               runtimeWorkDirectory,
               () -> {
                 KataGoRuntimeHelper.NvidiaRuntimeStatus status =
-                    KataGoRuntimeHelper.inspectNvidiaRuntime(enginePath);
+                    KataGoRuntimeHelper.inspectNvidiaRuntime(enginePath, "");
 
                 assertTrue(status.applicable);
                 assertTrue(status.ready);
@@ -724,11 +724,46 @@ public class KataGoRuntimeHelperTest {
               runtimeWorkDirectory,
               () -> {
                 KataGoRuntimeHelper.NvidiaRuntimeStatus status =
-                    KataGoRuntimeHelper.inspectNvidiaRuntime(enginePath);
+                    KataGoRuntimeHelper.inspectNvidiaRuntime(enginePath, "");
 
                 assertFalse(status.ready);
                 assertTrue(status.missingDlls.contains("nvrtc64_*.dll"));
                 assertTrue(status.missingDlls.contains("nvrtc-builtins64_*.dll"));
+              });
+        });
+  }
+
+  @Test
+  void standardNvidiaRuntimeCanUseNvrtcFromExplicitLaunchPath() throws Exception {
+    withOsName(
+        WINDOWS_OS_NAME,
+        () -> {
+          Path tempRoot = Files.createTempDirectory("katago-helper-nvidia-nvrtc-path");
+          Path engineDir =
+              Files.createDirectories(
+                  tempRoot.resolve("engines").resolve("katago").resolve("windows-x64"));
+          Files.writeString(engineDir.resolve("lizzieyzy-next-engine-backend.txt"), "nvidia");
+          Files.writeString(
+              engineDir.resolve("lizzieyzy-next-nvidia-runtime-manifest.txt"),
+              "Profile: cuda12.1-cudnn9\n");
+          Path enginePath = touch(engineDir.resolve("katago.exe"));
+          touchCuda12CoreWithoutNvrtc(engineDir);
+          touch(engineDir.resolve("cudnn64_9.dll"));
+          touch(engineDir.resolve("z.dll"));
+          Path launchPathDir = Files.createDirectories(tempRoot.resolve("launch-path"));
+          touch(launchPathDir.resolve("nvrtc64_120_0.dll"));
+          touch(launchPathDir.resolve("nvrtc-builtins64_126.dll"));
+          Path runtimeWorkDirectory = Files.createDirectories(tempRoot.resolve("runtime-root"));
+
+          withConfig(
+              runtimeWorkDirectory,
+              () -> {
+                KataGoRuntimeHelper.NvidiaRuntimeStatus status =
+                    KataGoRuntimeHelper.inspectNvidiaRuntime(
+                        enginePath, launchPathDir.toString());
+
+                assertTrue(status.ready);
+                assertTrue(status.missingDlls.isEmpty());
               });
         });
   }
@@ -758,7 +793,7 @@ public class KataGoRuntimeHelperTest {
               runtimeWorkDirectory,
               () -> {
                 KataGoRuntimeHelper.NvidiaRuntimeStatus status =
-                    KataGoRuntimeHelper.inspectNvidiaRuntime(enginePath);
+                    KataGoRuntimeHelper.inspectNvidiaRuntime(enginePath, "");
 
                 assertFalse(status.ready);
                 assertTrue(
@@ -1187,7 +1222,8 @@ public class KataGoRuntimeHelperTest {
                 writeCurrentTensorRtEngineManifest(targetDir);
 
                 KataGoRuntimeHelper.NvidiaRuntimeStatus runtimeStatus =
-                    KataGoRuntimeHelper.inspectNvidiaRuntime(targetDir.resolve("katago.exe"));
+                    KataGoRuntimeHelper.inspectNvidiaRuntime(
+                        targetDir.resolve("katago.exe"), "");
                 assertTrue(
                     runtimeStatus.ready,
                     "TensorRT runtime should be accepted when launch PATH dirs satisfy dependencies.");
@@ -1510,7 +1546,8 @@ public class KataGoRuntimeHelperTest {
                         + "\n");
 
                 KataGoRuntimeHelper.NvidiaRuntimeStatus runtimeStatus =
-                    KataGoRuntimeHelper.inspectNvidiaRuntime(targetDir.resolve("katago.exe"));
+                    KataGoRuntimeHelper.inspectNvidiaRuntime(
+                        targetDir.resolve("katago.exe"), "");
                 KataGoRuntimeHelper.TensorRtInstallStatus installStatus =
                     KataGoRuntimeHelper.inspectTensorRtInstall(snapshot);
 


### PR DESCRIPTION
## 概要

- 请求发布 `next-2026-08-24.1` 多平台 pre-release，提供简中、繁中、English、日本語、한국어、ไทย六语更新说明与完整下载表。
- 收录已合并并完成 RTX 50 真机验收的 CUDA 12.8/NVRTC 修复，以及 TensorRT AI 陪练 HumanSL companion、引擎生命周期、远程同步和诊断中心等近期改进。
- 修复 NVIDIA runtime 单元测试会被开发机系统 `PATH` 中的 CUDA DLL 污染的问题；产品仍允许使用系统 CUDA，测试夹具改用显式搜索路径并新增正向回归覆盖。
- Windows 上不再把不可执行本地 POSIX 夹具的 WSL `bash.exe` 误判为原生 bash；macOS 签名静态安全测试继续执行，真正的 shell 故障注入仍由 POSIX CI 运行。

## 验证

- Windows 11 / Oracle JDK 21.0.2
- `mvn -B -Djava.awt.headless=true -Dfmt.skip=true test`: **3088 tests, 0 failures, 0 errors, 14 skipped**
- `mvn -B -Djava.awt.headless=true -Dfmt.skip=true -DskipTests package`: **BUILD SUCCESS**
- `KataGoRuntimeHelperTest`: **61 tests, 0 failures, 0 errors**
- 全部 Python 发布脚本测试：**189 tests, 0 failures, 0 errors, 12 platform skips**
- 发布关键路径测试：**104 tests, 0 failures, 0 errors, 1 native-bash CI skip**
- Windows launcher packaging guards、release notes validator、line-ending policy、Markdown local links、`git diff --check`: **全部通过**

## 发布门禁

合并后发布器必须等待精确目标提交的 Linux/Windows JDK 21 CI 和 smoke test 成功，再分别构建并审计 Windows、Linux、macOS Intel、macOS Apple Silicon 资产；任一平台、版本、SHA-256、provenance 或资产清单不一致都会保持 draft，不会公开发布。