### PR TITLE
Add Board rules and SGFParser semantic round-trip regression tests

### DIFF
--- a/src/test/java/featurecat/lizzie/rules/BoardPlayCaptureHistoryRegressionTest.java
+++ b/src/test/java/featurecat/lizzie/rules/BoardPlayCaptureHistoryRegressionTest.java
@@ -1,0 +1,422 @@
+package featurecat.lizzie.rules;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import featurecat.lizzie.Lizzie;
+import java.util.Arrays;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+/**
+ * Direct Board rules regression: play, capture, pass, ko, handicap/root setup, variation history,
+ * and undo/redo / history-jump state. Complements existing history/sync/movelist/root-setup tests.
+ */
+class BoardPlayCaptureHistoryRegressionTest {
+  private static final int SIZE = 5;
+
+  @Test
+  void ordinaryPlayPlacesStoneAndAdvancesHistory() throws Exception {
+    try (RulesLayerTestHarness env = RulesLayerTestHarness.open(SIZE)) {
+      Board board = env.board();
+      board.place(2, 2, Stone.BLACK);
+      board.place(3, 3, Stone.WHITE);
+
+      assertEquals(Stone.BLACK, env.stoneAt(2, 2));
+      assertEquals(Stone.WHITE, env.stoneAt(3, 3));
+      assertEquals(2, board.getHistory().getMoveNumber());
+      assertTrue(board.getHistory().isBlacksTurn());
+      assertTrue(RulesLayerTestHarness.sameLastMove(env.current().getData(), 3, 3));
+      assertEquals(Stone.WHITE, env.current().getData().lastMoveColor);
+      assertEquals(0, env.current().getData().blackCaptures);
+      assertEquals(0, env.current().getData().whiteCaptures);
+      assertEquals(1, board.getHistory().getStart().numberOfChildren());
+      assertEquals(1, board.getHistory().getStart().next().orElseThrow().numberOfChildren());
+    }
+  }
+
+  @ParameterizedTest
+  @CsvSource({"-1,0", "0,-1", "5,0", "0,5", "99,99"})
+  void outOfBoundsPlaceIsIgnored(int x, int y) throws Exception {
+    try (RulesLayerTestHarness env = RulesLayerTestHarness.open(SIZE)) {
+      Board board = env.board();
+      BoardHistoryNode root = board.getHistory().getStart();
+      board.place(x, y, Stone.BLACK);
+
+      assertSame(root, env.current());
+      assertEquals(0, root.numberOfChildren());
+      assertEquals(0, board.getHistory().getMoveNumber());
+    }
+  }
+
+  @Test
+  void occupyingAnExistingStoneIsIgnored() throws Exception {
+    try (RulesLayerTestHarness env = RulesLayerTestHarness.open(SIZE)) {
+      Board board = env.board();
+      board.place(1, 1, Stone.BLACK);
+      BoardHistoryNode afterFirst = env.current();
+      int moveNumber = afterFirst.getData().moveNumber;
+
+      board.place(1, 1, Stone.WHITE);
+
+      assertSame(afterFirst, env.current());
+      assertEquals(Stone.BLACK, env.stoneAt(1, 1));
+      assertEquals(moveNumber, env.current().getData().moveNumber);
+      assertEquals(0, afterFirst.numberOfChildren());
+    }
+  }
+
+  @Test
+  void singleStoneCaptureClearsThePointAndIncrementsCaptures() throws Exception {
+    try (RulesLayerTestHarness env = RulesLayerTestHarness.open(SIZE)) {
+      Board board = env.board();
+      board.place(1, 0, Stone.BLACK);
+      board.place(0, 0, Stone.WHITE);
+      board.place(0, 1, Stone.BLACK);
+
+      assertEquals(Stone.EMPTY, env.stoneAt(0, 0), "the corner white stone should be captured.");
+      assertEquals(Stone.BLACK, env.stoneAt(1, 0));
+      assertEquals(Stone.BLACK, env.stoneAt(0, 1));
+      assertEquals(1, env.current().getData().blackCaptures);
+      assertEquals(0, env.current().getData().whiteCaptures);
+      assertEquals(3, env.current().getData().moveNumber);
+      assertEquals(0, env.current().getData().moveNumberList[Board.getIndex(0, 0)]);
+    }
+  }
+
+  @Test
+  void multiStoneCaptureRemovesTheWholeChain() throws Exception {
+    try (RulesLayerTestHarness env = RulesLayerTestHarness.open(SIZE)) {
+      Board board = env.board();
+      // Two adjacent white stones on the left edge, then black surrounds both.
+      board.place(1, 0, Stone.BLACK);
+      board.place(0, 0, Stone.WHITE);
+      board.place(1, 1, Stone.BLACK);
+      board.place(0, 1, Stone.WHITE);
+      board.place(0, 2, Stone.BLACK);
+
+      assertEquals(Stone.EMPTY, env.stoneAt(0, 0));
+      assertEquals(Stone.EMPTY, env.stoneAt(0, 1));
+      assertEquals(Stone.BLACK, env.stoneAt(1, 0));
+      assertEquals(Stone.BLACK, env.stoneAt(1, 1));
+      assertEquals(Stone.BLACK, env.stoneAt(0, 2));
+      assertEquals(2, env.current().getData().blackCaptures);
+      assertEquals(5, env.current().getData().moveNumber);
+    }
+  }
+
+  @Test
+  void suicidalFillIsRejected() throws Exception {
+    try (RulesLayerTestHarness env = RulesLayerTestHarness.open(SIZE)) {
+      Board board = env.board();
+      board.setupPlaceStone(1, 0, Stone.WHITE);
+      board.setupPlaceStone(0, 1, Stone.WHITE);
+      BoardHistoryNode root = board.getHistory().getStart();
+
+      board.place(0, 0, Stone.BLACK);
+
+      assertSame(root, env.current(), "suicide should not create a history node.");
+      assertEquals(Stone.EMPTY, env.stoneAt(0, 0));
+      assertEquals(0, root.numberOfChildren());
+    }
+  }
+
+  @Test
+  void passAndConsecutivePassKeepStonesAndAdvanceMoveNumbers() throws Exception {
+    try (RulesLayerTestHarness env = RulesLayerTestHarness.open(SIZE)) {
+      Board board = env.board();
+      board.place(2, 2, Stone.BLACK);
+      Stone[] afterPlay = board.getHistory().getStones().clone();
+
+      board.pass(Stone.WHITE);
+      BoardHistoryNode firstPass = env.current();
+      assertTrue(firstPass.getData().isPassNode());
+      assertFalse(firstPass.getData().dummy);
+      assertEquals(2, firstPass.getData().moveNumber);
+      assertArrayEquals(afterPlay, board.getHistory().getStones());
+      assertTrue(board.getHistory().isBlacksTurn());
+
+      board.pass(Stone.BLACK);
+      BoardHistoryNode secondPass = env.current();
+      assertTrue(secondPass.getData().isPassNode());
+      assertEquals(3, secondPass.getData().moveNumber);
+      assertArrayEquals(afterPlay, board.getHistory().getStones());
+      assertFalse(board.getHistory().isBlacksTurn());
+      assertEquals(0, secondPass.getData().blackCaptures);
+      assertNotSame(firstPass, secondPass);
+      assertEquals(firstPass, secondPass.previous().orElseThrow());
+    }
+  }
+
+  @Test
+  void replayingTheNextPassWalksHistoryInsteadOfForking() throws Exception {
+    try (RulesLayerTestHarness env = RulesLayerTestHarness.open(SIZE)) {
+      Board board = env.board();
+      board.pass(Stone.BLACK);
+      BoardHistoryNode passNode = env.current();
+      board.previousMove(false);
+      board.pass(Stone.BLACK);
+
+      assertSame(passNode, env.current());
+      assertEquals(1, board.getHistory().getStart().numberOfChildren());
+    }
+  }
+
+  @Test
+  void koRecaptureIsRejectedUntilThePositionChanges() throws Exception {
+    try (RulesLayerTestHarness env = RulesLayerTestHarness.open(SIZE)) {
+      Board board = env.board();
+      placeClassicKoShape(board);
+      board.setupSetSideToPlay(true);
+
+      board.place(3, 2, Stone.BLACK);
+      assertEquals(Stone.EMPTY, env.stoneAt(2, 2), "black should capture the ko stone.");
+      assertEquals(Stone.BLACK, env.stoneAt(3, 2));
+      assertEquals(1, env.current().getData().blackCaptures);
+      BoardHistoryNode afterCapture = env.current();
+      Stone[] afterCaptureStones = board.getHistory().getStones().clone();
+
+      board.place(2, 2, Stone.WHITE);
+      assertSame(afterCapture, env.current(), "immediate ko recapture should be rejected.");
+      assertArrayEquals(afterCaptureStones, board.getHistory().getStones());
+      assertEquals(Stone.EMPTY, env.stoneAt(2, 2));
+      assertEquals(0, afterCapture.numberOfChildren());
+
+      board.place(0, 0, Stone.WHITE);
+      board.place(0, 4, Stone.BLACK);
+      board.place(2, 2, Stone.WHITE);
+
+      assertEquals(Stone.WHITE, env.stoneAt(2, 2), "recapture is allowed after a ko threat.");
+      assertEquals(Stone.EMPTY, env.stoneAt(3, 2));
+      assertEquals(1, env.current().getData().whiteCaptures);
+      assertEquals(1, env.current().getData().blackCaptures);
+    }
+  }
+
+  @Test
+  void fixedHandicapReplacesRootWithSetupStonesAndWhiteToPlay() throws Exception {
+    try (RulesLayerTestHarness env = RulesLayerTestHarness.open(19)) {
+      Board board = env.board();
+      assertTrue(board.setupFixedHandicap(9));
+
+      BoardHistoryNode root = board.getHistory().getStart();
+      assertTrue(root.getData().isSnapshotNode());
+      assertEquals(0, root.numberOfChildren());
+      assertEquals(0, root.getData().moveNumber);
+      assertFalse(root.getData().blackToPlay, "fixed handicap should leave White to play.");
+      assertEquals(9, board.getHistory().getGameInfo().getHandicap());
+
+      int[][] expected = {
+        {3, 3}, {3, 15}, {15, 3}, {15, 15}, {9, 3}, {9, 15}, {3, 9}, {15, 9}, {9, 9}
+      };
+      for (int[] point : expected) {
+        assertEquals(Stone.BLACK, env.stoneAt(point[0], point[1]), Arrays.toString(point));
+      }
+      int blackCount = 0;
+      for (Stone stone : root.getData().stones) {
+        if (stone == Stone.BLACK) {
+          blackCount++;
+        }
+      }
+      assertEquals(9, blackCount);
+    }
+  }
+
+  @Test
+  void unsupportedHandicapOnSmallBoardIsRejected() throws Exception {
+    try (RulesLayerTestHarness env = RulesLayerTestHarness.open(SIZE)) {
+      Board board = env.board();
+      BoardHistoryNode root = board.getHistory().getStart();
+      assertFalse(board.setupFixedHandicap(2));
+      assertFalse(board.setupFixedHandicap(0));
+      assertSame(root, board.getHistory().getStart());
+      assertEquals(0, board.getHistory().getGameInfo().getHandicap());
+    }
+  }
+
+  @Test
+  void rootSetupThenOrdinaryPlayKeepsSetupOnRootAndMoveOnChild() throws Exception {
+    try (RulesLayerTestHarness env = RulesLayerTestHarness.open(SIZE)) {
+      Board board = env.board();
+      assertTrue(board.setupPlaceStone(0, 0, Stone.BLACK));
+      assertTrue(board.setupPlaceStone(4, 4, Stone.WHITE));
+      assertTrue(board.setupSetSideToPlay(false));
+
+      board.place(1, 1, Stone.WHITE);
+
+      BoardHistoryNode root = board.getHistory().getStart();
+      assertTrue(root.getData().isSnapshotNode());
+      assertEquals(Stone.BLACK, root.getData().stones[Board.getIndex(0, 0)]);
+      assertEquals(Stone.WHITE, root.getData().stones[Board.getIndex(4, 4)]);
+      assertEquals(1, root.numberOfChildren());
+      assertTrue(env.current().getData().isMoveNode());
+      assertEquals(1, env.current().getData().moveNumber);
+      assertEquals(Stone.WHITE, env.stoneAt(1, 1));
+    }
+  }
+
+  @Test
+  void playingADifferentMoveAfterUndoCreatesAVariationOffTheMainline() throws Exception {
+    try (RulesLayerTestHarness env = RulesLayerTestHarness.open(SIZE)) {
+      Board board = env.board();
+      board.place(0, 0, Stone.BLACK);
+      board.place(1, 1, Stone.WHITE);
+      BoardHistoryNode blackNode = board.getHistory().getStart().next().orElseThrow();
+      BoardHistoryNode mainlineWhite = env.current();
+
+      assertTrue(board.previousMove(false));
+      board.place(2, 2, Stone.WHITE);
+
+      assertEquals(2, blackNode.numberOfChildren());
+      assertSame(mainlineWhite, blackNode.getVariation(0).orElseThrow());
+      BoardHistoryNode variation = blackNode.getVariation(1).orElseThrow();
+      assertSame(variation, env.current());
+      assertTrue(RulesLayerTestHarness.sameLastMove(variation.getData(), 2, 2));
+      assertEquals(Stone.WHITE, env.stoneAt(2, 2));
+      assertEquals(Stone.EMPTY, env.stoneAt(1, 1), "the variation must not keep the mainline stone.");
+      assertEquals(Stone.WHITE, mainlineWhite.getData().stones[Board.getIndex(1, 1)]);
+      assertTrue(blackNode.next().isPresent());
+      assertSame(
+          mainlineWhite,
+          blackNode.next().orElseThrow(),
+          "mainline next() should remain the first child.");
+    }
+  }
+
+  @Test
+  void explicitNewBranchKeepsExistingRedoAndAddsASibling() throws Exception {
+    try (RulesLayerTestHarness env = RulesLayerTestHarness.open(SIZE)) {
+      Board board = env.board();
+      board.place(0, 0, Stone.BLACK);
+      board.place(4, 4, Stone.WHITE);
+      BoardHistoryNode blackNode = board.getHistory().getStart().next().orElseThrow();
+      board.previousMove(false);
+      board.place(1, 1, Stone.WHITE, true);
+
+      assertEquals(2, blackNode.numberOfChildren());
+      assertTrue(RulesLayerTestHarness.sameLastMove(blackNode.getVariation(0).orElseThrow().getData(), 4, 4));
+      assertTrue(RulesLayerTestHarness.sameLastMove(blackNode.getVariation(1).orElseThrow().getData(), 1, 1));
+    }
+  }
+
+  @Test
+  void undoAndRedoRestoreStonesCapturesAndCurrentNode() throws Exception {
+    try (RulesLayerTestHarness env = RulesLayerTestHarness.open(SIZE)) {
+      Board board = env.board();
+      board.place(1, 0, Stone.BLACK);
+      board.place(0, 0, Stone.WHITE);
+      board.place(0, 1, Stone.BLACK);
+      BoardHistoryNode afterCapture = env.current();
+      Stone[] capturedPosition = board.getHistory().getStones().clone();
+      int blackCaptures = afterCapture.getData().blackCaptures;
+      int moveNumber = afterCapture.getData().moveNumber;
+
+      assertTrue(board.previousMove(false));
+      assertEquals(Stone.WHITE, env.stoneAt(0, 0), "undo should restore the captured stone.");
+      assertEquals(0, env.current().getData().blackCaptures);
+      assertEquals(moveNumber - 1, env.current().getData().moveNumber);
+
+      assertTrue(board.previousMove(false));
+      assertTrue(board.previousMove(false));
+      assertEquals(board.getHistory().getStart(), env.current());
+      assertFalse(board.previousMove(false), "undo at root should be a no-op.");
+
+      assertTrue(board.nextMove(false));
+      assertTrue(board.nextMove(false));
+      assertTrue(board.nextMove(false));
+      assertSame(afterCapture, env.current());
+      assertArrayEquals(capturedPosition, board.getHistory().getStones());
+      assertEquals(blackCaptures, env.current().getData().blackCaptures);
+      assertEquals(moveNumber, env.current().getData().moveNumber);
+      assertFalse(board.nextMove(false), "redo past the end should be a no-op.");
+    }
+  }
+
+  @Test
+  void goToMoveNumberKeepsCapturesAndNodeIdentity() throws Exception {
+    try (RulesLayerTestHarness env = RulesLayerTestHarness.open(SIZE)) {
+      Board board = env.board();
+      board.place(1, 0, Stone.BLACK);
+      board.place(0, 0, Stone.WHITE);
+      board.place(0, 1, Stone.BLACK);
+      board.pass(Stone.WHITE);
+      BoardHistoryNode end = env.current();
+
+      assertTrue(board.goToMoveNumber(0));
+      assertSame(board.getHistory().getStart(), env.current());
+      assertEquals(Stone.EMPTY, env.stoneAt(1, 0));
+      assertEquals(0, env.current().getData().blackCaptures);
+
+      assertTrue(board.goToMoveNumber(3));
+      assertEquals(Stone.EMPTY, env.stoneAt(0, 0));
+      assertEquals(1, env.current().getData().blackCaptures);
+      assertEquals(3, env.current().getData().moveNumber);
+
+      assertTrue(board.goToMoveNumber(4));
+      assertSame(end, env.current());
+      assertTrue(end.getData().isPassNode());
+      assertEquals(1, end.getData().blackCaptures);
+    }
+  }
+
+  @Test
+  void nextVariationSwitchesBoardStateWithoutLosingTheOtherBranch() throws Exception {
+    try (RulesLayerTestHarness env = RulesLayerTestHarness.open(SIZE)) {
+      Board board = env.board();
+      board.place(0, 0, Stone.BLACK);
+      board.place(1, 1, Stone.WHITE);
+      BoardHistoryNode blackNode = board.getHistory().getStart().next().orElseThrow();
+      board.previousMove(false);
+      board.place(2, 2, Stone.WHITE);
+      BoardHistoryNode variation = env.current();
+
+      assertTrue(board.previousMove(false));
+      assertTrue(board.nextVariation(0));
+      assertEquals(Stone.WHITE, env.stoneAt(1, 1));
+      assertEquals(Stone.EMPTY, env.stoneAt(2, 2));
+
+      assertTrue(board.previousMove(false));
+      assertTrue(board.nextVariation(1));
+      assertSame(variation, env.current());
+      assertEquals(Stone.WHITE, env.stoneAt(2, 2));
+      assertEquals(Stone.EMPTY, env.stoneAt(1, 1));
+      assertEquals(2, blackNode.numberOfChildren());
+    }
+  }
+
+  @Test
+  void capturesAndCommentsSurviveJumpingAwayAndBack() throws Exception {
+    try (RulesLayerTestHarness env = RulesLayerTestHarness.open(SIZE)) {
+      Board board = env.board();
+      board.place(1, 0, Stone.BLACK);
+      board.place(0, 0, Stone.WHITE);
+      board.place(0, 1, Stone.BLACK);
+      env.current().getData().comment = "capture node";
+      BoardHistoryNode captureNode = env.current();
+
+      board.goToMoveNumber(0);
+      board.goToMoveNumber(3);
+
+      assertSame(captureNode, env.current());
+      assertEquals("capture node", env.current().getData().comment);
+      assertEquals(1, env.current().getData().blackCaptures);
+      assertEquals(Stone.EMPTY, env.stoneAt(0, 0));
+      assertEquals(3, env.current().getData().moveNumber);
+    }
+  }
+
+  private static void placeClassicKoShape(Board board) {
+    board.setupPlaceStone(2, 1, Stone.BLACK);
+    board.setupPlaceStone(1, 2, Stone.BLACK);
+    board.setupPlaceStone(2, 3, Stone.BLACK);
+    board.setupPlaceStone(3, 1, Stone.WHITE);
+    board.setupPlaceStone(4, 2, Stone.WHITE);
+    board.setupPlaceStone(3, 3, Stone.WHITE);
+    board.setupPlaceStone(2, 2, Stone.WHITE);
+  }
+}

