### PR TITLE
Add JaCoCo coverage reports to Maven verify and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,13 @@ jobs:
           "-Dfailsafe.failIfNoSpecifiedTests=true"
           verify
 
+      - name: Upload JaCoCo coverage report
+        uses: actions/upload-artifact@v6
+        with:
+          name: jacoco-coverage-report-windows
+          path: target/site/jacoco
+          if-no-files-found: error
+
   build:
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -185,3 +192,10 @@ jobs:
           -Dit.test=LoggingProviderSmokeIT
           -Dfailsafe.failIfNoSpecifiedTests=true
           verify
+
+      - name: Upload JaCoCo coverage report
+        uses: actions/upload-artifact@v6
+        with:
+          name: jacoco-coverage-report-linux
+          path: target/site/jacoco
+          if-no-files-found: error

--- a/pom.xml
+++ b/pom.xml
@@ -86,6 +86,26 @@
 				</configuration>
 			</plugin>
 			<plugin>
+				<groupId>org.jacoco</groupId>
+				<artifactId>jacoco-maven-plugin</artifactId>
+				<version>0.8.15</version>
+				<executions>
+					<execution>
+						<id>prepare-agent</id>
+						<goals>
+							<goal>prepare-agent</goal>
+						</goals>
+					</execution>
+					<execution>
+						<id>report</id>
+						<phase>verify</phase>
+						<goals>
+							<goal>report</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
 				<groupId>com.spotify.fmt</groupId>
 				<artifactId>fmt-maven-plugin</artifactId>
 				<version>2.29</version>


### PR DESCRIPTION
## Repro
Current `main` already runs JUnit in the Windows and Linux verification gates (`mvn … -DskipTests=false -DskipITs=false verify`). `pom.xml` had no JaCoCo plugin, so no coverage report was produced or retained in CI.

## Cause
Coverage observability was never wired. Surefire/Failsafe already run; this was not a skipped-test problem.

## Fix
- Bound `jacoco-maven-plugin` (0.8.15) to the existing test/`verify` lifecycle (`prepare-agent` + `report`). No `check` rules, no coverage threshold.
- After each verification gate, upload `target/site/jacoco` as `jacoco-coverage-report-windows` / `jacoco-coverage-report-linux`.
- Left Windows/Linux verify commands and shaded JAR package/verify unchanged.

## Verification
- Test failure still fails the verification job.
- After a successful `verify`, the JaCoCo HTML/XML report is uploaded as a workflow artifact.
- No line/branch coverage minimum.

Fixes #305
