### PR TITLE
fix(gui): sync bottom-toolbar hide vs Show checkmark

### DIFF
--- a/src/main/java/featurecat/lizzie/gui/BottomToolbar.java
+++ b/src/main/java/featurecat/lizzie/gui/BottomToolbar.java
@@ -550,6 +550,13 @@ public class BottomToolbar extends JPanel {
     return Lizzie.frame != null && Lizzie.frame.toolbarHeight > MAIN_BAR_HEIGHT;
   }
 
+  static int reconcilePersistedToolbarHeight(int currentHeight, int layoutDesiredHeight) {
+    if (currentHeight == 0) {
+      return 0;
+    }
+    return layoutDesiredHeight;
+  }
+
   private int layoutDetailPanels() {
     if (!isDetailExpanded()) {
       anaPanel.setVisible(false);
@@ -5107,7 +5114,8 @@ public class BottomToolbar extends JPanel {
       rebuildMoreActionsPopup(overflowButtons);
     }
 
-    int desiredHeight = layoutDetailPanels();
+    int desiredHeight =
+        reconcilePersistedToolbarHeight(Lizzie.frame.toolbarHeight, layoutDetailPanels());
     if (Lizzie.frame.toolbarHeight != desiredHeight) {
       Lizzie.frame.toolbarHeight = desiredHeight;
       javax.swing.SwingUtilities.invokeLater(

--- a/src/main/java/featurecat/lizzie/gui/Menu.java
+++ b/src/main/java/featurecat/lizzie/gui/Menu.java
@@ -4447,27 +4447,43 @@ public class Menu extends JMenuBar {
 
     final JFontCheckBoxMenuItem bottomToolbarVisible =
         new JFontCheckBoxMenuItem(resourceBundle.getString("Menu.visible"));
+    final JFontCheckBoxMenuItem bottomToolbarInVisible =
+        new JFontCheckBoxMenuItem(resourceBundle.getString("Menu.inVisible"));
+    final JFontCheckBoxMenuItem showDetailedBar = new JFontCheckBoxMenuItem("使用详细工具栏");
+    final Runnable syncBottomToolbarMarks =
+        new Runnable() {
+          public void run() {
+            boolean toolbarVisible =
+                LizzieFrame.toolbar != null && LizzieFrame.toolbar.isVisible();
+            syncBottomToolbarMenuMarks(
+                bottomToolbarVisible,
+                bottomToolbarInVisible,
+                showDetailedBar,
+                Lizzie.frame.toolbarHeight,
+                toolbarVisible);
+          }
+        };
     bottomToolBar.add(bottomToolbarVisible);
 
     bottomToolbarVisible.addActionListener(
         new ActionListener() {
           public void actionPerformed(ActionEvent e) {
-            Lizzie.frame.toolbarHeight = 26;
+            Lizzie.frame.toolbarHeight = BOTTOM_TOOLBAR_SHOWN_HEIGHT;
             LizzieFrame.toolbar.setVisible(true);
+            syncBottomToolbarMarks.run();
             if (Lizzie.config.showDoubleMenu) doubleMenu(false);
             Lizzie.frame.reSetLoc();
           }
         });
 
-    final JFontCheckBoxMenuItem bottomToolbarInVisible =
-        new JFontCheckBoxMenuItem(resourceBundle.getString("Menu.inVisible"));
     bottomToolBar.add(bottomToolbarInVisible);
 
     bottomToolbarInVisible.addActionListener(
         new ActionListener() {
           public void actionPerformed(ActionEvent e) {
-            Lizzie.frame.toolbarHeight = 0;
+            Lizzie.frame.toolbarHeight = BOTTOM_TOOLBAR_HIDDEN_HEIGHT;
             LizzieFrame.toolbar.setVisible(false);
+            syncBottomToolbarMarks.run();
             if (Lizzie.config.showDoubleMenu) doubleMenu(false);
             Lizzie.frame.reSetLoc();
           }
@@ -4476,13 +4492,12 @@ public class Menu extends JMenuBar {
     final JMenu detailedBar = new JFontMenu("详细工具栏(过时的)(仅中文)"); // ("详细工具栏(过时的)(仅中文)");
     if (Lizzie.config.isChinese) bottomToolBar.add(detailedBar);
 
-    final JFontCheckBoxMenuItem showDetailedBar = new JFontCheckBoxMenuItem("使用详细工具栏");
     detailedBar.add(showDetailedBar);
 
     showDetailedBar.addActionListener(
         new ActionListener() {
           public void actionPerformed(ActionEvent e) {
-            if (Lizzie.frame.toolbarHeight != 70) {
+            if (Lizzie.frame.toolbarHeight != BOTTOM_TOOLBAR_DETAILED_HEIGHT) {
               SwingUtilities.invokeLater(
                   new Runnable() {
                     public void run() {
@@ -4493,16 +4508,19 @@ public class Menu extends JMenuBar {
                               "确定使用详细工具栏?",
                               JOptionPane.YES_NO_OPTION);
                       if (ret == JOptionPane.NO_OPTION) {
+                        syncBottomToolbarMarks.run();
                         return;
                       }
-                      Lizzie.frame.toolbarHeight = 70;
+                      Lizzie.frame.toolbarHeight = BOTTOM_TOOLBAR_DETAILED_HEIGHT;
                       LizzieFrame.toolbar.setVisible(true);
+                      syncBottomToolbarMarks.run();
                       Lizzie.frame.reSetLoc();
                     }
                   });
             } else {
-              Lizzie.frame.toolbarHeight = 26;
+              Lizzie.frame.toolbarHeight = BOTTOM_TOOLBAR_SHOWN_HEIGHT;
               LizzieFrame.toolbar.setVisible(true);
+              syncBottomToolbarMarks.run();
               Lizzie.frame.reSetLoc();
             }
           }
@@ -4537,19 +4555,7 @@ public class Menu extends JMenuBar {
         new MenuListener() {
 
           public void menuSelected(MenuEvent e) {
-            if (Lizzie.frame.toolbarHeight == 0) {
-              bottomToolbarInVisible.setState(true);
-              bottomToolbarVisible.setState(false);
-              showDetailedBar.setState(false);
-            } else if (Lizzie.frame.toolbarHeight == 70) {
-              showDetailedBar.setState(true);
-              bottomToolbarInVisible.setState(false);
-              bottomToolbarVisible.setState(false);
-            } else {
-              bottomToolbarInVisible.setState(false);
-              bottomToolbarVisible.setState(true);
-              showDetailedBar.setState(false);
-            }
+            syncBottomToolbarMarks.run();
             if (Lizzie.config.showDetailedToolbarMenu) showDetailedMenu.setState(true);
             else showDetailedMenu.setState(false);
           }
@@ -10083,6 +10089,44 @@ public class Menu extends JMenuBar {
         stop,
         activeEngineAvailable,
         switching);
+  }
+
+  static final int BOTTOM_TOOLBAR_SHOWN_HEIGHT = 26;
+  static final int BOTTOM_TOOLBAR_HIDDEN_HEIGHT = 0;
+  static final int BOTTOM_TOOLBAR_DETAILED_HEIGHT = 70;
+
+  enum BottomToolbarMenuMark {
+    VISIBLE,
+    INVISIBLE,
+    DETAILED
+  }
+
+  static BottomToolbarMenuMark bottomToolbarMenuMark(int toolbarHeight, boolean toolbarVisible) {
+    if (!toolbarVisible || toolbarHeight == BOTTOM_TOOLBAR_HIDDEN_HEIGHT) {
+      return BottomToolbarMenuMark.INVISIBLE;
+    }
+    if (toolbarHeight == BOTTOM_TOOLBAR_DETAILED_HEIGHT) {
+      return BottomToolbarMenuMark.DETAILED;
+    }
+    return BottomToolbarMenuMark.VISIBLE;
+  }
+
+  static void syncBottomToolbarMenuMarks(
+      JCheckBoxMenuItem visibleItem,
+      JCheckBoxMenuItem invisibleItem,
+      JCheckBoxMenuItem detailedItem,
+      int toolbarHeight,
+      boolean toolbarVisible) {
+    BottomToolbarMenuMark mark = bottomToolbarMenuMark(toolbarHeight, toolbarVisible);
+    if (visibleItem != null) {
+      visibleItem.setState(mark == BottomToolbarMenuMark.VISIBLE);
+    }
+    if (invisibleItem != null) {
+      invisibleItem.setState(mark == BottomToolbarMenuMark.INVISIBLE);
+    }
+    if (detailedItem != null) {
+      detailedItem.setState(mark == BottomToolbarMenuMark.DETAILED);
+    }
   }
 
   static void applyEngineSwitchPresentation(

--- a/src/test/java/featurecat/lizzie/gui/BottomToolbarHeightContractTest.java
+++ b/src/test/java/featurecat/lizzie/gui/BottomToolbarHeightContractTest.java
@@ -1,0 +1,21 @@
+package featurecat.lizzie.gui;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+class BottomToolbarHeightContractTest {
+
+  @Test
+  void layoutMustNotResurrectAHiddenToolbarHeight() {
+    assertEquals(0, BottomToolbar.reconcilePersistedToolbarHeight(0, 26));
+    assertEquals(0, BottomToolbar.reconcilePersistedToolbarHeight(0, 70));
+  }
+
+  @Test
+  void shownAndDetailedHeightsStillFollowLayout() {
+    assertEquals(26, BottomToolbar.reconcilePersistedToolbarHeight(26, 26));
+    assertEquals(70, BottomToolbar.reconcilePersistedToolbarHeight(26, 70));
+    assertEquals(26, BottomToolbar.reconcilePersistedToolbarHeight(70, 26));
+  }
+}

--- a/src/test/java/featurecat/lizzie/gui/MenuBottomToolbarVisibilityTest.java
+++ b/src/test/java/featurecat/lizzie/gui/MenuBottomToolbarVisibilityTest.java
@@ -1,0 +1,86 @@
+package featurecat.lizzie.gui;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import javax.swing.JCheckBoxMenuItem;
+import org.junit.jupiter.api.Test;
+
+class MenuBottomToolbarVisibilityTest {
+
+  @Test
+  void shownContractIsTwentySixPixelsAndVisible() {
+    assertEquals(26, Menu.BOTTOM_TOOLBAR_SHOWN_HEIGHT);
+    assertEquals(0, Menu.BOTTOM_TOOLBAR_HIDDEN_HEIGHT);
+  }
+
+  @Test
+  void heightZeroSelectsInvisibleEvenIfVisibleFlagIsStale() {
+    assertEquals(
+        Menu.BottomToolbarMenuMark.INVISIBLE, Menu.bottomToolbarMenuMark(0, true));
+    assertEquals(
+        Menu.BottomToolbarMenuMark.INVISIBLE, Menu.bottomToolbarMenuMark(0, false));
+  }
+
+  @Test
+  void shownHeightSelectsVisibleOnlyWhenTheToolbarIsShowing() {
+    assertEquals(
+        Menu.BottomToolbarMenuMark.VISIBLE, Menu.bottomToolbarMenuMark(26, true));
+  }
+
+  @Test
+  void hideThatLeavesStaleShownHeightStillSelectsInvisible() {
+    assertEquals(
+        Menu.BottomToolbarMenuMark.INVISIBLE, Menu.bottomToolbarMenuMark(26, false));
+  }
+
+  @Test
+  void detailedHeightSelectsDetailedOnlyWhileVisible() {
+    assertEquals(
+        Menu.BottomToolbarMenuMark.DETAILED, Menu.bottomToolbarMenuMark(70, true));
+    assertEquals(
+        Menu.BottomToolbarMenuMark.INVISIBLE, Menu.bottomToolbarMenuMark(70, false));
+  }
+
+  @Test
+  void hideClickClearsShowCheckmarkWithoutWaitingForMenuSelected() {
+    JCheckBoxMenuItem show = new JCheckBoxMenuItem("Show");
+    JCheckBoxMenuItem hide = new JCheckBoxMenuItem("Invisible");
+    JCheckBoxMenuItem detailed = new JCheckBoxMenuItem("Detailed");
+    show.setState(true);
+    hide.setState(true);
+
+    Menu.syncBottomToolbarMenuMarks(show, hide, detailed, 0, false);
+
+    assertFalse(show.getState());
+    assertTrue(hide.getState());
+    assertFalse(detailed.getState());
+  }
+
+  @Test
+  void showClickChecksShowEvenIfSwingUncheckedTheAlreadySelectedItem() {
+    JCheckBoxMenuItem show = new JCheckBoxMenuItem("Show");
+    JCheckBoxMenuItem hide = new JCheckBoxMenuItem("Invisible");
+    show.setState(false);
+    hide.setState(false);
+
+    Menu.syncBottomToolbarMenuMarks(show, hide, null, 26, true);
+
+    assertTrue(show.getState());
+    assertFalse(hide.getState());
+  }
+
+  @Test
+  void menuSelectedUsesHeightAndVisibleTogether() {
+    JCheckBoxMenuItem show = new JCheckBoxMenuItem("Show");
+    JCheckBoxMenuItem hide = new JCheckBoxMenuItem("Invisible");
+    show.setState(true);
+    hide.setState(false);
+
+    Menu.syncBottomToolbarMenuMarks(show, hide, null, 26, false);
+
+    assertFalse(show.getState());
+    assertTrue(hide.getState());
+  }
+}


### PR DESCRIPTION
## Repro
Bottom tool bar visible, then switch it to hidden. Reopen View → Tool bar → Bottom tool bar: checkmark still pointed at Show while the bar was gone. Clicking Show again restored the bar.

## Cause
Checkmarks updated only in `menuSelected` from `toolbarHeight`. Hide set height 0 and `setVisible(false)`, but `reSetButtonLocation()` could write height 26 back. Show stayed checked until the submenu opened again, or until Show was clicked to “repair” it.

## Fix
- Refresh Invisible/Show checkmarks on the click from `toolbarHeight` and `toolbar.isVisible()`, not only the next `menuSelected`.
- Keep Visible/Invisible as 26 vs 0. Hide no longer gets height restored to 26 by layout, so persist (`main-window-other[0]`) and restart match the last choice.
- Show still shows the ~26px bar. Height 70 detailed bar not restyled. `showStatus` is not the toolbar. No Linux `setBounds` rewrite.

## Verification
Headless: `MenuBottomToolbarVisibilityTest` (8) and `BottomToolbarHeightContractTest` (2). Related menu tests passed. No GUI run. Merge gate is existing Windows/Linux `mvn verify`.

Fixes #324