--- a/src/test/java/featurecat/lizzie/rules/RulesLayerTestHarness.java
+++ b/src/test/java/featurecat/lizzie/rules/RulesLayerTestHarness.java
@@ -1,0 +1,302 @@
+package featurecat.lizzie.rules;
+
+import featurecat.lizzie.Config;
+import featurecat.lizzie.Lizzie;
+import featurecat.lizzie.analysis.EngineManager;
+import featurecat.lizzie.analysis.Leelaz;
+import featurecat.lizzie.gui.BoardRenderer;
+import featurecat.lizzie.gui.LizzieFrame;
+import featurecat.lizzie.gui.Menu;
+import featurecat.lizzie.gui.WinrateGraph;
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Optional;
+
+/**
+ * Minimal headless fixture for Board / SGFParser rules tests. Stubs GUI and engine callbacks so
+ * play, capture, history jumps, parse, and save can run without a window, network, or KataGo.
+ */
+final class RulesLayerTestHarness implements AutoCloseable {
+  private final int previousBoardWidth;
+  private final int previousBoardHeight;
+  private final Board previousBoard;
+  private final LizzieFrame previousFrame;
+  private final Menu previousMenu;
+  private final WinrateGraph previousWinrateGraph;
+  private final BoardRenderer previousBoardRenderer;
+  private final Leelaz previousLeelaz;
+  private final Config previousConfig;
+  private final boolean previousEngineEmpty;
+  private final boolean previousEngineGame;
+  private final boolean previousPreEngineGame;
+  private final boolean previousSavingRaw;
+  private final boolean previousUrlSgf;
+  private final featurecat.lizzie.analysis.EngineFollowController previousEngineFollowController;
+
+  private RulesLayerTestHarness(
+      int previousBoardWidth,
+      int previousBoardHeight,
+      Board previousBoard,
+      LizzieFrame previousFrame,
+      Menu previousMenu,
+      WinrateGraph previousWinrateGraph,
+      BoardRenderer previousBoardRenderer,
+      Leelaz previousLeelaz,
+      Config previousConfig,
+      boolean previousEngineEmpty,
+      boolean previousEngineGame,
+      boolean previousPreEngineGame,
+      boolean previousSavingRaw,
+      boolean previousUrlSgf,
+      featurecat.lizzie.analysis.EngineFollowController previousEngineFollowController) {
+    this.previousBoardWidth = previousBoardWidth;
+    this.previousBoardHeight = previousBoardHeight;
+    this.previousBoard = previousBoard;
+    this.previousFrame = previousFrame;
+    this.previousMenu = previousMenu;
+    this.previousWinrateGraph = previousWinrateGraph;
+    this.previousBoardRenderer = previousBoardRenderer;
+    this.previousLeelaz = previousLeelaz;
+    this.previousConfig = previousConfig;
+    this.previousEngineEmpty = previousEngineEmpty;
+    this.previousEngineGame = previousEngineGame;
+    this.previousPreEngineGame = previousPreEngineGame;
+    this.previousSavingRaw = previousSavingRaw;
+    this.previousUrlSgf = previousUrlSgf;
+    this.previousEngineFollowController = previousEngineFollowController;
+  }
+
+  static RulesLayerTestHarness open() throws Exception {
+    return open(5);
+  }
+
+  static RulesLayerTestHarness open(int boardSize) throws Exception {
+    int previousBoardWidth = Board.boardWidth;
+    int previousBoardHeight = Board.boardHeight;
+    Board previousBoard = Lizzie.board;
+    LizzieFrame previousFrame = Lizzie.frame;
+    Menu previousMenu = LizzieFrame.menu;
+    WinrateGraph previousWinrateGraph = LizzieFrame.winrateGraph;
+    BoardRenderer previousBoardRenderer = LizzieFrame.boardRenderer;
+    Leelaz previousLeelaz = Lizzie.leelaz;
+    Config previousConfig = Lizzie.config;
+    boolean previousEngineEmpty = EngineManager.isEmpty;
+    boolean previousEngineGame = EngineManager.isEngineGame;
+    boolean previousPreEngineGame = EngineManager.isPreEngineGame;
+    boolean previousSavingRaw = LizzieFrame.isSavingRaw;
+    boolean previousUrlSgf = LizzieFrame.urlSgf;
+    featurecat.lizzie.analysis.EngineFollowController previousEngineFollowController =
+        Lizzie.engineFollowController;
+
+    Board.boardWidth = boardSize;
+    Board.boardHeight = boardSize;
+    Zobrist.init();
+
+    TrackingBoard board = allocate(TrackingBoard.class);
+    board.startStonelist = new ArrayList<>();
+    board.hasStartStone = false;
+    board.movelistwr = new ArrayList<>();
+    board.setHistory(new BoardHistoryList(BoardData.empty(boardSize, boardSize)));
+    Lizzie.board = board;
+
+    TrackingFrame frame = allocate(TrackingFrame.class);
+    Lizzie.frame = frame;
+    LizzieFrame.menu = allocate(Menu.class);
+    LizzieFrame.menu.txtKomi = new javax.swing.JTextField();
+    LizzieFrame.winrateGraph = allocate(WinrateGraph.class);
+    LizzieFrame.boardRenderer = allocate(NoOpBoardRenderer.class);
+    LizzieFrame.isSavingRaw = false;
+    LizzieFrame.urlSgf = false;
+
+    TrackingLeelaz leelaz = new TrackingLeelaz();
+    Lizzie.setPrimaryEngine(leelaz);
+    EngineManager.isEmpty = true;
+    EngineManager.isEngineGame = false;
+    EngineManager.isPreEngineGame = false;
+    Lizzie.engineFollowController = null;
+
+    Config config = allocate(Config.class);
+    config.playSound = false;
+    config.noCapture = false;
+    config.readKomi = true;
+    config.appendWinrateToComment = false;
+    config.showComment = true;
+    config.newMoveNumberInBranch = false;
+    config.noRefreshOnMouseMove = false;
+    config.initialMaxScoreLead = 10;
+    Lizzie.config = config;
+
+    return new RulesLayerTestHarness(
+        previousBoardWidth,
+        previousBoardHeight,
+        previousBoard,
+        previousFrame,
+        previousMenu,
+        previousWinrateGraph,
+        previousBoardRenderer,
+        previousLeelaz,
+        previousConfig,
+        previousEngineEmpty,
+        previousEngineGame,
+        previousPreEngineGame,
+        previousSavingRaw,
+        previousUrlSgf,
+        previousEngineFollowController);
+  }
+
+  Board board() {
+    return Lizzie.board;
+  }
+
+  Stone stoneAt(int x, int y) {
+    return Lizzie.board.getHistory().getStones()[Board.getIndex(x, y)];
+  }
+
+  BoardHistoryNode current() {
+    return Lizzie.board.getHistory().getCurrentHistoryNode();
+  }
+
+  @Override
+  public void close() {
+    Board.boardWidth = previousBoardWidth;
+    Board.boardHeight = previousBoardHeight;
+    Zobrist.init();
+    Lizzie.board = previousBoard;
+    Lizzie.frame = previousFrame;
+    LizzieFrame.menu = previousMenu;
+    LizzieFrame.winrateGraph = previousWinrateGraph;
+    LizzieFrame.boardRenderer = previousBoardRenderer;
+    Lizzie.setPrimaryEngine(previousLeelaz);
+    Lizzie.config = previousConfig;
+    EngineManager.isEmpty = previousEngineEmpty;
+    EngineManager.isEngineGame = previousEngineGame;
+    EngineManager.isPreEngineGame = previousPreEngineGame;
+    LizzieFrame.isSavingRaw = previousSavingRaw;
+    LizzieFrame.urlSgf = previousUrlSgf;
+    Lizzie.engineFollowController = previousEngineFollowController;
+  }
+
+  static boolean sameLastMove(BoardData data, int x, int y) {
+    Optional<int[]> lastMove = data.lastMove;
+    return lastMove.isPresent() && Arrays.equals(lastMove.get(), new int[] {x, y});
+  }
+
+  @SuppressWarnings("unchecked")
+  static <T> T allocate(Class<T> type) {
+    try {
+      return (T) UnsafeHolder.UNSAFE.allocateInstance(type);
+    } catch (InstantiationException ex) {
+      throw new IllegalStateException("Failed to allocate " + type.getSimpleName(), ex);
+    }
+  }
+
+  static final class TrackingBoard extends Board {
+    @Override
+    public void clearAfterMove() {}
+  }
+
+  static final class TrackingFrame extends LizzieFrame {
+    @Override
+    public void refresh() {}
+
+    @Override
+    public void refresh(int mode) {}
+
+    @Override
+    public void onMainEnginePonder() {}
+
+    @Override
+    public void setPlayers(String whitePlayer, String blackPlayer) {}
+
+    @Override
+    public void resetTitle() {}
+
+    @Override
+    public void tryToResetByoTime() {}
+
+    @Override
+    public void setResult(String result) {}
+
+    @Override
+    public void requestProblemListRefresh() {}
+
+    @Override
+    public void refreshProblemListSnapshot() {}
+
+    @Override
+    public void clearKataEstimate() {}
+  }
+
+  static final class NoOpBoardRenderer extends BoardRenderer {
+    private NoOpBoardRenderer() {
+      super(false);
+    }
+
+    @Override
+    public void removedrawmovestone() {}
+  }
+
+  static final class TrackingLeelaz extends Leelaz {
+    TrackingLeelaz() throws IOException {
+      super("");
+    }
+
+    @Override
+    public void playMove(Stone color, String move) {}
+
+    @Override
+    public void playMove(Stone color, String move, boolean addPlayer, boolean blackToPlay) {}
+
+    @Override
+    public void undo() {}
+
+    @Override
+    public void undo(boolean addPlayer, boolean blackToPlay) {}
+
+    @Override
+    public void clearBestMoves() {}
+
+    @Override
+    public void maybeAjustPDA(BoardHistoryNode node) {}
+
+    @Override
+    public void modifyStart() {}
+
+    @Override
+    public void setModifyEnd() {}
+
+    @Override
+    public boolean isLoaded() {
+      return false;
+    }
+
+    @Override
+    public boolean isStarted() {
+      return false;
+    }
+
+    @Override
+    public boolean isPondering() {
+      return false;
+    }
+
+    @Override
+    public void clearPonderLimit() {}
+  }
+
+  private static final class UnsafeHolder {
+    private static final sun.misc.Unsafe UNSAFE = loadUnsafe();
+
+    private static sun.misc.Unsafe loadUnsafe() {
+      try {
+        Field field = sun.misc.Unsafe.class.getDeclaredField("theUnsafe");
+        field.setAccessible(true);
+        return (sun.misc.Unsafe) field.get(null);
+      } catch (ReflectiveOperationException ex) {
+        throw new IllegalStateException("Failed to access Unsafe", ex);
+      }
+    }
+  }
+}

