### PR TITLE
test(logging): await asynchronous rolling archives

### DIFF
--- a/src/test/java/featurecat/lizzie/logging/LoggingRuntimeTest.java
+++ b/src/test/java/featurecat/lizzie/logging/LoggingRuntimeTest.java
@@ -162,9 +162,10 @@ class LoggingRuntimeTest {
     }
     runtime.awaitIdle(80);
     assertTrue(Files.isRegularFile(tempDir.resolve("logs/app.log")));
-    try (Stream<Path> stream = Files.list(tempDir.resolve("logs/archive"))) {
-      assertTrue(stream.anyMatch(path -> path.getFileName().toString().startsWith("app.")));
-    }
+    List<String> archiveNames = awaitAppArchiveNames(tempDir.resolve("logs/archive"));
+    assertTrue(
+        archiveNames.stream().anyMatch(name -> name.startsWith("app.")),
+        "archive entries=" + archiveNames);
   }
 
   @Test
@@ -695,6 +696,22 @@ class LoggingRuntimeTest {
               });
     }
     return scanned.toString();
+  }
+
+  private static List<String> awaitAppArchiveNames(Path archiveDir)
+      throws IOException, InterruptedException {
+    long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(2);
+    List<String> names;
+    do {
+      try (Stream<Path> stream = Files.list(archiveDir)) {
+        names = stream.map(path -> path.getFileName().toString()).toList();
+      }
+      if (names.stream().anyMatch(name -> name.startsWith("app."))
+          || System.nanoTime() >= deadline) {
+        return names;
+      }
+      Thread.sleep(10L);
+    } while (true);
   }
 
   private static int count(String text, String token) {


### PR DESCRIPTION
## Why
Windows CI intermittently failed `LoggingRuntimeTest.rollingCreatesArchiveSegmentsAndKeepsActiveName` because the test listed `logs/archive` immediately after `LoggingRuntime.awaitIdle()`. Logback 1.6.3 compresses rolling archives asynchronously, so the `.gz` file may not be visible yet even though Lizzie's appender queue is idle.

## What
- poll for the exact `app.*` archive condition with a monotonic two-second deadline
- preserve the active `logs/app.log` assertion and real rolling setup
- keep timeout failures actionable by reporting the final archive entries

## Test plan
- [x] `mvn -B '-Dtest=LoggingRuntimeTest#rollingCreatesArchiveSegmentsAndKeepsActiveName' test` — 1 test passed
- [x] `mvn -B -Dtest=LoggingRuntimeTest test` — 27 tests passed
- [x] GitHub Actions Linux `build` — passed
- [x] GitHub Actions Windows `windows-script-validation` — passed

Related CI: https://github.com/wimi321/lizzieyzy-next/actions/runs/32940714640/job/98090956431
Validation run: https://github.com/wimi321/lizzieyzy-next/actions/runs/32944523302