### PR TITLE
chore(release): publish next-2026-08-26.1 pre-release

### DIFF
--- a/.github/release-notes/next-2026-08-26.1.md
+++ b/.github/release-notes/next-2026-08-26.1.md
@@ -1,0 +1,359 @@
+# LizzieYzy Next next-2026-08-26.1
+
+## 中文
+
+这是一次聚焦交互响应与日常稳定性的公开测试版。重点修复 Windows 下连续点击 KataGo 推荐选点时，偶尔要等一下才看见落子的现象；即使鼠标已经展开变化预览，新棋也应立即显示。
+
+### 本版主要更新
+
+- 本地落子会先结束旧分析代际，再异步发送 GTP `play`；旧局面的迟到分析不再被当成新局面结果，也不能用推荐圆遮住刚落下的棋子。
+- 落子时优先只重绘棋盘，评论、问题手等次要维护稍后合并刷新；150% Windows 缩放下不再为每批分析重建整个窗口。
+- 推荐点悬停变化改为确认停留后显示，并复用不变的变化图缓存；普通候选点和热力图还会过滤已被占用的位置，同时保留引擎对局的上一手候选显示语义。
+- “帮助 → 检查更新”支持用户手动选择正式或测试通道；普通更新仍由用户主动触发，不把 pre-release 当作正式版强制提醒。
+- 引擎对局未填写让子数时按分先处理；GIB 棋谱成功载入的返回值也已修正。
+- AI 讲解会隔离已被新请求替换的旧回调，避免迟到结果干扰当前讲解；相关棋盘、死活与请求边界增加了回归测试。
+
+### 下载前先看
+
+- 已安装 `next-2026-08-25.1` 完整包的 Windows 用户，可以使用 `windows64.core-update.zip` 获取本次程序修复；它不会替换现有权重、引擎、TensorRT 或 `user-data`。
+- 新安装用户下载对应完整包，仍会得到 KataGo v1.18.1 与默认 B11；更重视速度可在“一键设置 → 权重”明确切换 B10。
+- RTX 20/30/40/50 继续使用统一的 `windows64.nvidia` CUDA 包；TensorRT 仅作为 RTX 30 系及以下可选方案。
+- 这是 pre-release，建议先在独立目录测试，并保留现有 `user-data`、权重和棋谱备份。
+- DirectML、OpenVINO 和 ROCm 包仍为 experimental，未在缺少对应硬件的机器上冒充实测通过。
+
+### 下载建议
+
+| 你的电脑 | 直接下载这个 |
+| --- | --- |
+| Windows 64 位，OpenCL 推荐版，免安装 | [`2026-08-26-windows64.opencl.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-26.1/2026-08-26-windows64.opencl.portable.zip) |
+| 已有 Windows 免安装版，只更新主程序 | [`2026-08-26-windows64.core-update.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-26.1/2026-08-26-windows64.core-update.zip) |
+| Windows 64 位，OpenCL 安装版 | [`2026-08-26-windows64.opencl.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-26.1/2026-08-26-windows64.opencl.installer.exe) |
+| Windows 64 位，CPU 兼容版，免安装 | [`2026-08-26-windows64.with-katago.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-26.1/2026-08-26-windows64.with-katago.portable.zip) |
+| Windows 64 位，CPU 兼容安装版 | [`2026-08-26-windows64.with-katago.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-26.1/2026-08-26-windows64.with-katago.installer.exe) |
+| Windows 64 位，RTX 20/30/40/50 NVIDIA CUDA，免安装 | [`2026-08-26-windows64.nvidia.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-26.1/2026-08-26-windows64.nvidia.portable.zip) |
+| Windows 64 位，RTX 20/30/40/50 NVIDIA CUDA 安装版 | [`2026-08-26-windows64.nvidia.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-26.1/2026-08-26-windows64.nvidia.installer.exe) |
+| Windows DirectML 实验版 | [`2026-08-26-windows64.experimental.directml.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-26.1/2026-08-26-windows64.experimental.directml.portable.zip) |
+| Windows Intel OpenVINO 实验版 | [`2026-08-26-windows64.experimental.openvino.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-26.1/2026-08-26-windows64.experimental.openvino.portable.zip) |
+| Windows AMD RX 6000 ROCm 实验版 | [`2026-08-26-windows64.experimental.rocm.gfx103x.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-26.1/2026-08-26-windows64.experimental.rocm.gfx103x.portable.zip) |
+| Windows AMD RX 7000 ROCm 实验版 | [`2026-08-26-windows64.experimental.rocm.gfx110x.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-26.1/2026-08-26-windows64.experimental.rocm.gfx110x.portable.zip) |
+| Windows AMD Ryzen AI Max ROCm 实验版 | [`2026-08-26-windows64.experimental.rocm.gfx1151.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-26.1/2026-08-26-windows64.experimental.rocm.gfx1151.portable.zip) |
+| Windows AMD RX 9000 ROCm 实验版 | [`2026-08-26-windows64.experimental.rocm.gfx120x.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-26.1/2026-08-26-windows64.experimental.rocm.gfx120x.portable.zip) |
+| RTX 30 系及以下可选 TensorRT，需下载两个分卷 | [`2026-08-26-windows64.nvidia.tensorrt.portable.7z.001`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-26.1/2026-08-26-windows64.nvidia.tensorrt.portable.7z.001)<br>[`2026-08-26-windows64.nvidia.tensorrt.portable.7z.002`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-26.1/2026-08-26-windows64.nvidia.tensorrt.portable.7z.002) |
+| Windows 64 位，自行配置引擎，免安装 | [`2026-08-26-windows64.without.engine.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-26.1/2026-08-26-windows64.without.engine.portable.zip) |
+| Windows 64 位，自行配置引擎，安装版 | [`2026-08-26-windows64.without.engine.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-26.1/2026-08-26-windows64.without.engine.installer.exe) |
+| macOS Apple Silicon，Metal | [`2026-08-26-mac-apple-silicon.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-26.1/2026-08-26-mac-apple-silicon.with-katago.dmg) |
+| macOS Intel | [`2026-08-26-mac-intel.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-26.1/2026-08-26-mac-intel.with-katago.dmg) |
+| Linux 64 位，CPU 兼容版 | [`2026-08-26-linux64.with-katago.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-26.1/2026-08-26-linux64.with-katago.zip) |
+| Linux 64 位，OpenCL 版 | [`2026-08-26-linux64.opencl.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-26.1/2026-08-26-linux64.opencl.zip) |
+| Linux 64 位，NVIDIA CUDA 版 | [`2026-08-26-linux64.nvidia.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-26.1/2026-08-26-linux64.nvidia.zip) |
+
+### 为什么值得测试
+
+- Windows 11、RTX 3070、150% 缩放真机完成两轮共 50 次推荐点连续落子，其中 18 次点击时变化预览已经展开；50/50 次都显示真实棋子且窗口保持响应。
+- 从按下鼠标到检测到棋子的可见延迟为 106–151 ms，平均 121 ms、P95 140 ms；最慢一次 GTP 发送为 69.653 ms，应用日志无错误。
+- 合入最新 main 后完整测试为 3320 项，0 失败、0 错误、14 跳过；Maven 打包、Windows 启动器审计、换行策略与 PR CI 均通过。
+- macOS、Linux、RTX 40/50、DirectML、OpenVINO 与 ROCm 本轮未标记为新增硬件实测，欢迎重点反馈高缩放和连续落子体验。
+
+### 交流
+
+- QQ 群：`299419120`
+
+---
+
+## 繁體中文
+
+這是一次聚焦互動回應與日常穩定性的公開測試版。重點修復 Windows 下連續點擊 KataGo 建議選點時，偶爾要稍等才看見落子的問題；即使滑鼠已展開變化預覽，新棋也應立即顯示。
+
+### 本版主要更新
+
+- 本機落子會先結束舊分析代際，再非同步送出 GTP `play`；舊局面的遲到分析不再被當作新局面結果，也不能用建議圓遮住剛落下的棋子。
+- 落子時優先只重繪棋盤，評論、問題手等次要維護稍後合併刷新；150% Windows 縮放下不再為每批分析重建整個視窗。
+- 建議點懸停變化改為確認停留後顯示，並重用未改變的變化圖快取；普通候選點與熱力圖也會過濾已佔用位置，同時保留引擎對局的上一手候選語義。
+- 「說明 → 檢查更新」支援手動選擇正式或測試通道；一般更新仍由使用者主動觸發，不把 pre-release 當作正式版強制提醒。
+- 引擎對局未填讓子數時按分先處理；GIB 棋譜成功載入的回傳值亦已修正。
+- AI 講解會隔離已被新請求取代的舊回呼，避免遲到結果干擾目前講解，並補上相關回歸測試。
+
+### 下載前先看
+
+- 已安裝 `next-2026-08-25.1` 完整套件的 Windows 使用者，可用 `windows64.core-update.zip` 取得本次程式修復；它不會替換現有權重、引擎、TensorRT 或 `user-data`。
+- 新安裝請下載對應完整套件，仍包含 KataGo v1.18.1 與預設 B11；重視速度可在「一鍵設定 → 權重」明確切換 B10。
+- RTX 20/30/40/50 繼續使用統一 `windows64.nvidia` CUDA 套件；TensorRT 僅作為 RTX 30 系及以下可選方案。
+- 這是 pre-release，建議先在獨立目錄測試，並備份現有 `user-data`、權重與棋譜。
+- DirectML、OpenVINO 與 ROCm 仍為 experimental，未在缺少對應硬體的機器上宣稱實測通過。
+
+### 下載建議
+
+| 你的電腦 | 直接下載這個 |
+| --- | --- |
+| Windows 64 位，OpenCL 建議版，免安裝 | [`2026-08-26-windows64.opencl.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-26.1/2026-08-26-windows64.opencl.portable.zip) |
+| 既有 Windows 免安裝版，只更新主程式 | [`2026-08-26-windows64.core-update.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-26.1/2026-08-26-windows64.core-update.zip) |
+| Windows 64 位，OpenCL 安裝版 | [`2026-08-26-windows64.opencl.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-26.1/2026-08-26-windows64.opencl.installer.exe) |
+| Windows 64 位，CPU 相容版，免安裝 | [`2026-08-26-windows64.with-katago.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-26.1/2026-08-26-windows64.with-katago.portable.zip) |
+| Windows 64 位，CPU 相容安裝版 | [`2026-08-26-windows64.with-katago.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-26.1/2026-08-26-windows64.with-katago.installer.exe) |
+| Windows 64 位，RTX 20/30/40/50 NVIDIA CUDA，免安裝 | [`2026-08-26-windows64.nvidia.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-26.1/2026-08-26-windows64.nvidia.portable.zip) |
+| Windows 64 位，RTX 20/30/40/50 NVIDIA CUDA 安裝版 | [`2026-08-26-windows64.nvidia.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-26.1/2026-08-26-windows64.nvidia.installer.exe) |
+| Windows DirectML 實驗版 | [`2026-08-26-windows64.experimental.directml.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-26.1/2026-08-26-windows64.experimental.directml.portable.zip) |
+| Windows Intel OpenVINO 實驗版 | [`2026-08-26-windows64.experimental.openvino.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-26.1/2026-08-26-windows64.experimental.openvino.portable.zip) |
+| Windows AMD RX 6000 ROCm 實驗版 | [`2026-08-26-windows64.experimental.rocm.gfx103x.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-26.1/2026-08-26-windows64.experimental.rocm.gfx103x.portable.zip) |
+| Windows AMD RX 7000 ROCm 實驗版 | [`2026-08-26-windows64.experimental.rocm.gfx110x.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-26.1/2026-08-26-windows64.experimental.rocm.gfx110x.portable.zip) |
+| Windows AMD Ryzen AI Max ROCm 實驗版 | [`2026-08-26-windows64.experimental.rocm.gfx1151.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-26.1/2026-08-26-windows64.experimental.rocm.gfx1151.portable.zip) |
+| Windows AMD RX 9000 ROCm 實驗版 | [`2026-08-26-windows64.experimental.rocm.gfx120x.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-26.1/2026-08-26-windows64.experimental.rocm.gfx120x.portable.zip) |
+| RTX 30 系及以下可選 TensorRT，需下載兩個分卷 | [`2026-08-26-windows64.nvidia.tensorrt.portable.7z.001`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-26.1/2026-08-26-windows64.nvidia.tensorrt.portable.7z.001)<br>[`2026-08-26-windows64.nvidia.tensorrt.portable.7z.002`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-26.1/2026-08-26-windows64.nvidia.tensorrt.portable.7z.002) |
+| Windows 64 位，自行設定引擎，免安裝 | [`2026-08-26-windows64.without.engine.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-26.1/2026-08-26-windows64.without.engine.portable.zip) |
+| Windows 64 位，自行設定引擎，安裝版 | [`2026-08-26-windows64.without.engine.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-26.1/2026-08-26-windows64.without.engine.installer.exe) |
+| macOS Apple Silicon，Metal | [`2026-08-26-mac-apple-silicon.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-26.1/2026-08-26-mac-apple-silicon.with-katago.dmg) |
+| macOS Intel | [`2026-08-26-mac-intel.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-26.1/2026-08-26-mac-intel.with-katago.dmg) |
+| Linux 64 位，CPU 相容版 | [`2026-08-26-linux64.with-katago.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-26.1/2026-08-26-linux64.with-katago.zip) |
+| Linux 64 位，OpenCL 版 | [`2026-08-26-linux64.opencl.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-26.1/2026-08-26-linux64.opencl.zip) |
+| Linux 64 位，NVIDIA CUDA 版 | [`2026-08-26-linux64.nvidia.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-26.1/2026-08-26-linux64.nvidia.zip) |
+
+### 為什麼值得測試
+
+- Windows 11、RTX 3070、150% 縮放真機完成兩輪共 50 次建議點連續落子，其中 18 次點擊時變化預覽已展開；50/50 次均顯示真實棋子且視窗保持回應。
+- 從按下滑鼠到偵測到棋子的可見延遲為 106–151 ms，平均 121 ms、P95 140 ms；最慢 GTP 傳送為 69.653 ms，應用程式日誌無錯誤。
+- 合入最新 main 後完整測試 3320 項，0 失敗、0 錯誤、14 跳過；Maven 打包、Windows 啟動器稽核、換行策略與 PR CI 均通過。
+- macOS、Linux、RTX 40/50、DirectML、OpenVINO 與 ROCm 本輪未標記為新增硬體實測，歡迎回報高縮放與連續落子體驗。
+
+### 交流
+
+- QQ 群：`299419120`
+
+---
+
+## English
+
+This public preview focuses on input responsiveness and everyday stability. It fixes an intermittent Windows delay when repeatedly clicking KataGo candidates: a new stone should now appear immediately even when a hover variation is already visible.
+
+### Release highlights
+
+- A local move now retires the previous analysis generation before asynchronously sending GTP `play`. Late output from the old position can no longer be published as current analysis or cover the new stone with a candidate marker.
+- Move input performs an immediate board-only repaint and defers secondary comment and problem-list work. At 150% Windows scaling, ordinary analysis updates no longer rebuild the entire frame.
+- Hover variations wait for confirmed pointer intent and reuse unchanged branch images. Normal candidates and policy heatmaps filter occupied points while engine-game previous-candidate semantics remain intact.
+- Help → Check for Updates now supports an explicit stable or test channel. Checks remain user initiated, and a pre-release is not presented as a mandatory stable update.
+- An empty engine-game handicap is treated as an even game, and successful GIB loads now return the correct result.
+- AI commentary isolates callbacks from requests superseded by newer work, preventing late responses from affecting the current explanation; regression coverage was expanded around these boundaries.
+
+### Read before downloading
+
+- Windows users who already installed a complete `next-2026-08-25.1` bundle can use `windows64.core-update.zip` for this app fix. It does not replace existing weights, engines, TensorRT, or `user-data`.
+- New users should choose a matching full bundle, which still includes KataGo v1.18.1 and default B11. Explicitly choose B10 in Auto Setup when throughput matters more.
+- RTX 20/30/40/50 continue to use the unified `windows64.nvidia` CUDA package. TensorRT remains optional for RTX 30 series and earlier.
+- This is a pre-release. Test a separate copy first and keep backups of `user-data`, weights, and game records.
+- DirectML, OpenVINO, and ROCm remain experimental and are not claimed as tested on hardware that was unavailable locally.
+
+### Download guide
+
+| Your computer | Download this file |
+| --- | --- |
+| Windows x64, recommended OpenCL portable | [`2026-08-26-windows64.opencl.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-26.1/2026-08-26-windows64.opencl.portable.zip) |
+| Existing Windows portable install, app-only update | [`2026-08-26-windows64.core-update.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-26.1/2026-08-26-windows64.core-update.zip) |
+| Windows x64, OpenCL installer | [`2026-08-26-windows64.opencl.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-26.1/2026-08-26-windows64.opencl.installer.exe) |
+| Windows x64, CPU fallback portable | [`2026-08-26-windows64.with-katago.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-26.1/2026-08-26-windows64.with-katago.portable.zip) |
+| Windows x64, CPU fallback installer | [`2026-08-26-windows64.with-katago.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-26.1/2026-08-26-windows64.with-katago.installer.exe) |
+| Windows x64, RTX 20/30/40/50 NVIDIA CUDA portable | [`2026-08-26-windows64.nvidia.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-26.1/2026-08-26-windows64.nvidia.portable.zip) |
+| Windows x64, RTX 20/30/40/50 NVIDIA CUDA installer | [`2026-08-26-windows64.nvidia.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-26.1/2026-08-26-windows64.nvidia.installer.exe) |
+| Windows DirectML experimental | [`2026-08-26-windows64.experimental.directml.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-26.1/2026-08-26-windows64.experimental.directml.portable.zip) |
+| Windows Intel OpenVINO experimental | [`2026-08-26-windows64.experimental.openvino.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-26.1/2026-08-26-windows64.experimental.openvino.portable.zip) |
+| Windows AMD RX 6000 ROCm experimental | [`2026-08-26-windows64.experimental.rocm.gfx103x.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-26.1/2026-08-26-windows64.experimental.rocm.gfx103x.portable.zip) |
+| Windows AMD RX 7000 ROCm experimental | [`2026-08-26-windows64.experimental.rocm.gfx110x.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-26.1/2026-08-26-windows64.experimental.rocm.gfx110x.portable.zip) |
+| Windows AMD Ryzen AI Max ROCm experimental | [`2026-08-26-windows64.experimental.rocm.gfx1151.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-26.1/2026-08-26-windows64.experimental.rocm.gfx1151.portable.zip) |
+| Windows AMD RX 9000 ROCm experimental | [`2026-08-26-windows64.experimental.rocm.gfx120x.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-26.1/2026-08-26-windows64.experimental.rocm.gfx120x.portable.zip) |
+| Optional TensorRT for RTX 30 and earlier, download both parts | [`2026-08-26-windows64.nvidia.tensorrt.portable.7z.001`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-26.1/2026-08-26-windows64.nvidia.tensorrt.portable.7z.001)<br>[`2026-08-26-windows64.nvidia.tensorrt.portable.7z.002`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-26.1/2026-08-26-windows64.nvidia.tensorrt.portable.7z.002) |
+| Windows x64, bring your own engine, portable | [`2026-08-26-windows64.without.engine.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-26.1/2026-08-26-windows64.without.engine.portable.zip) |
+| Windows x64, bring your own engine, installer | [`2026-08-26-windows64.without.engine.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-26.1/2026-08-26-windows64.without.engine.installer.exe) |
+| macOS Apple Silicon, Metal | [`2026-08-26-mac-apple-silicon.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-26.1/2026-08-26-mac-apple-silicon.with-katago.dmg) |
+| macOS Intel | [`2026-08-26-mac-intel.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-26.1/2026-08-26-mac-intel.with-katago.dmg) |
+| Linux x64, CPU fallback | [`2026-08-26-linux64.with-katago.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-26.1/2026-08-26-linux64.with-katago.zip) |
+| Linux x64, OpenCL | [`2026-08-26-linux64.opencl.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-26.1/2026-08-26-linux64.opencl.zip) |
+| Linux x64, NVIDIA CUDA | [`2026-08-26-linux64.nvidia.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-26.1/2026-08-26-linux64.nvidia.zip) |
+
+### Why test this release
+
+- Real Windows 11, RTX 3070, and 150% scaling acceptance ran two rounds of 50 consecutive candidate clicks. Eighteen clicks occurred with a hover variation already visible; all 50 showed a real stone and the window remained responsive.
+- Mouse-down-to-visible-stone latency was 106–151 ms, averaging 121 ms with P95 at 140 ms. The slowest GTP send was 69.653 ms, and the application log contained no errors.
+- After merging the latest main, the full suite ran 3320 tests with 0 failures, 0 errors, and 14 skipped. Maven packaging, Windows launcher audit, line-ending policy, and PR CI all passed.
+- macOS, Linux, RTX 40/50, DirectML, OpenVINO, and ROCm are not marked as newly hardware-tested in this cycle. High-scaling and repeated-move feedback is welcome.
+
+### Contact
+
+- QQ group: `299419120`
+
+---
+
+## 日本語
+
+入力応答と日常の安定性に焦点を当てた公開テスト版です。Windows で KataGo の候補手を連続クリックした際、着手表示がまれに遅れる問題を修正しました。hover variation が表示中でも、新しい石は直ちに表示されます。
+
+### 主な更新
+
+- ローカル着手は旧 analysis generation を先に終了してから GTP `play` を非同期送信します。旧局面の遅延出力が現在の解析として公開されたり、候補マーカーで新しい石を覆ったりしません。
+- 着手時は棋盤だけを即時再描画し、comment と problem list の更新を後段にまとめます。Windows 150% scaling でも通常解析ごとに frame 全体を再構築しません。
+- hover variation は pointer の停止を確認してから表示し、未変更の branch image を再利用します。通常候補と policy heatmap は占有点を除外し、engine game の previous-candidate 表示は維持します。
+- Help → Check for Updates で stable/test channel を明示選択できます。確認はユーザー操作時のみで、pre-release を必須の stable update として通知しません。
+- engine game の handicap 未入力は互先として扱い、GIB 棋譜の読み込み成功も正しく返すよう修正しました。
+- 新しい AI 解説 request に置き換えられた旧 callback を隔離し、遅延応答が現在の解説へ影響しないようにしました。関連する regression test も追加しています。
+
+### ダウンロード前に
+
+- `next-2026-08-25.1` の complete bundle を導入済みの Windows ユーザーは、`windows64.core-update.zip` で今回の app 修正を適用できます。既存の weight、engine、TensorRT、`user-data` は置換しません。
+- 新規ユーザーは対応する full bundle を選んでください。KataGo v1.18.1 と既定 B11 を引き続き収録し、速度重視なら Auto Setup で B10 を明示選択できます。
+- RTX 20/30/40/50 は統合 `windows64.nvidia` CUDA package を使用します。TensorRT は RTX 30 系以前の optional 選択です。
+- pre-release のため、まず別 folder で試し、`user-data`、weight、棋譜を backup してください。
+- DirectML、OpenVINO、ROCm は experimental のままで、利用できない hardware を実機確認済みとは表示していません。
+
+### ダウンロード案内
+
+| 環境 | ダウンロードするファイル |
+| --- | --- |
+| Windows x64、推奨 OpenCL portable | [`2026-08-26-windows64.opencl.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-26.1/2026-08-26-windows64.opencl.portable.zip) |
+| 既存 Windows portable、app のみ更新 | [`2026-08-26-windows64.core-update.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-26.1/2026-08-26-windows64.core-update.zip) |
+| Windows x64、OpenCL installer | [`2026-08-26-windows64.opencl.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-26.1/2026-08-26-windows64.opencl.installer.exe) |
+| Windows x64、CPU fallback portable | [`2026-08-26-windows64.with-katago.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-26.1/2026-08-26-windows64.with-katago.portable.zip) |
+| Windows x64、CPU fallback installer | [`2026-08-26-windows64.with-katago.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-26.1/2026-08-26-windows64.with-katago.installer.exe) |
+| Windows x64、RTX 20/30/40/50 NVIDIA CUDA portable | [`2026-08-26-windows64.nvidia.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-26.1/2026-08-26-windows64.nvidia.portable.zip) |
+| Windows x64、RTX 20/30/40/50 NVIDIA CUDA installer | [`2026-08-26-windows64.nvidia.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-26.1/2026-08-26-windows64.nvidia.installer.exe) |
+| Windows DirectML experimental | [`2026-08-26-windows64.experimental.directml.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-26.1/2026-08-26-windows64.experimental.directml.portable.zip) |
+| Windows Intel OpenVINO experimental | [`2026-08-26-windows64.experimental.openvino.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-26.1/2026-08-26-windows64.experimental.openvino.portable.zip) |
+| Windows AMD RX 6000 ROCm experimental | [`2026-08-26-windows64.experimental.rocm.gfx103x.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-26.1/2026-08-26-windows64.experimental.rocm.gfx103x.portable.zip) |
+| Windows AMD RX 7000 ROCm experimental | [`2026-08-26-windows64.experimental.rocm.gfx110x.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-26.1/2026-08-26-windows64.experimental.rocm.gfx110x.portable.zip) |
+| Windows AMD Ryzen AI Max ROCm experimental | [`2026-08-26-windows64.experimental.rocm.gfx1151.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-26.1/2026-08-26-windows64.experimental.rocm.gfx1151.portable.zip) |
+| Windows AMD RX 9000 ROCm experimental | [`2026-08-26-windows64.experimental.rocm.gfx120x.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-26.1/2026-08-26-windows64.experimental.rocm.gfx120x.portable.zip) |
+| RTX 30 系以前向け optional TensorRT、両分割を取得 | [`2026-08-26-windows64.nvidia.tensorrt.portable.7z.001`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-26.1/2026-08-26-windows64.nvidia.tensorrt.portable.7z.001)<br>[`2026-08-26-windows64.nvidia.tensorrt.portable.7z.002`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-26.1/2026-08-26-windows64.nvidia.tensorrt.portable.7z.002) |
+| Windows x64、独自 engine、portable | [`2026-08-26-windows64.without.engine.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-26.1/2026-08-26-windows64.without.engine.portable.zip) |
+| Windows x64、独自 engine、installer | [`2026-08-26-windows64.without.engine.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-26.1/2026-08-26-windows64.without.engine.installer.exe) |
+| macOS Apple Silicon、Metal | [`2026-08-26-mac-apple-silicon.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-26.1/2026-08-26-mac-apple-silicon.with-katago.dmg) |
+| macOS Intel | [`2026-08-26-mac-intel.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-26.1/2026-08-26-mac-intel.with-katago.dmg) |
+| Linux x64、CPU fallback | [`2026-08-26-linux64.with-katago.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-26.1/2026-08-26-linux64.with-katago.zip) |
+| Linux x64、OpenCL | [`2026-08-26-linux64.opencl.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-26.1/2026-08-26-linux64.opencl.zip) |
+| Linux x64、NVIDIA CUDA | [`2026-08-26-linux64.nvidia.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-26.1/2026-08-26-linux64.nvidia.zip) |
+
+### テストする理由
+
+- Windows 11、RTX 3070、150% scaling の実機で候補手を 2 round、合計 50 回連続クリックしました。18 回は hover variation 表示中でしたが、50/50 回で実際の石が表示され、window も応答を維持しました。
+- mouse down から石表示まで 106–151 ms、平均 121 ms、P95 140 ms でした。最も遅い GTP send は 69.653 ms で、application log に error はありません。
+- 最新 main 統合後の full suite は 3320 tests、0 failures、0 errors、14 skipped です。Maven package、Windows launcher audit、line-ending policy、PR CI も通過しました。
+- macOS、Linux、RTX 40/50、DirectML、OpenVINO、ROCm は今回新たに hardware-tested とは表示していません。高 scaling と連続着手の feedback を歓迎します。
+
+### 連絡先
+
+- QQ group: `299419120`
+
+---
+
+## 한국어
+
+입력 반응성과 일상적인 안정성에 집중한 공개 preview입니다. Windows에서 KataGo 추천 수를 연속으로 클릭할 때 착수가 가끔 늦게 표시되던 문제를 수정했습니다. hover variation이 이미 표시된 상태에서도 새 돌이 즉시 나타나야 합니다.
+
+### 주요 업데이트
+
+- 로컬 착수는 비동기 GTP `play` 전송 전에 이전 analysis generation을 종료합니다. 이전 국면의 늦은 출력이 현재 분석으로 게시되거나 추천 표시가 새 돌을 가리는 일이 없습니다.
+- 착수 시 먼저 바둑판만 즉시 다시 그리고 comment와 problem list 같은 부가 작업은 뒤에서 묶어 처리합니다. Windows 150% 배율에서도 일반 분석 업데이트마다 전체 frame을 다시 만들지 않습니다.
+- hover variation은 pointer가 실제로 멈춘 뒤 표시하며 바뀌지 않은 branch image를 재사용합니다. 일반 후보와 policy heatmap은 이미 돌이 놓인 점을 제외하고, engine game의 previous-candidate 표시 의미는 유지합니다.
+- Help → Check for Updates에서 stable/test channel을 명시적으로 선택할 수 있습니다. 확인은 사용자가 요청할 때만 실행되며 pre-release를 필수 stable update로 안내하지 않습니다.
+- engine game의 handicap이 비어 있으면 호선으로 처리하고, GIB 기보를 성공적으로 불러왔을 때 올바른 결과를 반환합니다.
+- 새 AI 해설 요청으로 대체된 이전 callback을 격리하여 늦은 응답이 현재 설명을 방해하지 않도록 했고, 관련 회귀 테스트를 보강했습니다.
+
+### 다운로드 전 확인
+
+- `next-2026-08-25.1` complete bundle을 이미 설치한 Windows 사용자는 `windows64.core-update.zip`으로 이번 app 수정만 적용할 수 있습니다. 기존 weight, engine, TensorRT, `user-data`는 교체하지 않습니다.
+- 새 설치에는 해당 full bundle을 사용하세요. KataGo v1.18.1과 기본 B11이 계속 포함되며 처리량을 우선하면 Auto Setup에서 B10을 명시적으로 선택할 수 있습니다.
+- RTX 20/30/40/50은 통합 `windows64.nvidia` CUDA package를 계속 사용합니다. TensorRT는 RTX 30 시리즈 이하에서만 optional 선택입니다.
+- pre-release이므로 먼저 별도 folder에서 시험하고 `user-data`, weight, 기보를 backup하세요.
+- DirectML, OpenVINO, ROCm은 experimental이며 사용할 수 없는 hardware를 실기기 검증 완료로 표시하지 않았습니다.
+
+### 다운로드 안내
+
+| 환경 | 다운로드할 파일 |
+| --- | --- |
+| Windows x64, 권장 OpenCL portable | [`2026-08-26-windows64.opencl.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-26.1/2026-08-26-windows64.opencl.portable.zip) |
+| 기존 Windows portable, app-only update | [`2026-08-26-windows64.core-update.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-26.1/2026-08-26-windows64.core-update.zip) |
+| Windows x64, OpenCL installer | [`2026-08-26-windows64.opencl.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-26.1/2026-08-26-windows64.opencl.installer.exe) |
+| Windows x64, CPU fallback portable | [`2026-08-26-windows64.with-katago.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-26.1/2026-08-26-windows64.with-katago.portable.zip) |
+| Windows x64, CPU fallback installer | [`2026-08-26-windows64.with-katago.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-26.1/2026-08-26-windows64.with-katago.installer.exe) |
+| Windows x64, RTX 20/30/40/50 NVIDIA CUDA portable | [`2026-08-26-windows64.nvidia.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-26.1/2026-08-26-windows64.nvidia.portable.zip) |
+| Windows x64, RTX 20/30/40/50 NVIDIA CUDA installer | [`2026-08-26-windows64.nvidia.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-26.1/2026-08-26-windows64.nvidia.installer.exe) |
+| Windows DirectML experimental | [`2026-08-26-windows64.experimental.directml.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-26.1/2026-08-26-windows64.experimental.directml.portable.zip) |
+| Windows Intel OpenVINO experimental | [`2026-08-26-windows64.experimental.openvino.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-26.1/2026-08-26-windows64.experimental.openvino.portable.zip) |
+| Windows AMD RX 6000 ROCm experimental | [`2026-08-26-windows64.experimental.rocm.gfx103x.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-26.1/2026-08-26-windows64.experimental.rocm.gfx103x.portable.zip) |
+| Windows AMD RX 7000 ROCm experimental | [`2026-08-26-windows64.experimental.rocm.gfx110x.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-26.1/2026-08-26-windows64.experimental.rocm.gfx110x.portable.zip) |
+| Windows AMD Ryzen AI Max ROCm experimental | [`2026-08-26-windows64.experimental.rocm.gfx1151.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-26.1/2026-08-26-windows64.experimental.rocm.gfx1151.portable.zip) |
+| Windows AMD RX 9000 ROCm experimental | [`2026-08-26-windows64.experimental.rocm.gfx120x.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-26.1/2026-08-26-windows64.experimental.rocm.gfx120x.portable.zip) |
+| RTX 30 시리즈 이하 optional TensorRT, 두 part 모두 다운로드 | [`2026-08-26-windows64.nvidia.tensorrt.portable.7z.001`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-26.1/2026-08-26-windows64.nvidia.tensorrt.portable.7z.001)<br>[`2026-08-26-windows64.nvidia.tensorrt.portable.7z.002`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-26.1/2026-08-26-windows64.nvidia.tensorrt.portable.7z.002) |
+| Windows x64, 사용자 engine, portable | [`2026-08-26-windows64.without.engine.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-26.1/2026-08-26-windows64.without.engine.portable.zip) |
+| Windows x64, 사용자 engine, installer | [`2026-08-26-windows64.without.engine.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-26.1/2026-08-26-windows64.without.engine.installer.exe) |
+| macOS Apple Silicon, Metal | [`2026-08-26-mac-apple-silicon.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-26.1/2026-08-26-mac-apple-silicon.with-katago.dmg) |
+| macOS Intel | [`2026-08-26-mac-intel.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-26.1/2026-08-26-mac-intel.with-katago.dmg) |
+| Linux x64, CPU fallback | [`2026-08-26-linux64.with-katago.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-26.1/2026-08-26-linux64.with-katago.zip) |
+| Linux x64, OpenCL | [`2026-08-26-linux64.opencl.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-26.1/2026-08-26-linux64.opencl.zip) |
+| Linux x64, NVIDIA CUDA | [`2026-08-26-linux64.nvidia.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-26.1/2026-08-26-linux64.nvidia.zip) |
+
+### 테스트할 이유
+
+- Windows 11, RTX 3070, 150% 배율 실기기에서 추천 수 연속 클릭을 두 번에 걸쳐 총 50회 수행했습니다. 이 중 18회는 hover variation이 열린 상태였고, 50/50 모두 실제 돌이 표시되며 window가 응답 상태를 유지했습니다.
+- mouse down부터 돌 표시까지 106–151 ms, 평균 121 ms, P95 140 ms였습니다. 가장 느린 GTP send는 69.653 ms였고 application log에는 error가 없었습니다.
+- 최신 main 통합 후 full suite는 3320 tests, 0 failures, 0 errors, 14 skipped입니다. Maven package, Windows launcher audit, line-ending policy, PR CI가 모두 통과했습니다.
+- macOS, Linux, RTX 40/50, DirectML, OpenVINO, ROCm은 이번 cycle에서 새로 hardware-tested로 표시하지 않았습니다. 고배율 및 연속 착수 feedback을 환영합니다.
+
+### 연락처
+
+- QQ 그룹: `299419120`
+
+---
+
+## ภาษาไทย
+
+นี่คือ public preview ที่เน้นการตอบสนองของการคลิกและความเสถียรในการใช้งานประจำวัน แก้ปัญหาบน Windows ที่บางครั้งต้องรอก่อนเห็นหมากหลังคลิกจุดแนะนำของ KataGo ต่อเนื่อง แม้ hover variation กำลังแสดงอยู่ หมากใหม่ก็ควรปรากฏทันที
+
+### ไฮไลต์ของเวอร์ชันนี้
+
+- เมื่อผู้ใช้วางหมาก โปรแกรมจะยุติ analysis generation เดิมก่อนส่ง GTP `play` แบบ asynchronous ผลวิเคราะห์เก่าที่มาช้าจึงไม่ถูกเผยแพร่เป็นข้อมูลปัจจุบันและ marker จุดแนะนำไม่บังหมากใหม่
+- การวางหมากจะ repaint เฉพาะกระดานทันที แล้วรวมงานรองอย่าง comment และ problem list ไปทำภายหลัง ที่ Windows scaling 150% การอัปเดตวิเคราะห์ปกติจะไม่สร้าง frame ทั้งหมดใหม่
+- hover variation จะแสดงเมื่อ pointer หยุดอย่างตั้งใจและใช้ branch image ที่ไม่เปลี่ยนซ้ำ จุด candidate ทั่วไปและ policy heatmap จะกรองตำแหน่งที่มีหมากแล้ว พร้อมคงความหมาย previous-candidate ของ engine game
+- Help → Check for Updates ให้เลือก stable/test channel ได้อย่างชัดเจน การตรวจยังเกิดจากผู้ใช้สั่งเอง และไม่เสนอ pre-release เป็น stable update ที่บังคับ
+- engine game ที่เว้น handicap ว่างจะถือเป็นเกมเท่า และการโหลดไฟล์ GIB สำเร็จจะคืนผลลัพธ์ที่ถูกต้อง
+- AI commentary แยก callback เก่าที่ถูกคำขอใหม่แทนที่ เพื่อไม่ให้ผลล่าช้ารบกวนคำอธิบายปัจจุบัน พร้อมเพิ่ม regression tests สำหรับขอบเขตเหล่านี้
+
+### ก่อนดาวน์โหลด
+
+- ผู้ใช้ Windows ที่ติดตั้ง complete bundle `next-2026-08-25.1` แล้ว ใช้ `windows64.core-update.zip` เพื่อรับเฉพาะการแก้ไข app ครั้งนี้ได้ โดยไม่แทนที่ weight, engine, TensorRT หรือ `user-data`
+- ผู้ใช้ใหม่ควรดาวน์โหลด full bundle ที่ตรงกับเครื่อง ซึ่งยังมี KataGo v1.18.1 และ B11 เป็นค่าเริ่มต้น หากให้ความสำคัญกับ throughput มากกว่า ให้เลือก B10 ใน Auto Setup อย่างชัดเจน
+- RTX 20/30/40/50 ยังคงใช้ `windows64.nvidia` CUDA package เดียวกัน TensorRT เป็นตัวเลือกสำหรับ RTX 30 series และรุ่นก่อนหน้าเท่านั้น
+- นี่คือ pre-release ควรทดสอบใน folder แยกก่อน และ backup `user-data`, weight และ game records
+- DirectML, OpenVINO และ ROCm ยังเป็น experimental และเราไม่อ้างว่าผ่าน hardware test บนอุปกรณ์ที่ไม่มีในเครื่องทดสอบ
+
+### คู่มือดาวน์โหลด
+
+| คอมพิวเตอร์ของคุณ | ดาวน์โหลดไฟล์นี้ |
+| --- | --- |
+| Windows x64, OpenCL portable ที่แนะนำ | [`2026-08-26-windows64.opencl.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-26.1/2026-08-26-windows64.opencl.portable.zip) |
+| Windows portable เดิม, อัปเดตเฉพาะ app | [`2026-08-26-windows64.core-update.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-26.1/2026-08-26-windows64.core-update.zip) |
+| Windows x64, OpenCL installer | [`2026-08-26-windows64.opencl.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-26.1/2026-08-26-windows64.opencl.installer.exe) |
+| Windows x64, CPU fallback portable | [`2026-08-26-windows64.with-katago.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-26.1/2026-08-26-windows64.with-katago.portable.zip) |
+| Windows x64, CPU fallback installer | [`2026-08-26-windows64.with-katago.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-26.1/2026-08-26-windows64.with-katago.installer.exe) |
+| Windows x64, RTX 20/30/40/50 NVIDIA CUDA portable | [`2026-08-26-windows64.nvidia.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-26.1/2026-08-26-windows64.nvidia.portable.zip) |
+| Windows x64, RTX 20/30/40/50 NVIDIA CUDA installer | [`2026-08-26-windows64.nvidia.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-26.1/2026-08-26-windows64.nvidia.installer.exe) |
+| Windows DirectML experimental | [`2026-08-26-windows64.experimental.directml.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-26.1/2026-08-26-windows64.experimental.directml.portable.zip) |
+| Windows Intel OpenVINO experimental | [`2026-08-26-windows64.experimental.openvino.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-26.1/2026-08-26-windows64.experimental.openvino.portable.zip) |
+| Windows AMD RX 6000 ROCm experimental | [`2026-08-26-windows64.experimental.rocm.gfx103x.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-26.1/2026-08-26-windows64.experimental.rocm.gfx103x.portable.zip) |
+| Windows AMD RX 7000 ROCm experimental | [`2026-08-26-windows64.experimental.rocm.gfx110x.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-26.1/2026-08-26-windows64.experimental.rocm.gfx110x.portable.zip) |
+| Windows AMD Ryzen AI Max ROCm experimental | [`2026-08-26-windows64.experimental.rocm.gfx1151.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-26.1/2026-08-26-windows64.experimental.rocm.gfx1151.portable.zip) |
+| Windows AMD RX 9000 ROCm experimental | [`2026-08-26-windows64.experimental.rocm.gfx120x.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-26.1/2026-08-26-windows64.experimental.rocm.gfx120x.portable.zip) |
+| TensorRT สำหรับ RTX 30 และรุ่นก่อนหน้า, ดาวน์โหลดทั้งสอง part | [`2026-08-26-windows64.nvidia.tensorrt.portable.7z.001`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-26.1/2026-08-26-windows64.nvidia.tensorrt.portable.7z.001)<br>[`2026-08-26-windows64.nvidia.tensorrt.portable.7z.002`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-26.1/2026-08-26-windows64.nvidia.tensorrt.portable.7z.002) |
+| Windows x64, ใช้ engine ของคุณเอง, portable | [`2026-08-26-windows64.without.engine.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-26.1/2026-08-26-windows64.without.engine.portable.zip) |
+| Windows x64, ใช้ engine ของคุณเอง, installer | [`2026-08-26-windows64.without.engine.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-26.1/2026-08-26-windows64.without.engine.installer.exe) |
+| macOS Apple Silicon, Metal | [`2026-08-26-mac-apple-silicon.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-26.1/2026-08-26-mac-apple-silicon.with-katago.dmg) |
+| macOS Intel | [`2026-08-26-mac-intel.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-26.1/2026-08-26-mac-intel.with-katago.dmg) |
+| Linux x64, CPU fallback | [`2026-08-26-linux64.with-katago.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-26.1/2026-08-26-linux64.with-katago.zip) |
+| Linux x64, OpenCL | [`2026-08-26-linux64.opencl.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-26.1/2026-08-26-linux64.opencl.zip) |
+| Linux x64, NVIDIA CUDA | [`2026-08-26-linux64.nvidia.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-26.1/2026-08-26-linux64.nvidia.zip) |
+
+### เหตุผลที่ควรทดสอบ
+
+- ทดสอบจริงบน Windows 11, RTX 3070 และ scaling 150% ด้วยการคลิกจุดแนะนำต่อเนื่อง 2 รอบ รวม 50 ครั้ง โดย 18 ครั้งมี hover variation เปิดอยู่ ทั้ง 50/50 ครั้งแสดงหมากจริงและ window ยังตอบสนอง
+- ระยะจาก mouse down ถึงเห็นหมากอยู่ที่ 106–151 ms เฉลี่ย 121 ms และ P95 140 ms ส่วน GTP send ที่ช้าที่สุดคือ 69.653 ms โดยไม่มี error ใน application log
+- หลังรวม main ล่าสุด full suite รัน 3320 tests โดย 0 failures, 0 errors, 14 skipped และ Maven package, Windows launcher audit, line-ending policy กับ PR CI ผ่านทั้งหมด
+- macOS, Linux, RTX 40/50, DirectML, OpenVINO และ ROCm ไม่ได้ถูกระบุว่าเพิ่งผ่าน hardware test ในรอบนี้ ยินดีรับ feedback เรื่อง high scaling และการวางหมากต่อเนื่อง
+
+### ติดต่อ
+
+- QQ group: `299419120`

