### PR TITLE
Fix macOS Bash 3 release asset validation

### DIFF
--- a/scripts/test_release_asset_topology.py
+++ b/scripts/test_release_asset_topology.py
@@ -273,6 +273,10 @@ class TopologyDeletionTest(unittest.TestCase):
 class LinuxValidatorSmokeTest(unittest.TestCase):
     validator = Path(__file__).with_name("validate_release_assets.sh")
 
+    def test_validator_stays_compatible_with_macos_bash_3(self) -> None:
+        validator_text = self.validator.read_text(encoding="utf-8")
+        self.assertNotRegex(validator_text, r"\b(?:mapfile|readarray)\b")
+
     def run_validator(self, release_dir: Path) -> subprocess.CompletedProcess[str]:
         return subprocess.run(
             [

--- a/scripts/validate_release_assets.sh
+++ b/scripts/validate_release_assets.sh
@@ -24,7 +24,12 @@ if ! command -v "$PYTHON_BIN" >/dev/null 2>&1; then
 fi
 
 expected_output="$("$PYTHON_BIN" "$SCRIPT_DIR/release_asset_topology.py" expected-names --platform "$PLATFORM" --date-tag "$DATE_TAG")"
-mapfile -t expected <<< "$expected_output"
+expected=()
+while IFS= read -r expected_name; do
+  # Keep macOS Bash 3.2 compatibility and strip CR from native Windows Python.
+  expected_name="${expected_name%$'\r'}"
+  [[ -n "$expected_name" ]] && expected+=("$expected_name")
+done <<< "$expected_output"
 if [[ "${#expected[@]}" -eq 0 ]]; then
   echo "No expected public release assets for $PLATFORM"
   exit 1


### PR DESCRIPTION
## Root cause

The 
ext-2026-08-27.1 Apple Silicon build completed packaging, signing, notarization, Metal backend validation, and DMG validation, then failed because macOS Bash 3.2 does not provide the Bash 4 mapfile builtin.

## Fix

- replace mapfile with a Bash 3.2-compatible line reader
- normalize trailing CR emitted by native Windows Python so the same validator works under Git Bash
- add a regression guard against Bash 4-only line-reading builtins

## Validation

- release contract suite: 137 tests, 0 failures, 0 errors, 2 platform-specific skips
- Maven tests: 3395 tests, 0 failures, 0 errors, 15 skipped
- Maven package: success
- Git Bash exact/missing/unexpected asset smoke scenarios: success
- Bash syntax, line-ending policy, and git diff checks: success

Failed release remains draft and will not be published.