### PR TITLE
Fix Windows move input and candidate hover stalls

### DIFF
--- a/src/main/java/featurecat/lizzie/analysis/AnalysisCandidateValidator.java
+++ b/src/main/java/featurecat/lizzie/analysis/AnalysisCandidateValidator.java
@@ -1,0 +1,72 @@
+package featurecat.lizzie.analysis;
+
+import featurecat.lizzie.rules.Board;
+import featurecat.lizzie.rules.BoardData;
+import featurecat.lizzie.rules.Stone;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+/** Guards candidate overlays against analysis output that belongs to an older board position. */
+public final class AnalysisCandidateValidator {
+  private AnalysisCandidateValidator() {}
+
+  public static boolean isEmptyPoint(BoardData position, int[] coordinates) {
+    if (position == null
+        || position.stones == null
+        || coordinates == null
+        || coordinates.length < 2
+        || coordinates[0] < 0
+        || coordinates[0] >= Board.boardWidth
+        || coordinates[1] < 0
+        || coordinates[1] >= Board.boardHeight) {
+      return false;
+    }
+    int index = Board.getIndex(coordinates[0], coordinates[1]);
+    return index >= 0
+        && index < position.stones.length
+        && position.stones[index] == Stone.EMPTY;
+  }
+
+  public static boolean allCandidatesOnEmptyPoints(
+      List<MoveData> candidates, BoardData position) {
+    if (candidates == null || candidates.isEmpty()) {
+      return true;
+    }
+    for (MoveData candidate : candidates) {
+      Optional<int[]> coordinates = candidateCoordinates(candidate);
+      if (coordinates.isPresent() && !isEmptyPoint(position, coordinates.get())) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /** Removes only board-coordinate candidates that are occupied; pass-like moves remain intact. */
+  public static List<MoveData> withoutOccupiedCandidates(
+      List<MoveData> candidates, BoardData position) {
+    if (candidates == null || candidates.isEmpty()) {
+      return candidates;
+    }
+    ArrayList<MoveData> filtered = null;
+    for (int index = 0; index < candidates.size(); index++) {
+      MoveData candidate = candidates.get(index);
+      Optional<int[]> coordinates = candidateCoordinates(candidate);
+      boolean occupied = coordinates.isPresent() && !isEmptyPoint(position, coordinates.get());
+      if (occupied) {
+        if (filtered == null) {
+          filtered = new ArrayList<>(candidates.subList(0, index));
+        }
+      } else if (filtered != null) {
+        filtered.add(candidate);
+      }
+    }
+    return filtered == null ? candidates : filtered;
+  }
+
+  private static Optional<int[]> candidateCoordinates(MoveData candidate) {
+    return candidate == null || candidate.coordinate == null
+        ? Optional.empty()
+        : Board.asCoordinates(candidate.coordinate);
+  }
+}

--- a/src/main/java/featurecat/lizzie/analysis/Leelaz.java
+++ b/src/main/java/featurecat/lizzie/analysis/Leelaz.java
@@ -47,6 +47,7 @@ import java.util.Random;
 import java.util.Timer;
 import java.util.TimerTask;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -74,6 +75,9 @@ import org.json.JSONObject;
  */
 public class Leelaz {
   private static final AtomicLong ENGINE_ARBITRATION_ORDER_SEQUENCE = new AtomicLong();
+  private static final AtomicInteger COMMAND_DISPATCH_THREAD_SEQUENCE = new AtomicInteger();
+  private static final Executor COMMAND_DISPATCH_EXECUTOR =
+      Executors.newCachedThreadPool(Leelaz::newCommandDispatchThread);
 
   public enum ExclusiveGtpLeaseAvailability {
     AVAILABLE,
@@ -318,6 +322,8 @@ public class Leelaz {
   private ArrayDeque<QueuedCommand> foregroundRestoreQueue;
   private volatile boolean normalCommandSendInProgress;
   private QueuedCommand normalCommandBeingSent;
+  private final AtomicLong eventDispatchCommandRequests = new AtomicLong();
+  private final AtomicBoolean eventDispatchCommandScheduled = new AtomicBoolean();
   private final ThreadLocal<ExclusiveGtpSession> foregroundRestoreCommandSession =
       new ThreadLocal<>();
   private static final ThreadLocal<ExactSnapshotRestoreAdmission>
@@ -11460,6 +11466,84 @@ public class Leelaz {
 
   /** Sends a command from command queue for leelaz to execute if it is ready */
   private void trySendCommandFromQueue() {
+    if (SwingUtilities.isEventDispatchThread() && canDispatchOrdinaryCommandOffEventThread()) {
+      requestCommandDispatchOffEventThread();
+      return;
+    }
+    trySendCommandFromQueueNow();
+  }
+
+  private boolean canDispatchOrdinaryCommandOffEventThread() {
+    if (foregroundRestoreCommandSession.get() != null
+        || isExactSnapshotRestoreAdmissionContextActive()
+        || lifecycleCompletionCommandContext.get() != null
+        || ordinaryLiveBoardForwardingContext.get() != null
+        || engineGameStartupCommandContext.get() != null
+        || Boolean.TRUE.equals(deferredEngineGameRecoveryStartupContext.get())
+        || updateEngineStartAttemptContext.get() != null
+        || analysisOutputRecoveryTokenContext.get() != null
+        || startupPostActionCommandContext.get() != null
+        || restartBootstrapReceiptContext.get() != null) {
+      return false;
+    }
+    synchronized (commandQueue()) {
+      ArrayDeque<QueuedCommand> targetQueue =
+          foregroundRestoreInProgress ? foregroundRestoreCommandQueue() : commandQueue();
+      QueuedCommand queueHead = targetQueue.peekFirst();
+      return queueHead != null
+          && !queueHead.failOnSendError
+          && queueHead.onSendFailure == null
+          && queueHead.internalSendFailureHandler == null
+          && queueHead.settlement == null
+          && queueHead.restartBootstrapReceipt == null
+          && queueHead.readBoardGmaResponseBinding == null
+          && queueHead.expectedLeela0110StateToken == null
+          && !queueHead.foregroundRestoreCommand;
+    }
+  }
+
+  private void requestCommandDispatchOffEventThread() {
+    eventDispatchCommandRequests.incrementAndGet();
+    scheduleCommandDispatchOffEventThread();
+  }
+
+  private void scheduleCommandDispatchOffEventThread() {
+    if (!eventDispatchCommandScheduled.compareAndSet(false, true)) {
+      return;
+    }
+    COMMAND_DISPATCH_EXECUTOR.execute(
+        () -> {
+          long handledRequest = eventDispatchCommandRequests.get();
+          try {
+            trySendCommandFromQueueNow();
+          } catch (RuntimeException | Error failure) {
+            String detail =
+                "Asynchronous GTP command dispatch failed: "
+                    + safeFailureDetail(failure, failure.getClass().getSimpleName());
+            rememberRecentLine(recentStderrLines, detail);
+            System.err.println(detail);
+            if (failure instanceof Error) {
+              throw (Error) failure;
+            }
+          } finally {
+            eventDispatchCommandScheduled.set(false);
+            if (eventDispatchCommandRequests.get() != handledRequest) {
+              scheduleCommandDispatchOffEventThread();
+            }
+          }
+        });
+  }
+
+  private static Thread newCommandDispatchThread(Runnable runnable) {
+    Thread thread =
+        new Thread(
+            runnable,
+            "lizzie-gtp-command-dispatch-" + COMMAND_DISPATCH_THREAD_SEQUENCE.incrementAndGet());
+    thread.setDaemon(true);
+    return thread;
+  }
+
+  private void trySendCommandFromQueueNow() {
     // Defer sending "lz-analyze" if leelaz is not ready yet.
     // Though all commands should be deferred theoretically,
     // only "lz-analyze" is differed here for fear of

--- a/src/main/java/featurecat/lizzie/analysis/Leelaz.java
+++ b/src/main/java/featurecat/lizzie/analysis/Leelaz.java
@@ -4533,6 +4533,10 @@ public class Leelaz {
         || target.displayNode == null) {
       return;
     }
+    BoardData displayData = target.displayNode.getData();
+    if (!AnalysisCandidateValidator.allCandidatesOnEmptyPoints(parsed.moves, displayData)) {
+      return;
+    }
     boolean secondaryDisplay =
         Lizzie.config.isDoubleEngineMode() && Lizzie.leelaz2 != null && this == Lizzie.leelaz2;
     boolean engineGameParticipantToMove = true;
@@ -4551,7 +4555,6 @@ public class Leelaz {
       return;
     }
     List<MoveData> boardMoves = new ArrayList<>(parsed.moves);
-    BoardData displayData = target.displayNode.getData();
     if (secondaryDisplay) {
       if (parsed.kata) {
         displayData.tryToSetBestMoves2FromEngine(
@@ -6281,6 +6284,11 @@ public class Leelaz {
   private void invalidateAnalysisInfoPayloadForLocalStateChange(boolean resetScore) {
     analysisOutputGeneration.incrementAndGet();
     resetAnalysisInfoPayload(resetScore);
+  }
+
+  /** Quarantines the old streaming owner before an asynchronously dispatched local play. */
+  private void retireAnalysisInfoBeforeQueuedPlay() {
+    invalidateAnalysisInfoPayloadForLocalStateChange(false);
   }
 
   private void applyAnalysisStateMutation(AnalysisStateMutation mutation) {
@@ -18618,6 +18626,7 @@ public class Leelaz {
                 || ((Lizzie.config.analyzeBlack && color == Stone.WHITE)
                     || (Lizzie.config.analyzeWhite && color == Stone.BLACK)));
     boolean settleTrackingPonder = hasTrackingStreamSession() && ponderAfterMove;
+    retireAnalysisInfoBeforeQueuedPlay();
     sendCommand(
         "play " + colorString + " " + move,
         settleTrackingPonder ? this::settleTrackingPonderAfterPlayResponse : null);

--- a/src/main/java/featurecat/lizzie/analysis/ReadBoard.java
+++ b/src/main/java/featurecat/lizzie/analysis/ReadBoard.java
@@ -33,12 +33,17 @@ import java.util.Locale;
 import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.Set;
+import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import javax.swing.SwingUtilities;
 
 public class ReadBoard implements ReadBoardTrackingEligibilityAdapter.EligibilitySource {
+  private static final AtomicInteger PLACE_COMMAND_DISPATCH_THREAD_SEQUENCE = new AtomicInteger();
+  private static final Executor PLACE_COMMAND_DISPATCH_EXECUTOR =
+      Executors.newCachedThreadPool(ReadBoard::newPlaceCommandDispatchThread);
   private static final long PROCESS_EXIT_WAIT_TIMEOUT_MS = 1000L;
   private static final long PROCESS_DESTROY_WAIT_TIMEOUT_MS = 200L;
   private static final String LEGACY_NATIVE_READBOARD_EXE = "readboard.exe";
@@ -6123,9 +6128,15 @@ public class ReadBoard implements ReadBoardTrackingEligibilityAdapter.Eligibilit
     if (currentOutputStream == null) {
       return;
     }
+    sendCommandTo(currentOutputStream, command);
+  }
+
+  private static void sendCommandTo(BufferedOutputStream target, String command) {
     try {
-      currentOutputStream.write((command + "\n").getBytes());
-      currentOutputStream.flush();
+      synchronized (target) {
+        target.write((command + "\n").getBytes());
+        target.flush();
+      }
     } catch (IOException e) {
       // e.printStackTrace();
     }
@@ -6170,9 +6181,39 @@ public class ReadBoard implements ReadBoardTrackingEligibilityAdapter.Eligibilit
       if (Lizzie.frame.isPlayingAgainstLeelaz) needGenmove = true;
       localMoveSyncDebug("sendCommand external place after tracking " + pendingLocalMoveState());
     }
+    if (command.startsWith("place ") && SwingUtilities.isEventDispatchThread()) {
+      dispatchPlaceCommandOffEventThread(command);
+      return;
+    }
     if (usePipe) {
       sendCommandTo(command);
     } else if (readBoardStream != null) readBoardStream.sendCommand(command);
+  }
+
+  private void dispatchPlaceCommandOffEventThread(String command) {
+    BufferedOutputStream pipeTarget = usePipe ? outputStream : null;
+    ReadBoardStream socketTarget = usePipe ? null : readBoardStream;
+    if (pipeTarget == null && socketTarget == null) {
+      return;
+    }
+    PLACE_COMMAND_DISPATCH_EXECUTOR.execute(
+        () -> {
+          if (pipeTarget != null) {
+            sendCommandTo(pipeTarget, command);
+          } else {
+            socketTarget.sendCommand(command);
+          }
+        });
+  }
+
+  private static Thread newPlaceCommandDispatchThread(Runnable runnable) {
+    Thread thread =
+        new Thread(
+            runnable,
+            "readboard-place-command-dispatch-"
+                + PLACE_COMMAND_DISPATCH_THREAD_SEQUENCE.incrementAndGet());
+    thread.setDaemon(true);
+    return thread;
   }
 
   private void clearFailedLocalMoveStateIfOutgoingPlaceDiffers(String command) {

--- a/src/main/java/featurecat/lizzie/analysis/ReadBoardStream.java
+++ b/src/main/java/featurecat/lizzie/analysis/ReadBoardStream.java
@@ -77,8 +77,10 @@ public class ReadBoardStream extends Thread implements Closeable {
       return;
     }
     try {
-      out.write((command + "\n").getBytes());
-      out.flush();
+      synchronized (out) {
+        out.write((command + "\n").getBytes());
+        out.flush();
+      }
     } catch (IOException e) {
       // TODO Auto-generated catch block
       //  e.printStackTrace();

--- a/src/main/java/featurecat/lizzie/gui/BoardRenderer.java
+++ b/src/main/java/featurecat/lizzie/gui/BoardRenderer.java
@@ -1585,6 +1585,10 @@ public class BoardRenderer {
       return;
     }
 
+    if (!isSuggestionHoverPreviewReady()) {
+      return;
+    }
+
     Optional<MoveData> suggestedMove = mouseOveredMove();
     if (!suggestedMove.isPresent()
         || Lizzie.frame.shouldShowPolicyFor(Lizzie.frame.getDisplayNode())
@@ -1654,6 +1658,19 @@ public class BoardRenderer {
       pvVistis = branchPreviewList(suggestedMove.get().pvVisits);
     }
     if (variation == null) {
+      return;
+    }
+    if (Lizzie.config.noRefreshOnMouseMove
+        && notChangedMouseOverMove
+        && variation == cachedVariation
+        && displayedBranchLength == cachedDisplayedBranchLengthFroBranch
+        && !changedSize
+        && branch != null
+        && hasRenderedBranchImages()) {
+      mouseOverCoords = suggestedMove.get().coordinate;
+      branchOpt = Optional.of(branch);
+      variationOpt = Optional.of(variation);
+      isShowingBranch = true;
       return;
     }
     branch = null;
@@ -1781,6 +1798,19 @@ public class BoardRenderer {
     gShadow.dispose();
     branchStonesImage = tempBranchStonesImage;
     branchStonesShadowImage = tempBranchStonesShadowImage;
+  }
+
+  private boolean isSuggestionHoverPreviewReady() {
+    if (isIndependBoard) {
+      IndependentMainBoard board = Lizzie.frame.independentMainBoard;
+      if (board == null) {
+        return true;
+      }
+      int[] coords = board.mouseOverCoordinate;
+      return board.isSuggestionHoverPreviewReady(coords[0], coords[1]);
+    }
+    int[] coords = Lizzie.frame.mouseOverCoordinate;
+    return Lizzie.frame.isSuggestionHoverPreviewReady(coords[0], coords[1]);
   }
 
   private boolean compareVariationListEquals(List<String> variation, List<String> variation2) {

--- a/src/main/java/featurecat/lizzie/gui/BoardRenderer.java
+++ b/src/main/java/featurecat/lizzie/gui/BoardRenderer.java
@@ -8,6 +8,7 @@ import static java.lang.Math.min;
 import static java.lang.Math.round;
 
 import featurecat.lizzie.Lizzie;
+import featurecat.lizzie.analysis.AnalysisCandidateValidator;
 import featurecat.lizzie.analysis.Branch;
 import featurecat.lizzie.analysis.EngineManager;
 import featurecat.lizzie.analysis.Leelaz;
@@ -1573,6 +1574,11 @@ public class BoardRenderer {
         } else preEstimateArray = null;
       }
     }
+    if (!shouldShowPreviousBestMoves()) {
+      bestMoves =
+          AnalysisCandidateValidator.withoutOccupiedCandidates(
+              bestMoves, Lizzie.frame.getDisplayNode().getData());
+    }
 
     //    if ((Lizzie.board.getHistory().isBlacksTurn()
     //            && !Lizzie.frame.toolbar.chkShowBlack.isSelected())
@@ -1729,11 +1735,18 @@ public class BoardRenderer {
 
     g.setRenderingHint(KEY_ANTIALIASING, VALUE_ANTIALIAS_ON);
     drawShadowCache();
+    boolean overlayOnCachedStones =
+        canOverlayBranchOnCachedStones(Lizzie.frame.getDisplayNode().getData(), branch);
+    if (overlayOnCachedStones) {
+      g.drawImage(cachedStonesImage, 0, 0, null);
+      gShadow.drawImage(cachedStonesShadowImage, 0, 0, null);
+    }
     if (Lizzie.config.usePureStone) {
       for (int i = 0; i < Board.boardWidth; i++) {
         for (int j = 0; j < Board.boardHeight; j++) {
           // Display latest stone for ghost dead stone
           int index = Board.getIndex(i, j);
+          if (overlayOnCachedStones && !branch.isNewStone[index]) continue;
           Stone stone = branch.data.stones[index];
           if (!Lizzie.config.removeDeadChainInVariation && !shouldShowPreviousBestMoves())
             if (Lizzie.board.getData().stones[index] != Stone.EMPTY) continue;
@@ -1765,6 +1778,7 @@ public class BoardRenderer {
       for (int i = 0; i < Board.boardWidth; i++) {
         for (int j = 0; j < Board.boardHeight; j++) {
           int index = Board.getIndex(i, j);
+          if (overlayOnCachedStones && !branch.isNewStone[index]) continue;
           Stone stone = branch.data.stones[index];
           if (!Lizzie.config.removeDeadChainInVariation && !shouldShowPreviousBestMoves())
             if (Lizzie.board.getData().stones[index] != Stone.EMPTY) continue;
@@ -1798,6 +1812,39 @@ public class BoardRenderer {
     gShadow.dispose();
     branchStonesImage = tempBranchStonesImage;
     branchStonesShadowImage = tempBranchStonesShadowImage;
+  }
+
+  private boolean canOverlayBranchOnCachedStones(BoardData sourceData, Branch candidateBranch) {
+    return Lizzie.config.removeDeadChainInVariation
+        && !shouldShowPreviousBestMoves()
+        && cachedStonesImage.getWidth() == boardWidth
+        && cachedStonesImage.getHeight() == boardHeight
+        && cachedStonesShadowImage.getWidth() == boardWidth
+        && cachedStonesShadowImage.getHeight() == boardHeight
+        && cachedZhash.equals(sourceData.zobrist)
+        && branchPreservesExistingStones(
+            sourceData.stones, candidateBranch.data.stones, candidateBranch.isNewStone);
+  }
+
+  static boolean branchPreservesExistingStones(
+      Stone[] sourceStones, Stone[] branchStones, boolean[] newStones) {
+    if (sourceStones == null
+        || branchStones == null
+        || newStones == null
+        || sourceStones.length != branchStones.length
+        || sourceStones.length != newStones.length) {
+      return false;
+    }
+    for (int index = 0; index < sourceStones.length; index++) {
+      boolean changedExistingStone =
+          sourceStones[index] != Stone.EMPTY && sourceStones[index] != branchStones[index];
+      boolean untrackedChange =
+          !newStones[index] && sourceStones[index] != branchStones[index];
+      if (changedExistingStone || untrackedChange) {
+        return false;
+      }
+    }
+    return true;
   }
 
   private boolean isSuggestionHoverPreviewReady() {
@@ -2321,6 +2368,10 @@ public class BoardRenderer {
         if (heatcount.get(i) > 0) {
           int y1 = i / Board.boardWidth;
           int x1 = i % Board.boardWidth;
+          if (!AnalysisCandidateValidator.isEmptyPoint(
+              displayNode.getData(), new int[] {x1, y1})) {
+            continue;
+          }
           int suggestionX = x + scaledMarginWidth + squareWidth * x1;
           int suggestionY = y + scaledMarginHeight + squareHeight * y1;
           double percent = ((double) heatcount.get(i)) / maxPolicy;
@@ -4731,6 +4782,10 @@ public class BoardRenderer {
 
   public boolean isInside(int x1, int y1) {
     return x <= x1 && x1 < x + boardWidth && y <= y1 && y1 < y + boardHeight;
+  }
+
+  Rectangle getBoardBounds() {
+    return new Rectangle(x, y, boardWidth, boardHeight);
   }
 
   private boolean showCoordinates() {

--- a/src/main/java/featurecat/lizzie/gui/FloatBoard.java
+++ b/src/main/java/featurecat/lizzie/gui/FloatBoard.java
@@ -44,6 +44,7 @@ public class FloatBoard extends JDialog {
   private boolean isReplayVariation = false;
   // private JButton lockUnlock;
   public int[] mouseOverCoordinate = LizzieFrame.outOfBoundCoordinate;
+  private transient SuggestionHoverIntent suggestionHoverIntent;
   public Optional<List<String>> variationOpt;
   private int curSuggestionMoveOrderByNumber = -1;
   public int selectCoordsX1;
@@ -311,6 +312,7 @@ public class FloatBoard extends JDialog {
     addMouseListener(
         new MouseAdapter() {
           public void mousePressed(MouseEvent e) {
+            cancelPendingSuggestionHoverPreview();
             if (e.getButton() == MouseEvent.BUTTON1) // left click
             {
               onClicked(Utils.zoomOut(e.getX()), Utils.zoomOut(e.getY()));
@@ -321,6 +323,7 @@ public class FloatBoard extends JDialog {
     addMouseListener(
         new MouseAdapter() {
           public void mouseExited(MouseEvent e) {
+            cancelPendingSuggestionHoverPreview();
             //            btnClose.setVisible(false);
             //            lockUnlock.setVisible(false);
             //            topUntop.setVisible(false);
@@ -389,6 +392,7 @@ public class FloatBoard extends JDialog {
                   clearMoved();
                   needRepaint = true;
                   isMouseOver = true;
+                  armSuggestionHoverPreview(curCoords[0], curCoords[1]);
                   if (Lizzie.config.autoReplayBranch) {
                     Lizzie.frame.mouseOverChanged = true;
                     if (!Lizzie.config.autoReplayDisplayEntireVariationsFirst)
@@ -403,6 +407,7 @@ public class FloatBoard extends JDialog {
                 }
               }
             } else {
+              cancelPendingSuggestionHoverPreview();
               mouseOverCoordinate = LizzieFrame.outOfBoundCoordinate;
               if (isMouseOver) {
                 isMouseOver = false;
@@ -498,11 +503,33 @@ public class FloatBoard extends JDialog {
   }
 
   public void clearMoved() {
+    cancelPendingSuggestionHoverPreview();
     isReplayVariation = false;
     isMouseOver = false;
     boardRenderer.startNormalBoard();
     boardRenderer.clearBranch();
     boardRenderer.notShowingBranch();
+  }
+
+  private SuggestionHoverIntent suggestionHoverIntent() {
+    if (suggestionHoverIntent == null) {
+      suggestionHoverIntent = new SuggestionHoverIntent(this::refreshByLis);
+    }
+    return suggestionHoverIntent;
+  }
+
+  private void armSuggestionHoverPreview(int x, int y) {
+    suggestionHoverIntent().arm(x, y);
+  }
+
+  private void cancelPendingSuggestionHoverPreview() {
+    if (suggestionHoverIntent != null) {
+      suggestionHoverIntent.cancel();
+    }
+  }
+
+  boolean isSuggestionHoverPreviewReady(int x, int y) {
+    return suggestionHoverIntent == null || suggestionHoverIntent.permits(x, y);
   }
 
   private void paintMianPanel(Graphics g) {
@@ -579,6 +606,7 @@ public class FloatBoard extends JDialog {
   //  }
 
   public void setMouseOverCoords(int index) {
+    cancelPendingSuggestionHoverPreview();
     List<MoveData> bestMoves = Lizzie.board.getHistory().getData().bestMoves;
     if (bestMoves == null || bestMoves.isEmpty()) return;
     if (index >= bestMoves.size()) return;
@@ -682,6 +710,7 @@ public class FloatBoard extends JDialog {
   //  }
 
   private void onClicked(int x, int y) {
+    cancelPendingSuggestionHoverPreview();
     // Check for board click
     Optional<int[]> boardCoordinates;
 

--- a/src/main/java/featurecat/lizzie/gui/FloatBoardRenderer.java
+++ b/src/main/java/featurecat/lizzie/gui/FloatBoardRenderer.java
@@ -694,6 +694,7 @@ public class FloatBoardRenderer {
       cachedBoardHeight = boardHeight;
       cachedShadow = null;
       cachedGhostShadow2 = null;
+      invalidateBranchImageCache();
     }
     showingBranch = false;
     branchOpt = Optional.empty();
@@ -714,6 +715,10 @@ public class FloatBoardRenderer {
     variationOpt = Optional.empty();
 
     if ((isShowingRawBoard() || !Lizzie.config.showBranchNow())) {
+      return;
+    }
+
+    if (!isSuggestionHoverPreviewReady()) {
       return;
     }
 
@@ -770,6 +775,19 @@ public class FloatBoardRenderer {
       pvVistis = branchPreviewList(suggestedMove.get().pvVisits);
     }
     if (variation == null) {
+      return;
+    }
+    if (Lizzie.config.noRefreshOnMouseMove
+        && notChangedMouseOverMove
+        && variation == cachedVariation
+        && displayedBranchLength == cachedDisplayedBranchLengthFroBranch
+        && branch != null
+        && hasRenderedBranchImages()) {
+      mouseOverCoords = suggestedMove.get().coordinate;
+      branchOpt = Optional.of(branch);
+      variationOpt = Optional.of(variation);
+      showingBranch = true;
+      isShowingBranch = true;
       return;
     }
     branch = null;
@@ -873,6 +891,15 @@ public class FloatBoardRenderer {
     gShadow.dispose();
     branchStonesImage = tempBranchStonesImage;
     branchStonesShadowImage = tempBranchStonesShadowImage;
+  }
+
+  private boolean isSuggestionHoverPreviewReady() {
+    FloatBoard board = Lizzie.frame.floatBoard;
+    if (board == null) {
+      return true;
+    }
+    int[] coords = board.mouseOverCoordinate;
+    return board.isSuggestionHoverPreviewReady(coords[0], coords[1]);
   }
 
   private boolean compareVariationListEquals(List<String> variation, List<String> variation2) {

--- a/src/main/java/featurecat/lizzie/gui/IndependentMainBoard.java
+++ b/src/main/java/featurecat/lizzie/gui/IndependentMainBoard.java
@@ -61,6 +61,7 @@ public class IndependentMainBoard extends JFrame {
   private JButton lockUnlock;
   private JButton btnClose;
   public int[] mouseOverCoordinate = LizzieFrame.outOfBoundCoordinate;
+  private transient SuggestionHoverIntent suggestionHoverIntent;
   public Optional<List<String>> variationOpt;
   private int curSuggestionMoveOrderByNumber = -1;
   private Stone draggedstone;
@@ -311,6 +312,7 @@ public class IndependentMainBoard extends JFrame {
           }
 
           public void mousePressed(MouseEvent e) {
+            cancelPendingSuggestionHoverPreview();
             origin.x = e.getX();
             origin.y = e.getY();
 
@@ -431,6 +433,7 @@ public class IndependentMainBoard extends JFrame {
     addMouseListener(
         new MouseAdapter() {
           public void mouseExited(MouseEvent e) {
+            cancelPendingSuggestionHoverPreview();
             btnClose.setVisible(false);
             lockUnlock.setVisible(false);
             topUntop.setVisible(false);
@@ -566,6 +569,7 @@ public class IndependentMainBoard extends JFrame {
                     clearMoved();
                     needRepaint = true;
                     isMouseOver = true;
+                    armSuggestionHoverPreview(curCoords[0], curCoords[1]);
                     if (Lizzie.config.autoReplayBranch) {
                       Lizzie.frame.mouseOverChanged = true;
                       boardRenderer.setDisplayedBranchLength(1);
@@ -586,6 +590,7 @@ public class IndependentMainBoard extends JFrame {
                 }
                 Lizzie.board.clearPressStoneInfo(curCoords);
               } else {
+                cancelPendingSuggestionHoverPreview();
                 if (isMouseOver) {
                   mouseOverCoordinate = LizzieFrame.outOfBoundCoordinate;
                   isMouseOver = false;
@@ -665,11 +670,33 @@ public class IndependentMainBoard extends JFrame {
   }
 
   public void clearMoved() {
+    cancelPendingSuggestionHoverPreview();
     isReplayVariation = false;
     isMouseOver = false;
     boardRenderer.startNormalBoard();
     boardRenderer.clearBranch();
     boardRenderer.notShowingBranch();
+  }
+
+  private SuggestionHoverIntent suggestionHoverIntent() {
+    if (suggestionHoverIntent == null) {
+      suggestionHoverIntent = new SuggestionHoverIntent(this::refresh);
+    }
+    return suggestionHoverIntent;
+  }
+
+  private void armSuggestionHoverPreview(int x, int y) {
+    suggestionHoverIntent().arm(x, y);
+  }
+
+  private void cancelPendingSuggestionHoverPreview() {
+    if (suggestionHoverIntent != null) {
+      suggestionHoverIntent.cancel();
+    }
+  }
+
+  boolean isSuggestionHoverPreviewReady(int x, int y) {
+    return suggestionHoverIntent == null || suggestionHoverIntent.permits(x, y);
   }
 
   private void paintMianPanel(Graphics g) {
@@ -777,6 +804,7 @@ public class IndependentMainBoard extends JFrame {
   }
 
   private void onClicked(int x, int y) {
+    cancelPendingSuggestionHoverPreview();
     if (Lizzie.frame.isContributing) return;
     // Check for board click
     Optional<int[]> boardCoordinates;
@@ -837,6 +865,7 @@ public class IndependentMainBoard extends JFrame {
   }
 
   public void setMouseOverCoords(int index) {
+    cancelPendingSuggestionHoverPreview();
     List<MoveData> bestMoves = Lizzie.board.getHistory().getData().bestMoves;
     if (bestMoves == null || bestMoves.isEmpty()) return;
     if (index >= bestMoves.size()) return;

--- a/src/main/java/featurecat/lizzie/gui/Input.java
+++ b/src/main/java/featurecat/lizzie/gui/Input.java
@@ -26,6 +26,7 @@ public class Input implements MouseListener, KeyListener, MouseWheelListener, Mo
 
   @Override
   public void mousePressed(MouseEvent e) {
+    Lizzie.frame.cancelPendingSuggestionHoverPreview();
     boolean boardButton =
         e.getButton() == MouseEvent.BUTTON1 || e.getButton() == MouseEvent.BUTTON3;
     if (boardButton && Lizzie.frame.hasActiveHumanSlGame()) {

--- a/src/main/java/featurecat/lizzie/gui/LizzieFrame.java
+++ b/src/main/java/featurecat/lizzie/gui/LizzieFrame.java
@@ -468,6 +468,7 @@ public class LizzieFrame extends JFrame {
   public int[] suggestionclick = outOfBoundCoordinate;
   public int[] clickbadmove = outOfBoundCoordinate;
   public int[] mouseOverCoordinate = outOfBoundCoordinate;
+  private transient SuggestionHoverIntent suggestionHoverIntent;
   private int curSuggestionMoveOrderByNumber = -1;
   public boolean showControls = false;
   private long showControlTime;
@@ -7999,6 +8000,7 @@ public class LizzieFrame extends JFrame {
   }
 
   public void onClicked(int x, int y) {
+    cancelPendingSuggestionHoverPreview();
     if (isTrialActive()) {
       showTrialBlockedHint();
       return;
@@ -8263,6 +8265,7 @@ public class LizzieFrame extends JFrame {
   }
 
   public void onMouseExited() {
+    cancelPendingSuggestionHoverPreview();
     boolean needRepaint = false;
     if (Lizzie.config.isFourSubMode()) {
       if (Lizzie.frame.subBoardRenderer2.isMouseOver) {
@@ -8478,6 +8481,7 @@ public class LizzieFrame extends JFrame {
           clearMoved();
           needRepaint = true;
           isMouseOver = true;
+          armSuggestionHoverPreview(curCoords[0], curCoords[1]);
           if (Lizzie.config.autoReplayBranch) {
             mouseOverChanged = true;
             if (!Lizzie.config.autoReplayDisplayEntireVariationsFirst)
@@ -8512,6 +8516,7 @@ public class LizzieFrame extends JFrame {
       }
 
     } else {
+      cancelPendingSuggestionHoverPreview();
       mouseOverCoordinate = outOfBoundCoordinate;
       if (isMouseOver) {
         isMouseOver = false;
@@ -8536,6 +8541,7 @@ public class LizzieFrame extends JFrame {
   }
 
   public void clearMoved() {
+    cancelPendingSuggestionHoverPreview();
     isReplayVariation = false;
     Lizzie.frame.isMouseOver = false;
     clearBoardBranchPreview();
@@ -8546,6 +8552,7 @@ public class LizzieFrame extends JFrame {
   }
 
   void clearSuggestionTablePreview() {
+    cancelPendingSuggestionHoverPreview();
     clickOrder = -1;
     selectedorder = -1;
     currentRow = -1;
@@ -8557,6 +8564,7 @@ public class LizzieFrame extends JFrame {
 
   /** Clears transient analysis overlays while editing a static starting position. */
   private void clearSetupOverlayState() {
+    cancelPendingSuggestionHoverPreview();
     isReplayVariation = false;
     isMouseOver = false;
     clickOrder = -1;
@@ -8589,6 +8597,27 @@ public class LizzieFrame extends JFrame {
       boardRenderer2.startNormalBoard();
       boardRenderer2.clearBranch();
     }
+  }
+
+  private SuggestionHoverIntent suggestionHoverIntent() {
+    if (suggestionHoverIntent == null) {
+      suggestionHoverIntent = new SuggestionHoverIntent(this::refresh);
+    }
+    return suggestionHoverIntent;
+  }
+
+  private void armSuggestionHoverPreview(int x, int y) {
+    suggestionHoverIntent().arm(x, y);
+  }
+
+  public void cancelPendingSuggestionHoverPreview() {
+    if (suggestionHoverIntent != null) {
+      suggestionHoverIntent.cancel();
+    }
+  }
+
+  boolean isSuggestionHoverPreviewReady(int x, int y) {
+    return suggestionHoverIntent == null || suggestionHoverIntent.permits(x, y);
   }
 
   //  public void clearMoved2() {
@@ -12397,6 +12426,7 @@ public class LizzieFrame extends JFrame {
   }
 
   public void setMouseOverCoords(int index) {
+    cancelPendingSuggestionHoverPreview();
     if (Lizzie.config.isFloatBoardMode()) {
       this.independentMainBoard.setMouseOverCoords(index);
       return;
@@ -12418,6 +12448,7 @@ public class LizzieFrame extends JFrame {
   }
 
   private void handleTableClick(int row, int col) {
+    cancelPendingSuggestionHoverPreview();
     LizzieFrame.boardRenderer.startNormalBoard();
     if (listTable.getValueAt(row, 1).toString().startsWith("pass")) return;
     int[] coords = Board.convertNameToCoordinates(listTable.getValueAt(row, 1).toString());
@@ -18630,6 +18661,7 @@ public class LizzieFrame extends JFrame {
       if (independentMainBoard != null)
         independentMainBoard.mouseOverCoordinate = outOfBoundCoordinate;
     } else {
+      cancelPendingSuggestionHoverPreview();
       mouseOverCoordinate = outOfBoundCoordinate;
     }
   }

--- a/src/main/java/featurecat/lizzie/gui/LizzieFrame.java
+++ b/src/main/java/featurecat/lizzie/gui/LizzieFrame.java
@@ -525,6 +525,8 @@ public class LizzieFrame extends JFrame {
       new java.util.concurrent.atomic.AtomicBoolean(false);
   private final SwingRefreshCoalescer analysisRefreshCoalescer =
       new SwingRefreshCoalescer(33, this::flushAnalysisRefresh);
+  private final SwingRefreshCoalescer analysisSidebarRefreshCoalescer =
+      new SwingRefreshCoalescer(250, this::flushAnalysisSidebarRefresh);
   private JPanel kifuLoadGlassPane;
   private JLabel kifuLoadMessageLabel;
   private JProgressBar kifuLoadProgressBar;
@@ -791,6 +793,9 @@ public class LizzieFrame extends JFrame {
   private javax.swing.Timer quickAnalysisNavigationResumeTimer;
   private volatile TrackingAnalysisController trackingAnalysisController;
   private boolean redrawWinratePaneOnly = false;
+  private boolean redrawBoardSurfacesOnly = false;
+  private javax.swing.Timer deferredMoveUiRefreshTimer;
+  private static final int DEFERRED_MOVE_UI_REFRESH_MS = 180;
   public boolean mouseOverChanged = false;
   public boolean isAutoReplying = false;
   public boolean isBatchAnalysisMode = false;
@@ -5112,19 +5117,97 @@ public class LizzieFrame extends JFrame {
     return buffer;
   }
 
+  /** Copies the published frame into the spare buffer before repainting dynamic board surfaces. */
+  private BufferedImage acquireIncrementalPaintBuffer(int width, int height) {
+    boolean intoA = cachedImage != paintBufferA || paintBufferA == null;
+    BufferedImage buffer = intoA ? paintBufferA : paintBufferB;
+    if (buffer == null || buffer.getWidth() != width || buffer.getHeight() != height) {
+      buffer = new BufferedImage(width, height, TYPE_INT_ARGB);
+      if (intoA) paintBufferA = buffer;
+      else paintBufferB = buffer;
+    }
+    Graphics2D graphics = buffer.createGraphics();
+    graphics.setComposite(AlphaComposite.Src);
+    graphics.drawImage(cachedImage, 0, 0, null);
+    graphics.dispose();
+    return buffer;
+  }
+
+  private void redrawDynamicBoardSurfaces(BufferedImage target) {
+    Graphics2D graphics = target.createGraphics();
+    try {
+      redrawDynamicBoardSurface(graphics, boardRenderer);
+      if (boardRenderer2 != null) {
+        redrawDynamicBoardSurface(graphics, boardRenderer2);
+      }
+      if (Lizzie.config.showSubBoard || Lizzie.config.isFourSubMode()) {
+        redrawDynamicBoardSurface(graphics, subBoardRenderer);
+      }
+      if (Lizzie.config.isFourSubMode()) {
+        redrawDynamicBoardSurface(graphics, subBoardRenderer2);
+        redrawDynamicBoardSurface(graphics, subBoardRenderer3);
+        redrawDynamicBoardSurface(graphics, subBoardRenderer4);
+      }
+    } finally {
+      graphics.dispose();
+    }
+  }
+
+  private void redrawDynamicBoardSurface(Graphics2D graphics, BoardRenderer renderer) {
+    if (renderer == null) {
+      return;
+    }
+    Rectangle bounds = renderer.getBoardBounds();
+    if (bounds.width <= 0 || bounds.height <= 0) {
+      return;
+    }
+    Shape previousClip = graphics.getClip();
+    graphics.clipRect(bounds.x, bounds.y, bounds.width, bounds.height);
+    renderer.draw(graphics);
+    graphics.setClip(previousClip);
+  }
+
+  private void redrawDynamicBoardSurface(Graphics2D graphics, SubBoardRenderer renderer) {
+    if (renderer == null || renderer.boardWidth <= 0 || renderer.boardHeight <= 0) {
+      return;
+    }
+    Shape previousClip = graphics.getClip();
+    graphics.clipRect(renderer.x, renderer.y, renderer.boardWidth, renderer.boardHeight);
+    renderer.draw(graphics);
+    graphics.setClip(previousClip);
+  }
+
   /**
    * Draws the game board and interface
    *
    * @param g0 not used
    */
   public void paintMianPanel(Graphics g0) {
-    if (redrawWinratePaneOnly) {
-      drawWinratePane(this.grx, this.gry, this.grw, this.grh);
-      redrawWinratePaneOnly = false;
+    int panelWidth = mainPanel.getWidth();
+    int panelHeight = mainPanel.getHeight();
+    boolean canPaintIncrementally =
+        !showControls
+            && cachedImage != null
+            && cachedImage.getWidth() == panelWidth
+            && cachedImage.getHeight() == panelHeight;
+    if (canPaintIncrementally && (redrawBoardSurfacesOnly || redrawWinratePaneOnly)) {
+      if (redrawBoardSurfacesOnly) {
+        BufferedImage incrementalFrame =
+            acquireIncrementalPaintBuffer(panelWidth, panelHeight);
+        redrawDynamicBoardSurfaces(incrementalFrame);
+        cachedImage = incrementalFrame;
+        redrawBoardSurfacesOnly = false;
+      }
+      if (redrawWinratePaneOnly) {
+        drawWinratePane(this.grx, this.gry, this.grw, this.grh);
+        redrawWinratePaneOnly = false;
+      }
     } else {
+      redrawBoardSurfacesOnly = false;
+      redrawWinratePaneOnly = false;
       isSmallCap = false;
-      int width = mainPanel.getWidth();
-      int height = mainPanel.getHeight();
+      int width = panelWidth;
+      int height = panelHeight;
 
       Optional<Graphics2D> backgroundG = Optional.empty();
       if (cachedBackgroundWidth != width
@@ -6550,6 +6633,7 @@ public class LizzieFrame extends JFrame {
   public void refresh() {
     // 分开各部分刷新,1代表来自info move的刷新
     redrawWinratePaneOnly = false;
+    redrawBoardSurfacesOnly = false;
     if (independentSubBoard != null && independentSubBoard.isVisible())
       independentSubBoard.refresh();
     if (independentMainBoard != null && independentMainBoard.isVisible())
@@ -6563,22 +6647,41 @@ public class LizzieFrame extends JFrame {
 
   public void refresh(int mode) {
     // 分开各部分刷新,1代表来自info move的刷新
-    redrawWinratePaneOnly = false;
     if (independentSubBoard != null && independentSubBoard.isVisible())
       independentSubBoard.refresh();
     if (independentMainBoard != null && independentMainBoard.isVisible())
       independentMainBoard.refresh();
     if (floatBoard != null && floatBoard.isVisible()) floatBoard.refresh();
-    appendComment();
-    requestProblemListRefresh();
     switch (mode) {
       case 1:
         refreshFromInfo = true;
-        repaint();
+        redrawWinratePaneOnly = true;
+        redrawBoardSurfacesOnly = true;
+        if (mainPanel != null) mainPanel.repaint();
+        if (listTable != null && listTable.isVisible()) listTable.repaint();
+        if (analysisSidebarRefreshCoalescer != null) analysisSidebarRefreshCoalescer.request();
         notifyWebBoard(true);
         break;
       default:
     }
+  }
+
+  /** Gives a locally committed move priority over comments and other secondary UI maintenance. */
+  public void refreshAfterMove() {
+    if (!SwingUtilities.isEventDispatchThread() || mainPanel == null) {
+      refresh();
+      return;
+    }
+    redrawBoardSurfacesOnly = true;
+    repaintSuggestionHoverPreview();
+    if (listTable != null && listTable.isVisible()) listTable.repaint();
+    notifyWebBoard(false);
+    if (deferredMoveUiRefreshTimer == null) {
+      deferredMoveUiRefreshTimer =
+          new javax.swing.Timer(DEFERRED_MOVE_UI_REFRESH_MS, event -> refresh());
+      deferredMoveUiRefreshTimer.setRepeats(false);
+    }
+    deferredMoveUiRefreshTimer.restart();
   }
 
   private void notifyWebBoard(boolean analysisOnly) {
@@ -6717,6 +6820,11 @@ public class LizzieFrame extends JFrame {
     if (analysisRepaintRequested.getAndSet(false)) {
       refresh(1);
     }
+  }
+
+  private void flushAnalysisSidebarRefresh() {
+    appendComment();
+    requestProblemListRefresh();
   }
 
   private String statusEngineName(Leelaz engine) {
@@ -8000,7 +8108,7 @@ public class LizzieFrame extends JFrame {
   }
 
   public void onClicked(int x, int y) {
-    cancelPendingSuggestionHoverPreview();
+    clearSuggestionPreviewBeforeBoardClick();
     if (isTrialActive()) {
       showTrialBlockedHint();
       return;
@@ -8318,7 +8426,10 @@ public class LizzieFrame extends JFrame {
       }
     }
     Lizzie.board.clearPressStoneInfo(null);
-    if (needRepaint) refresh();
+    if (needRepaint && mainPanel != null) {
+      redrawBoardSurfacesOnly = true;
+      mainPanel.repaint();
+    }
   }
 
   public boolean shouldShowRect() {
@@ -8367,7 +8478,7 @@ public class LizzieFrame extends JFrame {
     if (targetNode != currentNode || previousHoverNode != targetNode) {
       redrawWinratePaneOnly = true;
       refreshWinratePane = true;
-      repaint();
+      if (mainPanel != null) mainPanel.repaint();
     }
     return true;
   }
@@ -8381,10 +8492,11 @@ public class LizzieFrame extends JFrame {
         && winrateGraph.mouseOverNode != null) {
       winrateGraph.clearMouseOverNode();
       this.redrawWinratePaneOnly = true;
-      repaint();
+      if (mainPanel != null) mainPanel.repaint();
       return false;
     }
     boolean needRepaint = false;
+    boolean mainBoardOnlyRepaint = true;
     curSuggestionMoveOrderByNumber = -1;
     if (!mainPanel.isFocusOwner() && !commentEditPane.isVisible()) {
       mainPanel.requestFocus();
@@ -8407,6 +8519,7 @@ public class LizzieFrame extends JFrame {
       } else {
         if (isMouseOnSub) {
           if ((!Lizzie.leelaz.isPondering() || EngineManager.isEmpty)) needRepaint = true;
+          mainBoardOnlyRepaint = false;
           isMouseOnSub = false;
           if (Lizzie.config.isFourSubMode()) {
             Lizzie.frame.subBoardRenderer2.isMouseOver = false;
@@ -8536,7 +8649,14 @@ public class LizzieFrame extends JFrame {
         }
       }
     }
-    if (needRepaint) refresh();
+    if (needRepaint) {
+      if (mainBoardOnlyRepaint) {
+        repaintSuggestionHoverPreview();
+      } else if (mainPanel != null) {
+        redrawBoardSurfacesOnly = true;
+        mainPanel.repaint();
+      }
+    }
     return inBoard;
   }
 
@@ -8601,9 +8721,17 @@ public class LizzieFrame extends JFrame {
 
   private SuggestionHoverIntent suggestionHoverIntent() {
     if (suggestionHoverIntent == null) {
-      suggestionHoverIntent = new SuggestionHoverIntent(this::refresh);
+      suggestionHoverIntent = new SuggestionHoverIntent(this::repaintSuggestionHoverPreview);
     }
     return suggestionHoverIntent;
+  }
+
+  private void repaintSuggestionHoverPreview() {
+    if (mainPanel == null) {
+      return;
+    }
+    redrawBoardSurfacesOnly = true;
+    mainPanel.repaint();
   }
 
   private void armSuggestionHoverPreview(int x, int y) {
@@ -8613,6 +8741,18 @@ public class LizzieFrame extends JFrame {
   public void cancelPendingSuggestionHoverPreview() {
     if (suggestionHoverIntent != null) {
       suggestionHoverIntent.cancel();
+    }
+  }
+
+  /** Prevents a settled PV overlay from covering the stone committed by the same mouse press. */
+  void clearSuggestionPreviewBeforeBoardClick() {
+    cancelPendingSuggestionHoverPreview();
+    mouseOverCoordinate = outOfBoundCoordinate;
+    suggestionclick = outOfBoundCoordinate;
+    boolean hadVisiblePreview = isMouseOver;
+    isMouseOver = false;
+    if (hadVisiblePreview) {
+      clearMoved();
     }
   }
 

--- a/src/main/java/featurecat/lizzie/gui/SubBoardRenderer.java
+++ b/src/main/java/featurecat/lizzie/gui/SubBoardRenderer.java
@@ -74,6 +74,17 @@ public class SubBoardRenderer {
   private BufferedImage cachedHeatImage = emptyImage;
 
   private BufferedImage branchStonesImage = emptyImage;
+  private BoardHistoryNode cachedBranchNode;
+  private Zobrist cachedBranchZhash;
+  private List<String> cachedBranchVariation = Collections.emptyList();
+  private int cachedBranchBestMove = -1;
+  private int cachedBranchDisplayedLength = Integer.MIN_VALUE;
+  private int cachedBranchBoardWidth = -1;
+  private int cachedBranchBoardHeight = -1;
+  private int cachedBranchStoneRadius = -1;
+  private boolean cachedBranchBlackToPlay;
+  private boolean cachedBranchRemovesDead;
+  private boolean cachedBranchNoCapture;
   //  private BufferedImage branchStonesShadowImage;
   // Reusable buffers for drawBranch, which runs on every engine update and otherwise
   // allocates a board-sized ARGB image each time. acquire always returns the buffer
@@ -140,6 +151,7 @@ public class SubBoardRenderer {
     cachedBackgroundImage = emptyImage;
     cachedBoardWidth = 0;
     cachedBoardHeight = 0;
+    invalidateBranchCache();
   }
 
   public void setOrder(int order) {
@@ -161,6 +173,7 @@ public class SubBoardRenderer {
 
   public void reDrawGobanAnyway() {
     cachedBoardWidth = -1;
+    invalidateBranchCache();
   }
 
   public void reDrawBackgroundAnyway() {
@@ -178,6 +191,13 @@ public class SubBoardRenderer {
 
   /** Draw a go board */
   public void draw(Graphics2D g) {
+    Rectangle clip = g.getClipBounds();
+    if (clip != null
+        && boardWidth > 0
+        && boardHeight > 0
+        && !clip.intersects(x, y, boardWidth, boardHeight)) {
+      return;
+    }
     Shape oldClip = g.getClip();
     g.clipRect(x, y, boardWidth, boardHeight);
     try {
@@ -325,6 +345,10 @@ public class SubBoardRenderer {
 
   public void clearBranch() {
     branchStonesImage = new BufferedImage(boardWidth, boardHeight, TYPE_INT_ARGB);
+    branchOpt = Optional.empty();
+    variationOpt = Optional.empty();
+    showingBranch = false;
+    invalidateBranchCache();
   }
 
   /**
@@ -831,24 +855,11 @@ public class SubBoardRenderer {
   /** Draw the 'ghost stones' which show a variationOpt Leelaz is thinking about */
   private void drawBranch() {
     showingBranch = false;
-    BufferedImage newImage = acquireBranchStoneBuffer(boardWidth, boardHeight);
-    // branchStonesImage = new BufferedImage(boardWidth, boardHeight, TYPE_INT_ARGB);
-    // branchStonesShadowImage = new BufferedImage(boardWidth, boardHeight, TYPE_INT_ARGB);
-    branchOpt = Optional.empty();
-
-    //    if (Lizzie.frame.isPlayingAgainstLeelaz) {
-    //      branchStonesImage = newImage;
-    //      return;
-    //    }
-
-    // Leela Zero isn't connected yet
     if (Lizzie.leelaz == null) {
-      branchStonesImage = newImage;
+      publishEmptyBranch();
       return;
     }
-    // calculate best moves and branch
-    //  if (Lizzie.frame.toolbar.isEnginePk && Lizzie.frame.toolbar.isGenmove) {
-    // reverseBestmoves = false;
+
     if (!isMouseOver) {
       BoardHistoryNode bestMoveNode;
       if (!Lizzie.board.getHistory().getCurrentHistoryNode().getData().bestMoves.isEmpty()) {
@@ -874,46 +885,41 @@ public class SubBoardRenderer {
       } else preEstimateArray = null;
     }
 
-    variationOpt = Optional.empty();
-
-    Graphics2D g = (Graphics2D) newImage.getGraphics();
-    g.setRenderingHint(RenderingHints.KEY_RENDERING, RenderingHints.VALUE_RENDER_QUALITY);
-    //  Graphics2D gShadow = (Graphics2D) branchStonesShadowImage.getGraphics();
-    //   gShadow.setRenderingHint(RenderingHints.KEY_RENDERING,
-    // RenderingHints.VALUE_RENDER_QUALITY);
-
     Optional<MoveData> suggestedMove = getBestMove();
     if (Lizzie.config.useMovesOwnership) {
       List<Double> array = getEstimateArray();
       if (array != null) estimateArray = array;
     }
     if (!suggestedMove.isPresent()) {
-      g.setColor(new Color(0, 0, 0, 255));
-      g.setFont(new Font(Config.sysDefaultFontName, Font.BOLD, stoneRadius * 3 / 2));
-      g.drawString(
-          "" + (this.bestmovesNum + 1),
-          boardWidth - stoneRadius * 9 / 5,
-          boardHeight - stoneRadius * 1 / 5);
-
-      branchStonesImage = newImage;
+      publishUnavailableBranchNumber();
       return;
     }
 
     if (!isMouseOver || (statChanged && !wheeled)) {
       if (!isMouseOver) stonesTemp = Lizzie.board.getData().stones;
-      if (suggestedMove.isPresent()) variation = suggestedMove.get().variation;
-      //  variationBlackToPlay =
-      //       Lizzie.board.getHistory().getCurrentHistoryNode().getData().blackToPlay;
+      variation = suggestedMove.get().variation;
       if (statChanged) {
         setDisplayedBranchLength(-2);
         statChanged = false;
       }
     }
     if (variation == null) {
+      publishEmptyBranch();
       return;
     }
-    //  if (!wheeled) oldBlackToPlay = Lizzie.board.getData().blackToPlay;
-    // branch = null;
+
+    BoardHistoryNode branchNode = Lizzie.board.getHistory().getCurrentHistoryNode();
+    if (canReuseBranch(branchNode, variation)) {
+      branchOpt = Optional.of(branch);
+      variationOpt = Optional.of(variation);
+      showingBranch = true;
+      return;
+    }
+
+    BufferedImage newImage = acquireBranchStoneBuffer(boardWidth, boardHeight);
+    Graphics2D g = newImage.createGraphics();
+    g.setRenderingHint(RenderingHints.KEY_RENDERING, RenderingHints.VALUE_RENDER_QUALITY);
+    g.setRenderingHint(KEY_ANTIALIASING, VALUE_ANTIALIAS_ON);
     branch =
         new Branch(
             Lizzie.board,
@@ -925,83 +931,134 @@ public class SubBoardRenderer {
             stonesTemp,
             false,
             null);
-    //    mouseOverCoords = suggestedMove.get().coordinate;
     branchOpt = Optional.of(branch);
     variationOpt = Optional.of(variation);
-
-    //
-    //    List<String> variation = suggestedMove.get().variation;
-    //    Branch branch = null;
-    //    if (Lizzie.frame.toolbar.isEnginePk && Lizzie.frame.toolbar.isGenmove)
-    //      branch =
-    //          new Branch(
-    //              Lizzie.board,
-    //              variation,
-    //              true,
-    //              this.displayedBranchLength > 0 ? displayedBranchLength : 199);
-    //    else
-    //      branch =
-    //          new Branch(
-    //              Lizzie.board,
-    //              variation,
-    //              reverseBestmoves,
-    //              this.displayedBranchLength > 0 ? displayedBranchLength : 199);
-    //    branchOpt = Optional.of(branch);
-    //    variationOpt = Optional.of(variation);
     showingBranch = true;
 
-    g.setRenderingHint(KEY_ANTIALIASING, VALUE_ANTIALIAS_ON);
+    try {
+      for (int i = 0; i < Board.boardWidth; i++) {
+        for (int j = 0; j < Board.boardHeight; j++) {
+          int index = Board.getIndex(i, j);
+          Stone stone = branch.data.stones[index];
+          if (stonesTemp != null && stonesTemp[index] != Stone.EMPTY) {
+            if (stone == Stone.BLACK_CAPTURED || stone == Stone.WHITE_CAPTURED) {
+              int stoneX = scaledMarginWidth + squareWidth * i;
+              int stoneY = scaledMarginHeight + squareHeight * j;
+              g.setPaint(paint);
+              fillCircle(g, stoneX, stoneY, stoneRadius + 1);
+              g.setColor(Color.BLACK);
+              g.setStroke(new BasicStroke(1));
+              g.drawLine(
+                  stoneX - (i == 0 ? 0 : (stoneRadius + 1)),
+                  stoneY,
+                  stoneX + (i == Board.boardWidth - 1 ? 0 : (stoneRadius + 1)),
+                  stoneY);
+              g.drawLine(
+                  stoneX,
+                  stoneY - (j == 0 ? 0 : (stoneRadius + 1)),
+                  stoneX,
+                  stoneY + (j == Board.boardHeight - 1 ? 0 : (stoneRadius + 1)));
+              drawCapturedStone(g, stoneX, stoneY, stone);
+              continue;
+            }
+          }
+          if (branch.data.moveNumberList[index] > maxBranchMoves()) continue;
 
-    for (int i = 0; i < Board.boardWidth; i++) {
-      for (int j = 0; j < Board.boardHeight; j++) {
-        // Display latest stone for ghost dead stone
-        int index = Board.getIndex(i, j);
-        Stone stone = branch.data.stones[index];
-        if (stonesTemp != null && stonesTemp[index] != Stone.EMPTY) {
+          int stoneX = scaledMarginWidth + squareWidth * i;
+          int stoneY = scaledMarginHeight + squareHeight * j;
           if (stone == Stone.BLACK_CAPTURED || stone == Stone.WHITE_CAPTURED) {
-            int stoneX = scaledMarginWidth + squareWidth * i;
-            int stoneY = scaledMarginHeight + squareHeight * j;
             g.setPaint(paint);
             fillCircle(g, stoneX, stoneY, stoneRadius + 1);
-            g.setColor(Color.BLACK);
-            g.setStroke(new BasicStroke(1));
-            g.drawLine(
-                stoneX - (i == 0 ? 0 : (stoneRadius + 1)),
-                stoneY,
-                stoneX + (i == Board.boardWidth - 1 ? 0 : (stoneRadius + 1)),
-                stoneY);
-            g.drawLine(
-                stoneX,
-                stoneY - (j == 0 ? 0 : (stoneRadius + 1)),
-                stoneX,
-                stoneY + (j == Board.boardHeight - 1 ? 0 : (stoneRadius + 1)));
             drawCapturedStone(g, stoneX, stoneY, stone);
-            continue;
-          }
+          } else drawStone(g, stoneX, stoneY, stone.unGhosted(), i, j);
         }
-        if (branch.data.moveNumberList[index] > maxBranchMoves()) continue;
-
-        int stoneX = scaledMarginWidth + squareWidth * i;
-        int stoneY = scaledMarginHeight + squareHeight * j;
-        if (stone == Stone.BLACK_CAPTURED || stone == Stone.WHITE_CAPTURED) {
-          g.setPaint(paint);
-          fillCircle(g, stoneX, stoneY, stoneRadius + 1);
-          drawCapturedStone(g, stoneX, stoneY, stone);
-        } else drawStone(g, stoneX, stoneY, stone.unGhosted(), i, j);
       }
+      g.setColor(new Color(0, 0, 0, 255));
+      g.setFont(new Font(Config.sysDefaultFontName, Font.BOLD, stoneRadius * 3 / 2));
+      g.drawString(
+          String.valueOf(this.bestmovesNum + 1),
+          boardWidth - stoneRadius * 9 / 5,
+          boardHeight - stoneRadius * 1 / 5);
+    } finally {
+      g.dispose();
     }
-    g = (Graphics2D) newImage.getGraphics();
-    g.setColor(new Color(0, 0, 0, 255));
-    // g.setFont(new Font("幼圆", Font.BOLD, stoneRadius * 5 / 4));
-    //  g.drawString("变化", boardWidth - stoneRadius * 14 / 3, boardWidth - stoneRadius * 2 / 7);
-    g.setFont(new Font(Config.sysDefaultFontName, Font.BOLD, stoneRadius * 3 / 2));
-    g.drawString(
-        String.valueOf(this.bestmovesNum + 1),
-        boardWidth - stoneRadius * 9 / 5,
-        boardHeight - stoneRadius * 1 / 5);
     branchStonesImage = newImage;
-    g.dispose();
-    //   gShadow.dispose();
+    rememberBranch(branchNode, variation);
+  }
+
+  private void publishEmptyBranch() {
+    branchStonesImage = acquireBranchStoneBuffer(boardWidth, boardHeight);
+    branchOpt = Optional.empty();
+    variationOpt = Optional.empty();
+    invalidateBranchCache();
+  }
+
+  private void publishUnavailableBranchNumber() {
+    BufferedImage newImage = acquireBranchStoneBuffer(boardWidth, boardHeight);
+    Graphics2D g = newImage.createGraphics();
+    try {
+      g.setRenderingHint(RenderingHints.KEY_RENDERING, RenderingHints.VALUE_RENDER_QUALITY);
+      g.setColor(new Color(0, 0, 0, 255));
+      g.setFont(new Font(Config.sysDefaultFontName, Font.BOLD, stoneRadius * 3 / 2));
+      g.drawString(
+          String.valueOf(this.bestmovesNum + 1),
+          boardWidth - stoneRadius * 9 / 5,
+          boardHeight - stoneRadius * 1 / 5);
+    } finally {
+      g.dispose();
+    }
+    branchStonesImage = newImage;
+    branchOpt = Optional.empty();
+    variationOpt = Optional.empty();
+    invalidateBranchCache();
+  }
+
+  private boolean canReuseBranch(BoardHistoryNode node, List<String> candidateVariation) {
+    return !isMouseOver
+        && branch != null
+        && branchOpt.isPresent()
+        && branchStonesImage != emptyImage
+        && cachedBranchNode == node
+        && cachedBranchZhash != null
+        && cachedBranchZhash.equals(node.getData().zobrist)
+        && cachedBranchVariation.equals(candidateVariation)
+        && cachedBranchBestMove == bestmovesNum
+        && cachedBranchDisplayedLength == displayedBranchLength
+        && cachedBranchBoardWidth == boardWidth
+        && cachedBranchBoardHeight == boardHeight
+        && cachedBranchStoneRadius == stoneRadius
+        && cachedBranchBlackToPlay == variationBlackToPlay
+        && cachedBranchRemovesDead == Lizzie.config.removeDeadChainInVariation
+        && cachedBranchNoCapture == Lizzie.config.noCapture;
+  }
+
+  private void rememberBranch(BoardHistoryNode node, List<String> candidateVariation) {
+    if (isMouseOver) {
+      invalidateBranchCache();
+      return;
+    }
+    cachedBranchNode = node;
+    cachedBranchZhash = node.getData().zobrist.clone();
+    cachedBranchVariation = new ArrayList<>(candidateVariation);
+    cachedBranchBestMove = bestmovesNum;
+    cachedBranchDisplayedLength = displayedBranchLength;
+    cachedBranchBoardWidth = boardWidth;
+    cachedBranchBoardHeight = boardHeight;
+    cachedBranchStoneRadius = stoneRadius;
+    cachedBranchBlackToPlay = variationBlackToPlay;
+    cachedBranchRemovesDead = Lizzie.config.removeDeadChainInVariation;
+    cachedBranchNoCapture = Lizzie.config.noCapture;
+  }
+
+  private void invalidateBranchCache() {
+    cachedBranchNode = null;
+    cachedBranchZhash = null;
+    cachedBranchVariation = Collections.emptyList();
+    cachedBranchBestMove = -1;
+    cachedBranchDisplayedLength = Integer.MIN_VALUE;
+    cachedBranchBoardWidth = -1;
+    cachedBranchBoardHeight = -1;
+    cachedBranchStoneRadius = -1;
   }
 
   private Optional<MoveData> getBestMove() {

--- a/src/main/java/featurecat/lizzie/gui/SuggestionHoverIntent.java
+++ b/src/main/java/featurecat/lizzie/gui/SuggestionHoverIntent.java
@@ -1,0 +1,65 @@
+package featurecat.lizzie.gui;
+
+import java.util.Objects;
+import javax.swing.Timer;
+
+/** Delays expensive variation rendering until the pointer has settled on a candidate. */
+final class SuggestionHoverIntent {
+  static final int DEFAULT_DELAY_MS = 120;
+
+  private final Runnable onReady;
+  private final Timer timer;
+  private int targetX = -1;
+  private int targetY = -1;
+  private boolean tracking;
+  private boolean ready;
+
+  SuggestionHoverIntent(Runnable onReady) {
+    this(DEFAULT_DELAY_MS, onReady);
+  }
+
+  SuggestionHoverIntent(int delayMs, Runnable onReady) {
+    if (delayMs < 0) {
+      throw new IllegalArgumentException("delayMs must not be negative");
+    }
+    this.onReady = Objects.requireNonNull(onReady, "onReady");
+    timer = new Timer(delayMs, event -> reveal());
+    timer.setRepeats(false);
+  }
+
+  void arm(int x, int y) {
+    if (tracking && targetX == x && targetY == y) {
+      return;
+    }
+    targetX = x;
+    targetY = y;
+    tracking = true;
+    ready = false;
+    timer.restart();
+  }
+
+  void cancel() {
+    timer.stop();
+    tracking = false;
+    ready = false;
+    targetX = -1;
+    targetY = -1;
+  }
+
+  boolean permits(int x, int y) {
+    return !tracking || targetX != x || targetY != y || ready;
+  }
+
+  boolean isPending() {
+    return tracking && !ready;
+  }
+
+  void reveal() {
+    if (!tracking || ready) {
+      return;
+    }
+    timer.stop();
+    ready = true;
+    onReady.run();
+  }
+}

--- a/src/main/java/featurecat/lizzie/gui/SuggestionHoverIntent.java
+++ b/src/main/java/featurecat/lizzie/gui/SuggestionHoverIntent.java
@@ -5,7 +5,7 @@ import javax.swing.Timer;
 
 /** Delays expensive variation rendering until the pointer has settled on a candidate. */
 final class SuggestionHoverIntent {
-  static final int DEFAULT_DELAY_MS = 120;
+  static final int DEFAULT_DELAY_MS = 200;
 
   private final Runnable onReady;
   private final Timer timer;

--- a/src/main/java/featurecat/lizzie/rules/Board.java
+++ b/src/main/java/featurecat/lizzie/rules/Board.java
@@ -2815,7 +2815,7 @@ public class Board {
                   + " "
                   + localMovePlaceState(forSync));
         }
-        Lizzie.frame.refresh();
+        Lizzie.frame.refreshAfterMove();
         return;
       }
       // load a copy of the data at the current node of history
@@ -3011,7 +3011,7 @@ public class Board {
       if (needGenmove) Lizzie.leelaz.genmove((color.isWhite() ? "B" : "W"));
       //   modifyEnd(false);
       if (Lizzie.config.playSound) Utils.playVoiceFile();
-      if (!forSync) Lizzie.frame.refresh();
+      if (!forSync) Lizzie.frame.refreshAfterMove();
     }
   }
 

--- a/src/test/java/featurecat/lizzie/analysis/AnalysisCandidateValidatorTest.java
+++ b/src/test/java/featurecat/lizzie/analysis/AnalysisCandidateValidatorTest.java
@@ -1,0 +1,62 @@
+package featurecat.lizzie.analysis;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import featurecat.lizzie.rules.Board;
+import featurecat.lizzie.rules.BoardData;
+import featurecat.lizzie.rules.Stone;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class AnalysisCandidateValidatorTest {
+  @Test
+  void staleBatchContainingAnOccupiedCandidateIsRejected() {
+    BoardData position = positionWithStone("D4");
+
+    assertFalse(
+        AnalysisCandidateValidator.allCandidatesOnEmptyPoints(
+            List.of(candidate("Q16"), candidate("D4")), position));
+  }
+
+  @Test
+  void rendererFilterRemovesOccupiedCandidateAndKeepsPass() {
+    BoardData position = positionWithStone("D4");
+    MoveData legal = candidate("Q16");
+    MoveData pass = candidate("pass");
+
+    List<MoveData> filtered =
+        AnalysisCandidateValidator.withoutOccupiedCandidates(
+            List.of(legal, candidate("D4"), pass), position);
+
+    assertEquals(List.of(legal, pass), filtered);
+  }
+
+  @Test
+  void currentBatchWithoutOccupiedCandidatesKeepsItsOriginalList() {
+    BoardData position = positionWithStone("D4");
+    List<MoveData> candidates = new ArrayList<>(List.of(candidate("Q16"), candidate("pass")));
+
+    assertTrue(AnalysisCandidateValidator.allCandidatesOnEmptyPoints(candidates, position));
+    assertSame(
+        candidates,
+        AnalysisCandidateValidator.withoutOccupiedCandidates(candidates, position));
+  }
+
+  private static BoardData positionWithStone(String coordinate) {
+    BoardData position = BoardData.empty(Board.boardWidth, Board.boardHeight);
+    int[] point = Board.asCoordinates(coordinate).orElseThrow();
+    position.stones[Board.getIndex(point[0], point[1])] = Stone.BLACK;
+    return position;
+  }
+
+  private static MoveData candidate(String coordinate) {
+    MoveData move = new MoveData();
+    move.coordinate = coordinate;
+    move.playouts = 10;
+    return move;
+  }
+}

--- a/src/test/java/featurecat/lizzie/analysis/LeelazEdtCommandDispatchTest.java
+++ b/src/test/java/featurecat/lizzie/analysis/LeelazEdtCommandDispatchTest.java
@@ -1,0 +1,102 @@
+package featurecat.lizzie.analysis;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import featurecat.lizzie.Config;
+import featurecat.lizzie.ConfigTestHelper;
+import featurecat.lizzie.Lizzie;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.file.Path;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import javax.swing.SwingUtilities;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class LeelazEdtCommandDispatchTest {
+  @TempDir Path tempDir;
+
+  private Config previousConfig;
+  private Leelaz previousPrimary;
+  private Leelaz previousSecondary;
+
+  @AfterEach
+  void tearDown() {
+    Lizzie.config = previousConfig;
+    Lizzie.setPrimaryEngine(previousPrimary);
+    Lizzie.leelaz2 = previousSecondary;
+  }
+
+  @Test
+  void blockedEngineOutputNeverBlocksTheSwingEventThread() throws Exception {
+    installGlobals();
+    BlockingOutput output = new BlockingOutput();
+    Leelaz engine = new Leelaz("");
+    engine.installCommandOutputForTest(output);
+    Lizzie.setPrimaryEngine(engine);
+
+    CountDownLatch sendReturned = new CountDownLatch(1);
+    CountDownLatch nextUiEventRan = new CountDownLatch(1);
+    try {
+      SwingUtilities.invokeLater(
+          () -> {
+            engine.sendCommandNoLeelaz2("play B D4");
+            sendReturned.countDown();
+          });
+
+      assertTrue(output.writeEntered.await(2, TimeUnit.SECONDS), "engine write never started");
+      SwingUtilities.invokeLater(nextUiEventRan::countDown);
+
+      assertTrue(
+          sendReturned.await(1, TimeUnit.SECONDS),
+          "GTP output blocked the Swing event thread");
+      assertTrue(
+          nextUiEventRan.await(1, TimeUnit.SECONDS),
+          "the next user input could not run while engine output was stalled");
+      assertFalse(output.writeRanOnEventThread.get(), "physical GTP output ran on the Swing EDT");
+    } finally {
+      output.releaseWrite.countDown();
+      output.writeCompleted.await(2, TimeUnit.SECONDS);
+    }
+  }
+
+  private void installGlobals() throws Exception {
+    previousConfig = Lizzie.config;
+    previousPrimary = Lizzie.leelaz;
+    previousSecondary = Lizzie.leelaz2;
+    Lizzie.config = ConfigTestHelper.createForTests(tempDir);
+    Lizzie.leelaz2 = null;
+  }
+
+  private static final class BlockingOutput extends OutputStream {
+    private final CountDownLatch writeEntered = new CountDownLatch(1);
+    private final CountDownLatch releaseWrite = new CountDownLatch(1);
+    private final CountDownLatch writeCompleted = new CountDownLatch(1);
+    private final AtomicBoolean writeRanOnEventThread = new AtomicBoolean();
+
+    @Override
+    public void write(int value) throws IOException {
+      write(new byte[] {(byte) value}, 0, 1);
+    }
+
+    @Override
+    public void write(byte[] bytes, int offset, int length) throws IOException {
+      writeRanOnEventThread.set(SwingUtilities.isEventDispatchThread());
+      writeEntered.countDown();
+      try {
+        if (!releaseWrite.await(5, TimeUnit.SECONDS)) {
+          throw new IOException("test output was not released");
+        }
+      } catch (InterruptedException interrupted) {
+        Thread.currentThread().interrupt();
+        throw new IOException("test output interrupted", interrupted);
+      } finally {
+        writeCompleted.countDown();
+      }
+    }
+  }
+}

--- a/src/test/java/featurecat/lizzie/analysis/LeelazEdtCommandDispatchTest.java
+++ b/src/test/java/featurecat/lizzie/analysis/LeelazEdtCommandDispatchTest.java
@@ -6,9 +6,13 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import featurecat.lizzie.Config;
 import featurecat.lizzie.ConfigTestHelper;
 import featurecat.lizzie.Lizzie;
+import featurecat.lizzie.gui.LizzieFrame;
+import featurecat.lizzie.rules.Stone;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.lang.reflect.Field;
 import java.nio.file.Path;
+import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -23,12 +27,14 @@ class LeelazEdtCommandDispatchTest {
   private Config previousConfig;
   private Leelaz previousPrimary;
   private Leelaz previousSecondary;
+  private LizzieFrame previousFrame;
 
   @AfterEach
   void tearDown() {
     Lizzie.config = previousConfig;
     Lizzie.setPrimaryEngine(previousPrimary);
     Lizzie.leelaz2 = previousSecondary;
+    Lizzie.frame = previousFrame;
   }
 
   @Test
@@ -64,12 +70,46 @@ class LeelazEdtCommandDispatchTest {
     }
   }
 
+  @Test
+  void queuedLocalPlayRetiresOldAnalysisBeforePhysicalWriteCompletes() throws Exception {
+    installGlobals();
+    BlockingOutput output = new BlockingOutput();
+    Leelaz engine = new Leelaz("");
+    engine.installCommandOutputForTest(output);
+    Lizzie.setPrimaryEngine(engine);
+    MoveData staleMove = new MoveData();
+    staleMove.coordinate = "D4";
+    staleMove.playouts = 100;
+    engine.setBestMovesForEngineGameTest(List.of(staleMove));
+
+    try {
+      SwingUtilities.invokeAndWait(() -> engine.playMove(Stone.BLACK, "D4"));
+
+      assertTrue(output.writeEntered.await(2, TimeUnit.SECONDS), "play write never started");
+      assertTrue(
+          engine.getBestMoves().isEmpty(),
+          "the previous streaming payload remained visible while play was queued");
+    } finally {
+      output.releaseWrite.countDown();
+      output.writeCompleted.await(2, TimeUnit.SECONDS);
+    }
+  }
+
   private void installGlobals() throws Exception {
     previousConfig = Lizzie.config;
     previousPrimary = Lizzie.leelaz;
     previousSecondary = Lizzie.leelaz2;
+    previousFrame = Lizzie.frame;
     Lizzie.config = ConfigTestHelper.createForTests(tempDir);
     Lizzie.leelaz2 = null;
+    Lizzie.frame = allocate(LizzieFrame.class);
+  }
+
+  @SuppressWarnings("unchecked")
+  private static <T> T allocate(Class<T> type) throws Exception {
+    Field field = sun.misc.Unsafe.class.getDeclaredField("theUnsafe");
+    field.setAccessible(true);
+    return (T) ((sun.misc.Unsafe) field.get(null)).allocateInstance(type);
   }
 
   private static final class BlockingOutput extends OutputStream {

--- a/src/test/java/featurecat/lizzie/analysis/ReadBoardEdtCommandDispatchTest.java
+++ b/src/test/java/featurecat/lizzie/analysis/ReadBoardEdtCommandDispatchTest.java
@@ -1,0 +1,97 @@
+package featurecat.lizzie.analysis;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import featurecat.lizzie.Lizzie;
+import featurecat.lizzie.gui.LizzieFrame;
+import java.io.BufferedOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.lang.reflect.Field;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import javax.swing.SwingUtilities;
+import org.junit.jupiter.api.Test;
+import sun.misc.Unsafe;
+
+class ReadBoardEdtCommandDispatchTest {
+  @Test
+  void blockedReadBoardOutputNeverBlocksTheSwingEventThread() throws Exception {
+    LizzieFrame previousFrame = Lizzie.frame;
+    BlockingOutput output = new BlockingOutput();
+    try {
+      ReadBoard readBoard = allocate(ReadBoard.class);
+      LizzieFrame frame = allocate(LizzieFrame.class);
+      frame.bothSync = true;
+      Lizzie.frame = frame;
+      setField(readBoard, "usePipe", true);
+      setField(readBoard, "outputStream", new BufferedOutputStream(output));
+
+      CountDownLatch sendReturned = new CountDownLatch(1);
+      CountDownLatch nextUiEventRan = new CountDownLatch(1);
+      SwingUtilities.invokeLater(
+          () -> {
+            readBoard.sendCommand("place 1 1");
+            sendReturned.countDown();
+          });
+
+      assertTrue(output.writeEntered.await(2, TimeUnit.SECONDS), "readboard write never started");
+      SwingUtilities.invokeLater(nextUiEventRan::countDown);
+
+      assertTrue(
+          sendReturned.await(1, TimeUnit.SECONDS),
+          "readboard output blocked the Swing event thread");
+      assertTrue(
+          nextUiEventRan.await(1, TimeUnit.SECONDS),
+          "the next user input could not run while readboard output was stalled");
+      assertFalse(output.writeRanOnEventThread.get(), "physical readboard output ran on the EDT");
+    } finally {
+      output.releaseWrite.countDown();
+      output.writeCompleted.await(2, TimeUnit.SECONDS);
+      Lizzie.frame = previousFrame;
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  private static <T> T allocate(Class<T> type) throws Exception {
+    Field field = Unsafe.class.getDeclaredField("theUnsafe");
+    field.setAccessible(true);
+    return (T) ((Unsafe) field.get(null)).allocateInstance(type);
+  }
+
+  private static void setField(ReadBoard target, String name, Object value) throws Exception {
+    Field field = ReadBoard.class.getDeclaredField(name);
+    field.setAccessible(true);
+    field.set(target, value);
+  }
+
+  private static final class BlockingOutput extends OutputStream {
+    private final CountDownLatch writeEntered = new CountDownLatch(1);
+    private final CountDownLatch releaseWrite = new CountDownLatch(1);
+    private final CountDownLatch writeCompleted = new CountDownLatch(1);
+    private final AtomicBoolean writeRanOnEventThread = new AtomicBoolean();
+
+    @Override
+    public void write(int value) throws IOException {
+      write(new byte[] {(byte) value}, 0, 1);
+    }
+
+    @Override
+    public void write(byte[] bytes, int offset, int length) throws IOException {
+      writeRanOnEventThread.set(SwingUtilities.isEventDispatchThread());
+      writeEntered.countDown();
+      try {
+        if (!releaseWrite.await(5, TimeUnit.SECONDS)) {
+          throw new IOException("test output was not released");
+        }
+      } catch (InterruptedException interrupted) {
+        Thread.currentThread().interrupt();
+        throw new IOException("test output interrupted", interrupted);
+      } finally {
+        writeCompleted.countDown();
+      }
+    }
+  }
+}

--- a/src/test/java/featurecat/lizzie/gui/MoveOnlyUiGateTest.java
+++ b/src/test/java/featurecat/lizzie/gui/MoveOnlyUiGateTest.java
@@ -399,6 +399,52 @@ class MoveOnlyUiGateTest {
   }
 
   @Test
+  void boardRendererDefersHeavyBranchUntilCandidateHoverSettles() throws Exception {
+    TestEnvironment env = TestEnvironment.open();
+    try {
+      Lizzie.config.showBranch = true;
+      Lizzie.config.showSuggestionVariations = true;
+      Lizzie.config.showBlackCandidates = true;
+      Lizzie.config.showWhiteCandidates = true;
+      Lizzie.config.noRefreshOnMouseMove = true;
+      Lizzie.config.usePureStone = true;
+      TrackingLizzieFrame frame = configuredFrame();
+      frame.priorityMoveCoords = new ArrayList<>();
+      Lizzie.frame = frame;
+      BoardData current = currentData();
+      MoveData suggested = current.bestMoves.get(0);
+      suggested.variation = List.of(suggested.coordinate, Board.convertCoordinatesToName(1, 1));
+      Lizzie.board = boardWith(historyForCurrentNode(current));
+      LizzieFrame.boardRenderer = new CoordinateBoardRenderer(new int[] {0, 1});
+      BoardRenderer renderer = configuredBranchRenderer();
+
+      frame.onMouseMoved(0, 0);
+      invokeDrawBranch(renderer);
+
+      Object emptyImage = getField(BoardRenderer.class, null, "emptyImage");
+      assertTrue(frame.isMouseOver, "candidate marker should still react immediately.");
+      assertFalse(frame.isSuggestionHoverPreviewReady(0, 1));
+      assertSame(
+          emptyImage,
+          getField(BoardRenderer.class, renderer, "branchStonesImage"),
+          "the expensive variation image must not be built during a quick candidate click.");
+
+      SuggestionHoverIntent intent =
+          (SuggestionHoverIntent)
+              getField(LizzieFrame.class, frame, "suggestionHoverIntent");
+      intent.reveal();
+      invokeDrawBranch(renderer);
+
+      BufferedImage branchImage =
+          (BufferedImage) getField(BoardRenderer.class, renderer, "branchStonesImage");
+      assertNotSame(emptyImage, branchImage, "settled hover should keep the full variation preview.");
+      assertTrue(hasVisiblePaint(branchImage));
+    } finally {
+      env.close();
+    }
+  }
+
+  @Test
   void boardRendererRedrawsBranchImagesAfterClearingSameHover() throws Exception {
     TestEnvironment env = TestEnvironment.open();
     try {
@@ -472,6 +518,7 @@ class MoveOnlyUiGateTest {
       invokeDrawBranch(renderer);
 
       Optional<List<String>> firstPreview = boardRendererVariationOpt(renderer);
+      Object firstBranch = getField(BoardRenderer.class, renderer, "branch");
       assertTrue(firstPreview.isPresent());
       assertIterableEquals(firstPv, firstPreview.get());
       assertNotSame(
@@ -485,6 +532,10 @@ class MoveOnlyUiGateTest {
 
       Optional<List<String>> secondPreview = boardRendererVariationOpt(renderer);
       assertTrue(secondPreview.isPresent());
+      assertSame(
+          firstBranch,
+          getField(BoardRenderer.class, renderer, "branch"),
+          "engine repaints must reuse the frozen branch instead of replaying the PV on the EDT.");
       assertIterableEquals(
           List.of(suggested.coordinate, Board.convertCoordinatesToName(1, 1)),
           secondPreview.get(),

--- a/src/test/java/featurecat/lizzie/gui/MoveOnlyUiGateTest.java
+++ b/src/test/java/featurecat/lizzie/gui/MoveOnlyUiGateTest.java
@@ -419,6 +419,10 @@ class MoveOnlyUiGateTest {
       BoardRenderer renderer = configuredBranchRenderer();
 
       frame.onMouseMoved(0, 0);
+      assertEquals(
+          0,
+          frame.fullRefreshes,
+          "candidate hover must not rebuild comments and the problem list on the EDT.");
       invokeDrawBranch(renderer);
 
       Object emptyImage = getField(BoardRenderer.class, null, "emptyImage");
@@ -433,6 +437,10 @@ class MoveOnlyUiGateTest {
           (SuggestionHoverIntent)
               getField(LizzieFrame.class, frame, "suggestionHoverIntent");
       intent.reveal();
+      assertEquals(
+          0,
+          frame.fullRefreshes,
+          "revealing a settled preview must remain a board-only repaint.");
       invokeDrawBranch(renderer);
 
       BufferedImage branchImage =
@@ -442,6 +450,100 @@ class MoveOnlyUiGateTest {
     } finally {
       env.close();
     }
+  }
+
+  @Test
+  void engineAnalysisRefreshSelectsIncrementalBoardAndWinratePainting() throws Exception {
+    TestEnvironment env = TestEnvironment.open();
+    try {
+      TrackingLizzieFrame frame = configuredFrame();
+      Lizzie.frame = frame;
+
+      frame.refresh(1);
+
+      assertTrue((boolean) getField(LizzieFrame.class, frame, "redrawBoardSurfacesOnly"));
+      assertTrue((boolean) getField(LizzieFrame.class, frame, "redrawWinratePaneOnly"));
+      assertEquals(
+          0,
+          frame.fullRefreshes,
+          "engine output must not route through the full-frame refresh used for layout changes.");
+    } finally {
+      env.close();
+    }
+  }
+
+  @Test
+  void committedMoveDefersFullUiMaintenanceUntilAfterImmediateBoardRepaint() throws Exception {
+    TestEnvironment env = TestEnvironment.open();
+    try {
+      TrackingLizzieFrame frame = configuredFrame();
+      Lizzie.frame = frame;
+
+      javax.swing.SwingUtilities.invokeAndWait(frame::refreshAfterMove);
+
+      assertTrue((boolean) getField(LizzieFrame.class, frame, "redrawBoardSurfacesOnly"));
+      assertEquals(
+          0,
+          frame.fullRefreshes,
+          "comments and layout work must not run in the move's input event.");
+
+      Thread.sleep(260L);
+      javax.swing.SwingUtilities.invokeAndWait(() -> {});
+      assertEquals(1, frame.fullRefreshes, "secondary move UI should still refresh after input.");
+    } finally {
+      env.close();
+    }
+  }
+
+  @Test
+  void boardClickClearsSettledSuggestionBeforeMoveRendering() throws Exception {
+    TestEnvironment env = TestEnvironment.open();
+    try {
+      TrackingLizzieFrame frame = configuredFrame();
+      Lizzie.frame = frame;
+      frame.isMouseOver = true;
+      frame.mouseOverCoordinate = new int[] {0, 1};
+      frame.suggestionclick = new int[] {0, 1};
+
+      frame.clearSuggestionPreviewBeforeBoardClick();
+
+      assertFalse(frame.isMouseOver);
+      assertSame(LizzieFrame.outOfBoundCoordinate, frame.mouseOverCoordinate);
+      assertSame(LizzieFrame.outOfBoundCoordinate, frame.suggestionclick);
+      assertEquals(
+          1,
+          frame.clearedMovePreviews,
+          "the visible PV must be cleared before the clicked stone is rendered.");
+    } finally {
+      env.close();
+    }
+  }
+
+  @Test
+  void incrementalBranchOverlayRequiresExistingStonesToRemainUnchanged() {
+    Stone[] source = {Stone.BLACK, Stone.EMPTY, Stone.WHITE};
+    Stone[] branch = {Stone.BLACK, Stone.WHITE, Stone.WHITE};
+    boolean[] newStones = {false, true, false};
+
+    assertTrue(BoardRenderer.branchPreservesExistingStones(source, branch, newStones));
+
+    branch[0] = Stone.BLACK_CAPTURED;
+    assertFalse(
+        BoardRenderer.branchPreservesExistingStones(source, branch, newStones),
+        "a captured existing stone requires a complete branch image redraw.");
+
+    newStones[0] = true;
+    assertFalse(
+        BoardRenderer.branchPreservesExistingStones(source, branch, newStones),
+        "an existing stone may not disappear even if a malformed branch marks it as new.");
+  }
+
+  @Test
+  void incrementalBranchOverlayRejectsMalformedBranchBuffers() {
+    assertFalse(
+        BoardRenderer.branchPreservesExistingStones(
+            new Stone[] {Stone.BLACK}, new Stone[] {Stone.BLACK, Stone.WHITE}, new boolean[] {false}));
+    assertFalse(BoardRenderer.branchPreservesExistingStones(null, null, null));
   }
 
   @Test
@@ -990,6 +1092,9 @@ class MoveOnlyUiGateTest {
   }
 
   private static final class TrackingLizzieFrame extends LizzieFrame {
+    private int fullRefreshes;
+    private int clearedMovePreviews;
+
     @Override
     public boolean isInPlayMode() {
       return false;
@@ -1001,10 +1106,14 @@ class MoveOnlyUiGateTest {
     }
 
     @Override
-    public void refresh() {}
+    public void refresh() {
+      fullRefreshes++;
+    }
 
     @Override
-    public void clearMoved() {}
+    public void clearMoved() {
+      clearedMovePreviews++;
+    }
 
     @Override
     public void repaint() {}

--- a/src/test/java/featurecat/lizzie/gui/PassPreviewGateTest.java
+++ b/src/test/java/featurecat/lizzie/gui/PassPreviewGateTest.java
@@ -1,6 +1,7 @@
 package featurecat.lizzie.gui;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -109,6 +110,32 @@ class PassPreviewGateTest {
     TestEnvironment env = TestEnvironment.open();
     try {
       assertBranchPassPreviewRendersThroughDrawPath(node -> node.addExtraStones(1, 1, true));
+    } finally {
+      env.close();
+    }
+  }
+
+  @Test
+  void subBoardSkipsRenderingWhenRepaintClipDoesNotIntersectIt() throws Exception {
+    TestEnvironment env = TestEnvironment.open();
+    try {
+      SubBoardRenderer subBoard = new SubBoardRenderer(false);
+      configurePassPreviewRenderer(subBoard);
+      Lizzie.board = null;
+      BufferedImage image =
+          new BufferedImage(
+              PREVIEW_CANVAS_SIZE + 20,
+              PREVIEW_CANVAS_SIZE + 20,
+              BufferedImage.TYPE_INT_ARGB);
+      Graphics2D graphics = image.createGraphics();
+      try {
+        graphics.setClip(PREVIEW_CANVAS_SIZE + 5, PREVIEW_CANVAS_SIZE + 5, 10, 10);
+        assertDoesNotThrow(
+            () -> subBoard.draw(graphics),
+            "a main-board-only repaint must not run the sub-board rendering pipeline.");
+      } finally {
+        graphics.dispose();
+      }
     } finally {
       env.close();
     }

--- a/src/test/java/featurecat/lizzie/gui/SuggestionHoverIntentTest.java
+++ b/src/test/java/featurecat/lizzie/gui/SuggestionHoverIntentTest.java
@@ -1,0 +1,77 @@
+package featurecat.lizzie.gui;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+
+class SuggestionHoverIntentTest {
+  private static final int TEST_DELAY_MS = 60_000;
+
+  @Test
+  void blocksOnlyTrackedCandidateUntilRevealed() {
+    AtomicInteger refreshes = new AtomicInteger();
+    SuggestionHoverIntent intent =
+        new SuggestionHoverIntent(TEST_DELAY_MS, refreshes::incrementAndGet);
+
+    intent.arm(3, 4);
+
+    assertTrue(intent.isPending());
+    assertFalse(intent.permits(3, 4));
+    assertTrue(intent.permits(4, 4));
+
+    intent.reveal();
+
+    assertFalse(intent.isPending());
+    assertTrue(intent.permits(3, 4));
+    assertEquals(1, refreshes.get());
+  }
+
+  @Test
+  void movingToAnotherCandidateReplacesPendingPreview() {
+    AtomicInteger refreshes = new AtomicInteger();
+    SuggestionHoverIntent intent =
+        new SuggestionHoverIntent(TEST_DELAY_MS, refreshes::incrementAndGet);
+
+    intent.arm(3, 4);
+    intent.arm(7, 8);
+
+    assertTrue(intent.permits(3, 4));
+    assertFalse(intent.permits(7, 8));
+    intent.reveal();
+    assertTrue(intent.permits(7, 8));
+    assertEquals(1, refreshes.get());
+  }
+
+  @Test
+  void quickClickCancellationPreventsDelayedRefresh() {
+    AtomicInteger refreshes = new AtomicInteger();
+    SuggestionHoverIntent intent =
+        new SuggestionHoverIntent(TEST_DELAY_MS, refreshes::incrementAndGet);
+
+    intent.arm(3, 4);
+    intent.cancel();
+    intent.reveal();
+
+    assertFalse(intent.isPending());
+    assertTrue(intent.permits(3, 4));
+    assertEquals(0, refreshes.get());
+  }
+
+  @Test
+  void repeatedMotionInsideReadyCandidateDoesNotRestartDelay() {
+    AtomicInteger refreshes = new AtomicInteger();
+    SuggestionHoverIntent intent =
+        new SuggestionHoverIntent(TEST_DELAY_MS, refreshes::incrementAndGet);
+
+    intent.arm(3, 4);
+    intent.reveal();
+    intent.arm(3, 4);
+
+    assertFalse(intent.isPending());
+    assertTrue(intent.permits(3, 4));
+    assertEquals(1, refreshes.get());
+  }
+}

--- a/src/test/java/featurecat/lizzie/update/UpdateAdmissionTest.java
+++ b/src/test/java/featurecat/lizzie/update/UpdateAdmissionTest.java
@@ -9,7 +9,10 @@ import java.io.IOException;
 import featurecat.lizzie.ConfigTestHelper;
 import featurecat.lizzie.Lizzie;
 import java.nio.file.Path;
+import java.util.Locale;
+import java.util.ResourceBundle;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.io.TempDir;
 import org.json.JSONObject;
 import org.junit.jupiter.api.Test;
@@ -17,9 +20,21 @@ import org.junit.jupiter.api.Test;
 class UpdateAdmissionTest {
   @TempDir Path tempDir;
 
+  private featurecat.lizzie.Config previousConfig;
+  private ResourceBundle previousResourceBundle;
+
+  @BeforeEach
+  void setUp() {
+    previousConfig = Lizzie.config;
+    previousResourceBundle = Lizzie.resourceBundle;
+    Lizzie.config = null;
+    Lizzie.resourceBundle = ResourceBundle.getBundle("l10n.DisplayStrings", Locale.US);
+  }
+
   @AfterEach
   void tearDown() {
-    Lizzie.config = null;
+    Lizzie.config = previousConfig;
+    Lizzie.resourceBundle = previousResourceBundle;
   }
 
   private static final String INSTALLED = "next-2026-08-01.1";


### PR DESCRIPTION
## 根因

Windows 落子卡顿有两条独立的 EDT 阻塞路径：

1. 棋盘点击进入 `Board.place()` 后，同步向本地 KataGo、远程算力或 readboard transport 执行 `write + flush`。管道或 socket 暂时阻塞时，Swing EDT 与棋盘锁会一起被占住。
2. 鼠标刚进入预测候选点时，主棋盘会在 EDT 上立即构造最长 199 手的 `Branch` 并生成整盘幽灵棋子图；点击事件需要排在这次重绘之后。分析结果刷新时还可能重复构造同一条冻结变化。

## 修复

- 普通用户 GTP 命令在 EDT 上只入队，由有序后台调度器完成物理输出。
- 需要同步失败语义的启动恢复、精确快照、引擎对局启动和前台租约恢复路径继续同步执行。
- readboard `place` 同样移出 EDT，并绑定发送时的 transport；pipe/socket 写入串行化。
- 预测候选点加入 120ms hover intent：候选标记立即显示，快速点击优先落子，停稳后再生成完整变化图。
- 点击、移出、切换棋谱/引擎、表格预览及棋盘状态切换都会取消过期预览，避免延迟回调污染新局面。
- `noRefreshOnMouseMove` 下复用已冻结的 `Branch` 与图像缓存，不再在每次分析刷新时重放同一 PV。
- 同步覆盖主棋盘、独立棋盘和浮动棋盘，并修复浮动棋盘尺寸变化后的分支图缓存失效。
- 修复 `UpdateAdmissionTest` 的语言环境污染，确保中文 Windows 上全量测试稳定。

## 自动化验证

最新 `origin/main`（`11725092`）基线：

- 候选点专项：28 tests，0 failures，0 errors，0 skipped。
- 完整测试：3279 tests，0 failures，0 errors，14 skipped。
- `mvn -B -Djava.awt.headless=true -Dfmt.skip=true -DskipTests package`：BUILD SUCCESS。
- `python scripts/test_windows_launcher_packaging.py`：passed。
- 本次新增文件 fmt 检查：2 files，0 non-complying。
- `git diff --check origin/main...HEAD`：passed。

## Windows 真机验收

隔离的 `next-2026-08-25.1` Windows NVIDIA portable 副本，包内 runtime，RTX 3070、CUDA 12.8、B11，Windows 11 23H2、150% 缩放：

- 引擎正常加载并持续分析。
- 鼠标移入预测点后 15ms 立即点击，130ms 时截图已确认棋子落下，窗口 `Responding=True`。
- 停稳后预测分支继续显示；没有删除 1、2、3 等变化顺序功能。
- 移出候选点、继续分析和后续界面操作保持响应。
- 既有 CUDA、智子云远程、OpenCL、SGF 与连续落子验收仍由前一提交覆盖。

本 PR 不包含 `.qa` 临时包、用户数据、配置、日志、账号或截图。