### PR TITLE
Release next-2026-08-25.1 pre-release

### DIFF
--- a/.github/release-notes/next-2026-08-25.1.md
+++ b/.github/release-notes/next-2026-08-25.1.md
@@ -1,0 +1,359 @@
+# LizzieYzy Next next-2026-08-25.1
+
+## 中文
+
+这是 KataGo v1.18.1、B11 默认权重与 Windows NVIDIA 统一 CUDA 包的公开测试版。完整包现在以更强的 B11 Transformer 为默认选择，同时保留 B10 速度方案；RTX 20/30/40/50 不再分包，统一使用 CUDA 12.8 + cuDNN 9.8。
+
+### 本版主要更新
+
+- 所有推荐完整包升级到官方 KataGo v1.18.1，并默认内置 `b11c768h12nbt3tflrs-fson-silu.bin.gz`。B11 单次判断更强、复杂局面效果更好，但搜索速度可能低于 B10。
+- KataGo 一键设置将 B11 设为“棋力优先”，同时保留 B10“速度均衡”和轻量快速方案；自定义权重、HumanSL、远程算力及老用户明确选择不会被覆盖。
+- Windows NVIDIA 合并为一个 CUDA 12.8 + cuDNN 9.8 包，覆盖 RTX 20/30/40/50，并补齐 NVRTC 运行时；旧 `nvidia50-cuda` 配置会兼容迁移，不再发布独立 50 系包。
+- TensorRT 改为 RTX 30 系及以下 NVIDIA 显卡的可选方案；RTX 40/50 默认推荐 CUDA。驱动 `570.65` 及以上直接加载，`528.33` 至 `570.64` 首次执行轻量真实推理探测，更旧驱动显示明确修复提示。
+- 官方 benchmark 现在解析 v1.18.1 推荐的搜索线程、NN 服务线程和 batch size，并按真实阶段连续显示进度；模型切换后不会错误复用旧测速结果。
+- 新增 DirectML、OpenVINO 与四种 ROCm 架构的实验便携包和应用内按需安装入口。它们不会自动安装、静默替换或假装已经完成对应硬件实测。
+
+### 下载前先看
+
+- 想直接得到 KataGo v1.18.1 和 B11，请下载对应的完整包；`windows64.core-update.zip` 只更新主程序，不会强制替换老用户现有权重或大体积引擎。
+- RTX 20/30/40/50 都下载统一的 `windows64.nvidia` 包。不要再下载旧 release 中的独立 `nvidia50` 包。
+- B11 在本机 RTX 3070 同参数约比 B10 慢 40%，但每次神经网络判断质量更高；更在意速度可在“一键设置 → 权重”切换 B10。
+- TensorRT 仅作为 RTX 30 系及以下可选项；RTX 40/50 请优先使用 CUDA。
+- DirectML、OpenVINO 和 ROCm 包均为 experimental，建议解压到新目录测试并保留原有 `user-data`、权重和棋谱备份。
+
+### 下载建议
+
+| 你的电脑 | 直接下载这个 |
+| --- | --- |
+| Windows 64 位，OpenCL 推荐版，免安装 | [`2026-08-25-windows64.opencl.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-25.1/2026-08-25-windows64.opencl.portable.zip) |
+| 已有 Windows 免安装版，只更新主程序 | [`2026-08-25-windows64.core-update.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-25.1/2026-08-25-windows64.core-update.zip) |
+| Windows 64 位，OpenCL 安装版 | [`2026-08-25-windows64.opencl.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-25.1/2026-08-25-windows64.opencl.installer.exe) |
+| Windows 64 位，CPU 兼容版，免安装 | [`2026-08-25-windows64.with-katago.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-25.1/2026-08-25-windows64.with-katago.portable.zip) |
+| Windows 64 位，CPU 兼容安装版 | [`2026-08-25-windows64.with-katago.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-25.1/2026-08-25-windows64.with-katago.installer.exe) |
+| Windows 64 位，RTX 20/30/40/50 NVIDIA CUDA，免安装 | [`2026-08-25-windows64.nvidia.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-25.1/2026-08-25-windows64.nvidia.portable.zip) |
+| Windows 64 位，RTX 20/30/40/50 NVIDIA CUDA 安装版 | [`2026-08-25-windows64.nvidia.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-25.1/2026-08-25-windows64.nvidia.installer.exe) |
+| Windows DirectML 实验版 | [`2026-08-25-windows64.experimental.directml.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-25.1/2026-08-25-windows64.experimental.directml.portable.zip) |
+| Windows Intel OpenVINO 实验版 | [`2026-08-25-windows64.experimental.openvino.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-25.1/2026-08-25-windows64.experimental.openvino.portable.zip) |
+| Windows AMD RX 6000 ROCm 实验版 | [`2026-08-25-windows64.experimental.rocm.gfx103x.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-25.1/2026-08-25-windows64.experimental.rocm.gfx103x.portable.zip) |
+| Windows AMD RX 7000 ROCm 实验版 | [`2026-08-25-windows64.experimental.rocm.gfx110x.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-25.1/2026-08-25-windows64.experimental.rocm.gfx110x.portable.zip) |
+| Windows AMD Ryzen AI Max ROCm 实验版 | [`2026-08-25-windows64.experimental.rocm.gfx1151.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-25.1/2026-08-25-windows64.experimental.rocm.gfx1151.portable.zip) |
+| Windows AMD RX 9000 ROCm 实验版 | [`2026-08-25-windows64.experimental.rocm.gfx120x.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-25.1/2026-08-25-windows64.experimental.rocm.gfx120x.portable.zip) |
+| RTX 30 系及以下可选 TensorRT，需下载两个分卷 | [`2026-08-25-windows64.nvidia.tensorrt.portable.7z.001`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-25.1/2026-08-25-windows64.nvidia.tensorrt.portable.7z.001)<br>[`2026-08-25-windows64.nvidia.tensorrt.portable.7z.002`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-25.1/2026-08-25-windows64.nvidia.tensorrt.portable.7z.002) |
+| Windows 64 位，自行配置引擎，免安装 | [`2026-08-25-windows64.without.engine.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-25.1/2026-08-25-windows64.without.engine.portable.zip) |
+| Windows 64 位，自行配置引擎，安装版 | [`2026-08-25-windows64.without.engine.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-25.1/2026-08-25-windows64.without.engine.installer.exe) |
+| macOS Apple Silicon，Metal | [`2026-08-25-mac-apple-silicon.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-25.1/2026-08-25-mac-apple-silicon.with-katago.dmg) |
+| macOS Intel | [`2026-08-25-mac-intel.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-25.1/2026-08-25-mac-intel.with-katago.dmg) |
+| Linux 64 位，CPU 兼容版 | [`2026-08-25-linux64.with-katago.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-25.1/2026-08-25-linux64.with-katago.zip) |
+| Linux 64 位，OpenCL 版 | [`2026-08-25-linux64.opencl.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-25.1/2026-08-25-linux64.opencl.zip) |
+| Linux 64 位，NVIDIA CUDA 版 | [`2026-08-25-linux64.nvidia.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-25.1/2026-08-25-linux64.nvidia.zip) |
+
+### 为什么值得测试
+
+- Windows 11 + RTX 3070 真机已完成 B11 全新启动、真实推理兼容探测、官方 benchmark、长棋谱快速胜率曲线、B10/B11 切换和重启复测。
+- 310 手棋谱约 0.5 秒出现首批快速胜率结果；测速完成后前台分析和单一主引擎均正确恢复。
+- 本地完整测试为 3111 项，0 失败、0 错误、14 跳过；195 项发布脚本测试 0 失败、12 跳过，PR 的 Windows/Linux 完整 CI 门均通过。
+- RTX 40/50、DirectML、OpenVINO 与 ROCm 对应硬件尚未冒充真机通过，欢迎用户重点反馈首次启动、测速和持续分析结果。
+
+### 交流
+
+- QQ 群：`299419120`
+
+---
+
+## 繁體中文
+
+這是 KataGo v1.18.1、B11 預設權重與 Windows NVIDIA 統一 CUDA 套件的公開測試版。完整套件現在預設使用更強的 B11 Transformer，同時保留 B10 速度方案；RTX 20/30/40/50 統一使用 CUDA 12.8 + cuDNN 9.8。
+
+### 本版主要更新
+
+- 所有建議完整套件升級到官方 KataGo v1.18.1，並預設內建 `b11c768h12nbt3tflrs-fson-silu.bin.gz`。B11 單次判斷更強、複雜局面效果更好，但搜尋速度可能低於 B10。
+- KataGo 一鍵設定將 B11 設為「棋力優先」，同時保留 B10「速度均衡」與輕量快速方案；自訂權重、HumanSL、遠端算力及舊使用者明確選擇不會被覆蓋。
+- Windows NVIDIA 合併為一個 CUDA 12.8 + cuDNN 9.8 套件，涵蓋 RTX 20/30/40/50 並補齊 NVRTC runtime；舊 `nvidia50-cuda` 設定會相容遷移，不再發布獨立 50 系套件。
+- TensorRT 改為 RTX 30 系及以下 NVIDIA 顯示卡的可選方案；RTX 40/50 預設建議 CUDA。驅動 `570.65` 以上直接載入，`528.33` 至 `570.64` 首次執行輕量真實推理探測，更舊驅動顯示明確修復提示。
+- 官方 benchmark 現在解析 v1.18.1 建議的搜尋執行緒、NN server 執行緒與 batch size，並按真實階段連續顯示進度；切換模型後不會錯誤沿用舊測速結果。
+- 新增 DirectML、OpenVINO 與四種 ROCm 架構的實驗便攜套件及應用內按需安裝入口，不會自動安裝或靜默替換目前引擎。
+
+### 下載前先看
+
+- 要直接取得 KataGo v1.18.1 與 B11，請下載對應完整套件；`windows64.core-update.zip` 只更新主程式，不會強制替換舊使用者現有權重或大型引擎。
+- RTX 20/30/40/50 都下載統一的 `windows64.nvidia` 套件，不要再使用舊 release 的獨立 `nvidia50` 套件。
+- B11 在 RTX 3070 同參數測試約比 B10 慢 40%，但每次神經網路判斷品質更高；重視速度可在「一鍵設定 → 權重」切換 B10。
+- TensorRT 僅作為 RTX 30 系及以下可選方案；RTX 40/50 請優先使用 CUDA。
+- DirectML、OpenVINO 與 ROCm 套件均為 experimental，請在新目錄測試並備份 `user-data`、權重與棋譜。
+
+### 下載建議
+
+| 你的電腦 | 直接下載這個 |
+| --- | --- |
+| Windows 64 位，OpenCL 建議版，免安裝 | [`2026-08-25-windows64.opencl.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-25.1/2026-08-25-windows64.opencl.portable.zip) |
+| 既有 Windows 免安裝版，只更新主程式 | [`2026-08-25-windows64.core-update.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-25.1/2026-08-25-windows64.core-update.zip) |
+| Windows 64 位，OpenCL 安裝版 | [`2026-08-25-windows64.opencl.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-25.1/2026-08-25-windows64.opencl.installer.exe) |
+| Windows 64 位，CPU 相容版，免安裝 | [`2026-08-25-windows64.with-katago.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-25.1/2026-08-25-windows64.with-katago.portable.zip) |
+| Windows 64 位，CPU 相容安裝版 | [`2026-08-25-windows64.with-katago.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-25.1/2026-08-25-windows64.with-katago.installer.exe) |
+| Windows 64 位，RTX 20/30/40/50 NVIDIA CUDA，免安裝 | [`2026-08-25-windows64.nvidia.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-25.1/2026-08-25-windows64.nvidia.portable.zip) |
+| Windows 64 位，RTX 20/30/40/50 NVIDIA CUDA 安裝版 | [`2026-08-25-windows64.nvidia.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-25.1/2026-08-25-windows64.nvidia.installer.exe) |
+| Windows DirectML 實驗版 | [`2026-08-25-windows64.experimental.directml.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-25.1/2026-08-25-windows64.experimental.directml.portable.zip) |
+| Windows Intel OpenVINO 實驗版 | [`2026-08-25-windows64.experimental.openvino.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-25.1/2026-08-25-windows64.experimental.openvino.portable.zip) |
+| Windows AMD RX 6000 ROCm 實驗版 | [`2026-08-25-windows64.experimental.rocm.gfx103x.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-25.1/2026-08-25-windows64.experimental.rocm.gfx103x.portable.zip) |
+| Windows AMD RX 7000 ROCm 實驗版 | [`2026-08-25-windows64.experimental.rocm.gfx110x.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-25.1/2026-08-25-windows64.experimental.rocm.gfx110x.portable.zip) |
+| Windows AMD Ryzen AI Max ROCm 實驗版 | [`2026-08-25-windows64.experimental.rocm.gfx1151.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-25.1/2026-08-25-windows64.experimental.rocm.gfx1151.portable.zip) |
+| Windows AMD RX 9000 ROCm 實驗版 | [`2026-08-25-windows64.experimental.rocm.gfx120x.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-25.1/2026-08-25-windows64.experimental.rocm.gfx120x.portable.zip) |
+| RTX 30 系及以下可選 TensorRT，需下載兩個分卷 | [`2026-08-25-windows64.nvidia.tensorrt.portable.7z.001`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-25.1/2026-08-25-windows64.nvidia.tensorrt.portable.7z.001)<br>[`2026-08-25-windows64.nvidia.tensorrt.portable.7z.002`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-25.1/2026-08-25-windows64.nvidia.tensorrt.portable.7z.002) |
+| Windows 64 位，自行設定引擎，免安裝 | [`2026-08-25-windows64.without.engine.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-25.1/2026-08-25-windows64.without.engine.portable.zip) |
+| Windows 64 位，自行設定引擎，安裝版 | [`2026-08-25-windows64.without.engine.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-25.1/2026-08-25-windows64.without.engine.installer.exe) |
+| macOS Apple Silicon，Metal | [`2026-08-25-mac-apple-silicon.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-25.1/2026-08-25-mac-apple-silicon.with-katago.dmg) |
+| macOS Intel | [`2026-08-25-mac-intel.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-25.1/2026-08-25-mac-intel.with-katago.dmg) |
+| Linux 64 位，CPU 相容版 | [`2026-08-25-linux64.with-katago.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-25.1/2026-08-25-linux64.with-katago.zip) |
+| Linux 64 位，OpenCL 版 | [`2026-08-25-linux64.opencl.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-25.1/2026-08-25-linux64.opencl.zip) |
+| Linux 64 位，NVIDIA CUDA 版 | [`2026-08-25-linux64.nvidia.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-25.1/2026-08-25-linux64.nvidia.zip) |
+
+### 為什麼值得測試
+
+- Windows 11 + RTX 3070 已完成 B11 全新啟動、真實推理相容探測、官方 benchmark、長棋譜快速勝率曲線、B10/B11 切換與重啟實測。
+- 310 手棋譜約 0.5 秒出現首批快速勝率結果；測速完成後前台分析與單一主引擎均正確恢復。
+- 本機完整測試 3111 項，0 失敗、0 錯誤、14 跳過；195 項發布腳本測試 0 失敗、12 跳過，PR 的 Windows/Linux CI 完整通過。
+- RTX 40/50、DirectML、OpenVINO 與 ROCm 尚未標記為硬體實測通過，歡迎重點回報首次啟動、測速與持續分析。
+
+### 交流
+
+- QQ 群：`299419120`
+
+---
+
+## English
+
+This public preview upgrades KataGo to v1.18.1, makes the stronger B11 Transformer the default full-package model, and replaces separate NVIDIA generations with one Windows CUDA 12.8 + cuDNN 9.8 package for RTX 20/30/40/50. B10 remains available when throughput matters more.
+
+### Release highlights
+
+- Every recommended full bundle now uses official KataGo v1.18.1 and includes `b11c768h12nbt3tflrs-fson-silu.bin.gz` by default. B11 makes stronger judgments per search, especially in complex positions, but can search more slowly than B10.
+- KataGo Auto Setup recommends B11 for playing strength and retains balanced and lightweight B10 choices. Custom weights, HumanSL, remote compute, and explicit existing-user choices are preserved.
+- Windows NVIDIA is now one CUDA 12.8 + cuDNN 9.8 package for RTX 20/30/40/50 with the complete NVRTC runtime. Legacy `nvidia50-cuda` configurations migrate safely; separate RTX 50 assets are retired.
+- TensorRT is now optional for RTX 30 series and earlier; RTX 40/50 default to CUDA. Drivers `570.65` or newer load directly, `528.33` through `570.64` run a lightweight real-inference probe once, and older drivers receive a clear repair state.
+- The official benchmark parser now captures v1.18.1 search threads, NN server threads, and batch size while reporting real stage progress. Switching models invalidates mismatched tuning results.
+- Experimental DirectML, OpenVINO, and four architecture-specific ROCm portable packages and opt-in installers are available without automatic installation or silent backend fallback.
+
+### Read before downloading
+
+- Download a matching full bundle to receive KataGo v1.18.1 and B11. `windows64.core-update.zip` updates the app core only and does not force existing users to replace their current model or large engine files.
+- RTX 20/30/40/50 all use the unified `windows64.nvidia` package. Do not use a separate `nvidia50` package from an older release.
+- On the tested RTX 3070, B11 searched about 40% more slowly than B10 under the same settings, while providing stronger neural-network judgments. Choose B10 on the Weights page when speed matters more.
+- TensorRT is an optional choice for RTX 30 series and earlier. RTX 40/50 users should prefer CUDA.
+- DirectML, OpenVINO, and ROCm builds are experimental. Test them in a new folder and keep backups of `user-data`, weights, and game records.
+
+### Download guide
+
+| Your computer | Download this file |
+| --- | --- |
+| Windows x64, recommended OpenCL portable | [`2026-08-25-windows64.opencl.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-25.1/2026-08-25-windows64.opencl.portable.zip) |
+| Existing Windows portable install, app-only update | [`2026-08-25-windows64.core-update.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-25.1/2026-08-25-windows64.core-update.zip) |
+| Windows x64, OpenCL installer | [`2026-08-25-windows64.opencl.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-25.1/2026-08-25-windows64.opencl.installer.exe) |
+| Windows x64, CPU fallback portable | [`2026-08-25-windows64.with-katago.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-25.1/2026-08-25-windows64.with-katago.portable.zip) |
+| Windows x64, CPU fallback installer | [`2026-08-25-windows64.with-katago.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-25.1/2026-08-25-windows64.with-katago.installer.exe) |
+| Windows x64, RTX 20/30/40/50 NVIDIA CUDA portable | [`2026-08-25-windows64.nvidia.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-25.1/2026-08-25-windows64.nvidia.portable.zip) |
+| Windows x64, RTX 20/30/40/50 NVIDIA CUDA installer | [`2026-08-25-windows64.nvidia.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-25.1/2026-08-25-windows64.nvidia.installer.exe) |
+| Windows DirectML experimental | [`2026-08-25-windows64.experimental.directml.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-25.1/2026-08-25-windows64.experimental.directml.portable.zip) |
+| Windows Intel OpenVINO experimental | [`2026-08-25-windows64.experimental.openvino.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-25.1/2026-08-25-windows64.experimental.openvino.portable.zip) |
+| Windows AMD RX 6000 ROCm experimental | [`2026-08-25-windows64.experimental.rocm.gfx103x.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-25.1/2026-08-25-windows64.experimental.rocm.gfx103x.portable.zip) |
+| Windows AMD RX 7000 ROCm experimental | [`2026-08-25-windows64.experimental.rocm.gfx110x.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-25.1/2026-08-25-windows64.experimental.rocm.gfx110x.portable.zip) |
+| Windows AMD Ryzen AI Max ROCm experimental | [`2026-08-25-windows64.experimental.rocm.gfx1151.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-25.1/2026-08-25-windows64.experimental.rocm.gfx1151.portable.zip) |
+| Windows AMD RX 9000 ROCm experimental | [`2026-08-25-windows64.experimental.rocm.gfx120x.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-25.1/2026-08-25-windows64.experimental.rocm.gfx120x.portable.zip) |
+| Optional TensorRT for RTX 30 and earlier, download both parts | [`2026-08-25-windows64.nvidia.tensorrt.portable.7z.001`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-25.1/2026-08-25-windows64.nvidia.tensorrt.portable.7z.001)<br>[`2026-08-25-windows64.nvidia.tensorrt.portable.7z.002`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-25.1/2026-08-25-windows64.nvidia.tensorrt.portable.7z.002) |
+| Windows x64, bring your own engine, portable | [`2026-08-25-windows64.without.engine.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-25.1/2026-08-25-windows64.without.engine.portable.zip) |
+| Windows x64, bring your own engine, installer | [`2026-08-25-windows64.without.engine.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-25.1/2026-08-25-windows64.without.engine.installer.exe) |
+| macOS Apple Silicon, Metal | [`2026-08-25-mac-apple-silicon.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-25.1/2026-08-25-mac-apple-silicon.with-katago.dmg) |
+| macOS Intel | [`2026-08-25-mac-intel.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-25.1/2026-08-25-mac-intel.with-katago.dmg) |
+| Linux x64, CPU fallback | [`2026-08-25-linux64.with-katago.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-25.1/2026-08-25-linux64.with-katago.zip) |
+| Linux x64, OpenCL | [`2026-08-25-linux64.opencl.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-25.1/2026-08-25-linux64.opencl.zip) |
+| Linux x64, NVIDIA CUDA | [`2026-08-25-linux64.nvidia.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-25.1/2026-08-25-linux64.nvidia.zip) |
+
+### Why test this release
+
+- Real Windows 11 and RTX 3070 acceptance covered clean B11 startup, the real-inference compatibility probe, official benchmark, long-SGF quick-winrate analysis, B10/B11 switching, and restart.
+- A 310-move SGF showed its first quick-winrate results in about 0.5 seconds; foreground analysis and a single main engine were restored after benchmark completion.
+- The final local suite ran 3111 tests with 0 failures, 0 errors, and 14 skipped. The 195 release-script tests had 0 failures and 12 skipped, and both Windows and Linux PR CI gates passed.
+- RTX 40/50, DirectML, OpenVINO, and ROCm hardware are not falsely marked as tested. Feedback on first launch, benchmark, and sustained analysis is especially useful.
+
+### Contact
+
+- QQ group: `299419120`
+
+---
+
+## 日本語
+
+KataGo v1.18.1、既定 B11 weight、Windows NVIDIA 統合 CUDA package の公開テスト版です。full package はより強い B11 Transformer を既定にし、速度重視の B10 も残します。RTX 20/30/40/50 は CUDA 12.8 + cuDNN 9.8 の単一 package を使用します。
+
+### 主な更新
+
+- すべての推奨 full bundle を公式 KataGo v1.18.1 に更新し、`b11c768h12nbt3tflrs-fson-silu.bin.gz` を既定にしました。B11 は複雑局面でより強い判断を行いますが、B10 より検索速度が低い場合があります。
+- KataGo 一括設定は B11 を棋力優先として推奨し、B10 の balanced/lightweight 選択も保持します。custom weight、HumanSL、remote compute、既存ユーザーの明示設定は変更しません。
+- Windows NVIDIA を RTX 20/30/40/50 共通の CUDA 12.8 + cuDNN 9.8 package に統合し、NVRTC runtime を完全に収録しました。旧 `nvidia50-cuda` 設定は互換移行します。
+- TensorRT は RTX 30 系以前の optional backend です。RTX 40/50 は CUDA を推奨します。driver `570.65` 以上は直接起動し、`528.33` から `570.64` は初回に軽量な実推論 probe を行います。
+- 公式 benchmark は v1.18.1 の search thread、NN server thread、batch size を解析し、実際の段階に沿って進捗を表示します。model 切替後に不一致の結果を再利用しません。
+- DirectML、OpenVINO、4 種類の ROCm architecture 向け experimental portable と opt-in installer を追加しました。自動導入や無断 fallback は行いません。
+
+### ダウンロード前に
+
+- KataGo v1.18.1 と B11 を得るには対応する full bundle を選んでください。`windows64.core-update.zip` は app core のみを更新し、既存 model や大型 engine を強制置換しません。
+- RTX 20/30/40/50 はすべて統合 `windows64.nvidia` package を使用します。旧 release の個別 `nvidia50` package は使用しないでください。
+- RTX 3070 の同条件では B11 は B10 より約 40% 低速でしたが、network 判断はより強力です。速度重視なら Weight ページで B10 を選択できます。
+- TensorRT は RTX 30 系以前の optional 選択です。RTX 40/50 は CUDA を優先してください。
+- DirectML、OpenVINO、ROCm は experimental です。新しい folder で試し、`user-data`、weight、棋譜を backup してください。
+
+### ダウンロード案内
+
+| 環境 | ダウンロードするファイル |
+| --- | --- |
+| Windows x64、推奨 OpenCL portable | [`2026-08-25-windows64.opencl.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-25.1/2026-08-25-windows64.opencl.portable.zip) |
+| 既存 Windows portable、app のみ更新 | [`2026-08-25-windows64.core-update.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-25.1/2026-08-25-windows64.core-update.zip) |
+| Windows x64、OpenCL installer | [`2026-08-25-windows64.opencl.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-25.1/2026-08-25-windows64.opencl.installer.exe) |
+| Windows x64、CPU fallback portable | [`2026-08-25-windows64.with-katago.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-25.1/2026-08-25-windows64.with-katago.portable.zip) |
+| Windows x64、CPU fallback installer | [`2026-08-25-windows64.with-katago.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-25.1/2026-08-25-windows64.with-katago.installer.exe) |
+| Windows x64、RTX 20/30/40/50 NVIDIA CUDA portable | [`2026-08-25-windows64.nvidia.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-25.1/2026-08-25-windows64.nvidia.portable.zip) |
+| Windows x64、RTX 20/30/40/50 NVIDIA CUDA installer | [`2026-08-25-windows64.nvidia.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-25.1/2026-08-25-windows64.nvidia.installer.exe) |
+| Windows DirectML experimental | [`2026-08-25-windows64.experimental.directml.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-25.1/2026-08-25-windows64.experimental.directml.portable.zip) |
+| Windows Intel OpenVINO experimental | [`2026-08-25-windows64.experimental.openvino.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-25.1/2026-08-25-windows64.experimental.openvino.portable.zip) |
+| Windows AMD RX 6000 ROCm experimental | [`2026-08-25-windows64.experimental.rocm.gfx103x.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-25.1/2026-08-25-windows64.experimental.rocm.gfx103x.portable.zip) |
+| Windows AMD RX 7000 ROCm experimental | [`2026-08-25-windows64.experimental.rocm.gfx110x.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-25.1/2026-08-25-windows64.experimental.rocm.gfx110x.portable.zip) |
+| Windows AMD Ryzen AI Max ROCm experimental | [`2026-08-25-windows64.experimental.rocm.gfx1151.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-25.1/2026-08-25-windows64.experimental.rocm.gfx1151.portable.zip) |
+| Windows AMD RX 9000 ROCm experimental | [`2026-08-25-windows64.experimental.rocm.gfx120x.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-25.1/2026-08-25-windows64.experimental.rocm.gfx120x.portable.zip) |
+| RTX 30 系以前向け optional TensorRT、両分割を取得 | [`2026-08-25-windows64.nvidia.tensorrt.portable.7z.001`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-25.1/2026-08-25-windows64.nvidia.tensorrt.portable.7z.001)<br>[`2026-08-25-windows64.nvidia.tensorrt.portable.7z.002`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-25.1/2026-08-25-windows64.nvidia.tensorrt.portable.7z.002) |
+| Windows x64、独自 engine、portable | [`2026-08-25-windows64.without.engine.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-25.1/2026-08-25-windows64.without.engine.portable.zip) |
+| Windows x64、独自 engine、installer | [`2026-08-25-windows64.without.engine.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-25.1/2026-08-25-windows64.without.engine.installer.exe) |
+| macOS Apple Silicon、Metal | [`2026-08-25-mac-apple-silicon.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-25.1/2026-08-25-mac-apple-silicon.with-katago.dmg) |
+| macOS Intel | [`2026-08-25-mac-intel.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-25.1/2026-08-25-mac-intel.with-katago.dmg) |
+| Linux x64、CPU fallback | [`2026-08-25-linux64.with-katago.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-25.1/2026-08-25-linux64.with-katago.zip) |
+| Linux x64、OpenCL | [`2026-08-25-linux64.opencl.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-25.1/2026-08-25-linux64.opencl.zip) |
+| Linux x64、NVIDIA CUDA | [`2026-08-25-linux64.nvidia.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-25.1/2026-08-25-linux64.nvidia.zip) |
+
+### テストする理由
+
+- Windows 11 + RTX 3070 で B11 の fresh start、実推論 compatibility probe、公式 benchmark、長い SGF の quick-winrate、B10/B11 切替、restart を実機確認しました。
+- 310 手 SGF は約 0.5 秒で最初の quick-winrate 結果を表示し、benchmark 後に foreground analysis と単一 main engine が復帰しました。
+- 最終 local suite は 3111 tests、0 failures、0 errors、14 skipped、release script は 195 tests、0 failures、12 skipped です。Windows/Linux PR CI gate も成功しました。
+- RTX 40/50、DirectML、OpenVINO、ROCm は実機確認済みとは表示していません。first launch、benchmark、長時間 analysis の feedback を歓迎します。
+
+### 連絡先
+
+- QQ group: `299419120`
+
+---
+
+## 한국어
+
+KataGo v1.18.1, 기본 B11 weight, Windows NVIDIA 통합 CUDA package를 제공하는 공개 preview입니다. full package는 더 강한 B11 Transformer를 기본으로 사용하며 B10 속도 선택도 유지합니다. RTX 20/30/40/50은 CUDA 12.8 + cuDNN 9.8 단일 package를 사용합니다.
+
+### 주요 업데이트
+
+- 모든 권장 full bundle을 공식 KataGo v1.18.1로 올리고 `b11c768h12nbt3tflrs-fson-silu.bin.gz`를 기본으로 포함했습니다. B11은 복잡한 국면에서 더 강한 판단을 하지만 B10보다 검색 속도가 느릴 수 있습니다.
+- KataGo 원클릭 설정은 B11을 기력 우선으로 권장하고 balanced/lightweight B10을 유지합니다. custom weight, HumanSL, remote compute, 기존 사용자의 명시적 선택은 덮어쓰지 않습니다.
+- Windows NVIDIA를 RTX 20/30/40/50 공통 CUDA 12.8 + cuDNN 9.8 package로 통합하고 NVRTC runtime을 완전하게 포함했습니다. 기존 `nvidia50-cuda` 설정은 호환 전환됩니다.
+- TensorRT는 RTX 30 시리즈 이하의 optional backend입니다. RTX 40/50은 CUDA를 권장합니다. driver `570.65` 이상은 바로 로드하고 `528.33`부터 `570.64`는 첫 실행에서 가벼운 실제 추론 probe를 수행합니다.
+- 공식 benchmark는 v1.18.1 search thread, NN server thread, batch size를 파싱하고 실제 단계에 맞춰 진행률을 표시합니다. model이 바뀌면 맞지 않는 이전 결과를 재사용하지 않습니다.
+- DirectML, OpenVINO와 4개 ROCm architecture용 experimental portable 및 opt-in installer를 추가했습니다. 자동 설치나 조용한 backend fallback은 없습니다.
+
+### 다운로드 전 확인
+
+- KataGo v1.18.1과 B11을 받으려면 해당 full bundle을 사용하세요. `windows64.core-update.zip`은 app core만 업데이트하며 기존 model이나 대용량 engine을 강제로 교체하지 않습니다.
+- RTX 20/30/40/50 모두 통합 `windows64.nvidia` package를 사용합니다. 이전 release의 별도 `nvidia50` package는 사용하지 마세요.
+- RTX 3070 동일 설정에서 B11은 B10보다 약 40% 느렸지만 neural-network 판단은 더 강합니다. 속도가 중요하면 Weight 페이지에서 B10을 선택할 수 있습니다.
+- TensorRT는 RTX 30 시리즈 이하의 optional 선택입니다. RTX 40/50은 CUDA를 우선하세요.
+- DirectML, OpenVINO, ROCm은 experimental입니다. 새 folder에서 시험하고 `user-data`, weight, 기보를 backup하세요.
+
+### 다운로드 안내
+
+| 환경 | 다운로드할 파일 |
+| --- | --- |
+| Windows x64, 권장 OpenCL portable | [`2026-08-25-windows64.opencl.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-25.1/2026-08-25-windows64.opencl.portable.zip) |
+| 기존 Windows portable, app-only update | [`2026-08-25-windows64.core-update.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-25.1/2026-08-25-windows64.core-update.zip) |
+| Windows x64, OpenCL installer | [`2026-08-25-windows64.opencl.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-25.1/2026-08-25-windows64.opencl.installer.exe) |
+| Windows x64, CPU fallback portable | [`2026-08-25-windows64.with-katago.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-25.1/2026-08-25-windows64.with-katago.portable.zip) |
+| Windows x64, CPU fallback installer | [`2026-08-25-windows64.with-katago.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-25.1/2026-08-25-windows64.with-katago.installer.exe) |
+| Windows x64, RTX 20/30/40/50 NVIDIA CUDA portable | [`2026-08-25-windows64.nvidia.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-25.1/2026-08-25-windows64.nvidia.portable.zip) |
+| Windows x64, RTX 20/30/40/50 NVIDIA CUDA installer | [`2026-08-25-windows64.nvidia.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-25.1/2026-08-25-windows64.nvidia.installer.exe) |
+| Windows DirectML experimental | [`2026-08-25-windows64.experimental.directml.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-25.1/2026-08-25-windows64.experimental.directml.portable.zip) |
+| Windows Intel OpenVINO experimental | [`2026-08-25-windows64.experimental.openvino.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-25.1/2026-08-25-windows64.experimental.openvino.portable.zip) |
+| Windows AMD RX 6000 ROCm experimental | [`2026-08-25-windows64.experimental.rocm.gfx103x.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-25.1/2026-08-25-windows64.experimental.rocm.gfx103x.portable.zip) |
+| Windows AMD RX 7000 ROCm experimental | [`2026-08-25-windows64.experimental.rocm.gfx110x.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-25.1/2026-08-25-windows64.experimental.rocm.gfx110x.portable.zip) |
+| Windows AMD Ryzen AI Max ROCm experimental | [`2026-08-25-windows64.experimental.rocm.gfx1151.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-25.1/2026-08-25-windows64.experimental.rocm.gfx1151.portable.zip) |
+| Windows AMD RX 9000 ROCm experimental | [`2026-08-25-windows64.experimental.rocm.gfx120x.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-25.1/2026-08-25-windows64.experimental.rocm.gfx120x.portable.zip) |
+| RTX 30 시리즈 이하 optional TensorRT, 두 part 모두 다운로드 | [`2026-08-25-windows64.nvidia.tensorrt.portable.7z.001`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-25.1/2026-08-25-windows64.nvidia.tensorrt.portable.7z.001)<br>[`2026-08-25-windows64.nvidia.tensorrt.portable.7z.002`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-25.1/2026-08-25-windows64.nvidia.tensorrt.portable.7z.002) |
+| Windows x64, 사용자 engine, portable | [`2026-08-25-windows64.without.engine.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-25.1/2026-08-25-windows64.without.engine.portable.zip) |
+| Windows x64, 사용자 engine, installer | [`2026-08-25-windows64.without.engine.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-25.1/2026-08-25-windows64.without.engine.installer.exe) |
+| macOS Apple Silicon, Metal | [`2026-08-25-mac-apple-silicon.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-25.1/2026-08-25-mac-apple-silicon.with-katago.dmg) |
+| macOS Intel | [`2026-08-25-mac-intel.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-25.1/2026-08-25-mac-intel.with-katago.dmg) |
+| Linux x64, CPU fallback | [`2026-08-25-linux64.with-katago.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-25.1/2026-08-25-linux64.with-katago.zip) |
+| Linux x64, OpenCL | [`2026-08-25-linux64.opencl.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-25.1/2026-08-25-linux64.opencl.zip) |
+| Linux x64, NVIDIA CUDA | [`2026-08-25-linux64.nvidia.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-25.1/2026-08-25-linux64.nvidia.zip) |
+
+### 테스트할 이유
+
+- Windows 11 + RTX 3070에서 B11 fresh start, 실제 추론 compatibility probe, 공식 benchmark, 긴 SGF quick-winrate, B10/B11 전환, restart를 실기기로 확인했습니다.
+- 310수 SGF는 약 0.5초에 첫 quick-winrate 결과를 표시했고 benchmark 후 foreground analysis와 단일 main engine이 복원되었습니다.
+- 최종 local suite는 3111 tests, 0 failures, 0 errors, 14 skipped이고 release script는 195 tests, 0 failures, 12 skipped입니다. Windows/Linux PR CI gate도 성공했습니다.
+- RTX 40/50, DirectML, OpenVINO, ROCm은 hardware-tested로 표시하지 않았습니다. first launch, benchmark, 장시간 analysis feedback을 환영합니다.
+
+### 연락처
+
+- QQ 그룹: `299419120`
+
+---
+
+## ภาษาไทย
+
+นี่คือ public preview ที่อัปเกรด KataGo เป็น v1.18.1 ใช้ B11 Transformer ที่แข็งแกร่งกว่าเป็น model เริ่มต้นของ full package และรวม Windows NVIDIA เป็น CUDA 12.8 + cuDNN 9.8 package เดียวสำหรับ RTX 20/30/40/50 โดยยังมี B10 ให้เลือกเมื่อเน้นความเร็ว
+
+### ไฮไลต์ของเวอร์ชันนี้
+
+- full bundle ที่แนะนำทั้งหมดใช้ KataGo v1.18.1 official และรวม `b11c768h12nbt3tflrs-fson-silu.bin.gz` เป็นค่าเริ่มต้น B11 ตัดสินได้แข็งแกร่งกว่า โดยเฉพาะตำแหน่งซับซ้อน แต่ค้นหาอาจช้ากว่า B10
+- KataGo Auto Setup แนะนำ B11 สำหรับความแข็งแกร่ง และยังมี B10 แบบ balanced/lightweight โดยไม่เขียนทับ custom weight, HumanSL, remote compute หรือค่าที่ผู้ใช้เดิมเลือกไว้ชัดเจน
+- Windows NVIDIA รวมเป็น CUDA 12.8 + cuDNN 9.8 package เดียวสำหรับ RTX 20/30/40/50 พร้อม NVRTC runtime ครบถ้วน ค่า `nvidia50-cuda` เดิมจะย้ายแบบเข้ากันได้และเลิกเผยแพร่ package RTX 50 แยก
+- TensorRT เป็นตัวเลือกสำหรับ RTX 30 series และรุ่นก่อนหน้า ส่วน RTX 40/50 แนะนำ CUDA driver `570.65` ขึ้นไปโหลดได้โดยตรง และ `528.33` ถึง `570.64` จะทำ real-inference probe ขนาดเล็กในครั้งแรก
+- benchmark official อ่านค่า search threads, NN server threads และ batch size ของ v1.18.1 พร้อมแสดง progress ตามขั้นตอนจริง และไม่ใช้ผล tuning ที่ไม่ตรงหลังเปลี่ยน model
+- เพิ่ม experimental portable และ opt-in installer สำหรับ DirectML, OpenVINO และ ROCm 4 architecture โดยไม่ติดตั้งอัตโนมัติหรือ fallback backend แบบเงียบ ๆ
+
+### ก่อนดาวน์โหลด
+
+- ดาวน์โหลด full bundle ที่ตรงกันเพื่อรับ KataGo v1.18.1 และ B11 ส่วน `windows64.core-update.zip` อัปเดตเฉพาะ app core และไม่บังคับเปลี่ยน model หรือ engine ขนาดใหญ่ของผู้ใช้เดิม
+- RTX 20/30/40/50 ใช้ `windows64.nvidia` package เดียวกันทั้งหมด อย่าใช้ package `nvidia50` แยกจาก release เก่า
+- บน RTX 3070 ที่ทดสอบ B11 ค้นหาช้ากว่า B10 ราว 40% ด้วยค่าเดียวกัน แต่ให้ neural-network judgment ที่แข็งแกร่งกว่า เลือก B10 ในหน้า Weights ได้เมื่อต้องการความเร็ว
+- TensorRT เป็นตัวเลือกสำหรับ RTX 30 series และรุ่นก่อนหน้า RTX 40/50 ควรเลือก CUDA
+- DirectML, OpenVINO และ ROCm เป็น experimental ควรทดสอบใน folder ใหม่และ backup `user-data`, weight และ game records
+
+### คู่มือดาวน์โหลด
+
+| คอมพิวเตอร์ของคุณ | ดาวน์โหลดไฟล์นี้ |
+| --- | --- |
+| Windows x64, OpenCL portable ที่แนะนำ | [`2026-08-25-windows64.opencl.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-25.1/2026-08-25-windows64.opencl.portable.zip) |
+| Windows portable เดิม, อัปเดตเฉพาะ app | [`2026-08-25-windows64.core-update.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-25.1/2026-08-25-windows64.core-update.zip) |
+| Windows x64, OpenCL installer | [`2026-08-25-windows64.opencl.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-25.1/2026-08-25-windows64.opencl.installer.exe) |
+| Windows x64, CPU fallback portable | [`2026-08-25-windows64.with-katago.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-25.1/2026-08-25-windows64.with-katago.portable.zip) |
+| Windows x64, CPU fallback installer | [`2026-08-25-windows64.with-katago.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-25.1/2026-08-25-windows64.with-katago.installer.exe) |
+| Windows x64, RTX 20/30/40/50 NVIDIA CUDA portable | [`2026-08-25-windows64.nvidia.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-25.1/2026-08-25-windows64.nvidia.portable.zip) |
+| Windows x64, RTX 20/30/40/50 NVIDIA CUDA installer | [`2026-08-25-windows64.nvidia.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-25.1/2026-08-25-windows64.nvidia.installer.exe) |
+| Windows DirectML experimental | [`2026-08-25-windows64.experimental.directml.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-25.1/2026-08-25-windows64.experimental.directml.portable.zip) |
+| Windows Intel OpenVINO experimental | [`2026-08-25-windows64.experimental.openvino.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-25.1/2026-08-25-windows64.experimental.openvino.portable.zip) |
+| Windows AMD RX 6000 ROCm experimental | [`2026-08-25-windows64.experimental.rocm.gfx103x.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-25.1/2026-08-25-windows64.experimental.rocm.gfx103x.portable.zip) |
+| Windows AMD RX 7000 ROCm experimental | [`2026-08-25-windows64.experimental.rocm.gfx110x.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-25.1/2026-08-25-windows64.experimental.rocm.gfx110x.portable.zip) |
+| Windows AMD Ryzen AI Max ROCm experimental | [`2026-08-25-windows64.experimental.rocm.gfx1151.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-25.1/2026-08-25-windows64.experimental.rocm.gfx1151.portable.zip) |
+| Windows AMD RX 9000 ROCm experimental | [`2026-08-25-windows64.experimental.rocm.gfx120x.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-25.1/2026-08-25-windows64.experimental.rocm.gfx120x.portable.zip) |
+| TensorRT สำหรับ RTX 30 และรุ่นก่อนหน้า, ดาวน์โหลดทั้งสอง part | [`2026-08-25-windows64.nvidia.tensorrt.portable.7z.001`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-25.1/2026-08-25-windows64.nvidia.tensorrt.portable.7z.001)<br>[`2026-08-25-windows64.nvidia.tensorrt.portable.7z.002`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-25.1/2026-08-25-windows64.nvidia.tensorrt.portable.7z.002) |
+| Windows x64, ใช้ engine ของคุณเอง, portable | [`2026-08-25-windows64.without.engine.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-25.1/2026-08-25-windows64.without.engine.portable.zip) |
+| Windows x64, ใช้ engine ของคุณเอง, installer | [`2026-08-25-windows64.without.engine.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-25.1/2026-08-25-windows64.without.engine.installer.exe) |
+| macOS Apple Silicon, Metal | [`2026-08-25-mac-apple-silicon.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-25.1/2026-08-25-mac-apple-silicon.with-katago.dmg) |
+| macOS Intel | [`2026-08-25-mac-intel.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-25.1/2026-08-25-mac-intel.with-katago.dmg) |
+| Linux x64, CPU fallback | [`2026-08-25-linux64.with-katago.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-25.1/2026-08-25-linux64.with-katago.zip) |
+| Linux x64, OpenCL | [`2026-08-25-linux64.opencl.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-25.1/2026-08-25-linux64.opencl.zip) |
+| Linux x64, NVIDIA CUDA | [`2026-08-25-linux64.nvidia.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-25.1/2026-08-25-linux64.nvidia.zip) |
+
+### เหตุผลที่ควรทดสอบ
+
+- ทดสอบจริงบน Windows 11 + RTX 3070 ครอบคลุม B11 fresh start, real-inference compatibility probe, benchmark official, quick-winrate สำหรับ SGF ยาว, การสลับ B10/B11 และ restart
+- SGF 310 move แสดง quick-winrate ชุดแรกในประมาณ 0.5 วินาที และคืน foreground analysis กับ main engine เดียวหลัง benchmark เสร็จ
+- final local suite รัน 3111 tests โดย 0 failures, 0 errors, 14 skipped ส่วน release scripts รัน 195 tests โดย 0 failures, 12 skipped และ Windows/Linux PR CI gate ผ่านทั้งหมด
+- RTX 40/50, DirectML, OpenVINO และ ROCm ไม่ได้ถูกอ้างว่า hardware-tested โปรดช่วยรายงาน first launch, benchmark และ sustained analysis
+
+### ติดต่อ
+
+- QQ group: `299419120`

--- a/.github/release-requests/next-2026-08-25.1.json
+++ b/.github/release-requests/next-2026-08-25.1.json
@@ -1,0 +1,7 @@
+{
+  "date_tag": "2026-08-25",
+  "release_tag": "next-2026-08-25.1",
+  "title": "LizzieYzy Next next-2026-08-25.1",
+  "prerelease": true,
+  "notes_file": ".github/release-notes/next-2026-08-25.1.md"
+}


### PR DESCRIPTION
## Summary

Request the audited multi-platform pre-release `next-2026-08-25.1` from the current main commit, including KataGo v1.18.1, the B11 default model, unified Windows NVIDIA CUDA packaging, optional TensorRT for RTX 30 and earlier, and experimental DirectML/OpenVINO/ROCm packages.

The release uses a new tag because `next-2026-08-24.2` was intentionally blocked before publication by its Windows binary-version audit. PR #312 fixed that audit and is included in this release target.

## Validation

- release request parsed successfully with the fail-closed publisher model
- canonical release notes validator passed
- 6 language sections
- 132 direct download links covering 22 unique user-visible assets
- no stale date/tag/test-count references
- Python release/package suite: 195 tests, 0 failures, 12 skipped
- `git diff --check`: passed