### PR TITLE
fix(gui): paint remaining markup after last-file marks

### DIFF
--- a/src/main/java/featurecat/lizzie/gui/BoardRenderer.java
+++ b/src/main/java/featurecat/lizzie/gui/BoardRenderer.java
@@ -51,6 +51,12 @@ public class BoardRenderer {
     MOVE_NUMBERS_THEN_RANK
   }
 
+  enum MarkupStroke {
+    DARK,
+    LIGHT,
+    DARK_WITH_LIGHT_HALO
+  }
+
   // Percentage of the boardLength to offset before drawing black lines
   // private static final double MARGIN = 0.03;
   private final ResourceBundle resourceBundle = Lizzie.resourceBundle;
@@ -222,6 +228,49 @@ public class BoardRenderer {
     return showingBranch
         ? MoveOverlayOrder.RANK_THEN_MOVE_NUMBERS
         : MoveOverlayOrder.RANK_ONLY;
+  }
+
+  static boolean isMarkupOnBoard(int x, int y, int boardWidth, int boardHeight) {
+    return x >= 0 && y >= 0 && x < boardWidth && y < boardHeight;
+  }
+
+  static List<String> remainingMarkupEntries(String propertyValue, int boardWidth, int boardHeight) {
+    List<String> remaining = new ArrayList<String>();
+    if (propertyValue == null || propertyValue.isEmpty()) {
+      return remaining;
+    }
+    for (String label : propertyValue.split(",")) {
+      String[] moves = label.split(":");
+      int[] move = SGFParser.convertSgfPosToCoord(moves[0]);
+      if (move != null && isMarkupOnBoard(move[0], move[1], boardWidth, boardHeight)) {
+        remaining.add(label);
+      }
+    }
+    return remaining;
+  }
+
+  static MarkupStroke markupStroke(Stone stone, boolean onStar) {
+    if (stone.isBlack()) {
+      return MarkupStroke.LIGHT;
+    }
+    if (onStar && stone.isEmpty()) {
+      return MarkupStroke.DARK_WITH_LIGHT_HALO;
+    }
+    return MarkupStroke.DARK;
+  }
+
+  static boolean isStarIntersection(
+      int x, int y, int boardWidth, int boardHeight, boolean chineseClassic) {
+    List<Point> points =
+        chineseClassic
+            ? BoardStylePainter.chineseClassicMarkerPoints(boardWidth, boardHeight)
+            : BoardStylePainter.standardStarPoints(boardWidth, boardHeight);
+    for (Point point : points) {
+      if (point.x == x && point.y == y) {
+        return true;
+      }
+    }
+    return false;
   }
 
   /** Draw a go board */
@@ -1080,36 +1129,16 @@ public class BoardRenderer {
           Board.boardHeight);
       return;
     }
