### PR TITLE
refactor(release): derive public assets from one topology

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,6 +143,8 @@ jobs:
             scripts/test_prepare_bundled_nvidia_runtime.py \
             scripts/test_publish_release_request.py \
             scripts/release_asset_provenance.py \
+            scripts/release_asset_topology.py \
+            scripts/test_release_asset_topology.py \
             scripts/test_release_asset_provenance.py \
             scripts/validate_release_notes.py \
             scripts/test_validate_release_notes.py \
@@ -164,6 +166,7 @@ jobs:
           python3 scripts/test_prepare_bundled_nvidia_runtime.py
           python3 -m unittest scripts.test_publish_release_request
           python3 -m unittest scripts.test_release_asset_provenance
+          python3 -m unittest scripts.test_release_asset_topology
           python3 -m unittest scripts.test_validate_release_notes
           python3 -m unittest scripts.test_macos_signing_security
           python3 -m unittest scripts.test_r2_release

--- a/.github/workflows/publish-requested-pre-release.yml
+++ b/.github/workflows/publish-requested-pre-release.yml
@@ -133,6 +133,7 @@ jobs:
             scripts.test_publish_release_request \
             scripts.test_generate_release_notes \
             scripts.test_release_asset_provenance \
+            scripts.test_release_asset_topology \
             scripts.test_validate_release_notes \
             scripts.test_macos_signing_security \
             scripts.test_validate_windows_release_assets \

--- a/scripts/generate_release_notes.py
+++ b/scripts/generate_release_notes.py
@@ -10,42 +10,19 @@ import sys
 from pathlib import Path
 from urllib.parse import quote
 
+try:
+    from scripts import release_asset_topology as topology
+except ModuleNotFoundError:  # Direct execution: python scripts/generate_release_notes.py
+    import release_asset_topology as topology  # type: ignore[no-redef]
+
 ROOT = Path(__file__).resolve().parents[1]
 VERSION_FILE = ROOT / 'engines' / 'katago' / 'VERSION.txt'
 PREPARE_BUNDLED_KATAGO_SCRIPT = ROOT / 'scripts' / 'prepare_bundled_katago.sh'
 KATAGO_ASSET_CATALOG = ROOT / 'src' / 'main' / 'resources' / 'katago-assets.json'
 
