### PR TITLE
Fix ROCm version audit in Windows release workflow

### DIFF
--- a/.github/workflows/build-windows-release.yml
+++ b/.github/workflows/build-windows-release.yml
@@ -344,14 +344,9 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          runnable_engines=(
+          runtime_version_engines=(
             "dist/windows/app-image-with-katago/LizzieYzy Next/app/engines/katago/windows-x64/katago.exe"
             "dist/windows/app-image-opencl/LizzieYzy Next OpenCL/app/engines/katago/windows-x64/katago.exe"
-          )
-          standard_packaged_engines=(
-            "${runnable_engines[@]}"
-            "dist/windows/app-image-nvidia/LizzieYzy Next NVIDIA/app/engines/katago/windows-x64/katago.exe"
-            "dist/windows/app-image-nvidia.tensorrt/LizzieYzy Next NVIDIA TensorRT/app/engines/katago/windows-x64/katago-human-sl-cuda.exe"
             "dist/windows/app-image-experimental.directml/LizzieYzy Next DirectML Experimental/app/engines/katago/windows-x64/katago.exe"
             "dist/windows/app-image-experimental.openvino/LizzieYzy Next OpenVINO Experimental/app/engines/katago/windows-x64/katago.exe"
             "dist/windows/app-image-experimental.rocm.gfx103x/LizzieYzy Next ROCm gfx103x Experimental/app/engines/katago/windows-x64/katago.exe"
@@ -359,23 +354,27 @@ jobs:
             "dist/windows/app-image-experimental.rocm.gfx1151/LizzieYzy Next ROCm gfx1151 Experimental/app/engines/katago/windows-x64/katago.exe"
             "dist/windows/app-image-experimental.rocm.gfx120x/LizzieYzy Next ROCm gfx120x Experimental/app/engines/katago/windows-x64/katago.exe"
           )
+          driver_gated_static_engines=(
+            "dist/windows/app-image-nvidia/LizzieYzy Next NVIDIA/app/engines/katago/windows-x64/katago.exe"
+            "dist/windows/app-image-nvidia.tensorrt/LizzieYzy Next NVIDIA TensorRT/app/engines/katago/windows-x64/katago-human-sl-cuda.exe"
+          )
           tensorrt_engine="dist/windows/app-image-nvidia.tensorrt/LizzieYzy Next NVIDIA TensorRT/app/engines/katago/windows-x64/katago.exe"
-          for engine in "${runnable_engines[@]}"; do
+          for engine in "${runtime_version_engines[@]}"; do
             test -f "$engine"
             version_output="$("$engine" version 2>&1)"
             printf '%s\n%s\n' "$engine" "$version_output"
             grep -q 'KataGo v1\.18\.1' <<<"$version_output"
           done
-          # GitHub-hosted Windows runners do not have an NVIDIA display driver, so
-          # CUDA/TensorRT executables cannot pass the Windows loader even when every
-          # redistributable DLL is bundled. Audit their embedded version marker after
-          # the runtime-file checks above; real NVIDIA execution is a hardware gate.
+          # CPU, OpenCL, ONNX and ROCm can report their version without initializing a
+          # device. CUDA/TensorRT cannot pass the Windows loader on a hosted runner
+          # without an NVIDIA display driver, so only those binaries use the static
+          # marker audit after the runtime-file checks above.
           python3 scripts/audit_katago_binary_version.py \
             --expected-version 1.18.1 \
             --reject-version 1.17.0 \
             --reject-version 1.17.1 \
             --reject-version 1.17.2 \
-            "${standard_packaged_engines[@]}"
+            "${driver_gated_static_engines[@]}"
           python3 scripts/audit_katago_binary_version.py \
             --expected-version 1.18.1 \
             --reject-version 1.17.0 \

--- a/scripts/test_validate_release_workflow_identity.py
+++ b/scripts/test_validate_release_workflow_identity.py
@@ -307,6 +307,38 @@ class ReleaseWorkflowIdentityWiringTest(unittest.TestCase):
         ].default
         self.assertGreater(publisher_wait, 280 * 60)
 