-    if (Board.boardWidth == 19 && Board.boardHeight == 19) {
-      drawStarPoints0(3, 3, 6, false, g);
-    } else if (Board.boardWidth == 15 && Board.boardHeight == 15) {
-      drawStarPoints0(2, 3, 8, true, g);
-    } else if (Board.boardWidth == 13 && Board.boardHeight == 13) {
-      drawStarPoints0(2, 3, 6, true, g);
-    } else if (Board.boardWidth == 9 && Board.boardHeight == 9) {
-      drawStarPoints0(2, 2, 4, true, g);
-    } else if (Board.boardWidth == 7 && Board.boardHeight == 7) {
-      drawStarPoints0(2, 2, 2, true, g);
-    } else if (Board.boardWidth == 5 && Board.boardHeight == 5) {
-      drawStarPoints0(0, 0, 2, true, g);
+    List<Point> points =
+        BoardStylePainter.standardStarPoints(Board.boardWidth, Board.boardHeight);
+    if (points.isEmpty()) {
+      return;
     }
-  }
-
-  private void drawStarPoints0(
-      int nStarpoints, int edgeOffset, int gridDistance, boolean center, Graphics2D g) {
     g.setRenderingHint(KEY_ANTIALIASING, VALUE_ANTIALIAS_ON);
     int starPointRadius = (int) (STARPOINT_DIAMETER * min(boardWidth, boardHeight)) / 2;
-    for (int i = 0; i < nStarpoints; i++) {
-      for (int j = 0; j < nStarpoints; j++) {
-        int centerX = scaledMarginWidth + squareWidth * (edgeOffset + gridDistance * i);
-        int centerY = scaledMarginHeight + squareHeight * (edgeOffset + gridDistance * j);
-        fillCircle(g, centerX, centerY, starPointRadius);
-      }
-    }
-
-    if (center) {
-      int centerX = scaledMarginWidth + squareWidth * (Board.boardWidth / 2);
-      int centerY = scaledMarginHeight + squareHeight * (Board.boardHeight / 2);
+    for (Point point : points) {
+      int centerX = scaledMarginWidth + squareWidth * point.x;
+      int centerY = scaledMarginHeight + squareHeight * point.y;
       fillCircle(g, centerX, centerY, starPointRadius);
     }
   }
@@ -4152,53 +4181,85 @@ public class BoardRenderer {
   private void drawStoneMarkup(Graphics2D g) {
     if (isShowingBranch) return;
     BoardData data = Lizzie.board.getHistory().getData();
+    Stone[] stones = Lizzie.board.getStones();
+    boolean chineseClassic = Lizzie.config.useChineseClassicBoardStyle();
 
     data.getProperties()
         .forEach(
             (key, value) -> {
-              if (SGFParser.isListProperty(key)) {
-                String[] labels = value.split(",");
-                for (String label : labels) {
-                  String[] moves = label.split(":");
-                  int[] move = SGFParser.convertSgfPosToCoord(moves[0]);
-                  if (move != null) {
-                    if (move[0] >= Board.boardWidth - 1 || move[1] >= Board.boardWidth - 1) return;
-                    if ((isIndependBoard
-                            ? Lizzie.frame.independentMainBoard.isMouseOver(move[0], move[1])
-                            : Lizzie.frame.isMouseOver(move[0], move[1]))
-                        && isShowingBranch) continue;
-                    int moveX = x + scaledMarginWidth + squareWidth * move[0];
-                    int moveY = y + scaledMarginHeight + squareHeight * move[1];
-                    g.setColor(
-                        Lizzie.board.getStones()[Board.getIndex(move[0], move[1])].isBlack()
-                            ? Color.WHITE
-                            : Color.BLACK);
-                    g.setStroke(new BasicStroke(2));
-                    if ("LB".equals(key) && moves.length > 1) {
-                      // Label
-                      double labelRadius = stoneRadius * 1.4;
-                      drawString(
-                          g,
-                          moveX,
-                          moveY,
-                          LizzieFrame.uiFont,
-                          moves[1],
-                          (float) labelRadius,
-                          labelRadius);
-                    } else if ("TR".equals(key)) {
-                      drawTriangle(g, moveX, moveY, (stoneRadius + 1) * 2 / 3);
-                    } else if ("SQ".equals(key)) {
-                      drawSquare(g, moveX, moveY, (stoneRadius + 1) / 2);
-                    } else if ("CR".equals(key)) {
-                      drawCircle(g, moveX, moveY, stoneRadius * 2 / 3);
-                    } else if ("MA".equals(key)) {
-                      drawMarkX(g, moveX, moveY, (stoneRadius + 1) / 2);
-                    }
-                  }
-                }
+              if (!SGFParser.isListProperty(key)) {
+                return;
               }
-              //     }
+              for (String label :
+                  remainingMarkupEntries(value, Board.boardWidth, Board.boardHeight)) {
+                String[] moves = label.split(":");
+                int[] move = SGFParser.convertSgfPosToCoord(moves[0]);
+                if (move == null) {
+                  continue;
+                }
+                if ((isIndependBoard
+                        ? Lizzie.frame.independentMainBoard.isMouseOver(move[0], move[1])
+                        : Lizzie.frame.isMouseOver(move[0], move[1]))
+                    && isShowingBranch) {
+                  continue;
+                }
+                int moveX = x + scaledMarginWidth + squareWidth * move[0];
+                int moveY = y + scaledMarginHeight + squareHeight * move[1];
+                Stone stone = stones[Board.getIndex(move[0], move[1])];
+                MarkupStroke stroke =
+                    markupStroke(
+                        stone,
+                        isStarIntersection(
+                            move[0],
+                            move[1],
+                            Board.boardWidth,
+                            Board.boardHeight,
+                            chineseClassic));
+                drawOneMarkup(g, key, moves, moveX, moveY, stroke);
+              }
             });
+  }
+
+  private void drawOneMarkup(
+      Graphics2D g, String key, String[] moves, int moveX, int moveY, MarkupStroke stroke) {
+    Color markColor = stroke == MarkupStroke.LIGHT ? Color.WHITE : Color.BLACK;
+    boolean label = "LB".equals(key) && moves.length > 1;
+    if (stroke == MarkupStroke.DARK_WITH_LIGHT_HALO) {
+      g.setColor(Color.WHITE);
+      if (label) {
+        drawMarkupLabel(g, moveX - 1, moveY, moves[1]);
+        drawMarkupLabel(g, moveX + 1, moveY, moves[1]);
+        drawMarkupLabel(g, moveX, moveY - 1, moves[1]);
+        drawMarkupLabel(g, moveX, moveY + 1, moves[1]);
+      } else {
+        g.setStroke(new BasicStroke(4));
+        drawMarkupShape(g, key, moveX, moveY);
+      }
+    }
+    g.setColor(markColor);
+    g.setStroke(new BasicStroke(2));
+    if (label) {
+      drawMarkupLabel(g, moveX, moveY, moves[1]);
+    } else {
+      drawMarkupShape(g, key, moveX, moveY);
+    }
+  }
+
+  private void drawMarkupLabel(Graphics2D g, int moveX, int moveY, String text) {
+    double labelRadius = stoneRadius * 1.4;
+    drawString(g, moveX, moveY, LizzieFrame.uiFont, text, (float) labelRadius, labelRadius);
+  }
+
+  private void drawMarkupShape(Graphics2D g, String key, int moveX, int moveY) {
+    if ("TR".equals(key)) {
+      drawTriangle(g, moveX, moveY, (stoneRadius + 1) * 2 / 3);
+    } else if ("SQ".equals(key)) {
+      drawSquare(g, moveX, moveY, (stoneRadius + 1) / 2);
+    } else if ("CR".equals(key)) {
+      drawCircle(g, moveX, moveY, stoneRadius * 2 / 3);
+    } else if ("MA".equals(key)) {
+      drawMarkX(g, moveX, moveY, (stoneRadius + 1) / 2);
+    }
   }
 
   /** Draws the triangle of a circle centered at (centerX, centerY) with radius $radius$ */

--- a/src/main/java/featurecat/lizzie/gui/BoardStylePainter.java
+++ b/src/main/java/featurecat/lizzie/gui/BoardStylePainter.java
@@ -57,6 +57,42 @@ final class BoardStylePainter {
     return points;
   }
 
+  static List<Point> standardStarPoints(int boardWidth, int boardHeight) {
+    if (boardWidth != boardHeight) {
+      return Collections.emptyList();
+    }
+    switch (boardWidth) {
+      case 19:
+        return starGrid(3, 3, 6, false, boardWidth);
+      case 15:
+        return starGrid(2, 3, 8, true, boardWidth);
+      case 13:
+        return starGrid(2, 3, 6, true, boardWidth);
+      case 9:
+        return starGrid(2, 2, 4, true, boardWidth);
+      case 7:
+        return starGrid(2, 2, 2, true, boardWidth);
+      case 5:
+        return starGrid(0, 0, 2, true, boardWidth);
+      default:
+        return Collections.emptyList();
+    }
+  }
+
+  private static List<Point> starGrid(
+      int nStarpoints, int edgeOffset, int gridDistance, boolean center, int boardSize) {
+    List<Point> points = new ArrayList<>();
+    for (int i = 0; i < nStarpoints; i++) {
+      for (int j = 0; j < nStarpoints; j++) {
+        points.add(new Point(edgeOffset + gridDistance * i, edgeOffset + gridDistance * j));
+      }
+    }
+    if (center) {
+      points.add(new Point(boardSize / 2, boardSize / 2));
+    }
+    return points;
+  }
+
   static String chineseClassicCoordinateLabel(int index, int boardSize) {
     if (index < 0 || index >= boardSize || boardSize <= 0) {
       return "";

--- a/src/test/java/featurecat/lizzie/gui/BoardRendererMarkupPaintTest.java
+++ b/src/test/java/featurecat/lizzie/gui/BoardRendererMarkupPaintTest.java
@@ -1,0 +1,62 @@
+package featurecat.lizzie.gui;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import featurecat.lizzie.rules.Stone;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class BoardRendererMarkupPaintTest {
+  @Test
+  void lastFileAndLastRankOnNineteenAreOnBoard() {
+    assertTrue(BoardRenderer.isMarkupOnBoard(18, 0, 19, 19));
+    assertTrue(BoardRenderer.isMarkupOnBoard(0, 18, 19, 19));
+    assertTrue(BoardRenderer.isMarkupOnBoard(18, 18, 19, 19));
+    assertFalse(BoardRenderer.isMarkupOnBoard(19, 0, 19, 19));
+    assertFalse(BoardRenderer.isMarkupOnBoard(0, 19, 19, 19));
+  }
+
+  @Test
+  void remainingPointsAfterLastFileStillPaint() {
+    assertEquals(List.of("sa", "dd"), BoardRenderer.remainingMarkupEntries("sa,dd", 19, 19));
+    assertEquals(List.of("as", "pd"), BoardRenderer.remainingMarkupEntries("as,pd", 19, 19));
+    assertEquals(List.of("ss:A", "dd:B"), BoardRenderer.remainingMarkupEntries("ss:A,dd:B", 19, 19));
+  }
+
+  @Test
+  void lastFileAndLastRankOnThirteenAreOnBoard() {
+    assertTrue(BoardRenderer.isMarkupOnBoard(12, 0, 13, 13));
+    assertTrue(BoardRenderer.isMarkupOnBoard(0, 12, 13, 13));
+    assertEquals(List.of("ma", "dd"), BoardRenderer.remainingMarkupEntries("ma,dd", 13, 13));
+    assertEquals(List.of("dd"), BoardRenderer.remainingMarkupEntries("ss,dd", 13, 13));
+  }
+
+  @Test
+  void emptyStarUsesHaloWhileEmptyPointStaysDarkAndBlackStoneStaysLight() {
+    assertEquals(
+        BoardRenderer.MarkupStroke.DARK, BoardRenderer.markupStroke(Stone.EMPTY, false));
+    assertEquals(
+        BoardRenderer.MarkupStroke.DARK_WITH_LIGHT_HALO,
+        BoardRenderer.markupStroke(Stone.EMPTY, true));
+    assertEquals(
+        BoardRenderer.MarkupStroke.LIGHT, BoardRenderer.markupStroke(Stone.BLACK, false));
+    assertEquals(
+        BoardRenderer.MarkupStroke.LIGHT, BoardRenderer.markupStroke(Stone.BLACK, true));
+    assertEquals(
+        BoardRenderer.MarkupStroke.DARK, BoardRenderer.markupStroke(Stone.WHITE, false));
+    assertEquals(
+        BoardRenderer.MarkupStroke.DARK, BoardRenderer.markupStroke(Stone.WHITE, true));
+  }
+
+  @Test
+  void starIntersectionsFollowDrawnMarkers() {
+    assertTrue(BoardRenderer.isStarIntersection(3, 3, 19, 19, false));
+    assertTrue(BoardRenderer.isStarIntersection(3, 9, 19, 19, false));
+    assertFalse(BoardRenderer.isStarIntersection(4, 4, 19, 19, false));
+    assertFalse(BoardRenderer.isStarIntersection(3, 9, 19, 19, true));
+    assertTrue(BoardRenderer.isStarIntersection(3, 3, 19, 19, true));
+    assertTrue(BoardRenderer.isStarIntersection(6, 6, 13, 13, false));
+  }
+}


### PR DESCRIPTION
## Summary

- After a markup-tool click, last-file and last-rank marks draw, and later marks of the same symbol keep drawing. Empty star points get a light halo; ordinary empty points stay dark.
- Root cause: the painter treated the last file/rank as off-board and `return`ed from the property `forEach`, dropping the rest of that symbol. Write path, analysis, and suggestions are unchanged.

## Type Of Change

- [x] Bug fix
- [ ] Feature
- [ ] Packaging / release update
- [ ] Docs / translation
- [ ] Refactor

## Testing

- [x] Tested locally
- [ ] Verified package contents if packaging changed
- [ ] Verified Fox sync flow if related
- [ ] Added screenshots if UI changed
- [ ] Updated README / docs if user-facing behavior changed
- [x] Noted affected platforms if the change is platform-specific
- [x] Verified there is no unrelated formatting or line-ending churn
- [ ] Ran `python3 scripts/check_line_endings.py` (or equivalent `python` on Windows)

WSL: `BoardRendererMarkupPaintTest,BoardStylePainterTest,SnapshotNodeRenderGateTest,MoveOnlyUiGateTest,WholeGameAnalysisResultViewTest` passed.
Windows hand test (`7747c1f5` shaded JAR, PID 79812): T/19 + interior triangle, readable hoshi marks, dark mark on empty non-star — all PASS.
#323 video delay: headless paint path 7ms; `draw()` not changed; this PR does not claim that delay is fixed.

## Notes

- Related: https://github.com/wimi321/lizzieyzy-next/issues/323
- Do not Closes #323: live delay may still exist; this PR only covers dropped edge marks and hoshi contrast.