### PR TITLE
Add analysis session, request builder, and ReadBoard stream regression tests

### DIFF
--- a/src/main/java/featurecat/lizzie/analysis/EngineManager.java
+++ b/src/main/java/featurecat/lizzie/analysis/EngineManager.java
@@ -273,6 +273,10 @@ public class EngineManager {
       return operationsInFlight.get();
     }
 
+    boolean retirementFinishedForTest() {
+      return retirementFinished.get();
+    }
+
     int openPhysicalRequestsForTest() {
       int open = 0;
       for (EngineGamePhysicalRequestLease request : physicalRequests) {

--- a/src/main/java/featurecat/lizzie/analysis/ReadBoardStream.java
+++ b/src/main/java/featurecat/lizzie/analysis/ReadBoardStream.java
@@ -4,7 +4,9 @@ import java.io.BufferedOutputStream;
 import java.io.BufferedReader;
 import java.io.Closeable;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.io.UnsupportedEncodingException;
 import java.net.Socket;
 import org.json.JSONException;
 
@@ -20,12 +22,30 @@ public class ReadBoardStream extends Thread implements Closeable {
     this.owner = owner;
     socket = s;
     try {
-      in = new BufferedReader(new InputStreamReader(socket.getInputStream(), "UTF-8"));
+      in = utf8Reader(socket.getInputStream());
       out = new BufferedOutputStream(socket.getOutputStream());
       start();
     } catch (Exception e) {
       e.printStackTrace();
     }
+  }
+
+  /**
+   * Test constructor: bind a UTF-8 byte stream without a socket or reader thread. {@link #run()}
+   * still performs the production line-framing loop.
+   */
+  ReadBoardStream(ReadBoard owner, InputStream rawInput) {
+    this.owner = owner;
+    try {
+      in = utf8Reader(rawInput);
+    } catch (UnsupportedEncodingException e) {
+      throw new IllegalStateException(e);
+    }
+  }
+
+  private static BufferedReader utf8Reader(InputStream rawInput)
+      throws UnsupportedEncodingException {
+    return new BufferedReader(new InputStreamReader(rawInput, "UTF-8"));
   }
 
   @Override

--- a/src/test/java/featurecat/lizzie/analysis/AnalysisRequestBuilderTest.java
+++ b/src/test/java/featurecat/lizzie/analysis/AnalysisRequestBuilderTest.java
@@ -1,0 +1,657 @@
+package featurecat.lizzie.analysis;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import featurecat.lizzie.Config;
+import featurecat.lizzie.Lizzie;
+import featurecat.lizzie.gui.LizzieFrame;
+import featurecat.lizzie.rules.Board;
+import featurecat.lizzie.rules.BoardData;
+import featurecat.lizzie.rules.BoardHistoryList;
+import featurecat.lizzie.rules.BoardHistoryNode;
+import featurecat.lizzie.rules.Movelist;
+import featurecat.lizzie.rules.Stone;
+import featurecat.lizzie.rules.Zobrist;
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Stream;
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class AnalysisRequestBuilderTest {
+  private static final int BOARD_SIZE = 3;
+  private static final int BOARD_AREA = BOARD_SIZE * BOARD_SIZE;
+
+  @ParameterizedTest
+  @CsvSource({
+    "false, false, false",
+    "true, false, false",
+    "false, true, false",
+    "false, false, true",
+    "true, true, false",
+    "true, false, true",
+    "false, true, true",
+    "true, true, true"
+  })
+  void booleanFlagsAreCopiedIndependentlyIntoTheRequest(
+      boolean includePVVisits, boolean includeOwnership, boolean includeMovesOwnership)
+      throws Exception {
+    try (TestEnvironment env = TestEnvironment.open()) {
+      BoardHistoryNode root = emptyHistoryRoot();
+
+      JSONObject request =
+          payload(
+              AnalysisRequestBuilder.buildRequest(
+                  "flags",
+                  root,
+                  50,
+                  includePVVisits,
+                  includeOwnership,
+                  includeMovesOwnership));
+
+      assertEquals("flags", request.getString("id"));
+      assertEquals(50, request.getInt("maxVisits"));
+      assertEquals(includePVVisits, request.getBoolean("includePVVisits"));
+      assertEquals(includeOwnership, request.getBoolean("includeOwnership"));
+      assertEquals(includeMovesOwnership, request.getBoolean("includeMovesOwnership"));
+      assertFalse(
+          includeOwnership && request.getBoolean("includeMovesOwnership") != includeMovesOwnership,
+          "ownership and moves-ownership are independent builder arguments");
+    }
+  }
+
+  @ParameterizedTest
+  @ValueSource(ints = {0, 1, 2, Integer.MAX_VALUE, -1})
+  void maxVisitsIsEmittedAsGivenIncludingBoundaries(int maxVisits) throws Exception {
+    try (TestEnvironment env = TestEnvironment.open()) {
+      JSONObject request =
+          payload(
+              AnalysisRequestBuilder.buildRequest(
+                  "visits", emptyHistoryRoot(), maxVisits, false, false, false));
+
+      assertEquals(maxVisits, request.getInt("maxVisits"));
+    }
+  }
+
+  @Test
+  void emptyBoardOmitsOptionalSetupFieldsAndAnalyzesTurnZero() throws Exception {
+    try (TestEnvironment env = TestEnvironment.open()) {
+      JSONObject request =
+          payload(
+              AnalysisRequestBuilder.buildRequest(
+                  "empty", emptyHistoryRoot(), 10, false, false, false));
+
+      assertFalse(request.has("initialStones"));
+      assertFalse(request.has("initialPlayer"));
+      assertEquals(List.of(), request.getJSONArray("moves").toList());
+      assertEquals(List.of(0), request.getJSONArray("analyzeTurns").toList());
+      assertEquals(BOARD_SIZE, request.getInt("boardXSize"));
+      assertEquals(BOARD_SIZE, request.getInt("boardYSize"));
+      assertEquals(GameInfo.DEFAULT_KOMI, request.getDouble("komi"), 0.0001);
+      assertEquals("tromp-taylor", request.get("rules"));
+      assertEquals(
+          "SIDETOMOVE",
+          request.getJSONObject("overrideSettings").getString("reportAnalysisWinratesAs"));
+    }
+  }
+
+  @Test
+  void snapshotRootSendsInitialStonesAndPlayerWithoutHistoryMoves() throws Exception {
+    try (TestEnvironment env = TestEnvironment.open()) {
+      BoardHistoryList history =
+          new BoardHistoryList(
+              snapshotNode(
+                  stones(placement(0, 0, Stone.BLACK), placement(1, 0, Stone.WHITE)),
+                  Optional.empty(),
+                  Stone.EMPTY,
+                  false,
+                  58));
+      boardWithHistory(history);
+
+      JSONObject request =
+          payload(
+              AnalysisRequestBuilder.buildRequest(
+                  "snapshot", history.getCurrentHistoryNode(), 20, false, false, false));
+
+      assertEquals(Set.of(List.of("B", "A3"), List.of("W", "B3")), stonePairs(request));
+      assertEquals("W", request.getString("initialPlayer"));
+      assertEquals(List.of(), request.getJSONArray("moves").toList());
+      assertEquals(List.of(0), request.getJSONArray("analyzeTurns").toList());
+    }
+  }
+
+  @Test
+  void configuredStartStonesAreUsedWhenTheRootIsNotASnapshotAnchor() throws Exception {
+    try (TestEnvironment env = TestEnvironment.open()) {
+      BoardHistoryList history = new BoardHistoryList(BoardData.empty(BOARD_SIZE, BOARD_SIZE));
+      boardWithHistory(history);
+      Lizzie.board.hasStartStone = true;
+      Lizzie.board.startStonelist = new ArrayList<>();
+      Lizzie.board.startStonelist.add(startStone(0, 0, true));
+      Lizzie.board.startStonelist.add(startStone(1, 0, false));
+      history.getStart().getData().blackToPlay = false;
+
+      JSONObject request =
+          payload(
+              AnalysisRequestBuilder.buildRequest(
+                  "start-stones", history.getStart(), 8, false, false, false));
+
+      assertEquals(Set.of(List.of("B", "A3"), List.of("W", "B3")), stonePairs(request));
+      assertEquals("W", request.getString("initialPlayer"));
+      assertEquals(List.of(), request.getJSONArray("moves").toList());
+    }
+  }
+
+  @Test
+  void historyMovesAndPassesAreSerializedInPlayOrder() throws Exception {
+    try (TestEnvironment env = TestEnvironment.open()) {
+      BoardHistoryList history = new BoardHistoryList(BoardData.empty(BOARD_SIZE, BOARD_SIZE));
+      history.add(
+          moveNode(stones(placement(0, 0, Stone.BLACK)), new int[] {0, 0}, Stone.BLACK, false, 1));
+      history.add(
+          passNode(stones(placement(0, 0, Stone.BLACK)), Stone.WHITE, true, 2));
+      boardWithHistory(history);
+
+      JSONObject request =
+          payload(
+              AnalysisRequestBuilder.buildRequest(
+                  "history", history.getCurrentHistoryNode(), 16, false, false, false));
+
+      assertEquals(
+          List.of(List.of("B", "A3"), List.of("W", "pass")), pairs(request.getJSONArray("moves")));
+      assertEquals(List.of(2), request.getJSONArray("analyzeTurns").toList());
+      assertFalse(request.has("initialStones"));
+      assertFalse(request.has("initialPlayer"));
+    }
+  }
+
+  @Test
+  void laterPositionMovesDoNotLeakIntoAnEarlierNodeRequest() throws Exception {
+    try (TestEnvironment env = TestEnvironment.open()) {
+      BoardHistoryList history = new BoardHistoryList(BoardData.empty(BOARD_SIZE, BOARD_SIZE));
+      history.add(
+          moveNode(stones(placement(0, 0, Stone.BLACK)), new int[] {0, 0}, Stone.BLACK, false, 1));
+      history.add(
+          moveNode(
+              stones(placement(0, 0, Stone.BLACK), placement(1, 0, Stone.WHITE)),
+              new int[] {1, 0},
+              Stone.WHITE,
+              true,
+              2));
+      boardWithHistory(history);
+      BoardHistoryNode root = history.getStart();
+      BoardHistoryNode first = root.next().orElseThrow();
+      BoardHistoryNode second = history.getCurrentHistoryNode();
+
+      JSONObject leafFirst =
+          payload(AnalysisRequestBuilder.buildRequest("leaf", second, 4, true, true, true));
+      JSONObject rootAfterLeaf =
+          payload(AnalysisRequestBuilder.buildRequest("root", root, 9, false, false, false));
+      JSONObject firstMove =
+          payload(AnalysisRequestBuilder.buildRequest("first", first, 9, false, false, false));
+
+      assertEquals(
+          List.of(List.of("B", "A3"), List.of("W", "B3")),
+          pairs(leafFirst.getJSONArray("moves")));
+      assertEquals(List.of(), rootAfterLeaf.getJSONArray("moves").toList());
+      assertEquals(List.of(0), rootAfterLeaf.getJSONArray("analyzeTurns").toList());
+      assertEquals(List.of(List.of("B", "A3")), pairs(firstMove.getJSONArray("moves")));
+      assertEquals(List.of(1), firstMove.getJSONArray("analyzeTurns").toList());
+      assertFalse(rootAfterLeaf.getBoolean("includePVVisits"));
+      assertFalse(rootAfterLeaf.getBoolean("includeOwnership"));
+      assertFalse(rootAfterLeaf.getBoolean("includeMovesOwnership"));
+    }
+  }
+
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("rulesModes")
+  void rulesModeSelectsSpecificObjectCurrentEngineAutoLoadOrDefault(
+      String name, RuleConfig rules, Object expectedRules) throws Exception {
+    try (TestEnvironment env = TestEnvironment.open()) {
+      rules.apply();
+
+      JSONObject request =
+          payload(
+              AnalysisRequestBuilder.buildRequest(
+                  name, emptyHistoryRoot(), 5, false, false, false));
+
+      if (expectedRules instanceof JSONObject) {
+        JSONObject expected = (JSONObject) expectedRules;
+        JSONObject actual = request.getJSONObject("rules");
+        for (String key : expected.keySet()) {
+          assertEquals(expected.get(key), actual.get(key), key);
+        }
+        assertEquals(expected.length(), actual.length());
+      } else {
+        assertEquals(expectedRules, request.get("rules"));
+      }
+    }
+  }
+
+  static Stream<Arguments> rulesModes() {
+    return Stream.of(
+        Arguments.of(
+            "specific-rules",
+            RuleConfig.specific("{\"koRule\":\"SIMPLE\",\"scoringRule\":\"AREA\"}"),
+            new JSONObject("{\"koRule\":\"SIMPLE\",\"scoringRule\":\"AREA\"}")),
+        Arguments.of("specific-rules-blank", RuleConfig.specific(""), "tromp-taylor"),
+        Arguments.of(
+            "current-engine-rules",
+            RuleConfig.currentEngine("= {\"scoringRule\":\"TERRITORY\"}"),
+            new JSONObject("{\"scoringRule\":\"TERRITORY\"}")),
+        Arguments.of(
+            "autoload-kata-rules",
+            RuleConfig.autoLoad("{\"taxRule\":\"NONE\"}"),
+            new JSONObject("{\"taxRule\":\"NONE\"}")),
+        Arguments.of(
+            "autoload-disabled",
+            new RuleConfig(true, "", "", false, "{\"taxRule\":\"SEVEN\"}"),
+            "tromp-taylor"),
+        Arguments.of(
+            "current-engine-blank-falls-through",
+            new RuleConfig(true, "", "", true, ""),
+            "tromp-taylor"));
+  }
+
+  @Test
+  void komiAndBoardSizeComeFromTheLiveGameNotFromPriorRequests() throws Exception {
+    try (TestEnvironment env = TestEnvironment.open()) {
+      BoardHistoryNode root = emptyHistoryRoot();
+      Lizzie.board.getHistory().getGameInfo().setKomiNoMenu(0.5);
+      JSONObject first =
+          payload(AnalysisRequestBuilder.buildRequest("k1", root, 3, false, false, false));
+
+      Lizzie.board.getHistory().getGameInfo().setKomiNoMenu(-6.5);
+      Board.boardWidth = 5;
+      Board.boardHeight = 4;
+      JSONObject second =
+          payload(AnalysisRequestBuilder.buildRequest("k2", root, 3, false, false, false));
+
+      assertEquals(0.5, first.getDouble("komi"), 0.0001);
+      assertEquals(BOARD_SIZE, first.getInt("boardXSize"));
+      assertEquals(BOARD_SIZE, first.getInt("boardYSize"));
+      assertEquals(-6.5, second.getDouble("komi"), 0.0001);
+      assertEquals(5, second.getInt("boardXSize"));
+      assertEquals(4, second.getInt("boardYSize"));
+      assertEquals("k1", first.getString("id"));
+      assertEquals("k2", second.getString("id"));
+    }
+  }
+
+  @Test
+  void returnedRequestObjectsDoNotShareOverrideSettings() throws Exception {
+    try (TestEnvironment env = TestEnvironment.open()) {
+      BoardHistoryNode root = emptyHistoryRoot();
+      JSONObject first = AnalysisRequestBuilder.buildRequest("a", root, 1, false, false, false);
+      first.getJSONObject("overrideSettings").put("reportAnalysisWinratesAs", "BLACK");
+      first.put("includePolicy", true);
+
+      JSONObject second =
+          payload(AnalysisRequestBuilder.buildRequest("b", root, 1, false, false, false));
+
+      assertEquals(
+          "SIDETOMOVE",
+          second.getJSONObject("overrideSettings").getString("reportAnalysisWinratesAs"));
+      assertFalse(second.has("includePolicy"));
+      assertEquals("b", second.getString("id"));
+    }
+  }
+
+  @Test
+  void nullIdOmitsTheIdFieldFromTheSerializedRequest() throws Exception {
+    try (TestEnvironment env = TestEnvironment.open()) {
+      JSONObject request =
+          payload(
+              AnalysisRequestBuilder.buildRequest(
+                  null, emptyHistoryRoot(), 1, false, false, false));
+
+      assertFalse(request.has("id"), "org.json omits a null id rather than sending JSON null");
+    }
+  }
+
+  @Test
+  void emptyIdIsSerializedAsAnEmptyString() throws Exception {
+    try (TestEnvironment env = TestEnvironment.open()) {
+      JSONObject request =
+          payload(
+              AnalysisRequestBuilder.buildRequest("", emptyHistoryRoot(), 1, false, false, false));
+
+      assertEquals("", request.getString("id"));
+    }
+  }
+
+  @Test
+  void nullAnalyzeNodeFailsFast() throws Exception {
+    try (TestEnvironment env = TestEnvironment.open()) {
+      assertThrows(
+          NullPointerException.class,
+          () -> AnalysisRequestBuilder.buildRequest("n", null, 1, false, false, false));
+    }
+  }
+
+  @Test
+  void malformedSpecificRulesAreRejectedByTheJsonParser() throws Exception {
+    try (TestEnvironment env = TestEnvironment.open()) {
+      Lizzie.config.analysisUseCurrentRules = false;
+      Lizzie.config.analysisSpecificRules = "{";
+
+      assertThrows(
+          JSONException.class,
+          () ->
+              AnalysisRequestBuilder.buildRequest(
+                  "bad-rules", emptyHistoryRoot(), 1, false, false, false));
+    }
+  }
+
+  @Test
+  void nullSpecificRulesNpeWhenNotUsingCurrentEngineRules() throws Exception {
+    try (TestEnvironment env = TestEnvironment.open()) {
+      Lizzie.config.analysisUseCurrentRules = false;
+      Lizzie.config.analysisSpecificRules = null;
+
+      assertThrows(
+          NullPointerException.class,
+          () ->
+              AnalysisRequestBuilder.buildRequest(
+                  "null-rules", emptyHistoryRoot(), 1, false, false, false));
+    }
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"", "=", "x", "=x"})
+  void currentEngineRulesThatAreTooShortOrNotJsonFailAsToday(String currentRules) throws Exception {
+    try (TestEnvironment env = TestEnvironment.open()) {
+      Lizzie.config.analysisUseCurrentRules = true;
+      Lizzie.config.currentKataGoRules = currentRules;
+      Lizzie.config.autoLoadKataRules = false;
+      Lizzie.config.kataRules = "";
+
+      if (currentRules.isEmpty()) {
+        JSONObject request =
+            payload(
+                AnalysisRequestBuilder.buildRequest(
+                    "short-rules", emptyHistoryRoot(), 1, false, false, false));
+        assertEquals("tromp-taylor", request.get("rules"));
+        return;
+      }
+
+      Class<? extends Exception> expected =
+          currentRules.length() < 2 ? StringIndexOutOfBoundsException.class : JSONException.class;
+      assertThrows(
+          expected,
+          () ->
+              AnalysisRequestBuilder.buildRequest(
+                  "short-rules", emptyHistoryRoot(), 1, false, false, false));
+    }
+  }
+
+  @Test
+  void currentEngineRulesWithoutTheEqualsSpacePrefixAreParsedFromTheThirdCharacter()
+      throws Exception {
+    try (TestEnvironment env = TestEnvironment.open()) {
+      Lizzie.config.analysisUseCurrentRules = true;
+      Lizzie.config.currentKataGoRules = "{\"scoringRule\":\"AREA\"}";
+
+      assertThrows(
+          JSONException.class,
+          () ->
+              AnalysisRequestBuilder.buildRequest(
+                  "unprefixed", emptyHistoryRoot(), 1, false, false, false),
+          "addRules uses substring(2), so a raw JSON object is not accepted");
+    }
+  }
+
+  private static JSONObject payload(JSONObject request) {
+    return new JSONObject(request.toString());
+  }
+
+  private static Set<List<String>> stonePairs(JSONObject request) {
+    return Set.copyOf(pairs(request.getJSONArray("initialStones")));
+  }
+
+  private static List<List<String>> pairs(JSONArray array) {
+    List<List<String>> result = new ArrayList<>();
+    for (int i = 0; i < array.length(); i++) {
+      JSONArray pair = array.getJSONArray(i);
+      List<String> item = new ArrayList<>();
+      for (int j = 0; j < pair.length(); j++) {
+        item.add(pair.getString(j));
+      }
+      result.add(List.copyOf(item));
+    }
+    return result;
+  }
+
+  private static BoardHistoryNode emptyHistoryRoot() throws Exception {
+    BoardHistoryList history = new BoardHistoryList(BoardData.empty(BOARD_SIZE, BOARD_SIZE));
+    boardWithHistory(history);
+    return history.getStart();
+  }
+
+  private static Board boardWithHistory(BoardHistoryList history) throws Exception {
+    Board board = allocate(Board.class);
+    board.startStonelist = new ArrayList<>();
+    board.hasStartStone = false;
+    board.setHistory(history);
+    Lizzie.board = board;
+    return board;
+  }
+
+  private static BoardData moveNode(
+      Stone[] stones, int[] lastMove, Stone color, boolean blackToPlay, int moveNumber) {
+    return BoardData.move(
+        stones,
+        lastMove,
+        color,
+        blackToPlay,
+        zobrist(stones),
+        moveNumber,
+        new int[BOARD_AREA],
+        0,
+        0,
+        50,
+        0);
+  }
+
+  private static BoardData passNode(
+      Stone[] stones, Stone color, boolean blackToPlay, int moveNumber) {
+    return BoardData.pass(
+        stones, color, blackToPlay, zobrist(stones), moveNumber, new int[BOARD_AREA], 0, 0, 50, 0);
+  }
+
+  private static BoardData snapshotNode(
+      Stone[] stones,
+      Optional<int[]> lastMove,
+      Stone lastMoveColor,
+      boolean blackToPlay,
+      int moveNumber) {
+    return BoardData.snapshot(
+        stones,
+        lastMove,
+        lastMoveColor,
+        blackToPlay,
+        zobrist(stones),
+        moveNumber,
+        new int[BOARD_AREA],
+        0,
+        0,
+        50,
+        0);
+  }
+
+  private static Stone[] stones(Placement... placements) {
+    Stone[] stones = emptyStones();
+    for (Placement placement : placements) {
+      stones[Board.getIndex(placement.x, placement.y)] = placement.color;
+    }
+    return stones;
+  }
+
+  private static Stone[] emptyStones() {
+    Stone[] stones = new Stone[BOARD_AREA];
+    for (int index = 0; index < BOARD_AREA; index++) {
+      stones[index] = Stone.EMPTY;
+    }
+    return stones;
+  }
+
+  private static Zobrist zobrist(Stone[] stones) {
+    Zobrist zobrist = new Zobrist();
+    for (int x = 0; x < BOARD_SIZE; x++) {
+      for (int y = 0; y < BOARD_SIZE; y++) {
+        Stone stone = stones[Board.getIndex(x, y)];
+        if (!stone.isEmpty()) {
+          zobrist.toggleStone(x, y, stone);
+        }
+      }
+    }
+    return zobrist;
+  }
+
+  private static Placement placement(int x, int y, Stone color) {
+    return new Placement(x, y, color);
+  }
+
+  private static Movelist startStone(int x, int y, boolean isBlack) {
+    Movelist move = new Movelist();
+    move.x = x;
+    move.y = y;
+    move.isblack = isBlack;
+    move.ispass = false;
+    return move;
+  }
+
+  @SuppressWarnings("unchecked")
+  private static <T> T allocate(Class<T> type) throws Exception {
+    return (T) UnsafeHolder.UNSAFE.allocateInstance(type);
+  }
+
+  private static final class Placement {
+    private final int x;
+    private final int y;
+    private final Stone color;
+
+    private Placement(int x, int y, Stone color) {
+      this.x = x;
+      this.y = y;
+      this.color = color;
+    }
+  }
+
+  private static final class RuleConfig {
+    private final boolean useCurrent;
+    private final String specific;
+    private final String currentEngine;
+    private final boolean autoLoad;
+    private final String kataRules;
+
+    private RuleConfig(
+        boolean useCurrent,
+        String specific,
+        String currentEngine,
+        boolean autoLoad,
+        String kataRules) {
+      this.useCurrent = useCurrent;
+      this.specific = specific;
+      this.currentEngine = currentEngine;
+      this.autoLoad = autoLoad;
+      this.kataRules = kataRules;
+    }
+
+    private static RuleConfig specific(String rules) {
+      return new RuleConfig(false, rules, "", false, "");
+    }
+
+    private static RuleConfig currentEngine(String rules) {
+      return new RuleConfig(true, "", rules, false, "");
+    }
+
+    private static RuleConfig autoLoad(String rules) {
+      return new RuleConfig(true, "", "", true, rules);
+    }
+
+    private void apply() {
+      Lizzie.config.analysisUseCurrentRules = useCurrent;
+      Lizzie.config.analysisSpecificRules = specific;
+      Lizzie.config.currentKataGoRules = currentEngine;
+      Lizzie.config.autoLoadKataRules = autoLoad;
+      Lizzie.config.kataRules = kataRules;
+    }
+  }
+
+  private static final class TestEnvironment implements AutoCloseable {
+    private final int previousBoardWidth;
+    private final int previousBoardHeight;
+    private final Config previousConfig;
+    private final Board previousBoard;
+    private final LizzieFrame previousFrame;
+
+    private TestEnvironment(
+        int previousBoardWidth,
+        int previousBoardHeight,
+        Config previousConfig,
+        Board previousBoard,
+        LizzieFrame previousFrame) {
+      this.previousBoardWidth = previousBoardWidth;
+      this.previousBoardHeight = previousBoardHeight;
+      this.previousConfig = previousConfig;
+      this.previousBoard = previousBoard;
+      this.previousFrame = previousFrame;
+    }
+
+    private static TestEnvironment open() throws Exception {
+      TestEnvironment environment =
+          new TestEnvironment(
+              Board.boardWidth, Board.boardHeight, Lizzie.config, Lizzie.board, Lizzie.frame);
+      Board.boardWidth = BOARD_SIZE;
+      Board.boardHeight = BOARD_SIZE;
+      Zobrist.init();
+      Config config = allocate(Config.class);
+      config.analysisUseCurrentRules = false;
+      config.analysisSpecificRules = "";
+      config.currentKataGoRules = "";
+      config.autoLoadKataRules = false;
+      config.kataRules = "";
+      Lizzie.config = config;
+      Lizzie.frame = allocate(LizzieFrame.class);
+      return environment;
+    }
+
+    @Override
+    public void close() {
+      Board.boardWidth = previousBoardWidth;
+      Board.boardHeight = previousBoardHeight;
+      Zobrist.init();
+      Lizzie.config = previousConfig;
+      Lizzie.board = previousBoard;
+      Lizzie.frame = previousFrame;
+    }
+  }
+
+  private static final class UnsafeHolder {
+    private static final sun.misc.Unsafe UNSAFE = loadUnsafe();
+
+    private static sun.misc.Unsafe loadUnsafe() {
+      try {
+        Field field = sun.misc.Unsafe.class.getDeclaredField("theUnsafe");
+        field.setAccessible(true);
+        return (sun.misc.Unsafe) field.get(null);
+      } catch (ReflectiveOperationException ex) {
+        throw new IllegalStateException("Failed to access Unsafe", ex);
+      }
+    }
+  }
+}

--- a/src/test/java/featurecat/lizzie/analysis/EngineManagerEngineGameStateMachineTest.java
+++ b/src/test/java/featurecat/lizzie/analysis/EngineManagerEngineGameStateMachineTest.java
@@ -4431,10 +4431,15 @@ class EngineManagerEngineGameStateMachineTest {
   private static void awaitNoEngineGameOperations(
       EngineManager.EngineGameTransaction transaction) {
     long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(2L);
-    while (transaction.operationsInFlightForTest() != 0 && System.nanoTime() < deadline) {
+    while (System.nanoTime() < deadline
+        && (transaction.operationsInFlightForTest() != 0
+            || !transaction.retirementFinishedForTest())) {
       Thread.onSpinWait();
     }
     assertEquals(0, transaction.operationsInFlightForTest());
+    assertTrue(
+        transaction.retirementFinishedForTest(),
+        "fallback watchdog retirement must finish before a successor can be admitted");
   }
 
   @SuppressWarnings("unchecked")

--- a/src/test/java/featurecat/lizzie/analysis/ReadBoardStreamTest.java
+++ b/src/test/java/featurecat/lizzie/analysis/ReadBoardStreamTest.java
@@ -8,15 +8,24 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import featurecat.lizzie.Lizzie;
 import featurecat.lizzie.gui.LizzieFrame;
 import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.lang.reflect.Field;
 import java.net.ServerSocket;
 import java.net.Socket;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 class ReadBoardStreamTest {
   @Test
@@ -119,6 +128,135 @@ class ReadBoardStreamTest {
     }
   }
 
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("framingChunks")
+  void equivalentByteStreamsParseTheSameRegardlessOfChunking(String name, int[] chunkSizes)
+      throws Exception {
+    byte[] bytes = utf8("full\nsecond\n你好\nready\nready\n");
+    RecordingReadBoard expectedOwner = recordingOwner();
+    ReadBoardStream expectedStream =
+        new ReadBoardStream(expectedOwner, new ByteArrayInputStream(bytes));
+    expectedStream.run();
+
+    RecordingReadBoard chunkedOwner = recordingOwner();
+    ReadBoardStream chunkedStream =
+        new ReadBoardStream(chunkedOwner, new ChunkedInputStream(bytes, chunkSizes));
+    chunkedStream.run();
+
+    assertEquals(expectedOwner.lines, chunkedOwner.lines, name);
+    assertEquals(expectedOwner.readyCount, chunkedOwner.readyCount, name);
+    assertEquals(List.of("full", "second", "你好", "ready", "ready"), chunkedOwner.lines);
+    assertEquals(2, chunkedOwner.readyCount, "exact ready lines still dispatch handleReady");
+  }
+
+  static Stream<Arguments> framingChunks() {
+    return Stream.of(
+        Arguments.of("single-byte", new int[] {1}),
+        Arguments.of("two-byte", new int[] {2}),
+        Arguments.of("eight-byte", new int[] {8}),
+        Arguments.of("whole-buffer", new int[] {1024}),
+        Arguments.of("full-message-then-partial", new int[] {5, 3, 20}),
+        Arguments.of("split-inside-utf8-codepoint", new int[] {11, 1, 1, 1, 20}));
+  }
+
+  @Test
+  void consecutiveMessagesAreDeliveredInOrderIncludingDuplicates() throws Exception {
+    RecordingReadBoard owner = recordingOwner();
+    ReadBoardStream stream =
+        new ReadBoardStream(owner, new ByteArrayInputStream(utf8("a\na\nready\nready\n")));
+    stream.run();
+
+    assertEquals(List.of("a", "a", "ready", "ready"), owner.lines);
+    assertEquals(2, owner.readyCount);
+  }
+
+  @Test
+  void oneReadCanHoldACompleteMessageAndTheNextPartial() throws Exception {
+    byte[] bytes = utf8("complete\npartial");
+    RecordingReadBoard owner = recordingOwner();
+    ReadBoardStream stream =
+        new ReadBoardStream(
+            owner, new ChunkedInputStream(bytes, new int[] {"complete\npar".length(), 32}));
+    stream.run();
+
+    assertEquals(List.of("complete", "partial"), owner.lines);
+    assertEquals(0, owner.readyCount);
+  }
+
+  @Test
+  void crLfCrAndLfTerminatorsProduceTheSameLogicalLines() throws Exception {
+    RecordingReadBoard lf = parseAll("one\ntwo\n");
+    RecordingReadBoard crlf = parseAll("one\r\ntwo\r\n");
+    RecordingReadBoard cr = parseAll("one\rtwo\r");
+
+    assertEquals(List.of("one", "two"), lf.lines);
+    assertEquals(lf.lines, crlf.lines);
+    assertEquals(lf.lines, cr.lines);
+  }
+
+  @Test
+  void emptyStreamAndBlankLinesAreFramedWithoutReadyDispatch() throws Exception {
+    RecordingReadBoard empty = parseAll("");
+    RecordingReadBoard blanks = parseAll("\n\nready \n");
+
+    assertEquals(List.of(), empty.lines);
+    assertEquals(0, empty.readyCount);
+    assertEquals(List.of("", "", "ready "), blanks.lines);
+    assertEquals(0, blanks.readyCount, "ready is exact; trailing space is a normal payload line");
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"Ready", "READY", " ready", "ready\t"})
+  void readyDispatchIsCaseSensitiveAndExact(String line) throws Exception {
+    RecordingReadBoard owner = parseAll(line + "\n");
+
+    assertEquals(List.of(line), owner.lines);
+    assertEquals(0, owner.readyCount);
+  }
+
+  @Test
+  void eofDeliversAnIncompleteFinalLineAndThenStops() throws Exception {
+    RecordingReadBoard owner = parseAll("complete\nincomplete");
+
+    assertEquals(List.of("complete", "incomplete"), owner.lines);
+  }
+
+  @Test
+  void malformedPayloadIsStillDeliveredAsAFramedLine() throws Exception {
+    RecordingReadBoard owner = parseAll("{not-json\nre=bad\n");
+
+    assertEquals(List.of("{not-json", "re=bad"), owner.lines);
+  }
+
+  @Test
+  void closedStreamDoesNotParseFurtherInput() throws Exception {
+    RecordingReadBoard owner = recordingOwner();
+    ReadBoardStream stream =
+        new ReadBoardStream(owner, new ByteArrayInputStream(utf8("ignored\nready\n")));
+    stream.close();
+    stream.run();
+
+    assertEquals(List.of(), owner.lines);
+    assertEquals(0, owner.readyCount);
+  }
+
+  private static RecordingReadBoard parseAll(String text) throws Exception {
+    RecordingReadBoard owner = recordingOwner();
+    ReadBoardStream stream = new ReadBoardStream(owner, new ByteArrayInputStream(utf8(text)));
+    stream.run();
+    return owner;
+  }
+
+  private static RecordingReadBoard recordingOwner() throws Exception {
+    RecordingReadBoard owner = allocate(RecordingReadBoard.class);
+    owner.lines = new ArrayList<>();
+    return owner;
+  }
+
+  private static byte[] utf8(String text) {
+    return text.getBytes(StandardCharsets.UTF_8);
+  }
+
   @SuppressWarnings("unchecked")
   private static <T> T allocate(Class<T> type) throws Exception {
     return (T) UnsafeHolder.UNSAFE.allocateInstance(type);
@@ -141,6 +279,62 @@ class ReadBoardStreamTest {
       } catch (ReflectiveOperationException ex) {
         throw new IllegalStateException("Failed to access Unsafe", ex);
       }
+    }
+  }
+
+  private static final class RecordingReadBoard extends ReadBoard {
+    private List<String> lines;
+    private int readyCount;
+
+    private RecordingReadBoard() throws Exception {
+      super(true, true);
+    }
+
+    @Override
+    public void parseLine(String line) {
+      lines.add(line);
+    }
+
+    @Override
+    void handleReady() {
+      readyCount++;
+    }
+  }
+
+  private static final class ChunkedInputStream extends InputStream {
+    private final byte[] bytes;
+    private final int[] chunkSizes;
+    private int position;
+    private int chunkIndex;
+
+    private ChunkedInputStream(byte[] bytes, int[] chunkSizes) {
+      this.bytes = bytes;
+      this.chunkSizes = chunkSizes;
+    }
+
+    @Override
+    public int read() {
+      byte[] one = new byte[1];
+      int n = read(one, 0, 1);
+      return n < 0 ? -1 : one[0] & 0xff;
+    }
+
+    @Override
+    public int read(byte[] buffer, int offset, int length) {
+      if (position >= bytes.length || length <= 0) {
+        return -1;
+      }
+      int chunk =
+          chunkSizes.length == 0
+              ? length
+              : chunkSizes[Math.min(chunkIndex, chunkSizes.length - 1)];
+      if (chunkIndex < chunkSizes.length) {
+        chunkIndex++;
+      }
+      int n = Math.min(Math.min(length, Math.max(1, chunk)), bytes.length - position);
+      System.arraycopy(bytes, position, buffer, offset, n);
+      position += n;
+      return n;
     }
   }
 

--- a/src/test/java/featurecat/lizzie/analysis/WholeGameAnalysisSessionTest.java
+++ b/src/test/java/featurecat/lizzie/analysis/WholeGameAnalysisSessionTest.java
@@ -2,6 +2,8 @@ package featurecat.lizzie.analysis;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import featurecat.lizzie.Config;
@@ -16,13 +18,18 @@ import featurecat.lizzie.rules.Zobrist;
 import java.io.IOException;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.BooleanSupplier;
 import javax.swing.SwingUtilities;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 
 class WholeGameAnalysisSessionTest {
   private static final int BOARD_SIZE = 3;
@@ -286,6 +293,363 @@ class WholeGameAnalysisSessionTest {
     }
   }
 
+  @Test
+  void startAdvancesThroughBaselineAndDeepThenCompletesAndReleasesTheEngine() throws Exception {
+    try (TestEnvironment env = TestEnvironment.open()) {
+      Lizzie.leelaz = null;
+      SessionAnalysisEngine engine = SessionFixture.newEngine();
+      engine.completeByInstallingAnalysis = true;
+      SessionFixture fixture = SessionFixture.createWithFactory(() -> engine);
+
+      fixture.session.start();
+
+      waitUntil(
+          () ->
+              fixture.session.state() == WholeGameAnalysisSession.State.COMPLETE
+                  && !fixture.snapshots.isEmpty()
+                  && lastSnapshot(fixture).state == WholeGameAnalysisSession.State.COMPLETE,
+          "session should reach COMPLETE");
+      assertTrue(engine.quitCalled.await(2, TimeUnit.SECONDS));
+      drainEdt();
+
+      List<WholeGameAnalysisSession.State> states = snapshotStates(fixture);
+      assertEquals(WholeGameAnalysisSession.State.PREPARING, states.get(0));
+      assertTrue(states.contains(WholeGameAnalysisSession.State.BASELINE));
+      assertTrue(states.contains(WholeGameAnalysisSession.State.DEEP));
+      assertEquals(WholeGameAnalysisSession.State.COMPLETE, states.get(states.size() - 1));
+      WholeGameAnalysisSession.Snapshot complete = lastSnapshot(fixture);
+      assertEquals(100, complete.overallPercent);
+      assertEquals(complete.totalPositions, complete.completedPositions);
+      assertEquals("WholeGameAnalysis.complete", complete.detailKey);
+      assertEquals(0L, complete.estimatedRemainingMillis);
+      assertTrue(engine.shutdownRequested);
+      assertTrue(engine.callbacksCleared);
+      assertEquals(1, fixture.frame.attachCount);
+      assertEquals(1, fixture.frame.finishedCount);
+      assertSame(engine, fixture.frame.lastFinishedEngine);
+      assertTrue(fixture.session.isTerminal());
+      assertFalse(fixture.session.isRunning());
+      assertFalse(fixture.session.isActive());
+      assertFalse(fixture.session.isPaused());
+      assertNull(getObjectField(fixture.session, "gameGuardTimer"));
+    }
+  }
+
+  @Test
+  void alreadyAnalyzedGameCompletesWithoutDispatchingARequest() throws Exception {
+    try (TestEnvironment env = TestEnvironment.open()) {
+      Lizzie.leelaz = null;
+      BoardHistoryList history = new BoardHistoryList(BoardData.empty(BOARD_SIZE, BOARD_SIZE));
+      BoardHistoryNode root = history.getStart();
+      BoardHistoryNode first = root.add(new BoardHistoryNode(passData(Stone.BLACK, 1)));
+      installCompleteAnalysis(root.getData(), 500);
+      installCompleteAnalysis(first.getData(), 500);
+      SessionAnalysisEngine engine = SessionFixture.newEngine();
+      SessionFixture fixture = SessionFixture.createWithHistory(history, () -> engine);
+
+      fixture.session.start();
+
+      waitUntil(
+          () ->
+              fixture.session.state() == WholeGameAnalysisSession.State.COMPLETE
+                  && !fixture.snapshots.isEmpty()
+                  && lastSnapshot(fixture).state == WholeGameAnalysisSession.State.COMPLETE,
+          "pre-analyzed session should complete");
+      drainEdt();
+
+      assertEquals(0, engine.requestCount);
+      assertEquals(WholeGameAnalysisSession.State.COMPLETE, fixture.session.state());
+      assertEquals(1, fixture.frame.finishedCount);
+      assertTrue(engine.quitCalled.await(2, TimeUnit.SECONDS));
+    }
+  }
+
+  @Test
+  void cancelDuringBaselineEndsTheSessionWithoutCompletingRemainingPositions() throws Exception {
+    try (TestEnvironment env = TestEnvironment.open()) {
+      Lizzie.leelaz = null;
+      SessionAnalysisEngine engine = SessionFixture.newEngine();
+      SessionFixture fixture = SessionFixture.createWithFactory(() -> engine);
+
+      fixture.session.start();
+      waitUntil(() -> engine.requestedNodes != null, "baseline request should dispatch");
+      drainEdt();
+      assertEquals(WholeGameAnalysisSession.State.BASELINE, fixture.session.state());
+      assertTrue(fixture.session.isRunning());
+
+      fixture.session.cancel();
+      drainEdt();
+
+      assertEquals(WholeGameAnalysisSession.State.CANCELLED, fixture.session.state());
+      WholeGameAnalysisSession.Snapshot cancelled = lastSnapshot(fixture);
+      assertEquals("WholeGameAnalysis.cancelled", cancelled.detailKey);
+      assertTrue(cancelled.completedPositions < cancelled.totalPositions);
+      assertTrue(engine.shutdownRequested);
+      assertTrue(engine.callbacksCleared);
+      assertTrue(engine.quitCalled.await(2, TimeUnit.SECONDS));
+      assertEquals(1, fixture.frame.finishedCount);
+      assertTrue(fixture.session.isTerminal());
+      assertFalse(fixture.session.isRunning());
+    }
+  }
+
+  @ParameterizedTest
+  @EnumSource(
+      value = WholeGameAnalysisSession.State.class,
+      names = {
+        "PREPARING",
+        "BASELINE",
+        "DEEP",
+        "PAUSING",
+        "PAUSED",
+        "COMPLETE",
+        "CANCELLED",
+        "FAILED"
+      })
+  void startIsANoOpUnlessTheSessionIsIdle(WholeGameAnalysisSession.State state) throws Exception {
+    try (TestEnvironment env = TestEnvironment.open()) {
+      SessionFixture fixture = SessionFixture.create();
+      putInState(fixture.session, state);
+
+      fixture.session.start();
+
+      assertEquals(state, fixture.session.state());
+    }
+  }
+
+  @ParameterizedTest
+  @EnumSource(
+      value = WholeGameAnalysisSession.State.class,
+      names = {"IDLE", "PAUSING", "PAUSED", "COMPLETE", "CANCELLED", "FAILED"})
+  void pauseIsANoOpOutsidePreparingBaselineOrDeep(WholeGameAnalysisSession.State state)
+      throws Exception {
+    try (TestEnvironment env = TestEnvironment.open()) {
+      SessionFixture fixture = SessionFixture.create();
+      putInState(fixture.session, state);
+
+      fixture.session.pause();
+
+      assertEquals(state, fixture.session.state());
+    }
+  }
+
+  @ParameterizedTest
+  @EnumSource(
+      value = WholeGameAnalysisSession.State.class,
+      names = {
+        "IDLE",
+        "PREPARING",
+        "BASELINE",
+        "DEEP",
+        "PAUSING",
+        "COMPLETE",
+        "CANCELLED",
+        "FAILED"
+      })
+  void resumeIsANoOpUnlessPaused(WholeGameAnalysisSession.State state) throws Exception {
+    try (TestEnvironment env = TestEnvironment.open()) {
+      SessionFixture fixture = SessionFixture.create();
+      putInState(fixture.session, state);
+
+      fixture.session.resume();
+
+      assertEquals(state, fixture.session.state());
+    }
+  }
+
+  @ParameterizedTest
+  @EnumSource(
+      value = WholeGameAnalysisSession.State.class,
+      names = {"COMPLETE", "CANCELLED", "FAILED"})
+  void cancelDoesNotReplaceAnAlreadyTerminalState(WholeGameAnalysisSession.State state)
+      throws Exception {
+    try (TestEnvironment env = TestEnvironment.open()) {
+      SessionFixture fixture = SessionFixture.create();
+      putInState(fixture.session, state);
+
+      fixture.session.cancel();
+
+      assertEquals(state, fixture.session.state());
+      assertTrue(fixture.session.isTerminal());
+    }
+  }
+
+  @Test
+  void cancelFromIdleMarksTheSessionCancelled() throws Exception {
+    try (TestEnvironment env = TestEnvironment.open()) {
+      SessionFixture fixture = SessionFixture.create();
+
+      fixture.session.cancel();
+      drainEdt();
+
+      assertEquals(WholeGameAnalysisSession.State.CANCELLED, fixture.session.state());
+      assertTrue(fixture.session.isTerminal());
+      assertEquals("WholeGameAnalysis.cancelled", lastSnapshot(fixture).detailKey);
+    }
+  }
+
+  @Test
+  void publishReadyIsIgnoredOnceTheSessionHasLeftIdle() throws Exception {
+    try (TestEnvironment env = TestEnvironment.open()) {
+      SessionFixture fixture = SessionFixture.create();
+      fixture.session.publishReady();
+      drainEdt();
+      assertEquals("WholeGameAnalysis.ready", lastSnapshot(fixture).detailKey);
+      int readySnapshots = fixture.snapshots.size();
+      putInState(fixture.session, WholeGameAnalysisSession.State.BASELINE);
+
+      fixture.session.publishReady();
+
+      assertEquals(readySnapshots, fixture.snapshots.size());
+      assertEquals(WholeGameAnalysisSession.State.BASELINE, fixture.session.state());
+    }
+  }
+
+  @Test
+  void engineFactoryFailureFailsTheSessionWithoutAttachingAnEngine() throws Exception {
+    try (TestEnvironment env = TestEnvironment.open()) {
+      Lizzie.leelaz = null;
+      SessionFixture fixture =
+          SessionFixture.createWithFactory(
+              () -> {
+                throw new IOException("engine missing");
+              });
+
+      fixture.session.start();
+
+      waitUntil(
+          () ->
+              fixture.session.state() == WholeGameAnalysisSession.State.FAILED
+                  && !fixture.snapshots.isEmpty()
+                  && lastSnapshot(fixture).state == WholeGameAnalysisSession.State.FAILED,
+          "factory failure should fail the session");
+      drainEdt();
+
+      assertEquals("WholeGameAnalysis.error.engine", lastSnapshot(fixture).detailKey);
+      assertEquals(0, fixture.frame.attachCount);
+      assertEquals(1, fixture.frame.finishedCount);
+      assertNull(fixture.frame.lastFinishedEngine);
+      assertTrue(fixture.session.isTerminal());
+      assertFalse(fixture.session.isRunning());
+      assertFalse(fixture.session.isActive());
+    }
+  }
+
+  @Test
+  void unloadedEngineFailsAndReleasesTheCreatedEngine() throws Exception {
+    try (TestEnvironment env = TestEnvironment.open()) {
+      Lizzie.leelaz = null;
+      SessionAnalysisEngine engine = SessionFixture.newEngine();
+      engine.loaded = false;
+      SessionFixture fixture = SessionFixture.createWithFactory(() -> engine);
+
+      fixture.session.start();
+
+      waitUntil(
+          () -> fixture.session.state() == WholeGameAnalysisSession.State.FAILED,
+          "unloaded engine should fail");
+      assertTrue(engine.quitCalled.await(2, TimeUnit.SECONDS));
+      drainEdt();
+
+      assertEquals("WholeGameAnalysis.error.engine", lastSnapshot(fixture).detailKey);
+      assertEquals(0, fixture.frame.attachCount);
+      assertEquals(1, fixture.frame.finishedCount);
+      assertTrue(fixture.session.isTerminal());
+    }
+  }
+
+  @Test
+  void negativeWholeGameRequestCountFailsImmediately() throws Exception {
+    try (TestEnvironment env = TestEnvironment.open()) {
+      Lizzie.leelaz = null;
+      SessionAnalysisEngine engine = SessionFixture.newEngine();
+      engine.requestResultOverride = -1;
+      SessionFixture fixture = SessionFixture.createWithFactory(() -> engine);
+
+      fixture.session.start();
+
+      waitUntil(
+          () ->
+              fixture.session.state() == WholeGameAnalysisSession.State.FAILED
+                  && !fixture.snapshots.isEmpty()
+                  && "WholeGameAnalysis.error.request".equals(lastSnapshot(fixture).detailKey),
+          "negative request count should fail");
+      drainEdt();
+
+      assertEquals(1, engine.requestCount);
+      assertEquals("WholeGameAnalysis.error.request", lastSnapshot(fixture).detailKey);
+      assertTrue(engine.shutdownRequested);
+      assertTrue(engine.callbacksCleared);
+      assertTrue(engine.quitCalled.await(2, TimeUnit.SECONDS));
+    }
+  }
+
+  @Test
+  void emptySuccessfulDispatchRetriesThenFailsWhenPositionsStayPending() throws Exception {
+    try (TestEnvironment env = TestEnvironment.open()) {
+      Lizzie.leelaz = null;
+      SessionAnalysisEngine engine = SessionFixture.newEngine();
+      engine.requestResultOverride = 0;
+      SessionFixture fixture = SessionFixture.createWithFactory(() -> engine);
+
+      fixture.session.start();
+
+      waitUntil(
+          () ->
+              fixture.session.state() == WholeGameAnalysisSession.State.FAILED
+                  && engine.requestCount >= WholeGameAnalysisSession.MAX_STAGE_ATTEMPTS
+                  && !fixture.snapshots.isEmpty()
+                  && "WholeGameAnalysis.error.request".equals(lastSnapshot(fixture).detailKey),
+          "exhausted stage attempts should fail");
+      drainEdt();
+
+      assertEquals(WholeGameAnalysisSession.MAX_STAGE_ATTEMPTS, engine.requestCount);
+      assertEquals("WholeGameAnalysis.error.request", lastSnapshot(fixture).detailKey);
+      assertTrue(fixture.session.isTerminal());
+      assertTrue(engine.quitCalled.await(2, TimeUnit.SECONDS));
+    }
+  }
+
+  @Test
+  void gameChangeDuringEngineAcceptFailsConsistentlyAndClosesTheEngine() throws Exception {
+    try (TestEnvironment env = TestEnvironment.open()) {
+      SessionFixture fixture = SessionFixture.create();
+      setField(fixture.session, "state", WholeGameAnalysisSession.State.PREPARING);
+      setField(fixture.session, "engineStartGeneration", 1);
+      Lizzie.board
+          .getHistory()
+          .getGameInfo()
+          .setKomi(Lizzie.board.getHistory().getGameInfo().getKomi() + 1.0);
+
+      invokeAcceptEngine(
+          fixture.session, fixture.engine, 1, WholeGameAnalysisSession.State.BASELINE);
+      drainEdt();
+
+      assertEquals(WholeGameAnalysisSession.State.FAILED, fixture.session.state());
+      assertEquals("WholeGameAnalysis.error.gameChanged", lastSnapshot(fixture).detailKey);
+      assertEquals(0, fixture.frame.attachCount);
+      assertTrue(fixture.engine.quitCalled.await(2, TimeUnit.SECONDS));
+      assertTrue(fixture.session.isTerminal());
+    }
+  }
+
+  @Test
+  void failedSessionIgnoresALaterStartPauseAndResume() throws Exception {
+    try (TestEnvironment env = TestEnvironment.open()) {
+      SessionFixture fixture = SessionFixture.create();
+      putInState(fixture.session, WholeGameAnalysisSession.State.FAILED);
+      int snapshots = fixture.snapshots.size();
+
+      fixture.session.start();
+      fixture.session.pause();
+      fixture.session.resume();
+      fixture.session.cancel();
+
+      assertEquals(WholeGameAnalysisSession.State.FAILED, fixture.session.state());
+      assertEquals(snapshots, fixture.snapshots.size());
+    }
+  }
+
   private static void invokeEngineFailure(WholeGameAnalysisSession session, int generation)
       throws Exception {
     Method method = WholeGameAnalysisSession.class.getDeclaredMethod("onEngineFailure", int.class);
@@ -317,6 +681,48 @@ class WholeGameAnalysisSessionTest {
     Field field = WholeGameAnalysisSession.class.getDeclaredField(name);
     field.setAccessible(true);
     field.set(target, value);
+  }
+
+  private static void putInState(
+      WholeGameAnalysisSession session, WholeGameAnalysisSession.State state) throws Exception {
+    boolean terminal =
+        state == WholeGameAnalysisSession.State.COMPLETE
+            || state == WholeGameAnalysisSession.State.CANCELLED
+            || state == WholeGameAnalysisSession.State.FAILED;
+    setField(session, "state", state);
+    setField(session, "terminal", terminal);
+  }
+
+  private static List<WholeGameAnalysisSession.State> snapshotStates(SessionFixture fixture) {
+    List<WholeGameAnalysisSession.State> states = new ArrayList<>();
+    for (WholeGameAnalysisSession.Snapshot snapshot : fixture.snapshots) {
+      states.add(snapshot.state);
+    }
+    return states;
+  }
+
+  private static WholeGameAnalysisSession.Snapshot lastSnapshot(SessionFixture fixture) {
+    assertFalse(fixture.snapshots.isEmpty(), "expected at least one session snapshot");
+    return fixture.snapshots.get(fixture.snapshots.size() - 1);
+  }
+
+  private static void waitUntil(BooleanSupplier condition, String message) throws Exception {
+    long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(2);
+    while (System.nanoTime() < deadline) {
+      drainEdt();
+      if (condition.getAsBoolean()) {
+        return;
+      }
+      Thread.yield();
+    }
+    drainEdt();
+    assertTrue(condition.getAsBoolean(), message);
+  }
+
+  private static Object getObjectField(Object target, String name) throws Exception {
+    Field field = WholeGameAnalysisSession.class.getDeclaredField(name);
+    field.setAccessible(true);
+    return field.get(target);
   }
 
   private static int getIntField(Object target, String name) throws Exception {
@@ -388,10 +794,18 @@ class WholeGameAnalysisSessionTest {
   private static final class SessionFixture {
     private final WholeGameAnalysisSession session;
     private final SessionAnalysisEngine engine;
+    private final TrackingFrame frame;
+    private final List<WholeGameAnalysisSession.Snapshot> snapshots;
 
-    private SessionFixture(WholeGameAnalysisSession session, SessionAnalysisEngine engine) {
+    private SessionFixture(
+        WholeGameAnalysisSession session,
+        SessionAnalysisEngine engine,
+        TrackingFrame frame,
+        List<WholeGameAnalysisSession.Snapshot> snapshots) {
       this.session = session;
       this.engine = engine;
+      this.frame = frame;
+      this.snapshots = snapshots;
     }
 
     private static SessionFixture create() throws Exception {
@@ -401,6 +815,12 @@ class WholeGameAnalysisSessionTest {
     private static SessionFixture createWithFactory(WholeGameAnalysisSession.EngineFactory factory)
         throws Exception {
       BoardHistoryList history = new BoardHistoryList(BoardData.empty(BOARD_SIZE, BOARD_SIZE));
+      return createWithHistory(history, factory);
+    }
+
+    private static SessionFixture createWithHistory(
+        BoardHistoryList history, WholeGameAnalysisSession.EngineFactory factory)
+        throws Exception {
       Board board = allocate(Board.class);
       board.setHistory(history);
       Lizzie.board = board;
@@ -408,17 +828,19 @@ class WholeGameAnalysisSessionTest {
       Lizzie.frame = frame;
       WholeGameAnalysisPlan plan = WholeGameAnalysisPlan.create(history.getStart(), 32, 500);
       SessionAnalysisEngine engine = newEngine();
+      List<WholeGameAnalysisSession.Snapshot> snapshots = new CopyOnWriteArrayList<>();
       WholeGameAnalysisSession session =
           factory == null
-              ? new WholeGameAnalysisSession(frame, plan, snapshot -> {})
-              : new WholeGameAnalysisSession(frame, plan, snapshot -> {}, factory);
-      return new SessionFixture(session, engine);
+              ? new WholeGameAnalysisSession(frame, plan, snapshots::add)
+              : new WholeGameAnalysisSession(frame, plan, snapshots::add, factory);
+      return new SessionFixture(session, engine, frame, snapshots);
     }
 
     private static SessionAnalysisEngine newEngine() {
       try {
         SessionAnalysisEngine engine = allocate(SessionAnalysisEngine.class);
         engine.quitCalled = new CountDownLatch(1);
+        engine.loaded = true;
         return engine;
       } catch (Exception ex) {
         throw new IllegalStateException(ex);
@@ -433,6 +855,9 @@ class WholeGameAnalysisSessionTest {
     private CountDownLatch quitCalled;
     private volatile List<BoardHistoryNode> requestedNodes;
     private volatile int requestedVisits;
+    private boolean completeByInstallingAnalysis;
+    private Integer requestResultOverride;
+    private boolean loaded = true;
 
     private SessionAnalysisEngine() throws IOException {
       super(true);
@@ -455,7 +880,7 @@ class WholeGameAnalysisSessionTest {
 
     @Override
     public boolean isLoaded() {
-      return true;
+      return loaded;
     }
 
     @Override
@@ -464,6 +889,17 @@ class WholeGameAnalysisSessionTest {
       requestCount++;
       this.requestedNodes = List.copyOf(requestedNodes);
       requestedVisits = targetVisits;
+      if (completeByInstallingAnalysis) {
+        for (BoardHistoryNode node : requestedNodes) {
+          installCompleteAnalysis(node.getData(), targetVisits);
+        }
+      }
+      if (requestResultOverride != null) {
+        return requestResultOverride;
+      }
+      if (completeByInstallingAnalysis) {
+        return 0;
+      }
       return requestedNodes.size();
     }
   }
@@ -497,17 +933,26 @@ class WholeGameAnalysisSessionTest {
   }
 
   private static final class TrackingFrame extends LizzieFrame {
+    private int attachCount;
+    private int finishedCount;
+    private AnalysisEngine lastFinishedEngine;
+
     private TrackingFrame() {}
 
     @Override
     public void onWholeGameAnalysisFinished(
         WholeGameAnalysisSession session,
         AnalysisEngine completedEngine,
-        boolean resumeForegroundAnalysis) {}
+        boolean resumeForegroundAnalysis) {
+      finishedCount++;
+      lastFinishedEngine = completedEngine;
+    }
 
     @Override
     public void attachWholeGameAnalysisEngine(
-        WholeGameAnalysisSession session, AnalysisEngine engine) {}
+        WholeGameAnalysisSession session, AnalysisEngine engine) {
+      attachCount++;
+    }
   }
 
   private static final class TestEnvironment implements AutoCloseable {
@@ -516,24 +961,32 @@ class WholeGameAnalysisSessionTest {
     private final Config previousConfig;
     private final Board previousBoard;
     private final LizzieFrame previousFrame;
+    private final Leelaz previousLeelaz;
 
     private TestEnvironment(
         int previousBoardWidth,
         int previousBoardHeight,
         Config previousConfig,
         Board previousBoard,
-        LizzieFrame previousFrame) {
+        LizzieFrame previousFrame,
+        Leelaz previousLeelaz) {
       this.previousBoardWidth = previousBoardWidth;
       this.previousBoardHeight = previousBoardHeight;
       this.previousConfig = previousConfig;
       this.previousBoard = previousBoard;
       this.previousFrame = previousFrame;
+      this.previousLeelaz = previousLeelaz;
     }
 
     private static TestEnvironment open() {
       TestEnvironment environment =
           new TestEnvironment(
-              Board.boardWidth, Board.boardHeight, Lizzie.config, Lizzie.board, Lizzie.frame);
+              Board.boardWidth,
+              Board.boardHeight,
+              Lizzie.config,
+              Lizzie.board,
+              Lizzie.frame,
+              Lizzie.leelaz);
       Board.boardWidth = BOARD_SIZE;
       Board.boardHeight = BOARD_SIZE;
       Zobrist.init();
@@ -560,6 +1013,7 @@ class WholeGameAnalysisSessionTest {
       Lizzie.config = previousConfig;
       Lizzie.board = previousBoard;
       Lizzie.frame = previousFrame;
+      Lizzie.leelaz = previousLeelaz;
     }
   }
 


### PR DESCRIPTION
## Repro
On current `main`, `AnalysisRequestBuilder` had no test class. `ReadBoardStreamTest` covered owner-after-detach and TCP ready/paused, not chunking/EOF/partial framing. `WholeGameAnalysisSessionTest` covered engine failure, pause/resume, cancel, and snapshot invalidation, but not start/advance/complete, mid-end, invalid transitions, resource release, or exception/early-stop consistency.

## Cause
Those paths were untested. This is a regression-suite gap, not a product-behavior break.

## Fix
- Extended `WholeGameAnalysisSessionTest` for start/advance/complete, mid-session cancel, invalid/repeat transitions, resource release, and exception/early-stop consistency. Left the existing cases in place.
- Added `AnalysisRequestBuilderTest` asserting serialized request meaning (combinations, optional fields, modes, boundaries, illegal input, no cross-contamination).
- Extended `ReadBoardStreamTest` with equivalent-chunking, consecutive/split/partial reads, EOF, blank/malformed lines, and duplicates. Did not replace owner-after-detach or TCP ready tests.
- Package-private `ReadBoardStream` constructor binds a UTF-8 `InputStream` without a socket/reader thread so framing can run synchronously. Public socket behavior is unchanged.

Pinned current behavior (not changed):
- Builder: `includeOwnership` / `includeMovesOwnership` are independent; null `id` is omitted; `currentKataGoRules` uses `substring(2)` so raw/truncated JSON can throw; null `analysisSpecificRules` NPEs; `maxVisits` is not validated.
- Stream: incomplete final line on EOF is still a payload; `ready` is exact-line only; malformed lines are framed and passed through.
- Session: `start()` no-ops unless IDLE; `cancel()` from IDLE marks CANCELLED; `startWholeGameRequest` `-1` fails immediately, `0` retries to `MAX_STAGE_ATTEMPTS`.

## Verification
Local Surefire for the three classes plus the unit suite. Merge gate is existing Windows/Linux `mvn verify`. Deterministic: no sleep, network, KataGo, GPU, GUI, or `readboard.exe`.

Fixes #310