--- a/src/test/java/featurecat/lizzie/rules/SGFParserSemanticRoundTripTest.java
+++ b/src/test/java/featurecat/lizzie/rules/SGFParserSemanticRoundTripTest.java
@@ -1,0 +1,374 @@
+package featurecat.lizzie.rules;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import featurecat.lizzie.Lizzie;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/**
+ * SGFParser model-semantic tests and parse → write → parse round-trip. Complements existing
+ * root-setup / node-kind SGF coverage; asserts board/history meaning rather than SGF bytes.
+ */
+class SGFParserSemanticRoundTripTest {
+  private static final int SIZE = 5;
+
+  @Test
+  void mainlineMovesPreserveOrderColorAndBoard() throws Exception {
+    try (RulesLayerTestHarness ignored = RulesLayerTestHarness.open(SIZE)) {
+      BoardHistoryList history =
+          SGFParser.parseSgf("(;SZ[5];B[ba];W[cc];B[de];W[ee])", true);
+
+      assertEquals(List.of("BLACK 1,0", "WHITE 2,2", "BLACK 3,4", "WHITE 4,4"), mainlineMoves(history));
+      BoardHistoryNode end = history.getEnd();
+      assertEquals(Stone.BLACK, end.getData().stones[Board.getIndex(1, 0)]);
+      assertEquals(Stone.WHITE, end.getData().stones[Board.getIndex(2, 2)]);
+      assertEquals(4, end.getData().moveNumber);
+      assertTrue(end.getData().blackToPlay);
+    }
+  }
+
+  @Test
+  void variationsKeepParentChildStructureAndDistinctBoards() throws Exception {
+    try (RulesLayerTestHarness ignored = RulesLayerTestHarness.open(SIZE)) {
+      BoardHistoryList history =
+          SGFParser.parseSgf("(;SZ[5];B[aa](;W[bb];B[cc])(;W[dd];B[ee]))", true);
+
+      BoardHistoryNode root = history.getStart();
+      BoardHistoryNode black = root.next().orElseThrow();
+      assertEquals(2, black.numberOfChildren());
+      BoardHistoryNode mainWhite = black.getVariation(0).orElseThrow();
+      BoardHistoryNode varWhite = black.getVariation(1).orElseThrow();
+      assertTrue(RulesLayerTestHarness.sameLastMove(mainWhite.getData(), 1, 1));
+      assertTrue(RulesLayerTestHarness.sameLastMove(varWhite.getData(), 3, 3));
+      assertSame(black, mainWhite.previous().orElseThrow());
+      assertSame(black, varWhite.previous().orElseThrow());
+      assertEquals(Stone.WHITE, mainWhite.getData().stones[Board.getIndex(1, 1)]);
+      assertEquals(Stone.EMPTY, mainWhite.getData().stones[Board.getIndex(3, 3)]);
+      assertEquals(Stone.WHITE, varWhite.getData().stones[Board.getIndex(3, 3)]);
+      assertEquals(Stone.EMPTY, varWhite.getData().stones[Board.getIndex(1, 1)]);
+      assertEquals(List.of("BLACK 0,0", "WHITE 1,1", "BLACK 2,2"), mainlineMoves(history));
+    }
+  }
+
+  @Test
+  void abAwAndPlApplyAsRootSetupNotAsMoves() throws Exception {
+    try (RulesLayerTestHarness ignored = RulesLayerTestHarness.open(SIZE)) {
+      BoardHistoryList history =
+          SGFParser.parseSgf("(;SZ[5]AB[aa][ee]AW[cc]PL[W])", true);
+
+      BoardHistoryNode root = history.getStart();
+      assertEquals(0, root.numberOfChildren());
+      assertEquals(0, root.getData().moveNumber);
+      assertEquals(Stone.BLACK, root.getData().stones[Board.getIndex(0, 0)]);
+      assertEquals(Stone.BLACK, root.getData().stones[Board.getIndex(4, 4)]);
+      assertEquals(Stone.WHITE, root.getData().stones[Board.getIndex(2, 2)]);
+      assertFalse(root.getData().blackToPlay);
+      assertTrue(root.getData().getProperties().containsKey("AB"));
+      assertTrue(root.getData().getProperties().containsKey("AW"));
+    }
+  }
+
+  @Test
+  void komiIsAppliedWhenParseSgfFirstFlagIsTrue() throws Exception {
+    try (RulesLayerTestHarness ignored = RulesLayerTestHarness.open(SIZE)) {
+      BoardHistoryList withKomi = SGFParser.parseSgf("(;SZ[5]KM[6.5];B[aa])", true);
+      assertEquals(6.5, withKomi.getGameInfo().getKomi(), 0.0001);
+
+      BoardHistoryList withoutFirstFlag = SGFParser.parseSgf("(;SZ[5]KM[6.5];B[aa])", false);
+      assertEquals(
+          7.5,
+          withoutFirstFlag.getGameInfo().getKomi(),
+          0.0001,
+          "parseSgf(..., false) currently skips applying the KM tag to GameInfo.");
+    }
+  }
+
+  @Test
+  void handicapPropertySetsGameInfoAndWhiteToPlayOnAbSetup() throws Exception {
+    try (RulesLayerTestHarness ignored = RulesLayerTestHarness.open(SIZE)) {
+      BoardHistoryList history =
+          SGFParser.parseSgf("(;SZ[5]HA[2]AB[aa][ee];W[cc])", true);
+
+      assertEquals(2, history.getGameInfo().getHandicap());
+      BoardHistoryNode root = history.getStart();
+      assertFalse(root.getData().blackToPlay, "handicap AB without PL should leave White to play.");
+      assertEquals(Stone.BLACK, root.getData().stones[Board.getIndex(0, 0)]);
+      assertEquals(Stone.BLACK, root.getData().stones[Board.getIndex(4, 4)]);
+      assertEquals(1, root.numberOfChildren());
+      assertEquals(Stone.WHITE, root.next().orElseThrow().getData().lastMoveColor);
+    }
+  }
+
+  @Test
+  void passIsEmptyMoveValueAndDoesNotChangeStones() throws Exception {
+    try (RulesLayerTestHarness ignored = RulesLayerTestHarness.open(SIZE)) {
+      BoardHistoryList history = SGFParser.parseSgf("(;SZ[5];B[cc];W[];B[aa])", true);
+
+      BoardHistoryNode pass = history.getStart().next().orElseThrow().next().orElseThrow();
+      assertTrue(pass.getData().isPassNode());
+      assertEquals(Stone.WHITE, pass.getData().lastMoveColor);
+      assertEquals(Stone.BLACK, pass.getData().stones[Board.getIndex(2, 2)]);
+      assertEquals(Stone.EMPTY, pass.getData().stones[Board.getIndex(0, 0)]);
+      BoardHistoryNode afterPass = pass.next().orElseThrow();
+      assertEquals(Stone.BLACK, afterPass.getData().stones[Board.getIndex(0, 0)]);
+      assertEquals(3, afterPass.getData().moveNumber);
+    }
+  }
+
+  @Test
+  void commentsSupportChineseUnicodeEscapedBracketBackslashAndMultiline() throws Exception {
+    try (RulesLayerTestHarness ignored = RulesLayerTestHarness.open(SIZE)) {
+      String sgf =
+          "(;SZ[5]C[根注释：中文 and \\] and \\\\ slash\nsecond line];B[aa]C[move \\] and κ])";
+      BoardHistoryList history = SGFParser.parseSgf(sgf, true);
+
+      assertEquals(
+          "根注释：中文 and ] and \\ slash\nsecond line",
+          history.getStart().getData().comment);
+      assertEquals(
+          "move ] and κ",
+          history.getStart().next().orElseThrow().getData().comment);
+    }
+  }
+
+  @Test
+  void unknownNonCriticalPropertiesAreKeptOnTheModel() throws Exception {
+    try (RulesLayerTestHarness ignored = RulesLayerTestHarness.open(SIZE)) {
+      BoardHistoryList history =
+          SGFParser.parseSgf("(;SZ[5]XX[keep-me]GN[Friendly];B[aa]LB[aa:A])", true);
+
+      assertEquals("keep-me", history.getStart().getData().getProperty("XX"));
+      assertEquals("Friendly", history.getStart().getData().getProperty("GN"));
+      assertEquals("aa:A", history.getStart().next().orElseThrow().getData().getProperty("LB"));
+    }
+  }
+
+  @Test
+  void tolerantPrefixSuffixAndOptionalRootSemicolonStillParse() throws Exception {
+    try (RulesLayerTestHarness ignored = RulesLayerTestHarness.open(SIZE)) {
+      BoardHistoryList wrapped =
+          SGFParser.parseSgf("junk before\n(;SZ[5];B[aa]) trailing", true);
+      assertNotNull(wrapped);
+      assertEquals(List.of("BLACK 0,0"), mainlineMoves(wrapped));
+
+      BoardHistoryList optionalSemicolon = SGFParser.parseSgf("(SZ[5];B[bb])", true);
+      assertNotNull(optionalSemicolon);
+      assertEquals(List.of("BLACK 1,1"), mainlineMoves(optionalSemicolon));
+    }
+  }
+
+  @Test
+  void emptyAndNonSgfStringsParseWithoutThrowing() throws Exception {
+    try (RulesLayerTestHarness ignored = RulesLayerTestHarness.open(SIZE)) {
+      assertDoesNotThrow(() -> SGFParser.parseSgf("", true));
+      assertNull(SGFParser.parseSgf("", true));
+      assertDoesNotThrow(() -> SGFParser.parseSgf("not sgf", true));
+      assertFalse(SGFParser.isSGF("not sgf"));
+    }
+  }
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "",
+        "not sgf",
+        "(",
+        ")",
+        ";",
+        "B[aa]",
+        "(;SZ[5];B[",
+        "(;SZ[5];B[aa]"
+      })
+  void incompleteOrNonSgfInputIsHandledWithoutThrowing(String raw) throws Exception {
+    try (RulesLayerTestHarness ignored = RulesLayerTestHarness.open(SIZE)) {
+      BoardHistoryList parsed = assertDoesNotThrow(() -> SGFParser.parseSgf(raw, true));
+      if (parsed != null) {
+        assertTrue(
+            parsed.getStart() != null,
+            "a parsed tree should have a root even when the input is nonstandard.");
+      }
+    }
+  }
+
+  @Test
+  void invalidCoordinatesAreDroppedRatherThanThrown() throws Exception {
+    try (RulesLayerTestHarness ignored = RulesLayerTestHarness.open(SIZE)) {
+      BoardHistoryList history =
+          assertDoesNotThrow(() -> SGFParser.parseSgf("(;SZ[5];B[zz];W[aa])", true));
+      assertNotNull(history);
+      // Current behavior: off-board B[zz] is ignored, so White's move becomes the first child.
+      assertEquals(List.of("WHITE 0,0"), mainlineMoves(history));
+    }
+  }
+
+  @Test
+  void parseAppliesCapturesAndMoveNumbers() throws Exception {
+    try (RulesLayerTestHarness ignored = RulesLayerTestHarness.open(SIZE)) {
+      BoardHistoryList history = SGFParser.parseSgf("(;SZ[5];B[ba];W[aa];B[ab])", true);
+      BoardHistoryNode capture = history.getEnd();
+      assertEquals(Stone.EMPTY, capture.getData().stones[Board.getIndex(0, 0)]);
+      assertEquals(1, capture.getData().blackCaptures);
+      assertEquals(3, capture.getData().moveNumber);
+    }
+  }
+
+  @Test
+  void representativeSemanticRoundTripPreservesTreeSetupAndText() throws Exception {
+    try (RulesLayerTestHarness env = RulesLayerTestHarness.open(SIZE)) {
+      String source =
+          "(;SZ[5]KM[6.5]HA[2]PL[W]AB[ee]AW[ce]"
+              + "C[根注释：中文 and \\] and \\\\ slash\nsecond line]"
+              + "XX[keep-me]"
+              + ";W[ba]C[white approach]"
+              + ";B[aa]"
+              + ";W[ab]C[captures the corner]"
+              + ";B[]C[black pass]"
+              + ";W[cc]"
+              + "(;B[cd]C[mainline]"
+              + ";W[dc])"
+              + "(;B[db]C[branch unicode κ]))";
+
+      BoardHistoryList first = SGFParser.parseSgf(source, true);
+      assertNotNull(first);
+      Lizzie.board.setHistory(first);
+      String written = SGFParser.saveToString(false);
+      BoardHistoryList second = SGFParser.parseSgf(written, true);
+      assertNotNull(second);
+
+      assertTreeSemanticsEqual(first, second);
+      assertFalse(
+          written.equals(source),
+          "round-trip is allowed to change whitespace, property order, and wrappers.");
+    }
+  }
+
+  @Test
+  void livePlayCaptureVariationAndCommentRoundTrip() throws Exception {
+    try (RulesLayerTestHarness env = RulesLayerTestHarness.open(SIZE)) {
+      Board board = env.board();
+      board.getHistory().getGameInfo().setKomiNoMenu(0.5);
+      board.setupPlaceStone(4, 4, Stone.BLACK);
+      board.setupSetSideToPlay(true);
+      board.getHistory().getStart().getData().comment = "live root 中文";
+
+      board.place(1, 0, Stone.BLACK);
+      board.place(0, 0, Stone.WHITE);
+      board.place(0, 1, Stone.BLACK);
+      env.current().getData().comment = "captured with ] and \\";
+      BoardHistoryNode capture = env.current();
+      board.pass(Stone.WHITE);
+      board.previousMove(false);
+      board.place(2, 2, Stone.WHITE, true);
+      env.current().getData().comment = "variation";
+
+      String written = SGFParser.saveToString(false);
+      BoardHistoryList roundTrip = SGFParser.parseSgf(written, true);
+      assertNotNull(roundTrip);
+
+      assertEquals(0.5, roundTrip.getGameInfo().getKomi(), 0.0001);
+      assertEquals(Stone.BLACK, roundTrip.getStart().getData().stones[Board.getIndex(4, 4)]);
+      assertTrue(roundTrip.getStart().getData().comment.contains("live root 中文"));
+
+      BoardHistoryNode rtCapture = findCaptureNode(roundTrip.getStart());
+      assertNotNull(rtCapture);
+      assertEquals(1, rtCapture.getData().blackCaptures);
+      assertEquals(Stone.EMPTY, rtCapture.getData().stones[Board.getIndex(0, 0)]);
+      assertTrue(rtCapture.getData().comment.contains("captured with ] and \\"));
+      assertEquals(2, capture.numberOfChildren());
+      assertEquals(2, rtCapture.numberOfChildren());
+    }
+  }
+
+  private static BoardHistoryNode findCaptureNode(BoardHistoryNode root) {
+    ArrayList<BoardHistoryNode> pending = new ArrayList<>();
+    pending.add(root);
+    while (!pending.isEmpty()) {
+      BoardHistoryNode node = pending.remove(pending.size() - 1);
+      if (node.getData().blackCaptures > 0 || node.getData().whiteCaptures > 0) {
+        return node;
+      }
+      pending.addAll(node.getVariations());
+    }
+    return null;
+  }
+
+  static List<String> mainlineMoves(BoardHistoryList history) {
+    List<String> moves = new ArrayList<>();
+    BoardHistoryNode node = history.getStart();
+    while (node.next().isPresent()) {
+      node = node.next().get();
+      moves.add(describeMove(node));
+    }
+    return moves;
+  }
+
+  private static String describeMove(BoardHistoryNode node) {
+    BoardData data = node.getData();
+    if (data.isPassNode()) {
+      return data.lastMoveColor + " pass";
+    }
+    if (data.lastMove.isPresent()) {
+      int[] coord = data.lastMove.get();
+      return data.lastMoveColor + " " + coord[0] + "," + coord[1];
+    }
+    return String.valueOf(data.getNodeKind());
+  }
+
+  static void assertTreeSemanticsEqual(BoardHistoryList expected, BoardHistoryList actual) {
+    assertEquals(expected.getGameInfo().getKomi(), actual.getGameInfo().getKomi(), 0.0001);
+    assertEquals(expected.getGameInfo().getHandicap(), actual.getGameInfo().getHandicap());
+    assertNodeSemanticsEqual(expected.getStart(), actual.getStart());
+  }
+
+  private static void assertNodeSemanticsEqual(BoardHistoryNode expected, BoardHistoryNode actual) {
+    BoardData expectedData = expected.getData();
+    BoardData actualData = actual.getData();
+    assertEquals(expectedData.getNodeKind(), actualData.getNodeKind());
+    assertEquals(expectedData.moveNumber, actualData.moveNumber);
+    assertEquals(expectedData.lastMoveColor, actualData.lastMoveColor);
+    assertEquals(expectedData.blackToPlay, actualData.blackToPlay);
+    assertEquals(expectedData.blackCaptures, actualData.blackCaptures);
+    assertEquals(expectedData.whiteCaptures, actualData.whiteCaptures);
+    assertEquals(expectedData.dummy, actualData.dummy);
+    assertEquals(normalizeComment(expectedData.comment), normalizeComment(actualData.comment));
+    assertLastMoveEqual(expectedData.lastMove, actualData.lastMove);
+    assertArrayEquals(expectedData.stones, actualData.stones);
+    assertPropertyPresentIfOriginalHadIt(expectedData, actualData, "XX");
+    assertPropertyPresentIfOriginalHadIt(expectedData, actualData, "AB");
+    assertPropertyPresentIfOriginalHadIt(expectedData, actualData, "AW");
+    assertEquals(expected.numberOfChildren(), actual.numberOfChildren());
+    for (int i = 0; i < expected.numberOfChildren(); i++) {
+      assertNodeSemanticsEqual(
+          expected.getVariation(i).orElseThrow(), actual.getVariation(i).orElseThrow());
+    }
+  }
+
+  private static void assertLastMoveEqual(Optional<int[]> expected, Optional<int[]> actual) {
+    assertEquals(expected.isPresent(), actual.isPresent());
+    expected.ifPresent(value -> assertArrayEquals(value, actual.orElseThrow()));
+  }
+
+  private static void assertPropertyPresentIfOriginalHadIt(
+      BoardData expected, BoardData actual, String key) {
+    String expectedValue = expected.getProperty(key);
+    if (expectedValue != null && !expectedValue.isEmpty()) {
+      assertNotNull(actual.getProperty(key), "property " + key + " should survive round-trip");
+    }
+  }
+
+  private static String normalizeComment(String comment) {
+    return comment == null ? "" : comment;
+  }
+}