-ASSET_SPECS = [
-    ('windows_installer', 'windows64.with-katago.installer.exe', 'Windows 64 位，CPU 兼容版', 'Windows x64, CPU fallback'),
-    ('windows_portable', 'windows64.with-katago.portable.zip', 'Windows 64 位，CPU 兼容版，免安装', 'Windows x64, CPU fallback, no installer'),
-    ('windows_opencl_installer', 'windows64.opencl.installer.exe', 'Windows 64 位，OpenCL 推荐版', 'Windows x64, OpenCL recommended'),
-    ('windows_opencl_portable', 'windows64.opencl.portable.zip', 'Windows 64 位，OpenCL 推荐版，免安装', 'Windows x64, OpenCL recommended, no installer'),
-    ('windows_nvidia_installer', 'windows64.nvidia.installer.exe', 'Windows 64 位，英伟达显卡', 'Windows x64, NVIDIA GPU'),
-    ('windows_nvidia_portable', 'windows64.nvidia.portable.zip', 'Windows 64 位，英伟达显卡，免安装', 'Windows x64, NVIDIA GPU, no installer'),
-    ('windows_directml_experimental', 'windows64.experimental.directml.portable.zip', 'Windows 64 位，DirectML 实验版', 'Windows x64, DirectML experimental'),
-    ('windows_openvino_experimental', 'windows64.experimental.openvino.portable.zip', 'Windows 64 位，OpenVINO 实验版', 'Windows x64, OpenVINO experimental'),
-    ('windows_rocm_gfx103x_experimental', 'windows64.experimental.rocm.gfx103x.portable.zip', 'Windows 64 位，ROCm RX 6000 实验版', 'Windows x64, ROCm RX 6000 experimental'),
-    ('windows_rocm_gfx110x_experimental', 'windows64.experimental.rocm.gfx110x.portable.zip', 'Windows 64 位，ROCm RX 7000 实验版', 'Windows x64, ROCm RX 7000 experimental'),
-    ('windows_rocm_gfx1151_experimental', 'windows64.experimental.rocm.gfx1151.portable.zip', 'Windows 64 位，ROCm Ryzen AI Max 实验版', 'Windows x64, ROCm Ryzen AI Max experimental'),
-    ('windows_rocm_gfx120x_experimental', 'windows64.experimental.rocm.gfx120x.portable.zip', 'Windows 64 位，ROCm RX 9000 实验版', 'Windows x64, ROCm RX 9000 experimental'),
-    ('windows_no_engine_installer', 'windows64.without.engine.installer.exe', 'Windows 64 位，想自己配引擎，也想安装器', 'Windows x64, your own engine with installer'),
-    ('windows_no_engine_portable', 'windows64.without.engine.portable.zip', 'Windows 64 位，想自己配引擎', 'Windows x64, your own engine'),
-    ('mac_arm64', 'mac-apple-silicon.with-katago.dmg', 'macOS Apple Silicon', 'macOS Apple Silicon'),
-    ('mac_amd64', 'mac-intel.with-katago.dmg', 'macOS Intel', 'macOS Intel'),
-    ('linux64', 'linux64.with-katago.zip', 'Linux 64 位，CPU 兼容版', 'Linux x64, CPU fallback'),
-    ('linux64_opencl', 'linux64.opencl.zip', 'Linux 64 位，OpenCL 版', 'Linux x64, OpenCL'),
-    ('linux64_nvidia', 'linux64.nvidia.zip', 'Linux 64 位，NVIDIA CUDA 版', 'Linux x64, NVIDIA CUDA'),
-]
-TENSORRT_SPLIT_README_SUFFIX = 'windows64.nvidia.tensorrt.portable.README.txt'
-TENSORRT_SPLIT_PART_PATTERN = r'windows64\.nvidia\.tensorrt\.portable\.7z\.\d+$'
-TENSORRT_SPLIT_MANIFEST_SUFFIX = 'windows64.nvidia.tensorrt.portable.manifest.json'
-TENSORRT_SPLIT_SHA256_SUFFIX = 'windows64.nvidia.tensorrt.portable.sha256.txt'
-WINDOWS_CORE_UPDATE_SUFFIX = 'windows64.core-update.zip'
-TENSORRT_SPLIT_ASSET_KEYS = (
-    'windows_tensorrt_split_readme',
-    'windows_tensorrt_split_parts',
-    'windows_tensorrt_split_sha256',
-    'windows_tensorrt_split_manifest',
+TENSORRT_SPLIT_PART_KEYS = (
+    'windows_tensorrt_split_001',
+    'windows_tensorrt_split_002',
 )
 TENSORRT_SPLIT_DOWNLOAD_ASSET_KEYS = (
     'windows_tensorrt_split_parts',
@@ -217,23 +194,36 @@ def asset_names_from_dir(release_dir: str, date_tag: str | None) -> list[str]:
     return names
 
 
-def pick_asset(asset_names: list[str], suffix: str, date_tag: str | None) -> str | None:
-    matches = [name for name in asset_names if name.endswith(suffix)]
+def resolve_published_name(
+    asset_names: list[str],
+    asset: topology.ReleaseAsset,
+    date_tag: str | None,
+) -> str | None:
+    names = set(asset_names)
     if date_tag:
-        dated = [name for name in matches if name.startswith(f'{date_tag}-')]
-        if dated:
-            matches = dated
+        rendered = asset.filename.render(date_tag)
+        return rendered if rendered in names else None
+    if asset.filename.kind is topology.FilenameKind.LITERAL:
+        return asset.filename.value if asset.filename.value in names else None
+    matches = [name for name in asset_names if name.endswith(asset.filename.value)]
     return sorted(matches)[-1] if matches else None
 
 
-def pick_assets_matching(asset_names: list[str], pattern: str, date_tag: str | None) -> list[str]:
-    regex = re.compile(pattern)
-    matches = [name for name in asset_names if regex.search(name)]
-    if date_tag:
-        dated = [name for name in matches if name.startswith(f'{date_tag}-')]
-        if dated:
-            matches = dated
-    return sorted(matches)
+def build_asset_map(
+    asset_names: list[str],
+    date_tag: str | None,
+) -> dict[str, str | list[str] | None]:
+    asset_map: dict[str, str | list[str] | None] = {
+        asset.key: resolve_published_name(asset_names, asset, date_tag)
+        for asset in topology.assets()
+    }
+    parts = [
+        name
+        for key in TENSORRT_SPLIT_PART_KEYS
+        if isinstance(name := asset_map.get(key), str)
+    ]
+    asset_map['windows_tensorrt_split_parts'] = parts
+    return asset_map
 
 
 def release_asset_url(repo: str, release_tag: str | None, asset_name: str) -> str | None:
@@ -285,7 +275,7 @@ def validate_release_sections(sections: list[dict[str, object]]) -> None:
             + ', '.join(RELEASE_LANGUAGES)
         )
 
-    expected_download_rows = len(ASSET_SPECS)
+    expected_download_rows = len(topology.release_notes_table_assets())
     for section in sections:
         language = str(section['language'])
         missing = [key for key in SECTION_KEYS if key not in section]
@@ -327,14 +317,6 @@ def add_windows_core_update_download_row(
     assets_cn: dict[str, str],
     assets: dict[str, str],
 ) -> None:
-    labels_by_language = {
-        '中文': '已有 Windows 免安装版，日常升级小包',
-        '繁體中文': '已有 Windows 免安裝版，日常升級小包',
-        'English': 'Existing Windows portable install, small routine update',
-        '日本語': '既存の Windows portable 版向け小型更新',
-        '한국어': '기존 Windows portable 사용자를 위한 소형 업데이트',
-        'ภาษาไทย': 'อัปเดตเล็กสำหรับผู้ใช้ Windows portable เดิม',
-    }
     before_note_by_language = {
         '中文': '已经有 Windows 免安装版的老用户，日常升级优先下载 `windows64.core-update.zip`，关闭软件后解压到旧目录覆盖；引擎、权重、TensorRT、设置和棋谱都会保留。',
         '繁體中文': '已經有 Windows 免安裝版的舊使用者，日常升級優先下載 `windows64.core-update.zip`，關閉軟體後解壓到舊目錄覆蓋；引擎、權重、TensorRT、設定和棋譜都會保留。',
@@ -369,7 +351,7 @@ def add_windows_core_update_download_row(
                     break
             rows.insert(
                 insert_at,
-                (labels_by_language.get(language, labels_by_language['English']), core_asset),
+                (CORE_UPDATE_DOWNLOAD_LABELS.get(language, CORE_UPDATE_DOWNLOAD_LABELS['English']), core_asset),
             )
 
         before = section['before']
@@ -460,14 +442,7 @@ def add_tensorrt_split_download_row(
 ) -> None:
     if not any(asset_map.get(key) for key in TENSORRT_SPLIT_DOWNLOAD_ASSET_KEYS):
         return
-    labels_by_language = {
-        '中文': 'RTX 30 系及以下可选：TensorRT 预装分卷包（需下载全部 .7z.00N）',
-        '繁體中文': 'RTX 30 系及以下可選：TensorRT 預裝分卷包（需下載全部 .7z.00N）',
-        'English': 'Optional TensorRT split package for RTX 30 and earlier; download every .7z.00N part',
-        '日本語': 'RTX 30 以前向け任意：TensorRT 分割パッケージ（.7z.00N を全て取得）',
-        '한국어': 'RTX 30 이하 선택: TensorRT 분할 패키지(.7z.00N 전체 다운로드 필요)',
-        'ภาษาไทย': 'ตัวเลือกสำหรับ RTX 30 และเก่ากว่า: TensorRT split package ต้องดาวน์โหลด .7z.00N ครบ',
-    }
+    labels_by_language = TENSORRT_SPLIT_DOWNLOAD_LABELS
     before_note_by_language = {
         '中文': 'TensorRT 分卷包是 RTX 30 系及以下显卡的可选离线路径；RTX 40/50 请使用 CUDA。必须下载全部 `.7z.00N` 并从 `.001` 解压。',
         '繁體中文': 'TensorRT 分卷包是 RTX 30 系及以下顯示卡的可選離線路徑；RTX 40/50 請使用 CUDA。必須下載全部 `.7z.00N` 並從 `.001` 解壓。',
@@ -530,159 +505,185 @@ def render_language_section(section: dict[str, object]) -> str:
     return '\n'.join(lines).rstrip()
 
 
-def standard_download_rows(labels: list[str], localized_assets: dict[str, str]) -> list[tuple[str, str]]:
-    asset_order = [
-        'windows_opencl_portable',
-        'windows_opencl_installer',
-        'windows_portable',
-        'windows_installer',
-        'windows_nvidia_portable',
-        'windows_nvidia_installer',
-        'windows_directml_experimental',
-        'windows_openvino_experimental',
-        'windows_rocm_gfx103x_experimental',
-        'windows_rocm_gfx110x_experimental',
-        'windows_rocm_gfx1151_experimental',
-        'windows_rocm_gfx120x_experimental',
-        'windows_no_engine_portable',
-        'windows_no_engine_installer',
-        'mac_arm64',
-        'mac_amd64',
-        'linux64',
-        'linux64_opencl',
-        'linux64_nvidia',
-    ]
-    return list(zip(labels, (localized_assets[key] for key in asset_order)))
+def standard_download_rows(labels: dict[str, str], localized_assets: dict[str, str]) -> list[tuple[str, str]]:
+    table = topology.release_notes_table_assets()
+    if set(labels) != {asset.key for asset in table}:
+        raise SystemExit('download labels must cover topology release-notes table assets exactly')
+    return [(labels[asset.key], localized_assets[asset.key]) for asset in table]
 
 
 STANDARD_DOWNLOAD_LABELS = {
-    'zh': [
-        'Windows 64 位，OpenCL 版，推荐更快，免安装',
-        'Windows 64 位，OpenCL 版，想安装',
-        'Windows 64 位，CPU 兼容版，免安装',
-        'Windows 64 位，CPU 兼容版，想安装',
-        'Windows 64 位，NVIDIA 显卡，免安装',
-        'Windows 64 位，NVIDIA 显卡，想安装',
-        'Windows 64 位，DirectML 实验版，DirectX 12 GPU',
-        'Windows 64 位，OpenVINO 实验版，Intel GPU/NPU',
-        'Windows 64 位，ROCm 实验版，AMD RX 6000',
-        'Windows 64 位，ROCm 实验版，AMD RX 7000',
-        'Windows 64 位，ROCm 实验版，Ryzen AI Max',
-        'Windows 64 位，ROCm 实验版，AMD RX 9000',
-        'Windows 64 位，想自己配引擎',
-        'Windows 64 位，想自己配引擎，也想安装器',
-        'macOS Apple Silicon',
-        'macOS Intel',
-        'Linux 64 位，CPU 兼容版',
-        'Linux 64 位，OpenCL 版，AMD/Intel GPU',
-        'Linux 64 位，NVIDIA CUDA 版',
-    ],
-    'zh_hant': [
-        'Windows 64 位，OpenCL 版，推薦更快，免安裝',
-        'Windows 64 位，OpenCL 版，想安裝',
-        'Windows 64 位，CPU 相容版，免安裝',
-        'Windows 64 位，CPU 相容版，想安裝',
-        'Windows 64 位，NVIDIA 顯示卡，免安裝',
-        'Windows 64 位，NVIDIA 顯示卡，想安裝',
-        'Windows 64 位，DirectML 實驗版，DirectX 12 GPU',
-        'Windows 64 位，OpenVINO 實驗版，Intel GPU/NPU',
-        'Windows 64 位，ROCm 實驗版，AMD RX 6000',
-        'Windows 64 位，ROCm 實驗版，AMD RX 7000',
-        'Windows 64 位，ROCm 實驗版，Ryzen AI Max',
-        'Windows 64 位，ROCm 實驗版，AMD RX 9000',
-        'Windows 64 位，想自己配引擎',
-        'Windows 64 位，想自己配引擎，也想安裝器',
-        'macOS Apple Silicon',
-        'macOS Intel',
-        'Linux 64 位，CPU 相容版',
-        'Linux 64 位，OpenCL 版，AMD/Intel GPU',
-        'Linux 64 位，NVIDIA CUDA 版',
-    ],
-    'en': [
-        'Windows 64-bit, OpenCL, recommended and faster, no install',
-        'Windows 64-bit, OpenCL, installer',
-        'Windows 64-bit, CPU compatible build, no install',
-        'Windows 64-bit, CPU compatible build, installer',
-        'Windows 64-bit, NVIDIA GPU, no install',
-        'Windows 64-bit, NVIDIA GPU, installer',
-        'Windows 64-bit, DirectML experimental, DirectX 12 GPU',
-        'Windows 64-bit, OpenVINO experimental, Intel GPU/NPU',
-        'Windows 64-bit, ROCm experimental, AMD RX 6000',
-        'Windows 64-bit, ROCm experimental, AMD RX 7000',
-        'Windows 64-bit, ROCm experimental, Ryzen AI Max',
-        'Windows 64-bit, ROCm experimental, AMD RX 9000',
-        'Windows 64-bit, configure your own engine',
-        'Windows 64-bit, configure your own engine, installer',
-        'macOS Apple Silicon',
-        'macOS Intel',
-        'Linux 64-bit, CPU compatible build',
-        'Linux 64-bit, OpenCL for AMD/Intel GPU',
-        'Linux 64-bit, NVIDIA CUDA',
-    ],
-    'ja': [
-        'Windows 64-bit、OpenCL 推奨高速版、インストール不要',
-        'Windows 64-bit、OpenCL 版、インストーラ',
-        'Windows 64-bit、CPU 互換版、インストール不要',
-        'Windows 64-bit、CPU 互換版、インストーラ',
-        'Windows 64-bit、NVIDIA GPU、インストール不要',
-        'Windows 64-bit、NVIDIA GPU、インストーラ',
-        'Windows 64-bit、DirectML experimental、DirectX 12 GPU',
-        'Windows 64-bit、OpenVINO experimental、Intel GPU/NPU',
-        'Windows 64-bit、ROCm experimental、AMD RX 6000',
-        'Windows 64-bit、ROCm experimental、AMD RX 7000',
-        'Windows 64-bit、ROCm experimental、Ryzen AI Max',
-        'Windows 64-bit、ROCm experimental、AMD RX 9000',
-        'Windows 64-bit、自分でエンジンを設定したい場合',
-        'Windows 64-bit、自分でエンジンを設定したい場合、インストーラ',
-        'macOS Apple Silicon',
-        'macOS Intel',
-        'Linux 64-bit、CPU 互換版',
-        'Linux 64-bit、OpenCL、AMD/Intel GPU',
-        'Linux 64-bit、NVIDIA CUDA',
-    ],
-    'ko': [
-        'Windows 64-bit, OpenCL 추천 고속판, 무설치',
-        'Windows 64-bit, OpenCL, 설치형',
-        'Windows 64-bit, CPU 호환 빌드, 무설치',
-        'Windows 64-bit, CPU 호환 빌드, 설치형',
-        'Windows 64-bit, NVIDIA GPU, 무설치',
-        'Windows 64-bit, NVIDIA GPU, 설치형',
-        'Windows 64-bit, DirectML experimental, DirectX 12 GPU',
-        'Windows 64-bit, OpenVINO experimental, Intel GPU/NPU',
-        'Windows 64-bit, ROCm experimental, AMD RX 6000',
-        'Windows 64-bit, ROCm experimental, AMD RX 7000',
-        'Windows 64-bit, ROCm experimental, Ryzen AI Max',
-        'Windows 64-bit, ROCm experimental, AMD RX 9000',
-        'Windows 64-bit, 직접 엔진 설정',
-        'Windows 64-bit, 직접 엔진 설정, 설치형',
-        'macOS Apple Silicon',
-        'macOS Intel',
-        'Linux 64-bit, CPU 호환 빌드',
-        'Linux 64-bit, OpenCL, AMD/Intel GPU',
-        'Linux 64-bit, NVIDIA CUDA',
-    ],
-    'th': [
-        'Windows 64-bit, OpenCL, แนะนำและเร็วกว่า, ไม่ต้องติดตั้ง',
-        'Windows 64-bit, OpenCL, แบบติดตั้ง',
-        'Windows 64-bit, CPU compatible build, ไม่ต้องติดตั้ง',
-        'Windows 64-bit, CPU compatible build, แบบติดตั้ง',
-        'Windows 64-bit, การ์ดจอ NVIDIA, ไม่ต้องติดตั้ง',
-        'Windows 64-bit, การ์ดจอ NVIDIA, แบบติดตั้ง',
-        'Windows 64-bit, DirectML experimental, DirectX 12 GPU',
-        'Windows 64-bit, OpenVINO experimental, Intel GPU/NPU',
-        'Windows 64-bit, ROCm experimental, AMD RX 6000',
-        'Windows 64-bit, ROCm experimental, AMD RX 7000',
-        'Windows 64-bit, ROCm experimental, Ryzen AI Max',
-        'Windows 64-bit, ROCm experimental, AMD RX 9000',
-        'Windows 64-bit, ต้องการตั้งค่า engine เอง',
-        'Windows 64-bit, ต้องการตั้งค่า engine เองและอยากใช้ installer',
-        'macOS Apple Silicon',
-        'macOS Intel',
-        'Linux 64-bit, CPU compatible build',
-        'Linux 64-bit, OpenCL สำหรับ AMD/Intel GPU',
-        'Linux 64-bit, NVIDIA CUDA',
-    ],
+    'zh': {
+        'windows_opencl_portable': 'Windows 64 位，OpenCL 版，推荐更快，免安装',
+        'windows_opencl_installer': 'Windows 64 位，OpenCL 版，想安装',
+        'windows_portable': 'Windows 64 位，CPU 兼容版，免安装',
+        'windows_installer': 'Windows 64 位，CPU 兼容版，想安装',
+        'windows_nvidia_portable': 'Windows 64 位，NVIDIA 显卡，免安装',
+        'windows_nvidia_installer': 'Windows 64 位，NVIDIA 显卡，想安装',
+        'windows_directml_experimental': 'Windows 64 位，DirectML 实验版，DirectX 12 GPU',
+        'windows_openvino_experimental': 'Windows 64 位，OpenVINO 实验版，Intel GPU/NPU',
+        'windows_rocm_gfx103x_experimental': 'Windows 64 位，ROCm 实验版，AMD RX 6000',
+        'windows_rocm_gfx110x_experimental': 'Windows 64 位，ROCm 实验版，AMD RX 7000',
+        'windows_rocm_gfx1151_experimental': 'Windows 64 位，ROCm 实验版，Ryzen AI Max',
+        'windows_rocm_gfx120x_experimental': 'Windows 64 位，ROCm 实验版，AMD RX 9000',
+        'windows_no_engine_portable': 'Windows 64 位，想自己配引擎',
+        'windows_no_engine_installer': 'Windows 64 位，想自己配引擎，也想安装器',
+        'mac_arm64': 'macOS Apple Silicon',
+        'mac_amd64': 'macOS Intel',
+        'linux64': 'Linux 64 位，CPU 兼容版',
+        'linux64_opencl': 'Linux 64 位，OpenCL 版，AMD/Intel GPU',
+        'linux64_nvidia': 'Linux 64 位，NVIDIA CUDA 版',
+    },
+    'zh_hant': {
+        'windows_opencl_portable': 'Windows 64 位，OpenCL 版，推薦更快，免安裝',
+        'windows_opencl_installer': 'Windows 64 位，OpenCL 版，想安裝',
+        'windows_portable': 'Windows 64 位，CPU 相容版，免安裝',
+        'windows_installer': 'Windows 64 位，CPU 相容版，想安裝',
+        'windows_nvidia_portable': 'Windows 64 位，NVIDIA 顯示卡，免安裝',
+        'windows_nvidia_installer': 'Windows 64 位，NVIDIA 顯示卡，想安裝',
+        'windows_directml_experimental': 'Windows 64 位，DirectML 實驗版，DirectX 12 GPU',
+        'windows_openvino_experimental': 'Windows 64 位，OpenVINO 實驗版，Intel GPU/NPU',
+        'windows_rocm_gfx103x_experimental': 'Windows 64 位，ROCm 實驗版，AMD RX 6000',
+        'windows_rocm_gfx110x_experimental': 'Windows 64 位，ROCm 實驗版，AMD RX 7000',
+        'windows_rocm_gfx1151_experimental': 'Windows 64 位，ROCm 實驗版，Ryzen AI Max',
+        'windows_rocm_gfx120x_experimental': 'Windows 64 位，ROCm 實驗版，AMD RX 9000',
+        'windows_no_engine_portable': 'Windows 64 位，想自己配引擎',
+        'windows_no_engine_installer': 'Windows 64 位，想自己配引擎，也想安裝器',
+        'mac_arm64': 'macOS Apple Silicon',
+        'mac_amd64': 'macOS Intel',
+        'linux64': 'Linux 64 位，CPU 相容版',
+        'linux64_opencl': 'Linux 64 位，OpenCL 版，AMD/Intel GPU',
+        'linux64_nvidia': 'Linux 64 位，NVIDIA CUDA 版',
+    },
+    'en': {
+        'windows_opencl_portable': 'Windows 64-bit, OpenCL, recommended and faster, no install',
+        'windows_opencl_installer': 'Windows 64-bit, OpenCL, installer',
+        'windows_portable': 'Windows 64-bit, CPU compatible build, no install',
+        'windows_installer': 'Windows 64-bit, CPU compatible build, installer',
+        'windows_nvidia_portable': 'Windows 64-bit, NVIDIA GPU, no install',
+        'windows_nvidia_installer': 'Windows 64-bit, NVIDIA GPU, installer',
+        'windows_directml_experimental': 'Windows 64-bit, DirectML experimental, DirectX 12 GPU',
+        'windows_openvino_experimental': 'Windows 64-bit, OpenVINO experimental, Intel GPU/NPU',
+        'windows_rocm_gfx103x_experimental': 'Windows 64-bit, ROCm experimental, AMD RX 6000',
+        'windows_rocm_gfx110x_experimental': 'Windows 64-bit, ROCm experimental, AMD RX 7000',
+        'windows_rocm_gfx1151_experimental': 'Windows 64-bit, ROCm experimental, Ryzen AI Max',
+        'windows_rocm_gfx120x_experimental': 'Windows 64-bit, ROCm experimental, AMD RX 9000',
+        'windows_no_engine_portable': 'Windows 64-bit, configure your own engine',
+        'windows_no_engine_installer': 'Windows 64-bit, configure your own engine, installer',
+        'mac_arm64': 'macOS Apple Silicon',
+        'mac_amd64': 'macOS Intel',
+        'linux64': 'Linux 64-bit, CPU compatible build',
+        'linux64_opencl': 'Linux 64-bit, OpenCL for AMD/Intel GPU',
+        'linux64_nvidia': 'Linux 64-bit, NVIDIA CUDA',
+    },
+    'ja': {
+        'windows_opencl_portable': 'Windows 64-bit、OpenCL 推奨高速版、インストール不要',
+        'windows_opencl_installer': 'Windows 64-bit、OpenCL 版、インストーラ',
+        'windows_portable': 'Windows 64-bit、CPU 互換版、インストール不要',
+        'windows_installer': 'Windows 64-bit、CPU 互換版、インストーラ',
+        'windows_nvidia_portable': 'Windows 64-bit、NVIDIA GPU、インストール不要',
+        'windows_nvidia_installer': 'Windows 64-bit、NVIDIA GPU、インストーラ',
+        'windows_directml_experimental': 'Windows 64-bit、DirectML experimental、DirectX 12 GPU',
+        'windows_openvino_experimental': 'Windows 64-bit、OpenVINO experimental、Intel GPU/NPU',
+        'windows_rocm_gfx103x_experimental': 'Windows 64-bit、ROCm experimental、AMD RX 6000',
+        'windows_rocm_gfx110x_experimental': 'Windows 64-bit、ROCm experimental、AMD RX 7000',
+        'windows_rocm_gfx1151_experimental': 'Windows 64-bit、ROCm experimental、Ryzen AI Max',
+        'windows_rocm_gfx120x_experimental': 'Windows 64-bit、ROCm experimental、AMD RX 9000',
+        'windows_no_engine_portable': 'Windows 64-bit、自分でエンジンを設定したい場合',
+        'windows_no_engine_installer': 'Windows 64-bit、自分でエンジンを設定したい場合、インストーラ',
+        'mac_arm64': 'macOS Apple Silicon',
+        'mac_amd64': 'macOS Intel',
+        'linux64': 'Linux 64-bit、CPU 互換版',
+        'linux64_opencl': 'Linux 64-bit、OpenCL、AMD/Intel GPU',
+        'linux64_nvidia': 'Linux 64-bit、NVIDIA CUDA',
+    },
+    'ko': {
+        'windows_opencl_portable': 'Windows 64-bit, OpenCL 추천 고속판, 무설치',
+        'windows_opencl_installer': 'Windows 64-bit, OpenCL, 설치형',
+        'windows_portable': 'Windows 64-bit, CPU 호환 빌드, 무설치',
+        'windows_installer': 'Windows 64-bit, CPU 호환 빌드, 설치형',
+        'windows_nvidia_portable': 'Windows 64-bit, NVIDIA GPU, 무설치',
+        'windows_nvidia_installer': 'Windows 64-bit, NVIDIA GPU, 설치형',
+        'windows_directml_experimental': 'Windows 64-bit, DirectML experimental, DirectX 12 GPU',
+        'windows_openvino_experimental': 'Windows 64-bit, OpenVINO experimental, Intel GPU/NPU',
+        'windows_rocm_gfx103x_experimental': 'Windows 64-bit, ROCm experimental, AMD RX 6000',
+        'windows_rocm_gfx110x_experimental': 'Windows 64-bit, ROCm experimental, AMD RX 7000',
+        'windows_rocm_gfx1151_experimental': 'Windows 64-bit, ROCm experimental, Ryzen AI Max',
+        'windows_rocm_gfx120x_experimental': 'Windows 64-bit, ROCm experimental, AMD RX 9000',
+        'windows_no_engine_portable': 'Windows 64-bit, 직접 엔진 설정',
+        'windows_no_engine_installer': 'Windows 64-bit, 직접 엔진 설정, 설치형',
+        'mac_arm64': 'macOS Apple Silicon',
+        'mac_amd64': 'macOS Intel',
+        'linux64': 'Linux 64-bit, CPU 호환 빌드',
+        'linux64_opencl': 'Linux 64-bit, OpenCL, AMD/Intel GPU',
+        'linux64_nvidia': 'Linux 64-bit, NVIDIA CUDA',
+    },
+    'th': {
+        'windows_opencl_portable': 'Windows 64-bit, OpenCL, แนะนำและเร็วกว่า, ไม่ต้องติดตั้ง',
+        'windows_opencl_installer': 'Windows 64-bit, OpenCL, แบบติดตั้ง',
+        'windows_portable': 'Windows 64-bit, CPU compatible build, ไม่ต้องติดตั้ง',
+        'windows_installer': 'Windows 64-bit, CPU compatible build, แบบติดตั้ง',
+        'windows_nvidia_portable': 'Windows 64-bit, การ์ดจอ NVIDIA, ไม่ต้องติดตั้ง',
+        'windows_nvidia_installer': 'Windows 64-bit, การ์ดจอ NVIDIA, แบบติดตั้ง',
+        'windows_directml_experimental': 'Windows 64-bit, DirectML experimental, DirectX 12 GPU',
+        'windows_openvino_experimental': 'Windows 64-bit, OpenVINO experimental, Intel GPU/NPU',
+        'windows_rocm_gfx103x_experimental': 'Windows 64-bit, ROCm experimental, AMD RX 6000',
+        'windows_rocm_gfx110x_experimental': 'Windows 64-bit, ROCm experimental, AMD RX 7000',
+        'windows_rocm_gfx1151_experimental': 'Windows 64-bit, ROCm experimental, Ryzen AI Max',
+        'windows_rocm_gfx120x_experimental': 'Windows 64-bit, ROCm experimental, AMD RX 9000',
+        'windows_no_engine_portable': 'Windows 64-bit, ต้องการตั้งค่า engine เอง',
+        'windows_no_engine_installer': 'Windows 64-bit, ต้องการตั้งค่า engine เองและอยากใช้ installer',
+        'mac_arm64': 'macOS Apple Silicon',
+        'mac_amd64': 'macOS Intel',
+        'linux64': 'Linux 64-bit, CPU compatible build',
+        'linux64_opencl': 'Linux 64-bit, OpenCL สำหรับ AMD/Intel GPU',
+        'linux64_nvidia': 'Linux 64-bit, NVIDIA CUDA',
+    },
 }
+CORE_UPDATE_DOWNLOAD_LABELS = {
+    '中文': '已有 Windows 免安装版，日常升级小包',
+    '繁體中文': '已有 Windows 免安裝版，日常升級小包',
+    'English': 'Existing Windows portable install, small routine update',
+    '日本語': '既存の Windows portable 版向け小型更新',
+    '한국어': '기존 Windows portable 사용자를 위한 소형 업데이트',
+    'ภาษาไทย': 'อัปเดตเล็กสำหรับผู้ใช้ Windows portable เดิม',
+}
+TENSORRT_SPLIT_DOWNLOAD_LABELS = {
+    '中文': 'RTX 30 系及以下可选：TensorRT 预装分卷包（需下载全部 .7z.00N）',
+    '繁體中文': 'RTX 30 系及以下可選：TensorRT 預裝分卷包（需下載全部 .7z.00N）',
+    'English': 'Optional TensorRT split package for RTX 30 and earlier; download every .7z.00N part',
+    '日本語': 'RTX 30 以前向け任意：TensorRT 分割パッケージ（.7z.00N を全て取得）',
+    '한국어': 'RTX 30 이하 선택: TensorRT 분할 패키지(.7z.00N 전체 다운로드 필요)',
+    'ภาษาไทย': 'ตัวเลือกสำหรับ RTX 30 และเก่ากว่า: TensorRT split package ต้องดาวน์โหลด .7z.00N ครบ',
+}
+
+
+def validate_presentation_label_coverage() -> None:
+    table_keys = {asset.key for asset in topology.release_notes_table_assets()}
+    extra_keys = {
+        asset.key
+        for asset in topology.release_notes_assets()
+        if asset.key not in table_keys
+    }
+    covered_extra = {'windows_core_update', *TENSORRT_SPLIT_PART_KEYS}
+    if extra_keys != covered_extra:
+        raise SystemExit(
+            'release-notes extra labels must cover topology release-notes assets exactly'
+        )
+    for language, labels in STANDARD_DOWNLOAD_LABELS.items():
+        if set(labels) != table_keys:
+            raise SystemExit(
+                f'{language} download labels must cover topology release-notes table assets exactly'
+            )
+        if any(not str(value).strip() for value in labels.values()):
+            raise SystemExit(f'{language} download labels must not be empty')
+    if set(CORE_UPDATE_DOWNLOAD_LABELS) != set(RELEASE_LANGUAGES):
+        raise SystemExit('core-update labels must cover every release language')
+    if set(TENSORRT_SPLIT_DOWNLOAD_LABELS) != set(RELEASE_LANGUAGES):
+        raise SystemExit('TensorRT split labels must cover every release language')
+
+
+validate_presentation_label_coverage()
 
 
 def build_next_2026_05_17_2_notes(
@@ -8711,35 +8712,10 @@ def main() -> int:
     else:
         asset_names = asset_names_from_dir(args.release_dir, args.date_tag)
 
-    asset_map = {
-        key: pick_asset(asset_names, suffix, args.date_tag)
-        for key, suffix, _cn, _en in ASSET_SPECS
-    }
-    asset_map['windows_core_update'] = pick_asset(
-        asset_names,
-        WINDOWS_CORE_UPDATE_SUFFIX,
-        args.date_tag,
-    )
-    asset_map['windows_tensorrt_split_readme'] = pick_asset(
-        asset_names,
-        TENSORRT_SPLIT_README_SUFFIX,
-        args.date_tag,
-    )
-    asset_map['windows_tensorrt_split_parts'] = pick_assets_matching(
-        asset_names,
-        TENSORRT_SPLIT_PART_PATTERN,
-        args.date_tag,
-    )
-    asset_map['windows_tensorrt_split_sha256'] = pick_asset(
-        asset_names,
-        TENSORRT_SPLIT_SHA256_SUFFIX,
-        args.date_tag,
-    )
-    asset_map['windows_tensorrt_split_manifest'] = pick_asset(
-        asset_names,
-        TENSORRT_SPLIT_MANIFEST_SUFFIX,
-        args.date_tag,
-    )
+    try:
+        asset_map = build_asset_map(asset_names, args.date_tag)
+    except topology.TopologyError as exc:
+        raise SystemExit(str(exc)) from exc
     bundle = load_bundle_metadata()
     notes = build_release_notes(asset_map, bundle, args.repo, args.release_tag)
 

--- a/scripts/publish_release_request.py
+++ b/scripts/publish_release_request.py
@@ -25,8 +25,10 @@ import zipfile
 
 try:
     from scripts import release_asset_provenance as provenance
+    from scripts import release_asset_topology as topology
 except ModuleNotFoundError:  # Direct execution: python scripts/publish_release_request.py
     import release_asset_provenance as provenance  # type: ignore[no-redef]
+    import release_asset_topology as topology  # type: ignore[no-redef]
 
 
 API_VERSION = "2026-03-10"
@@ -40,30 +42,7 @@ LOCALIZED_NOTE_HEADINGS = (
     "## 한국어",
     "## ภาษาไทย",
 )
-DIRECT_DOWNLOAD_SUFFIXES = (
-    "windows64.opencl.portable.zip",
-    "windows64.core-update.zip",
-    "windows64.opencl.installer.exe",
-    "windows64.with-katago.portable.zip",
-    "windows64.with-katago.installer.exe",
-    "windows64.nvidia.portable.zip",
-    "windows64.nvidia.installer.exe",
-    "windows64.experimental.directml.portable.zip",
-    "windows64.experimental.openvino.portable.zip",
-    "windows64.experimental.rocm.gfx103x.portable.zip",
-    "windows64.experimental.rocm.gfx110x.portable.zip",
-    "windows64.experimental.rocm.gfx1151.portable.zip",
-    "windows64.experimental.rocm.gfx120x.portable.zip",
-    "windows64.nvidia.tensorrt.portable.7z.001",
-    "windows64.nvidia.tensorrt.portable.7z.002",
-    "windows64.without.engine.portable.zip",
-    "windows64.without.engine.installer.exe",
-    "mac-apple-silicon.with-katago.dmg",
-    "mac-intel.with-katago.dmg",
-    "linux64.with-katago.zip",
-    "linux64.opencl.zip",
-    "linux64.nvidia.zip",
-)
+
 ACTIVE_RUN_STATUSES = {"queued", "in_progress", "waiting", "requested", "pending"}
 WORKFLOW_IDENTITY_CONVERGENCE_SECONDS = 90
 CI_WORKFLOW_FILE = "ci.yml"
@@ -98,6 +77,10 @@ def _localized_note_sections(body: str) -> dict[str, str]:
     return sections
 
 
+def direct_download_names(date_tag: str) -> tuple[str, ...]:
+    return topology.direct_download_names(date_tag)
+
+
 def validate_direct_download_tables(
     body: str,
     date_tag: str,
@@ -116,9 +99,7 @@ def validate_direct_download_tables(
         download_end = subsections[3].start()
         download_section = section[download_start:download_end]
         lines = download_section.splitlines()
-        expected_names = [
-            f"{date_tag}-{suffix}" for suffix in DIRECT_DOWNLOAD_SUFFIXES
-        ]
+        expected_names = list(direct_download_names(date_tag))
 
         for filename in expected_names:
             url = (
@@ -210,10 +191,8 @@ class ReleaseRequest:
 class WorkflowSpec:
     platform: str
     workflow_file: str
-    exact_suffixes: tuple[str, ...]
     run_name_template: str
     provenance_platform: str
-    required_patterns: tuple[re.Pattern[str], ...] = ()
     dispatch_inputs: tuple[tuple[str, str], ...] = ()
 
     def expected_run_name(
@@ -227,72 +206,22 @@ class WorkflowSpec:
 
     def missing_assets(self, asset_names: Iterable[str], date_tag: str) -> list[str]:
         names = set(asset_names)
-        missing = [
-            f"{date_tag}-{suffix}"
-            for suffix in self.exact_suffixes
-            if f"{date_tag}-{suffix}" not in names
+        return [
+            expected
+            for expected in topology.public_inventory(self.provenance_platform, date_tag)
+            if expected not in names
         ]
-        for pattern in self.required_patterns:
-            rendered = re.compile(pattern.pattern.format(date=re.escape(date_tag)))
-            if not any(rendered.fullmatch(name) for name in names):
-                missing.append(pattern.pattern.format(date=date_tag))
-        return missing
 
 
-WORKFLOWS = (
+WORKFLOWS = tuple(
     WorkflowSpec(
-        "Windows",
-        "build-windows-release.yml",
-        (
-            "windows64.opencl.installer.exe",
-            "windows64.opencl.portable.zip",
-            "windows64.nvidia.installer.exe",
-            "windows64.nvidia.portable.zip",
-            "windows64.experimental.directml.portable.zip",
-            "windows64.experimental.openvino.portable.zip",
-            "windows64.experimental.rocm.gfx103x.portable.zip",
-            "windows64.experimental.rocm.gfx110x.portable.zip",
-            "windows64.experimental.rocm.gfx1151.portable.zip",
-            "windows64.experimental.rocm.gfx120x.portable.zip",
-            "windows64.with-katago.installer.exe",
-            "windows64.with-katago.portable.zip",
-            "windows64.without.engine.installer.exe",
-            "windows64.without.engine.portable.zip",
-            "windows64.core-update.zip",
-            "windows64.nvidia.tensorrt.portable.README.txt",
-            "windows64.nvidia.tensorrt.portable.manifest.json",
-            "windows64.nvidia.tensorrt.portable.sha256.txt",
-            "windows64.nvidia.tensorrt.portable.7z.001",
-            "windows64.nvidia.tensorrt.portable.7z.002",
-        ),
-        "Windows release {release_tag} | {date_tag} | prerelease={prerelease}",
-        "windows",
-        dispatch_inputs=(("release_prerelease", "true"),),
-    ),
-    WorkflowSpec(
-        "Linux",
-        "build-linux-release.yml",
-        ("linux64.with-katago.zip", "linux64.opencl.zip", "linux64.nvidia.zip"),
-        "Linux release {release_tag} | {date_tag} | prerelease={prerelease}",
-        "linux",
-        dispatch_inputs=(("release_prerelease", "true"),),
-    ),
-    WorkflowSpec(
-        "macOS Intel",
-        "build-macos-amd64-release.yml",
-        ("mac-intel.with-katago.dmg",),
-        "macOS Intel release {release_tag} | {date_tag} | prerelease={prerelease}",
-        "mac-amd64",
-        dispatch_inputs=(("release_prerelease", "true"),),
-    ),
-    WorkflowSpec(
-        "macOS Apple Silicon",
-        "build-macos-arm64-release.yml",
-        ("mac-apple-silicon.with-katago.dmg",),
-        "macOS Apple Silicon release {release_tag} | {date_tag} | prerelease={prerelease}",
-        "mac-arm64",
-        dispatch_inputs=(("release_prerelease", "true"),),
-    ),
+        unit.publisher_identity,
+        unit.workflow_file,
+        unit.run_name_template,
+        unit.platform,
+        unit.dispatch_inputs,
+    )
+    for unit in topology.release_units()
 )
 
 
@@ -1216,11 +1145,9 @@ class ReleasePublisher:
                 f"{spec.platform} provenance manifest is invalid: {exc}"
             ) from exc
 
-        publisher_names = {
-            f"{self.request.date_tag}-{suffix}" for suffix in spec.exact_suffixes
-        }
-        if spec.provenance_platform == "windows":
-            publisher_names.add("lizzieyzy-next-update-manifest.json")
+        publisher_names = set(
+            topology.public_inventory(spec.provenance_platform, self.request.date_tag)
+        )
         if set(records) != publisher_names:
             raise PublishError(
                 f"{spec.platform} publisher and provenance asset inventories disagree"

--- a/scripts/release_asset_provenance.py
+++ b/scripts/release_asset_provenance.py
@@ -10,40 +10,14 @@ from pathlib import Path
 import re
 import sys
 
+try:
+    from scripts import release_asset_topology as topology
+except ModuleNotFoundError:  # Direct execution: python scripts/release_asset_provenance.py
+    import release_asset_topology as topology  # type: ignore[no-redef]
+
 
 SCHEMA_VERSION = 1
 PROVENANCE_FILENAME = "release-asset-provenance.json"
-PLATFORM_ASSET_SUFFIXES: dict[str, tuple[str, ...]] = {
-    "windows": (
-        "windows64.opencl.installer.exe",
-        "windows64.opencl.portable.zip",
-        "windows64.nvidia.installer.exe",
-        "windows64.nvidia.portable.zip",
-        "windows64.experimental.directml.portable.zip",
-        "windows64.experimental.openvino.portable.zip",
-        "windows64.experimental.rocm.gfx103x.portable.zip",
-        "windows64.experimental.rocm.gfx110x.portable.zip",
-        "windows64.experimental.rocm.gfx1151.portable.zip",
-        "windows64.experimental.rocm.gfx120x.portable.zip",
-        "windows64.with-katago.installer.exe",
-        "windows64.with-katago.portable.zip",
-        "windows64.without.engine.installer.exe",
-        "windows64.without.engine.portable.zip",
-        "windows64.core-update.zip",
-        "windows64.nvidia.tensorrt.portable.README.txt",
-        "windows64.nvidia.tensorrt.portable.manifest.json",
-        "windows64.nvidia.tensorrt.portable.sha256.txt",
-        "windows64.nvidia.tensorrt.portable.7z.001",
-        "windows64.nvidia.tensorrt.portable.7z.002",
-    ),
-    "linux": (
-        "linux64.with-katago.zip",
-        "linux64.opencl.zip",
-        "linux64.nvidia.zip",
-    ),
-    "mac-amd64": ("mac-intel.with-katago.dmg",),
-    "mac-arm64": ("mac-apple-silicon.with-katago.dmg",),
-}
 
 
 class ProvenanceError(RuntimeError):
@@ -68,7 +42,7 @@ def validate_identity(
     run_id: int,
     run_attempt: int,
 ) -> None:
-    require(platform in PLATFORM_ASSET_SUFFIXES, f"Unsupported release platform: {platform}")
+    _require_supported_platform(platform)
     require(
         re.fullmatch(r"\d{4}-\d{2}-\d{2}", date_tag) is not None,
         "dateTag must use YYYY-MM-DD",
@@ -86,16 +60,22 @@ def validate_identity(
     _positive_integer(run_attempt, "workflowRunAttempt")
 
 
+def _require_supported_platform(platform: str) -> None:
+    try:
+        topology.release_unit(platform)
+    except topology.TopologyError as exc:
+        raise ProvenanceError(str(exc)) from exc
+
+
 def expected_asset_names(platform: str, date_tag: str) -> tuple[str, ...]:
-    require(platform in PLATFORM_ASSET_SUFFIXES, f"Unsupported release platform: {platform}")
-    names = [f"{date_tag}-{suffix}" for suffix in PLATFORM_ASSET_SUFFIXES[platform]]
-    if platform == "windows":
-        names.append("lizzieyzy-next-update-manifest.json")
-    return tuple(sorted(names))
+    try:
+        return topology.provenance_names(platform, date_tag)
+    except topology.TopologyError as exc:
+        raise ProvenanceError(str(exc)) from exc
 
 
 def artifact_name(platform: str, run_attempt: int) -> str:
-    require(platform in PLATFORM_ASSET_SUFFIXES, f"Unsupported release platform: {platform}")
+    _require_supported_platform(platform)
     _positive_integer(run_attempt, "workflowRunAttempt")
     return f"release-asset-provenance-{platform}-attempt-{run_attempt}"
 
@@ -217,7 +197,7 @@ def validate_provenance(
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--release-dir", required=True, type=Path)
-    parser.add_argument("--platform", required=True, choices=tuple(PLATFORM_ASSET_SUFFIXES))
+    parser.add_argument("--platform", required=True, choices=topology.platforms())
     parser.add_argument("--date-tag", required=True)
     parser.add_argument("--release-tag", required=True)
     parser.add_argument("--target-sha", required=True)

--- a/scripts/release_asset_topology.py
+++ b/scripts/release_asset_topology.py
@@ -1,0 +1,342 @@
+#!/usr/bin/env python3
+"""发布资产拓扑: public GitHub Release assets and their release relationships.
+
+The topology describes a version's release results: each asset's stable identity,
+filename rule, owning platform, publishing roles, and workflow unit. It does not
+package, hash, or publish those assets.
+"""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+from enum import Enum
+import re
+import sys
+
+
+DATE_TAG_PATTERN = re.compile(r"\d{4}-\d{2}-\d{2}")
+
+
+class TopologyError(RuntimeError):
+    """Unsupported platform or invalid required topology input."""
+
+
+class Role(Enum):
+    RELEASE_NOTES = "release_notes"
+    DIRECT_DOWNLOAD = "direct_download"
+    PROVENANCE = "provenance"
+
+
+class FilenameKind(Enum):
+    DATE_PREFIXED = "date_prefixed"
+    LITERAL = "literal"
+
+
+@dataclass(frozen=True)
+class FilenameRule:
+    kind: FilenameKind
+    value: str
+
+    def render(self, date_tag: str) -> str:
+        require_date_tag(date_tag)
+        if self.kind is FilenameKind.LITERAL:
+            return self.value
+        return f"{date_tag}-{self.value}"
+
+
+@dataclass(frozen=True)
+class ReleaseAsset:
+    key: str
+    filename: FilenameRule
+    platform: str
+    roles: frozenset[Role]
+    public_order: int
+    release_notes_order: int | None = None
+    direct_download_order: int | None = None
+
+
+@dataclass(frozen=True)
+class ReleaseUnit:
+    platform: str
+    publisher_identity: str
+    workflow_file: str
+    run_name_template: str
+    dispatch_inputs: tuple[tuple[str, str], ...]
+    assets: tuple[ReleaseAsset, ...]
+
+
+def require_date_tag(date_tag: str) -> None:
+    if DATE_TAG_PATTERN.fullmatch(date_tag) is None:
+        raise TopologyError("date-tag must use YYYY-MM-DD")
+
+
+def _asset(
+    key: str,
+    name: str,
+    platform: str,
+    *,
+    public: int,
+    literal: bool = False,
+    notes_table: int | None = None,
+    direct: int | None = None,
+    notes: bool = False,
+) -> ReleaseAsset:
+    roles = {Role.PROVENANCE}
+    if notes or notes_table is not None:
+        roles.add(Role.RELEASE_NOTES)
+    if direct is not None:
+        roles.add(Role.DIRECT_DOWNLOAD)
+    return ReleaseAsset(
+        key=key,
+        filename=FilenameRule(
+            FilenameKind.LITERAL if literal else FilenameKind.DATE_PREFIXED,
+            name,
+        ),
+        platform=platform,
+        roles=frozenset(roles),
+        public_order=public,
+        release_notes_order=notes_table,
+        direct_download_order=direct,
+    )
+
+
+_WINDOWS_ASSETS = (
+    _asset("windows_opencl_installer", "windows64.opencl.installer.exe", "windows", public=0, notes_table=1, direct=2),
+    _asset("windows_opencl_portable", "windows64.opencl.portable.zip", "windows", public=1, notes_table=0, direct=0),
+    _asset("windows_nvidia_installer", "windows64.nvidia.installer.exe", "windows", public=2, notes_table=5, direct=6),
+    _asset("windows_nvidia_portable", "windows64.nvidia.portable.zip", "windows", public=3, notes_table=4, direct=5),
+    _asset(
+        "windows_directml_experimental",
+        "windows64.experimental.directml.portable.zip",
+        "windows",
+        public=4,
+        notes_table=6,
+        direct=7,
+    ),
+    _asset(
+        "windows_openvino_experimental",
+        "windows64.experimental.openvino.portable.zip",
+        "windows",
+        public=5,
+        notes_table=7,
+        direct=8,
+    ),
+    _asset(
+        "windows_rocm_gfx103x_experimental",
+        "windows64.experimental.rocm.gfx103x.portable.zip",
+        "windows",
+        public=6,
+        notes_table=8,
+        direct=9,
+    ),
+    _asset(
+        "windows_rocm_gfx110x_experimental",
+        "windows64.experimental.rocm.gfx110x.portable.zip",
+        "windows",
+        public=7,
+        notes_table=9,
+        direct=10,
+    ),
+    _asset(
+        "windows_rocm_gfx1151_experimental",
+        "windows64.experimental.rocm.gfx1151.portable.zip",
+        "windows",
+        public=8,
+        notes_table=10,
+        direct=11,
+    ),
+    _asset(
+        "windows_rocm_gfx120x_experimental",
+        "windows64.experimental.rocm.gfx120x.portable.zip",
+        "windows",
+        public=9,
+        notes_table=11,
+        direct=12,
+    ),
+    _asset("windows_installer", "windows64.with-katago.installer.exe", "windows", public=10, notes_table=3, direct=4),
+    _asset("windows_portable", "windows64.with-katago.portable.zip", "windows", public=11, notes_table=2, direct=3),
+    _asset(
+        "windows_no_engine_installer",
+        "windows64.without.engine.installer.exe",
+        "windows",
+        public=12,
+        notes_table=13,
+        direct=16,
+    ),
+    _asset(
+        "windows_no_engine_portable",
+        "windows64.without.engine.portable.zip",
+        "windows",
+        public=13,
+        notes_table=12,
+        direct=15,
+    ),
+    _asset("windows_core_update", "windows64.core-update.zip", "windows", public=14, notes=True, direct=1),
+    _asset(
+        "windows_update_manifest",
+        "lizzieyzy-next-update-manifest.json",
+        "windows",
+        public=15,
+        literal=True,
+    ),
+    _asset(
+        "windows_tensorrt_split_001",
+        "windows64.nvidia.tensorrt.portable.7z.001",
+        "windows",
+        public=16,
+        notes=True,
+        direct=13,
+    ),
+    _asset(
+        "windows_tensorrt_split_002",
+        "windows64.nvidia.tensorrt.portable.7z.002",
+        "windows",
+        public=17,
+        notes=True,
+        direct=14,
+    ),
+    _asset("windows_tensorrt_split_readme", "windows64.nvidia.tensorrt.portable.README.txt", "windows", public=18),
+    _asset(
+        "windows_tensorrt_split_manifest",
+        "windows64.nvidia.tensorrt.portable.manifest.json",
+        "windows",
+        public=19,
+    ),
+    _asset("windows_tensorrt_split_sha256", "windows64.nvidia.tensorrt.portable.sha256.txt", "windows", public=20),
+)
+
+_LINUX_ASSETS = (
+    _asset("linux64_opencl", "linux64.opencl.zip", "linux", public=0, notes_table=17, direct=20),
+    _asset("linux64_nvidia", "linux64.nvidia.zip", "linux", public=1, notes_table=18, direct=21),
+    _asset("linux64", "linux64.with-katago.zip", "linux", public=2, notes_table=16, direct=19),
+)
+
+_MAC_AMD64_ASSETS = (
+    _asset("mac_amd64", "mac-intel.with-katago.dmg", "mac-amd64", public=0, notes_table=15, direct=18),
+)
+_MAC_ARM64_ASSETS = (
+    _asset("mac_arm64", "mac-apple-silicon.with-katago.dmg", "mac-arm64", public=0, notes_table=14, direct=17),
+)
+
+_DISPATCH_INPUTS = (("release_prerelease", "true"),)
+
+_UNITS = (
+    ReleaseUnit(
+        "windows",
+        "Windows",
+        "build-windows-release.yml",
+        "Windows release {release_tag} | {date_tag} | prerelease={prerelease}",
+        _DISPATCH_INPUTS,
+        _WINDOWS_ASSETS,
+    ),
+    ReleaseUnit(
+        "linux",
+        "Linux",
+        "build-linux-release.yml",
+        "Linux release {release_tag} | {date_tag} | prerelease={prerelease}",
+        _DISPATCH_INPUTS,
+        _LINUX_ASSETS,
+    ),
+    ReleaseUnit(
+        "mac-amd64",
+        "macOS Intel",
+        "build-macos-amd64-release.yml",
+        "macOS Intel release {release_tag} | {date_tag} | prerelease={prerelease}",
+        _DISPATCH_INPUTS,
+        _MAC_AMD64_ASSETS,
+    ),
+    ReleaseUnit(
+        "mac-arm64",
+        "macOS Apple Silicon",
+        "build-macos-arm64-release.yml",
+        "macOS Apple Silicon release {release_tag} | {date_tag} | prerelease={prerelease}",
+        _DISPATCH_INPUTS,
+        _MAC_ARM64_ASSETS,
+    ),
+)
+
+
+def platforms() -> tuple[str, ...]:
+    return tuple(unit.platform for unit in _UNITS)
+
+
+def release_units() -> tuple[ReleaseUnit, ...]:
+    return _UNITS
+
+
+def release_unit(platform: str) -> ReleaseUnit:
+    for unit in _UNITS:
+        if unit.platform == platform:
+            return unit
+    raise TopologyError(f"Unsupported platform: {platform}")
+
+
+def assets() -> tuple[ReleaseAsset, ...]:
+    return tuple(asset for unit in _UNITS for asset in unit.assets)
+
+
+def asset(key: str) -> ReleaseAsset:
+    for item in assets():
+        if item.key == key:
+            return item
+    raise TopologyError(f"Unknown release asset: {key}")
+
+
+def public_inventory(platform: str, date_tag: str) -> tuple[str, ...]:
+    unit = release_unit(platform)
+    return tuple(item.filename.render(date_tag) for item in unit.assets)
+
+
+def provenance_names(platform: str, date_tag: str) -> tuple[str, ...]:
+    return tuple(sorted(public_inventory(platform, date_tag)))
+
+
+def direct_download_names(date_tag: str) -> tuple[str, ...]:
+    ordered = sorted(
+        (item for item in assets() if Role.DIRECT_DOWNLOAD in item.roles),
+        key=lambda item: item.direct_download_order or 0,
+    )
+    return tuple(item.filename.render(date_tag) for item in ordered)
+
+
+def release_notes_table_assets() -> tuple[ReleaseAsset, ...]:
+    return tuple(
+        sorted(
+            (item for item in assets() if item.release_notes_order is not None),
+            key=lambda item: item.release_notes_order or 0,
+        )
+    )
+
+
+def release_notes_assets() -> tuple[ReleaseAsset, ...]:
+    table = release_notes_table_assets()
+    extras = tuple(
+        item
+        for item in assets()
+        if Role.RELEASE_NOTES in item.roles and item.release_notes_order is None
+    )
+    return table + extras
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    expected = subparsers.add_parser(
+        "expected-names",
+        help="Print public inventory filenames, one per line, in topology order",
+    )
+    expected.add_argument("--platform", required=True)
+    expected.add_argument("--date-tag", required=True)
+    args = parser.parse_args(argv)
+    try:
+        for name in public_inventory(args.platform, args.date_tag):
+            print(name)
+    except TopologyError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_generate_release_notes.py
+++ b/scripts/test_generate_release_notes.py
@@ -14,33 +14,20 @@ if SPEC is None or SPEC.loader is None:
     raise RuntimeError(f"Unable to load {SCRIPT_PATH}")
 NOTES = importlib.util.module_from_spec(SPEC)
 SPEC.loader.exec_module(NOTES)
+topology = NOTES.topology
 
 
 class GenerateReleaseNotesTest(unittest.TestCase):
     def setUp(self) -> None:
         date_tag = "2026-07-13"
         self.asset_map = {
-            key: f"{date_tag}-{suffix}"
-            for key, suffix, _cn, _en in NOTES.ASSET_SPECS
+            asset.key: asset.filename.render(date_tag)
+            for asset in topology.assets()
         }
-        self.asset_map.update(
-            {
-                "windows_core_update": f"{date_tag}-windows64.core-update.zip",
-                "windows_tensorrt_split_readme": (
-                    f"{date_tag}-windows64.nvidia.tensorrt.portable.README.txt"
-                ),
-                "windows_tensorrt_split_parts": [
-                    f"{date_tag}-windows64.nvidia.tensorrt.portable.7z.001",
-                    f"{date_tag}-windows64.nvidia.tensorrt.portable.7z.002",
-                ],
-                "windows_tensorrt_split_sha256": (
-                    f"{date_tag}-windows64.nvidia.tensorrt.portable.sha256.txt"
-                ),
-                "windows_tensorrt_split_manifest": (
-                    f"{date_tag}-windows64.nvidia.tensorrt.portable.manifest.json"
-                ),
-            }
-        )
+        self.asset_map["windows_tensorrt_split_parts"] = [
+            topology.asset("windows_tensorrt_split_001").filename.render(date_tag),
+            topology.asset("windows_tensorrt_split_002").filename.render(date_tag),
+        ]
 
     def build_notes(self, release_tag: str) -> str:
         return NOTES.build_release_notes(

--- a/scripts/test_publish_release_request.py
+++ b/scripts/test_publish_release_request.py
@@ -20,6 +20,7 @@ from unittest import mock
 import zipfile
 
 from scripts import release_asset_provenance as provenance
+from scripts import release_asset_topology as topology
 
 
 SCRIPT_PATH = Path(__file__).with_name("publish_release_request.py")
@@ -50,9 +51,8 @@ def request_payload(**overrides: object) -> dict[str, object]:
 
 def all_asset_names() -> list[str]:
     names: list[str] = []
-    for spec in PUBLISH.WORKFLOWS:
-        names.extend(f"{DATE_TAG}-{suffix}" for suffix in spec.exact_suffixes)
-    names.append("lizzieyzy-next-update-manifest.json")
+    for unit in topology.release_units():
+        names.extend(topology.public_inventory(unit.platform, DATE_TAG))
     return names
 
 
@@ -221,9 +221,9 @@ class FakeClient:
         if conclusion == "success":
             for spec in PUBLISH.WORKFLOWS:
                 if spec.workflow_file == workflow_file:
-                    names = [f"{DATE_TAG}-{suffix}" for suffix in spec.exact_suffixes]
-                    if spec.platform == "Windows":
-                        names.append("lizzieyzy-next-update-manifest.json")
+                    names = list(
+                        topology.public_inventory(spec.provenance_platform, DATE_TAG)
+                    )
                     replace_names = set(names)
                     self.assets = [
                         item
@@ -1002,11 +1002,11 @@ class ReleasePublisherTest(unittest.TestCase):
         for heading in PUBLISH.LOCALIZED_NOTE_HEADINGS:
             rows = [
                 (
-                    f"| Test platform | [`{DATE_TAG}-{suffix}`]"
+                    f"| Test platform | [`{name}`]"
                     f"(https://github.com/wimi321/lizzieyzy-next/releases/download/"
-                    f"{RELEASE_TAG}/{DATE_TAG}-{suffix}) |"
+                    f"{RELEASE_TAG}/{name}) |"
                 )
-                for suffix in PUBLISH.DIRECT_DOWNLOAD_SUFFIXES
+                for name in PUBLISH.direct_download_names(DATE_TAG)
             ]
             blocks.append(
                 "\n".join(

--- a/scripts/test_release_asset_topology.py
+++ b/scripts/test_release_asset_topology.py
@@ -1,0 +1,330 @@
+#!/usr/bin/env python3
+"""Contract tests for the 发布资产拓扑."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+from scripts import generate_release_notes as notes
+from scripts import publish_release_request as publisher
+from scripts import release_asset_provenance as provenance
+from scripts import release_asset_topology as topology
+
+
+DATE_TAG = "2026-08-19"
+SCRIPT = Path(__file__).with_name("release_asset_topology.py")
+
+WINDOWS_PUBLIC = (
+    f"{DATE_TAG}-windows64.opencl.installer.exe",
+    f"{DATE_TAG}-windows64.opencl.portable.zip",
+    f"{DATE_TAG}-windows64.nvidia.installer.exe",
+    f"{DATE_TAG}-windows64.nvidia.portable.zip",
+    f"{DATE_TAG}-windows64.experimental.directml.portable.zip",
+    f"{DATE_TAG}-windows64.experimental.openvino.portable.zip",
+    f"{DATE_TAG}-windows64.experimental.rocm.gfx103x.portable.zip",
+    f"{DATE_TAG}-windows64.experimental.rocm.gfx110x.portable.zip",
+    f"{DATE_TAG}-windows64.experimental.rocm.gfx1151.portable.zip",
+    f"{DATE_TAG}-windows64.experimental.rocm.gfx120x.portable.zip",
+    f"{DATE_TAG}-windows64.with-katago.installer.exe",
+    f"{DATE_TAG}-windows64.with-katago.portable.zip",
+    f"{DATE_TAG}-windows64.without.engine.installer.exe",
+    f"{DATE_TAG}-windows64.without.engine.portable.zip",
+    f"{DATE_TAG}-windows64.core-update.zip",
+    "lizzieyzy-next-update-manifest.json",
+    f"{DATE_TAG}-windows64.nvidia.tensorrt.portable.7z.001",
+    f"{DATE_TAG}-windows64.nvidia.tensorrt.portable.7z.002",
+    f"{DATE_TAG}-windows64.nvidia.tensorrt.portable.README.txt",
+    f"{DATE_TAG}-windows64.nvidia.tensorrt.portable.manifest.json",
+    f"{DATE_TAG}-windows64.nvidia.tensorrt.portable.sha256.txt",
+)
+LINUX_PUBLIC = (
+    f"{DATE_TAG}-linux64.opencl.zip",
+    f"{DATE_TAG}-linux64.nvidia.zip",
+    f"{DATE_TAG}-linux64.with-katago.zip",
+)
+MAC_ARM64_PUBLIC = (f"{DATE_TAG}-mac-apple-silicon.with-katago.dmg",)
+MAC_AMD64_PUBLIC = (f"{DATE_TAG}-mac-intel.with-katago.dmg",)
+DIRECT_DOWNLOAD = (
+    f"{DATE_TAG}-windows64.opencl.portable.zip",
+    f"{DATE_TAG}-windows64.core-update.zip",
+    f"{DATE_TAG}-windows64.opencl.installer.exe",
+    f"{DATE_TAG}-windows64.with-katago.portable.zip",
+    f"{DATE_TAG}-windows64.with-katago.installer.exe",
+    f"{DATE_TAG}-windows64.nvidia.portable.zip",
+    f"{DATE_TAG}-windows64.nvidia.installer.exe",
+    f"{DATE_TAG}-windows64.experimental.directml.portable.zip",
+    f"{DATE_TAG}-windows64.experimental.openvino.portable.zip",
+    f"{DATE_TAG}-windows64.experimental.rocm.gfx103x.portable.zip",
+    f"{DATE_TAG}-windows64.experimental.rocm.gfx110x.portable.zip",
+    f"{DATE_TAG}-windows64.experimental.rocm.gfx1151.portable.zip",
+    f"{DATE_TAG}-windows64.experimental.rocm.gfx120x.portable.zip",
+    f"{DATE_TAG}-windows64.nvidia.tensorrt.portable.7z.001",
+    f"{DATE_TAG}-windows64.nvidia.tensorrt.portable.7z.002",
+    f"{DATE_TAG}-windows64.without.engine.portable.zip",
+    f"{DATE_TAG}-windows64.without.engine.installer.exe",
+    f"{DATE_TAG}-mac-apple-silicon.with-katago.dmg",
+    f"{DATE_TAG}-mac-intel.with-katago.dmg",
+    f"{DATE_TAG}-linux64.with-katago.zip",
+    f"{DATE_TAG}-linux64.opencl.zip",
+    f"{DATE_TAG}-linux64.nvidia.zip",
+)
+NOTES_TABLE_KEYS = (
+    "windows_opencl_portable",
+    "windows_opencl_installer",
+    "windows_portable",
+    "windows_installer",
+    "windows_nvidia_portable",
+    "windows_nvidia_installer",
+    "windows_directml_experimental",
+    "windows_openvino_experimental",
+    "windows_rocm_gfx103x_experimental",
+    "windows_rocm_gfx110x_experimental",
+    "windows_rocm_gfx1151_experimental",
+    "windows_rocm_gfx120x_experimental",
+    "windows_no_engine_portable",
+    "windows_no_engine_installer",
+    "mac_arm64",
+    "mac_amd64",
+    "linux64",
+    "linux64_opencl",
+    "linux64_nvidia",
+)
+WORKFLOW_UNITS = (
+    (
+        "windows",
+        "Windows",
+        "build-windows-release.yml",
+        "Windows release {release_tag} | {date_tag} | prerelease={prerelease}",
+    ),
+    (
+        "linux",
+        "Linux",
+        "build-linux-release.yml",
+        "Linux release {release_tag} | {date_tag} | prerelease={prerelease}",
+    ),
+    (
+        "mac-amd64",
+        "macOS Intel",
+        "build-macos-amd64-release.yml",
+        "macOS Intel release {release_tag} | {date_tag} | prerelease={prerelease}",
+    ),
+    (
+        "mac-arm64",
+        "macOS Apple Silicon",
+        "build-macos-arm64-release.yml",
+        "macOS Apple Silicon release {release_tag} | {date_tag} | prerelease={prerelease}",
+    ),
+)
+
+
+class ReleaseAssetTopologyContractTest(unittest.TestCase):
+    def test_universe_has_exactly_the_current_26_public_assets(self) -> None:
+        keys = tuple(asset.key for asset in topology.assets())
+        names = tuple(asset.filename.render(DATE_TAG) for asset in topology.assets())
+
+        self.assertEqual(26, len(keys))
+        self.assertEqual(26, len(set(keys)))
+        self.assertEqual(
+            WINDOWS_PUBLIC + LINUX_PUBLIC + MAC_AMD64_PUBLIC + MAC_ARM64_PUBLIC,
+            names,
+        )
+        self.assertEqual(
+            1,
+            sum(asset.filename.kind is topology.FilenameKind.LITERAL for asset in topology.assets()),
+        )
+        manifest = topology.asset("windows_update_manifest")
+        self.assertEqual("lizzieyzy-next-update-manifest.json", manifest.filename.value)
+        self.assertEqual(
+            (
+                f"{DATE_TAG}-windows64.nvidia.tensorrt.portable.7z.001",
+                f"{DATE_TAG}-windows64.nvidia.tensorrt.portable.7z.002",
+            ),
+            (
+                topology.asset("windows_tensorrt_split_001").filename.render(DATE_TAG),
+                topology.asset("windows_tensorrt_split_002").filename.render(DATE_TAG),
+            ),
+        )
+
+    def test_platform_inventories_match_current_public_sets(self) -> None:
+        self.assertEqual(WINDOWS_PUBLIC, topology.public_inventory("windows", DATE_TAG))
+        self.assertEqual(LINUX_PUBLIC, topology.public_inventory("linux", DATE_TAG))
+        self.assertEqual(MAC_ARM64_PUBLIC, topology.public_inventory("mac-arm64", DATE_TAG))
+        self.assertEqual(MAC_AMD64_PUBLIC, topology.public_inventory("mac-amd64", DATE_TAG))
+
+    def test_role_queries_preserve_current_subsets_and_order(self) -> None:
+        self.assertEqual(DIRECT_DOWNLOAD, topology.direct_download_names(DATE_TAG))
+        self.assertEqual(
+            NOTES_TABLE_KEYS,
+            tuple(asset.key for asset in topology.release_notes_table_assets()),
+        )
+        notes_keys = {asset.key for asset in topology.release_notes_assets()}
+        self.assertTrue(
+            {
+                "windows_core_update",
+                "windows_tensorrt_split_001",
+                "windows_tensorrt_split_002",
+            }.issubset(notes_keys)
+        )
+        self.assertNotIn("windows_update_manifest", notes_keys)
+        self.assertEqual(
+            tuple(sorted(WINDOWS_PUBLIC)),
+            topology.provenance_names("windows", DATE_TAG),
+        )
+        self.assertEqual(
+            tuple(sorted(LINUX_PUBLIC)),
+            topology.provenance_names("linux", DATE_TAG),
+        )
+
+    def test_release_units_own_workflow_and_platform_identity(self) -> None:
+        units = topology.release_units()
+        self.assertEqual(
+            WORKFLOW_UNITS,
+            tuple(
+                (
+                    unit.platform,
+                    unit.publisher_identity,
+                    unit.workflow_file,
+                    unit.run_name_template,
+                )
+                for unit in units
+            ),
+        )
+        self.assertEqual(
+            WINDOWS_PUBLIC,
+            tuple(asset.filename.render(DATE_TAG) for asset in topology.release_unit("windows").assets),
+        )
+        for unit in units:
+            self.assertEqual((("release_prerelease", "true"),), unit.dispatch_inputs)
+
+    def test_unsupported_platform_or_invalid_date_tag_fails(self) -> None:
+        with self.assertRaisesRegex(topology.TopologyError, "Unsupported platform"):
+            topology.public_inventory("win32", DATE_TAG)
+        with self.assertRaisesRegex(topology.TopologyError, "YYYY-MM-DD"):
+            topology.public_inventory("linux", "20260819")
+        with self.assertRaisesRegex(topology.TopologyError, "YYYY-MM-DD"):
+            topology.public_inventory("linux", "")
+
+
+class ExpectedNamesCliTest(unittest.TestCase):
+    def run_cli(self, *args: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [sys.executable, str(SCRIPT), *args],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+
+    def test_prints_one_filename_per_line_in_public_order(self) -> None:
+        result = self.run_cli(
+            "expected-names",
+            "--platform",
+            "linux",
+            "--date-tag",
+            DATE_TAG,
+        )
+        self.assertEqual(0, result.returncode, result.stderr)
+        self.assertEqual("\n".join(LINUX_PUBLIC) + "\n", result.stdout)
+
+    def test_rejects_unsupported_platform_and_invalid_date_tag(self) -> None:
+        unsupported = self.run_cli(
+            "expected-names",
+            "--platform",
+            "win32",
+            "--date-tag",
+            DATE_TAG,
+        )
+        self.assertNotEqual(0, unsupported.returncode)
+        self.assertIn("Unsupported platform", unsupported.stderr)
+        invalid = self.run_cli(
+            "expected-names",
+            "--platform",
+            "linux",
+            "--date-tag",
+            "19-08-2026",
+        )
+        self.assertNotEqual(0, invalid.returncode)
+
+
+class TopologyDeletionTest(unittest.TestCase):
+    def test_consumers_have_no_independent_asset_catalog(self) -> None:
+        self.assertFalse(hasattr(notes, "ASSET_SPECS"))
+        self.assertFalse(hasattr(notes, "TENSORRT_SPLIT_PART_PATTERN"))
+        self.assertFalse(hasattr(publisher, "DIRECT_DOWNLOAD_SUFFIXES"))
+        self.assertFalse(hasattr(provenance, "PLATFORM_ASSET_SUFFIXES"))
+        self.assertFalse(hasattr(publisher.WORKFLOWS[0], "exact_suffixes"))
+        self.assertEqual(
+            topology.direct_download_names(DATE_TAG),
+            publisher.direct_download_names(DATE_TAG),
+        )
+        self.assertEqual(
+            topology.provenance_names("linux", DATE_TAG),
+            provenance.expected_asset_names("linux", DATE_TAG),
+        )
+        self.assertEqual(
+            [unit.workflow_file for unit in topology.release_units()],
+            [spec.workflow_file for spec in publisher.WORKFLOWS],
+        )
+
+
+class LinuxValidatorSmokeTest(unittest.TestCase):
+    validator = Path(__file__).with_name("validate_release_assets.sh")
+
+    def run_validator(self, release_dir: Path) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [
+                "bash",
+                str(self.validator),
+                "linux",
+                str(release_dir),
+                DATE_TAG,
+            ],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+
+    def write_linux_inventory(self, release_dir: Path, names: tuple[str, ...]) -> None:
+        release_dir.mkdir(parents=True, exist_ok=True)
+        for name in names:
+            (release_dir / name).write_bytes(b"asset")
+
+    def test_accepts_exact_linux_inventory(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            release_dir = Path(temp)
+            self.write_linux_inventory(release_dir, LINUX_PUBLIC)
+            result = self.run_validator(release_dir)
+            self.assertEqual(0, result.returncode, result.stderr + result.stdout)
+            self.assertIn("Validated public release assets for linux", result.stdout)
+
+    def test_rejects_missing_expected_linux_asset(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            release_dir = Path(temp)
+            self.write_linux_inventory(release_dir, LINUX_PUBLIC[1:])
+            result = self.run_validator(release_dir)
+            self.assertNotEqual(0, result.returncode)
+            combined = result.stdout + result.stderr
+            self.assertTrue(
+                "Missing expected asset" in combined or "Unexpected asset count" in combined,
+                combined,
+            )
+
+    def test_rejects_unexpected_helper_asset(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            release_dir = Path(temp)
+            self.write_linux_inventory(release_dir, LINUX_PUBLIC)
+            (release_dir / f"{DATE_TAG}-linux64-sha256.txt").write_text("deadbeef\n")
+            result = self.run_validator(release_dir)
+            self.assertNotEqual(0, result.returncode)
+            combined = result.stdout + result.stderr
+            self.assertTrue(
+                "Unexpected helper file" in combined or "Unexpected asset" in combined,
+                combined,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_validate_release_notes.py
+++ b/scripts/test_validate_release_notes.py
@@ -18,8 +18,7 @@ def complete_notes() -> str:
     blocks: list[str] = []
     for heading in publisher.LOCALIZED_NOTE_HEADINGS:
         links = []
-        for suffix in publisher.DIRECT_DOWNLOAD_SUFFIXES:
-            name = f"{DATE_TAG}-{suffix}"
+        for name in publisher.direct_download_names(DATE_TAG):
             url = (
                 f"https://github.com/{REPOSITORY}/releases/download/"
                 f"{RELEASE_TAG}/{name}"
@@ -89,8 +88,7 @@ class GeneratedReleaseNotesValidationTest(unittest.TestCase):
             self.validate(repository="https://github.com/wimi321/lizzieyzy-next")
 
     def test_rejects_missing_direct_download_link(self) -> None:
-        suffix = publisher.DIRECT_DOWNLOAD_SUFFIXES[0]
-        name = f"{DATE_TAG}-{suffix}"
+        name = publisher.direct_download_names(DATE_TAG)[0]
         url = (
             f"https://github.com/{REPOSITORY}/releases/download/"
             f"{RELEASE_TAG}/{name}"

--- a/scripts/validate_release_assets.sh
+++ b/scripts/validate_release_assets.sh
@@ -18,51 +18,17 @@ if [[ ! -d "$RELEASE_DIR" ]]; then
   exit 1
 fi
 
-expected=()
-case "$PLATFORM" in
-  windows)
-    expected=(
-      "${DATE_TAG}-windows64.opencl.installer.exe"
-      "${DATE_TAG}-windows64.opencl.portable.zip"
-      "${DATE_TAG}-windows64.nvidia.installer.exe"
-      "${DATE_TAG}-windows64.nvidia.portable.zip"
-      "${DATE_TAG}-windows64.experimental.directml.portable.zip"
-      "${DATE_TAG}-windows64.experimental.openvino.portable.zip"
-      "${DATE_TAG}-windows64.experimental.rocm.gfx103x.portable.zip"
-      "${DATE_TAG}-windows64.experimental.rocm.gfx110x.portable.zip"
-      "${DATE_TAG}-windows64.experimental.rocm.gfx1151.portable.zip"
-      "${DATE_TAG}-windows64.experimental.rocm.gfx120x.portable.zip"
-      "${DATE_TAG}-windows64.with-katago.installer.exe"
-      "${DATE_TAG}-windows64.with-katago.portable.zip"
-      "${DATE_TAG}-windows64.without.engine.installer.exe"
-      "${DATE_TAG}-windows64.without.engine.portable.zip"
-      "${DATE_TAG}-windows64.core-update.zip"
-      "lizzieyzy-next-update-manifest.json"
-      "${DATE_TAG}-windows64.nvidia.tensorrt.portable.7z.001"
-      "${DATE_TAG}-windows64.nvidia.tensorrt.portable.7z.002"
-      "${DATE_TAG}-windows64.nvidia.tensorrt.portable.README.txt"
-      "${DATE_TAG}-windows64.nvidia.tensorrt.portable.manifest.json"
-      "${DATE_TAG}-windows64.nvidia.tensorrt.portable.sha256.txt"
-    )
-    ;;
-  mac-arm64)
-    expected=("${DATE_TAG}-mac-apple-silicon.with-katago.dmg")
-    ;;
-  mac-amd64)
-    expected=("${DATE_TAG}-mac-intel.with-katago.dmg")
-    ;;
-  linux)
-    expected=(
-      "${DATE_TAG}-linux64.opencl.zip"
-      "${DATE_TAG}-linux64.nvidia.zip"
-      "${DATE_TAG}-linux64.with-katago.zip"
-    )
-    ;;
-  *)
-    echo "Unsupported platform: $PLATFORM"
-    exit 1
-    ;;
-esac
+PYTHON_BIN="python3"
+if ! command -v "$PYTHON_BIN" >/dev/null 2>&1; then
+  PYTHON_BIN="python"
+fi
+
+expected_output="$("$PYTHON_BIN" "$SCRIPT_DIR/release_asset_topology.py" expected-names --platform "$PLATFORM" --date-tag "$DATE_TAG")"
+mapfile -t expected <<< "$expected_output"
+if [[ "${#expected[@]}" -eq 0 ]]; then
+  echo "No expected public release assets for $PLATFORM"
+  exit 1
+fi
 
 actual=()
 shopt -s nullglob
@@ -77,10 +43,21 @@ if [[ "${#actual[@]}" -eq 0 ]]; then
   exit 1
 fi
 
+is_expected() {
+  local name="$1"
+  local expected_name
+  for expected_name in "${expected[@]}"; do
+    if [[ "$name" == "$expected_name" ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
 for name in "${actual[@]}"; do
   case "$name" in
     *.txt|*.sha256|*.sha256.txt|*.md)
-      if [[ "$PLATFORM" != "windows" ]] || [[ "$name" != "${DATE_TAG}-windows64.nvidia.tensorrt.portable.README.txt" && "$name" != "${DATE_TAG}-windows64.nvidia.tensorrt.portable.sha256.txt" ]]; then
+      if ! is_expected "$name"; then
         echo "Unexpected helper file in public release set: $name"
         exit 1
       fi


### PR DESCRIPTION
## Summary

- Define all 26 public GitHub Release assets, filename rules, platform ownership, role-specific ordering, provenance coverage, and workflow mapping in one executable topology.
- Cut release-note generation, pre-release publishing, provenance, and Bash inventory validation over to that topology, removing the duplicated suffix matrices while preserving existing outputs and CLI behavior.
- Add topology contract, CLI, deletion, and Linux validator smoke coverage, and run the new suite in CI and the pre-release publishing workflow.

This prevents the release notes, publisher, provenance records, and public-asset validator from drifting as the release matrix evolves.

## Type Of Change

- [ ] Bug fix
- [ ] Feature
- [x] Packaging / release update
- [ ] Docs / translation
- [x] Refactor

## Testing

- [x] Tested locally
- [x] Verified package contents if packaging changed — N/A; package producers and contents are unchanged
- [x] Verified Fox sync flow if related — N/A; not related
- [x] Added screenshots if UI changed — N/A; no UI changes
- [x] Updated README / docs if user-facing behavior changed — N/A; behavior is unchanged
- [x] Noted affected platforms if the change is platform-specific — covers Windows, Linux, macOS Intel, and macOS Apple Silicon release units
- [x] Verified there is no unrelated formatting or line-ending churn
- [ ] Ran `python3 scripts/check_line_endings.py` — not rerun during PR preparation

Passed:

- `scripts.test_release_asset_topology`
  - exact 26-asset topology contract
  - expected-names CLI
  - deletion checks
  - Linux validator valid/missing/extra smoke cases
- release-notes generation and validation tests
- publish-request tests
- release-asset provenance tests
- Windows release-asset tests
- workflow-identity tests

Not run:

- `mvn test`
- full cross-platform packaging or package-content verification

The omitted checks do not exercise the changed contract: this refactor does not modify Java code, package producers, archive contents, workflow invocation, or public asset behavior.

## Notes

- Public asset names, counts, platform subsets, direct-download tables, TensorRT `.001`/`.002` handling, provenance coverage, workflow identities, and validator entrypoints remain unchanged.
- Human-facing release-note labels remain in the release-notes adapter; package producers and workflow upload globs remain unchanged.
- `public_order` and `Role.PROVENANCE` are recorded topology metadata; current inventory/provenance ordering still follows the release-unit asset tuple.
- `publisher.direct_download_names` is an intentional forwarding seam used by release-note validation and tests; it does not contain a second asset catalog.