--- a/.github/release-requests/next-2026-08-26.1.json
+++ b/.github/release-requests/next-2026-08-26.1.json
@@ -1,0 +1,7 @@
+{
+  "date_tag": "2026-08-26",
+  "release_tag": "next-2026-08-26.1",
+  "title": "LizzieYzy Next next-2026-08-26.1",
+  "prerelease": true,
+  "notes_file": ".github/release-notes/next-2026-08-26.1.md"
+}


### PR DESCRIPTION
## Summary
- request the audited `next-2026-08-26.1` public pre-release
- publish six-language notes with direct links for Windows, macOS, and Linux assets
- include the candidate-point input responsiveness fix from #326 plus the latest stability changes already on `main`

## Validation
- Windows 11, RTX 3070 Laptop, 150% scaling: 50/50 consecutive candidate clicks succeeded, including 18 clicks with hover variations visible
- visible-stone latency: 106-151 ms, average 121 ms, P95 140 ms; no application log errors
- Maven: 3320 tests, 0 failures, 0 errors, 14 skipped; package succeeded
- launcher packaging and line-ending audits passed
- release metadata/asset/signing/workflow tests: 125 passed, 0 failed, 2 skipped
- release-note direct-link validator passed for all six languages

Merging this PR triggers the repository's fail-closed multi-platform pre-release publisher. The release remains a draft until every required asset is built and audited.