### PR DESCRIPTION
## Repro
On current `main`, rules-layer tests cover history/sync/movelist/root setup. They do not systematically lock Board play/capture/pass/ko/history-jump, SGF attribute parse, or parse → model → write → parse semantic round-trip.

## Cause
Those paths were untested. This is a regression-suite gap, not a product-behavior break.

## Fix
- `BoardPlayCaptureHistoryRegressionTest`: ordinary play; single- and multi-stone capture; suicide/out-of-bounds/occupied ignored as today; pass and consecutive pass; ko recapture rejected until a threat; fixed handicap on 19×19; root setup then play; mainline vs variation; undo/redo; `goToMoveNumber`; variation switch. Rules layer only.
- `SGFParserSemanticRoundTripTest`: mainline; variations; AB/AW/PL/KM/HA; pass; Chinese/Unicode comments; escaped `]`; backslash; multiline; unknown properties; tolerant prefix/suffix; incomplete/corrupt input; capture/move numbers; two semantic round-trips (representative SGF and live play). Compares meaning, not SGF bytes.
- `RulesLayerTestHarness`: shared headless Board/SGF fixture.
- No production code change.

Pinned current behavior (not changed):
- `parseSgf(..., false)` does not apply `KM` onto `GameInfo`; `parseSgf(..., true)` does.
- Off-board coords such as `B[zz]` on 5×5 are dropped, not treated as pass. Pass is empty `B[]` / `W[]` only.
- `SGFParser.parseSgf("")` returns null. `SGFParser.isSGF("")` throws `StringIndexOutOfBoundsException` (`substring(1)`). Existing helper-edge; left as-is.

## Verification
Local: `mvn -B -Dfmt.skip=true -Djava.awt.headless=true -Dtest=BoardPlayCaptureHistoryRegressionTest,SGFParserSemanticRoundTripTest test` (44 tests). Merge gate is existing Windows/Linux `mvn verify`. Deterministic: no sleep, network, engine, GPU, GUI, or readboard.

Fixes #316