+    def test_windows_katago_version_audit_uses_runtime_checks_when_possible(self) -> None:
+        workflow = self.workflow("build-windows-release.yml")
+        runtime_start = workflow.index("runtime_version_engines=(")
+        static_start = workflow.index("driver_gated_static_engines=(")
+        runtime_block = workflow[runtime_start:static_start]
+        static_end = workflow.index("tensorrt_engine=", static_start)
+        static_block = workflow[static_start:static_end]
+
+        for flavor in (
+            "app-image-with-katago",
+            "app-image-opencl",
+            "app-image-experimental.directml",
+            "app-image-experimental.openvino",
+            "app-image-experimental.rocm.gfx103x",
+            "app-image-experimental.rocm.gfx110x",
+            "app-image-experimental.rocm.gfx1151",
+            "app-image-experimental.rocm.gfx120x",
+        ):
+            self.assertIn(flavor, runtime_block)
+        self.assertNotIn("app-image-nvidia/", runtime_block)
+        self.assertNotIn("app-image-nvidia.tensorrt", runtime_block)
+
+        self.assertIn("app-image-nvidia/", static_block)
+        self.assertIn("katago-human-sl-cuda.exe", static_block)
+        self.assertNotIn("app-image-experimental", static_block)
+        self.assertIn('for engine in "${runtime_version_engines[@]}"', workflow)
+        self.assertIn('version_output="$("$engine" version 2>&1)"', workflow)
+        self.assertIn(
+            '"${driver_gated_static_engines[@]}"',
+            workflow,
+        )
+
     def test_publisher_explicit_waits_leave_job_timeout_margin(self) -> None:
         workflow = (
             self.root / ".github/workflows/publish-requested-pre-release.yml"

--- a/scripts/test_windows_launcher_packaging.py
+++ b/scripts/test_windows_launcher_packaging.py
@@ -96,13 +96,13 @@ def main() -> None:
         "scripts/audit_katago_package_metadata.py",
         "build-windows-release.yml",
     )
-    require(workflow, 'runnable_engines=(', "build-windows-release.yml")
-    require(workflow, 'standard_packaged_engines=(', "build-windows-release.yml")
+    require(workflow, 'runtime_version_engines=(', "build-windows-release.yml")
+    require(workflow, 'driver_gated_static_engines=(', "build-windows-release.yml")
     require(workflow, 'tensorrt_engine=', "build-windows-release.yml")
     require(workflow, "--expected-version 1.18.1", "build-windows-release.yml")
     require(package_script, "write_tensorrt_version_file", "package_windows_exe.sh")
     require(package_script, "Windows TensorRT bundle", "package_windows_exe.sh")
-    require(workflow, "GitHub-hosted Windows runners do not have an NVIDIA display driver", "build-windows-release.yml")
+    require(workflow, "without an NVIDIA display driver", "build-windows-release.yml")
     require(
         workflow,
         "windows-x64/z.dll",


### PR DESCRIPTION
## Summary

- execute `katago.exe version` for CPU, OpenCL, DirectML, OpenVINO, and all four ROCm package variants
- reserve embedded-string auditing for CUDA/TensorRT binaries that cannot pass the Windows loader without an NVIDIA display driver
- add regression coverage that keeps runtime-safe experimental backends out of the static-only audit set

This fixes the false failure in [Windows release run 32743392819](https://github.com/wimi321/lizzieyzy-next/actions/runs/32743392819): official ROCm executables report KataGo v1.18.1 at runtime, but do not retain the exact ASCII marker assumed by the static scanner.

## Validation

- official DirectML, OpenVINO, and ROCm gfx103X/gfx110X/gfx1151/gfx120X assets matched the catalog size and SHA-256
- all six experimental executables returned `KataGo v1.18.1` with exit code 0 on Windows; ROCm additionally reported Git revision `92ee95c0...` and `Using ROCm backend`
- `mvn -B -Djava.awt.headless=true -Dfmt.skip=true test`: 3111 tests, 0 failures, 0 errors, 14 skipped
- `mvn -B -Djava.awt.headless=true -Dfmt.skip=true -DskipTests package`: success
- Python release/package suite: 195 tests, 0 failures, 12 skipped
- Windows launcher packaging guards: passed
- actionlint v1.7.12: 8 workflows passed
- `git diff --check`: passed