### PR TITLE
Release next-2026-08-27.2 pre-release

### DIFF
--- a/.github/release-notes/next-2026-08-27.2.md
+++ b/.github/release-notes/next-2026-08-27.2.md
@@ -1,0 +1,365 @@
+# LizzieYzy Next next-2026-08-27.2
+
+## 中文
+
+这是一次聚焦分析可靠性、AI 陪练体验与引擎工作流的公开测试版。重点修复棋力评估结果异常趋同、闪电分析报错、缓存分析后“Kata形势”点击无显示，以及 AI 陪练实时模式缺少胜率曲线等问题。
+
+### 本版主要更新
+
+- 棋力评估不再把不同水平错误压成相同的“1.0 段”；级位、业余段位与职业段位会保留真实层级和清楚的显示名称。
+- 闪电分析恢复稳定的引擎与模型选择、租约清理和前台分析恢复；已有完整快速数据时会正常结束，不再弹错误或把主分析留在暂停状态。
+- AI 陪练取消多余的训练报告与认输入口：复盘模式结束后直接回到主界面，实时模式像主界面一样显示推荐点和胜率曲线，退出后仍可继续复盘。
+- “Kata形势”在高计算量缓存已存在时会补入新请求的 ownership 数据，同时保留更强的计算量、候选手和引擎信息，主副引擎均覆盖。
+- 引擎对局重新区分冷启动与热重启，丢弃重启后的过期独占提示；新对局设置可以保存，底部工具栏显隐勾选、剩余标记绘制与新版设置入口也已修正。
+- 手动检查更新会统一说明“已是最新、找到更新、检查失败”等结果；发布资产继续由单一拓扑生成并执行多平台 fail-closed 校验。
+- 修复 macOS 自带 Bash 3.2 不支持 Bash 4 `mapfile`，导致 DMG 完成签名与公证后资产校验误失败；同一校验器现在也兼容 Windows Git Bash 的 CRLF 输出。
+
+### 下载前先看
+
+- 已安装 `next-2026-08-26.1` 完整包的 Windows 用户，可以使用 `windows64.core-update.zip` 获取本次程序修复；它不会替换现有权重、引擎、TensorRT 或 `user-data`。
+- 新安装用户下载对应完整包，仍会得到 KataGo v1.18.1 与默认 B11；更重视速度可在“一键设置 → 权重”明确切换 B10。
+- RTX 20/30/40/50 继续使用统一的 `windows64.nvidia` CUDA 包；TensorRT 仅作为 RTX 30 系及以下可选方案。
+- 这是 pre-release，建议先在独立目录测试，并保留现有 `user-data`、权重和棋谱备份。
+- DirectML、OpenVINO 和 ROCm 包仍为 experimental，未在缺少对应硬件的机器上冒充实测通过。
+
+### 下载建议
+
+| 你的电脑 | 直接下载这个 |
+| --- | --- |
+| Windows 64 位，OpenCL 推荐版，免安装 | [`2026-08-27-windows64.opencl.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-27.2/2026-08-27-windows64.opencl.portable.zip) |
+| 已有 Windows 免安装版，只更新主程序 | [`2026-08-27-windows64.core-update.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-27.2/2026-08-27-windows64.core-update.zip) |
+| Windows 64 位，OpenCL 安装版 | [`2026-08-27-windows64.opencl.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-27.2/2026-08-27-windows64.opencl.installer.exe) |
+| Windows 64 位，CPU 兼容版，免安装 | [`2026-08-27-windows64.with-katago.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-27.2/2026-08-27-windows64.with-katago.portable.zip) |
+| Windows 64 位，CPU 兼容安装版 | [`2026-08-27-windows64.with-katago.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-27.2/2026-08-27-windows64.with-katago.installer.exe) |
+| Windows 64 位，RTX 20/30/40/50 NVIDIA CUDA，免安装 | [`2026-08-27-windows64.nvidia.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-27.2/2026-08-27-windows64.nvidia.portable.zip) |
+| Windows 64 位，RTX 20/30/40/50 NVIDIA CUDA 安装版 | [`2026-08-27-windows64.nvidia.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-27.2/2026-08-27-windows64.nvidia.installer.exe) |
+| Windows DirectML 实验版 | [`2026-08-27-windows64.experimental.directml.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-27.2/2026-08-27-windows64.experimental.directml.portable.zip) |
+| Windows Intel OpenVINO 实验版 | [`2026-08-27-windows64.experimental.openvino.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-27.2/2026-08-27-windows64.experimental.openvino.portable.zip) |
+| Windows AMD RX 6000 ROCm 实验版 | [`2026-08-27-windows64.experimental.rocm.gfx103x.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-27.2/2026-08-27-windows64.experimental.rocm.gfx103x.portable.zip) |
+| Windows AMD RX 7000 ROCm 实验版 | [`2026-08-27-windows64.experimental.rocm.gfx110x.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-27.2/2026-08-27-windows64.experimental.rocm.gfx110x.portable.zip) |
+| Windows AMD Ryzen AI Max ROCm 实验版 | [`2026-08-27-windows64.experimental.rocm.gfx1151.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-27.2/2026-08-27-windows64.experimental.rocm.gfx1151.portable.zip) |
+| Windows AMD RX 9000 ROCm 实验版 | [`2026-08-27-windows64.experimental.rocm.gfx120x.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-27.2/2026-08-27-windows64.experimental.rocm.gfx120x.portable.zip) |
+| RTX 30 系及以下可选 TensorRT，需下载两个分卷 | [`2026-08-27-windows64.nvidia.tensorrt.portable.7z.001`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-27.2/2026-08-27-windows64.nvidia.tensorrt.portable.7z.001)<br>[`2026-08-27-windows64.nvidia.tensorrt.portable.7z.002`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-27.2/2026-08-27-windows64.nvidia.tensorrt.portable.7z.002) |
+| Windows 64 位，自行配置引擎，免安装 | [`2026-08-27-windows64.without.engine.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-27.2/2026-08-27-windows64.without.engine.portable.zip) |
+| Windows 64 位，自行配置引擎，安装版 | [`2026-08-27-windows64.without.engine.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-27.2/2026-08-27-windows64.without.engine.installer.exe) |
+| macOS Apple Silicon，Metal | [`2026-08-27-mac-apple-silicon.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-27.2/2026-08-27-mac-apple-silicon.with-katago.dmg) |
+| macOS Intel | [`2026-08-27-mac-intel.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-27.2/2026-08-27-mac-intel.with-katago.dmg) |
+| Linux 64 位，CPU 兼容版 | [`2026-08-27-linux64.with-katago.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-27.2/2026-08-27-linux64.with-katago.zip) |
+| Linux 64 位，OpenCL 版 | [`2026-08-27-linux64.opencl.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-27.2/2026-08-27-linux64.opencl.zip) |
+| Linux 64 位，NVIDIA CUDA 版 | [`2026-08-27-linux64.nvidia.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-27.2/2026-08-27-linux64.nvidia.zip) |
+
+### 为什么值得测试
+
+- Windows 11、RTX 3070 真机使用带包内 Java 的临时 EXE 和 B11 OpenCL 完成验收：合法 20 手 SGF 正常打开，快速胜率曲线约 10 秒完成，`Ctrl+B` 闪电分析无错误并恢复前台分析。
+- 在已有约 22k 缓存计算量的局面点击“Kata形势”，约 1.3 秒出现覆盖层；GTP 明确记录 `ownership true movesOwnership true`，全程只保留一个主 KataGo 进程。
+- 合入最新 main 后完整测试为 3395 项，0 失败、0 错误、15 跳过；Maven 打包、Windows 启动器审计、`git diff --check` 与 PR 必需检查均通过。
+- macOS、Linux、RTX 40/50、DirectML、OpenVINO 与 ROCm 本轮未标记为新增硬件实测，欢迎重点反馈不同后端下的闪电分析与 AI 陪练体验。
+
+### 交流
+
+- QQ 群：`299419120`
+
+---
+
+## 繁體中文
+
+這是一次聚焦分析可靠性、AI 陪練體驗與引擎流程的公開測試版。重點修復棋力評估結果異常趨同、閃電分析錯誤、快取分析後「Kata形勢」沒有顯示，以及 AI 陪練即時模式缺少勝率曲線等問題。
+
+### 本版主要更新
+
+- 棋力評估不再把不同水平錯誤壓成相同的「1.0 段」；級位、業餘段位與職業段位會保留真實層級和清楚名稱。
+- 閃電分析恢復穩定的引擎與模型選擇、租約清理及前台分析恢復；已有完整快速資料時會正常結束，不再顯示錯誤或讓主分析停在暫停狀態。
+- AI 陪練移除多餘的訓練報告與認輸入口：複盤模式結束後直接回到主介面，即時模式像主介面一樣顯示建議點和勝率曲線，退出後仍可繼續複盤。
+- 「Kata形勢」在高計算量快取已存在時會補入新要求的 ownership 資料，同時保留更強的計算量、候選手和引擎資訊，主副引擎均已涵蓋。
+- 引擎對局重新區分冷啟動與熱重啟，丟棄重啟後過期的獨占提示；新對局設定可保存，底部工具列顯隱勾選、剩餘標記繪製與新版設定入口也已修正。
+- 手動檢查更新會統一說明「已是最新、找到更新、檢查失敗」等結果；發布資產繼續由單一拓撲產生並執行多平台 fail-closed 驗證。
+- 修正 macOS 內建 Bash 3.2 不支援 Bash 4 `mapfile`，導致 DMG 完成簽署與公證後資產驗證誤判失敗；同一驗證器現在也相容 Windows Git Bash 的 CRLF 輸出。
+
+### 下載前先看
+
+- 已安裝 `next-2026-08-26.1` 完整套件的 Windows 使用者，可用 `windows64.core-update.zip` 取得本次程式修復；它不會替換現有權重、引擎、TensorRT 或 `user-data`。
+- 新安裝請下載對應完整套件，仍包含 KataGo v1.18.1 與預設 B11；重視速度可在「一鍵設定 → 權重」明確切換 B10。
+- RTX 20/30/40/50 繼續使用統一 `windows64.nvidia` CUDA 套件；TensorRT 僅作為 RTX 30 系及以下可選方案。
+- 這是 pre-release，建議先在獨立目錄測試，並備份現有 `user-data`、權重與棋譜。
+- DirectML、OpenVINO 與 ROCm 仍為 experimental，未在缺少對應硬體的機器上宣稱實測通過。
+
+### 下載建議
+
+| 你的電腦 | 直接下載這個 |
+| --- | --- |
+| Windows 64 位，OpenCL 建議版，免安裝 | [`2026-08-27-windows64.opencl.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-27.2/2026-08-27-windows64.opencl.portable.zip) |
+| 既有 Windows 免安裝版，只更新主程式 | [`2026-08-27-windows64.core-update.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-27.2/2026-08-27-windows64.core-update.zip) |
+| Windows 64 位，OpenCL 安裝版 | [`2026-08-27-windows64.opencl.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-27.2/2026-08-27-windows64.opencl.installer.exe) |
+| Windows 64 位，CPU 相容版，免安裝 | [`2026-08-27-windows64.with-katago.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-27.2/2026-08-27-windows64.with-katago.portable.zip) |
+| Windows 64 位，CPU 相容安裝版 | [`2026-08-27-windows64.with-katago.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-27.2/2026-08-27-windows64.with-katago.installer.exe) |
+| Windows 64 位，RTX 20/30/40/50 NVIDIA CUDA，免安裝 | [`2026-08-27-windows64.nvidia.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-27.2/2026-08-27-windows64.nvidia.portable.zip) |
+| Windows 64 位，RTX 20/30/40/50 NVIDIA CUDA 安裝版 | [`2026-08-27-windows64.nvidia.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-27.2/2026-08-27-windows64.nvidia.installer.exe) |
+| Windows DirectML 實驗版 | [`2026-08-27-windows64.experimental.directml.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-27.2/2026-08-27-windows64.experimental.directml.portable.zip) |
+| Windows Intel OpenVINO 實驗版 | [`2026-08-27-windows64.experimental.openvino.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-27.2/2026-08-27-windows64.experimental.openvino.portable.zip) |
+| Windows AMD RX 6000 ROCm 實驗版 | [`2026-08-27-windows64.experimental.rocm.gfx103x.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-27.2/2026-08-27-windows64.experimental.rocm.gfx103x.portable.zip) |
+| Windows AMD RX 7000 ROCm 實驗版 | [`2026-08-27-windows64.experimental.rocm.gfx110x.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-27.2/2026-08-27-windows64.experimental.rocm.gfx110x.portable.zip) |
+| Windows AMD Ryzen AI Max ROCm 實驗版 | [`2026-08-27-windows64.experimental.rocm.gfx1151.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-27.2/2026-08-27-windows64.experimental.rocm.gfx1151.portable.zip) |
+| Windows AMD RX 9000 ROCm 實驗版 | [`2026-08-27-windows64.experimental.rocm.gfx120x.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-27.2/2026-08-27-windows64.experimental.rocm.gfx120x.portable.zip) |
+| RTX 30 系及以下可選 TensorRT，需下載兩個分卷 | [`2026-08-27-windows64.nvidia.tensorrt.portable.7z.001`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-27.2/2026-08-27-windows64.nvidia.tensorrt.portable.7z.001)<br>[`2026-08-27-windows64.nvidia.tensorrt.portable.7z.002`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-27.2/2026-08-27-windows64.nvidia.tensorrt.portable.7z.002) |
+| Windows 64 位，自行設定引擎，免安裝 | [`2026-08-27-windows64.without.engine.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-27.2/2026-08-27-windows64.without.engine.portable.zip) |
+| Windows 64 位，自行設定引擎，安裝版 | [`2026-08-27-windows64.without.engine.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-27.2/2026-08-27-windows64.without.engine.installer.exe) |
+| macOS Apple Silicon，Metal | [`2026-08-27-mac-apple-silicon.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-27.2/2026-08-27-mac-apple-silicon.with-katago.dmg) |
+| macOS Intel | [`2026-08-27-mac-intel.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-27.2/2026-08-27-mac-intel.with-katago.dmg) |
+| Linux 64 位，CPU 相容版 | [`2026-08-27-linux64.with-katago.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-27.2/2026-08-27-linux64.with-katago.zip) |
+| Linux 64 位，OpenCL 版 | [`2026-08-27-linux64.opencl.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-27.2/2026-08-27-linux64.opencl.zip) |
+| Linux 64 位，NVIDIA CUDA 版 | [`2026-08-27-linux64.nvidia.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-27.2/2026-08-27-linux64.nvidia.zip) |
+
+### 為什麼值得測試
+
+- Windows 11、RTX 3070 真機以包內 Java 的臨時 EXE 和 B11 OpenCL 驗收：合法 20 手 SGF 正常開啟，快速勝率曲線約 10 秒完成，`Ctrl+B` 閃電分析無錯誤並恢復前台分析。
+- 在已有約 22k 快取計算量的局面點擊「Kata形勢」，約 1.3 秒出現覆蓋層；GTP 明確記錄 `ownership true movesOwnership true`，全程只保留一個主 KataGo 程序。
+- 合入最新 main 後完整測試 3395 項，0 失敗、0 錯誤、15 跳過；Maven 打包、Windows 啟動器稽核、`git diff --check` 與 PR 必要檢查均通過。
+- macOS、Linux、RTX 40/50、DirectML、OpenVINO 與 ROCm 本輪未標記為新增硬體實測，歡迎回報不同後端的閃電分析與 AI 陪練體驗。
+
+### 交流
+
+- QQ 群：`299419120`
+
+---
+
+## English
+
+This public preview focuses on analysis reliability, the AI Coach experience, and engine workflows. It fixes collapsed strength-evaluation ranks, Flash Analysis errors, Kata Position not appearing after cached analysis, and a missing win-rate graph in AI Coach live mode.
+
+### Release highlights
+
+- Strength Evaluation no longer collapses different levels to the same "1.0 dan" result. Kyu, amateur dan, and professional ranks retain their actual distinctions and readable labels.
+- Flash Analysis now has reliable engine/model selection, lease cleanup, and foreground-analysis recovery. Complete quick data ends cleanly instead of showing an error or leaving primary analysis paused.
+- AI Coach removes the redundant training report and resign action. Review mode returns directly to the main board; live mode shows normal candidates and the win-rate graph, and the game remains available for review afterward.
+- Kata Position backfills newly requested ownership into an existing high-visit cache while preserving the stronger visit count, candidates, and engine metadata for both primary and secondary engines.
+- Engine games again distinguish cold starts from warm restarts and discard stale exclusive-lease dialogs. New Game settings persist, and toolbar visibility checkmarks, remaining markup, and modern settings access are corrected.
+- Manual update checks now report up-to-date, update-found, and failure outcomes consistently. Release assets continue to come from one topology with fail-closed multi-platform validation.
+- Fixed macOS Bash 3.2 rejecting the Bash 4-only `mapfile` command after DMG signing and notarization. The shared validator now also handles CRLF output from native Windows Python under Git Bash.
+
+### Read before downloading
+
+- Windows users who already installed a complete `next-2026-08-26.1` bundle can use `windows64.core-update.zip` for this app fix. It does not replace existing weights, engines, TensorRT, or `user-data`.
+- New users should choose a matching full bundle, which still includes KataGo v1.18.1 and default B11. Explicitly choose B10 in Auto Setup when throughput matters more.
+- RTX 20/30/40/50 continue to use the unified `windows64.nvidia` CUDA package. TensorRT remains optional for RTX 30 series and earlier.
+- This is a pre-release. Test a separate copy first and keep backups of `user-data`, weights, and game records.
+- DirectML, OpenVINO, and ROCm remain experimental and are not claimed as tested on hardware that was unavailable locally.
+
+### Download guide
+
+| Your computer | Download this file |
+| --- | --- |
+| Windows x64, recommended OpenCL portable | [`2026-08-27-windows64.opencl.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-27.2/2026-08-27-windows64.opencl.portable.zip) |
+| Existing Windows portable install, app-only update | [`2026-08-27-windows64.core-update.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-27.2/2026-08-27-windows64.core-update.zip) |
+| Windows x64, OpenCL installer | [`2026-08-27-windows64.opencl.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-27.2/2026-08-27-windows64.opencl.installer.exe) |
+| Windows x64, CPU fallback portable | [`2026-08-27-windows64.with-katago.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-27.2/2026-08-27-windows64.with-katago.portable.zip) |
+| Windows x64, CPU fallback installer | [`2026-08-27-windows64.with-katago.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-27.2/2026-08-27-windows64.with-katago.installer.exe) |
+| Windows x64, RTX 20/30/40/50 NVIDIA CUDA portable | [`2026-08-27-windows64.nvidia.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-27.2/2026-08-27-windows64.nvidia.portable.zip) |
+| Windows x64, RTX 20/30/40/50 NVIDIA CUDA installer | [`2026-08-27-windows64.nvidia.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-27.2/2026-08-27-windows64.nvidia.installer.exe) |
+| Windows DirectML experimental | [`2026-08-27-windows64.experimental.directml.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-27.2/2026-08-27-windows64.experimental.directml.portable.zip) |
+| Windows Intel OpenVINO experimental | [`2026-08-27-windows64.experimental.openvino.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-27.2/2026-08-27-windows64.experimental.openvino.portable.zip) |
+| Windows AMD RX 6000 ROCm experimental | [`2026-08-27-windows64.experimental.rocm.gfx103x.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-27.2/2026-08-27-windows64.experimental.rocm.gfx103x.portable.zip) |
+| Windows AMD RX 7000 ROCm experimental | [`2026-08-27-windows64.experimental.rocm.gfx110x.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-27.2/2026-08-27-windows64.experimental.rocm.gfx110x.portable.zip) |
+| Windows AMD Ryzen AI Max ROCm experimental | [`2026-08-27-windows64.experimental.rocm.gfx1151.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-27.2/2026-08-27-windows64.experimental.rocm.gfx1151.portable.zip) |
+| Windows AMD RX 9000 ROCm experimental | [`2026-08-27-windows64.experimental.rocm.gfx120x.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-27.2/2026-08-27-windows64.experimental.rocm.gfx120x.portable.zip) |
+| Optional TensorRT for RTX 30 and earlier, download both parts | [`2026-08-27-windows64.nvidia.tensorrt.portable.7z.001`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-27.2/2026-08-27-windows64.nvidia.tensorrt.portable.7z.001)<br>[`2026-08-27-windows64.nvidia.tensorrt.portable.7z.002`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-27.2/2026-08-27-windows64.nvidia.tensorrt.portable.7z.002) |
+| Windows x64, bring your own engine, portable | [`2026-08-27-windows64.without.engine.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-27.2/2026-08-27-windows64.without.engine.portable.zip) |
+| Windows x64, bring your own engine, installer | [`2026-08-27-windows64.without.engine.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-27.2/2026-08-27-windows64.without.engine.installer.exe) |
+| macOS Apple Silicon, Metal | [`2026-08-27-mac-apple-silicon.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-27.2/2026-08-27-mac-apple-silicon.with-katago.dmg) |
+| macOS Intel | [`2026-08-27-mac-intel.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-27.2/2026-08-27-mac-intel.with-katago.dmg) |
+| Linux x64, CPU fallback | [`2026-08-27-linux64.with-katago.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-27.2/2026-08-27-linux64.with-katago.zip) |
+| Linux x64, OpenCL | [`2026-08-27-linux64.opencl.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-27.2/2026-08-27-linux64.opencl.zip) |
+| Linux x64, NVIDIA CUDA | [`2026-08-27-linux64.nvidia.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-27.2/2026-08-27-linux64.nvidia.zip) |
+
+### Why test this release
+
+- Real Windows 11 and RTX 3070 acceptance used the packaged Java runtime with B11 OpenCL. A valid 20-move SGF opened normally, its quick win-rate curve completed in about 10 seconds, and `Ctrl+B` Flash Analysis returned to foreground analysis without an error.
+- Enabling Kata Position on a position with roughly 22k cached visits displayed ownership in about 1.3 seconds. GTP recorded `ownership true movesOwnership true`, and only one primary KataGo process remained.
+- After merging the latest main, the full suite ran 3395 tests with 0 failures, 0 errors, and 15 skipped. Maven packaging, the Windows launcher audit, `git diff --check`, and required PR checks all passed.
+- macOS, Linux, RTX 40/50, DirectML, OpenVINO, and ROCm are not marked as newly hardware-tested in this cycle. Feedback on Flash Analysis and AI Coach across backends is especially useful.
+
+### Contact
+
+- QQ group: `299419120`
+
+---
+
+## 日本語
+
+解析の信頼性、AI 陪練の体験、engine workflow に焦点を当てた公開テスト版です。棋力評価の rank が同じ値に潰れる問題、Flash Analysis の error、cache 済み解析後に Kata 形勢が表示されない問題、AI 陪練 live mode の勝率 graph 欠落を修正しました。
+
+### 主な更新
+
+- 棋力評価は異なる level を同じ「1.0 段」にしません。級位、アマ段位、プロ段位の実際の差と読みやすい表示名を保持します。
+- Flash Analysis の engine/model 選択、lease cleanup、foreground analysis の復帰を安定化しました。quick data が揃っている場合は error を出さず正常終了し、主解析を pause のまま残しません。
+- AI 陪練から不要な training report と投了操作を削除しました。review mode は main board に直接戻り、live mode は通常の候補手と勝率 graph を表示し、終了後もそのまま検討できます。
+- 高 visits の cache が存在する場合、Kata 形勢は新しく要求した ownership だけを補完し、より強い visits、候補手、engine metadata を主/副 engine とも保持します。
+- engine game の cold start と warm restart を再び区別し、再起動後の古い exclusive-lease dialog を破棄します。New Game 設定の保存、toolbar 表示 check、残り markup、新設定への入口も修正しました。
+- 手動 update check は最新、更新あり、失敗を一貫して表示します。release asset は単一 topology と multi-platform fail-closed 検証を継続します。
+- macOS 標準の Bash 3.2 が Bash 4 専用 `mapfile` を使えず、DMG の署名・notarization 後に asset 検証が誤って失敗する問題を修正しました。同じ validator は Windows Git Bash の CRLF 出力にも対応します。
+
+### ダウンロード前に
+
+- `next-2026-08-26.1` の complete bundle を導入済みの Windows ユーザーは、`windows64.core-update.zip` で今回の app 修正を適用できます。既存の weight、engine、TensorRT、`user-data` は置換しません。
+- 新規ユーザーは対応する full bundle を選んでください。KataGo v1.18.1 と既定 B11 を引き続き収録し、速度重視なら Auto Setup で B10 を明示選択できます。
+- RTX 20/30/40/50 は統合 `windows64.nvidia` CUDA package を使用します。TensorRT は RTX 30 系以前の optional 選択です。
+- pre-release のため、まず別 folder で試し、`user-data`、weight、棋譜を backup してください。
+- DirectML、OpenVINO、ROCm は experimental のままで、利用できない hardware を実機確認済みとは表示していません。
+
+### ダウンロード案内
+
+| 環境 | ダウンロードするファイル |
+| --- | --- |
+| Windows x64、推奨 OpenCL portable | [`2026-08-27-windows64.opencl.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-27.2/2026-08-27-windows64.opencl.portable.zip) |
+| 既存 Windows portable、app のみ更新 | [`2026-08-27-windows64.core-update.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-27.2/2026-08-27-windows64.core-update.zip) |
+| Windows x64、OpenCL installer | [`2026-08-27-windows64.opencl.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-27.2/2026-08-27-windows64.opencl.installer.exe) |
+| Windows x64、CPU fallback portable | [`2026-08-27-windows64.with-katago.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-27.2/2026-08-27-windows64.with-katago.portable.zip) |
+| Windows x64、CPU fallback installer | [`2026-08-27-windows64.with-katago.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-27.2/2026-08-27-windows64.with-katago.installer.exe) |
+| Windows x64、RTX 20/30/40/50 NVIDIA CUDA portable | [`2026-08-27-windows64.nvidia.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-27.2/2026-08-27-windows64.nvidia.portable.zip) |
+| Windows x64、RTX 20/30/40/50 NVIDIA CUDA installer | [`2026-08-27-windows64.nvidia.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-27.2/2026-08-27-windows64.nvidia.installer.exe) |
+| Windows DirectML experimental | [`2026-08-27-windows64.experimental.directml.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-27.2/2026-08-27-windows64.experimental.directml.portable.zip) |
+| Windows Intel OpenVINO experimental | [`2026-08-27-windows64.experimental.openvino.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-27.2/2026-08-27-windows64.experimental.openvino.portable.zip) |
+| Windows AMD RX 6000 ROCm experimental | [`2026-08-27-windows64.experimental.rocm.gfx103x.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-27.2/2026-08-27-windows64.experimental.rocm.gfx103x.portable.zip) |
+| Windows AMD RX 7000 ROCm experimental | [`2026-08-27-windows64.experimental.rocm.gfx110x.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-27.2/2026-08-27-windows64.experimental.rocm.gfx110x.portable.zip) |
+| Windows AMD Ryzen AI Max ROCm experimental | [`2026-08-27-windows64.experimental.rocm.gfx1151.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-27.2/2026-08-27-windows64.experimental.rocm.gfx1151.portable.zip) |
+| Windows AMD RX 9000 ROCm experimental | [`2026-08-27-windows64.experimental.rocm.gfx120x.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-27.2/2026-08-27-windows64.experimental.rocm.gfx120x.portable.zip) |
+| RTX 30 系以前向け optional TensorRT、両分割を取得 | [`2026-08-27-windows64.nvidia.tensorrt.portable.7z.001`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-27.2/2026-08-27-windows64.nvidia.tensorrt.portable.7z.001)<br>[`2026-08-27-windows64.nvidia.tensorrt.portable.7z.002`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-27.2/2026-08-27-windows64.nvidia.tensorrt.portable.7z.002) |
+| Windows x64、独自 engine、portable | [`2026-08-27-windows64.without.engine.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-27.2/2026-08-27-windows64.without.engine.portable.zip) |
+| Windows x64、独自 engine、installer | [`2026-08-27-windows64.without.engine.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-27.2/2026-08-27-windows64.without.engine.installer.exe) |
+| macOS Apple Silicon、Metal | [`2026-08-27-mac-apple-silicon.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-27.2/2026-08-27-mac-apple-silicon.with-katago.dmg) |
+| macOS Intel | [`2026-08-27-mac-intel.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-27.2/2026-08-27-mac-intel.with-katago.dmg) |
+| Linux x64、CPU fallback | [`2026-08-27-linux64.with-katago.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-27.2/2026-08-27-linux64.with-katago.zip) |
+| Linux x64、OpenCL | [`2026-08-27-linux64.opencl.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-27.2/2026-08-27-linux64.opencl.zip) |
+| Linux x64、NVIDIA CUDA | [`2026-08-27-linux64.nvidia.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-27.2/2026-08-27-linux64.nvidia.zip) |
+
+### テストする理由
+
+- Windows 11、RTX 3070 実機で packaged Java と B11 OpenCL を検証しました。合法な 20 手 SGF は正常に開き、quick win-rate curve は約 10 秒で完了し、`Ctrl+B` Flash Analysis は error なく foreground analysis に復帰しました。
+- 約 22k visits が cache された局面で Kata 形勢を有効化すると約 1.3 秒で ownership が表示されました。GTP は `ownership true movesOwnership true` を記録し、primary KataGo process は 1 つだけです。
+- 最新 main 統合後の full suite は 3395 tests、0 failures、0 errors、15 skipped です。Maven package、Windows launcher audit、`git diff --check`、PR required checks も通過しました。
+- macOS、Linux、RTX 40/50、DirectML、OpenVINO、ROCm は今回新たに hardware-tested とは表示していません。各 backend の Flash Analysis と AI 陪練の feedback を歓迎します。
+
+### 連絡先
+
+- QQ group: `299419120`
+
+---
+
+## 한국어
+
+분석 신뢰성, AI 코치 경험, engine workflow에 집중한 공개 preview입니다. 기력 평가 rank가 같은 값으로 합쳐지는 문제, Flash Analysis 오류, cache 분석 뒤 Kata 형세가 나타나지 않는 문제, AI 코치 live mode의 승률 graph 누락을 수정했습니다.
+
+### 주요 업데이트
+
+- 기력 평가는 서로 다른 수준을 모두 같은 "1.0단"으로 표시하지 않습니다. 급, 아마 단, 프로 단의 실제 차이와 읽기 쉬운 이름을 유지합니다.
+- Flash Analysis의 engine/model 선택, lease 정리, foreground analysis 복구를 안정화했습니다. quick data가 이미 완성된 경우 오류 없이 정상 종료하고 주 분석을 pause 상태로 남기지 않습니다.
+- AI 코치에서 불필요한 training report와 기권 동작을 제거했습니다. review mode는 main board로 바로 돌아가고 live mode는 일반 추천 수와 승률 graph를 표시하며, 종료 뒤에도 그대로 복기할 수 있습니다.
+- 높은 visits cache가 있을 때 Kata 형세는 새로 요청한 ownership만 보충하고 더 강한 visits, 후보 수, engine metadata를 primary/secondary engine 모두에서 보존합니다.
+- engine game의 cold start와 warm restart를 다시 구분하고 재시작 뒤 오래된 exclusive-lease dialog를 버립니다. New Game 설정 저장, toolbar 표시 check, 남은 markup, 새 설정 진입점도 수정했습니다.
+- 수동 update check는 최신, 업데이트 발견, 실패 결과를 일관되게 안내합니다. release asset은 단일 topology와 multi-platform fail-closed 검증을 계속 사용합니다.
+- macOS 기본 Bash 3.2에서 Bash 4 전용 `mapfile`을 사용할 수 없어 DMG 서명과 공증 뒤 asset 검증이 잘못 실패하던 문제를 수정했습니다. 같은 validator가 Windows Git Bash의 CRLF 출력도 처리합니다.
+
+### 다운로드 전 확인
+
+- `next-2026-08-26.1` complete bundle을 이미 설치한 Windows 사용자는 `windows64.core-update.zip`으로 이번 app 수정만 적용할 수 있습니다. 기존 weight, engine, TensorRT, `user-data`는 교체하지 않습니다.
+- 새 설치에는 해당 full bundle을 사용하세요. KataGo v1.18.1과 기본 B11이 계속 포함되며 처리량을 우선하면 Auto Setup에서 B10을 명시적으로 선택할 수 있습니다.
+- RTX 20/30/40/50은 통합 `windows64.nvidia` CUDA package를 계속 사용합니다. TensorRT는 RTX 30 시리즈 이하에서만 optional 선택입니다.
+- pre-release이므로 먼저 별도 folder에서 시험하고 `user-data`, weight, 기보를 backup하세요.
+- DirectML, OpenVINO, ROCm은 experimental이며 사용할 수 없는 hardware를 실기기 검증 완료로 표시하지 않았습니다.
+
+### 다운로드 안내
+
+| 환경 | 다운로드할 파일 |
+| --- | --- |
+| Windows x64, 권장 OpenCL portable | [`2026-08-27-windows64.opencl.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-27.2/2026-08-27-windows64.opencl.portable.zip) |
+| 기존 Windows portable, app-only update | [`2026-08-27-windows64.core-update.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-27.2/2026-08-27-windows64.core-update.zip) |
+| Windows x64, OpenCL installer | [`2026-08-27-windows64.opencl.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-27.2/2026-08-27-windows64.opencl.installer.exe) |
+| Windows x64, CPU fallback portable | [`2026-08-27-windows64.with-katago.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-27.2/2026-08-27-windows64.with-katago.portable.zip) |
+| Windows x64, CPU fallback installer | [`2026-08-27-windows64.with-katago.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-27.2/2026-08-27-windows64.with-katago.installer.exe) |
+| Windows x64, RTX 20/30/40/50 NVIDIA CUDA portable | [`2026-08-27-windows64.nvidia.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-27.2/2026-08-27-windows64.nvidia.portable.zip) |
+| Windows x64, RTX 20/30/40/50 NVIDIA CUDA installer | [`2026-08-27-windows64.nvidia.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-27.2/2026-08-27-windows64.nvidia.installer.exe) |
+| Windows DirectML experimental | [`2026-08-27-windows64.experimental.directml.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-27.2/2026-08-27-windows64.experimental.directml.portable.zip) |
+| Windows Intel OpenVINO experimental | [`2026-08-27-windows64.experimental.openvino.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-27.2/2026-08-27-windows64.experimental.openvino.portable.zip) |
+| Windows AMD RX 6000 ROCm experimental | [`2026-08-27-windows64.experimental.rocm.gfx103x.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-27.2/2026-08-27-windows64.experimental.rocm.gfx103x.portable.zip) |
+| Windows AMD RX 7000 ROCm experimental | [`2026-08-27-windows64.experimental.rocm.gfx110x.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-27.2/2026-08-27-windows64.experimental.rocm.gfx110x.portable.zip) |
+| Windows AMD Ryzen AI Max ROCm experimental | [`2026-08-27-windows64.experimental.rocm.gfx1151.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-27.2/2026-08-27-windows64.experimental.rocm.gfx1151.portable.zip) |
+| Windows AMD RX 9000 ROCm experimental | [`2026-08-27-windows64.experimental.rocm.gfx120x.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-27.2/2026-08-27-windows64.experimental.rocm.gfx120x.portable.zip) |
+| RTX 30 시리즈 이하 optional TensorRT, 두 part 모두 다운로드 | [`2026-08-27-windows64.nvidia.tensorrt.portable.7z.001`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-27.2/2026-08-27-windows64.nvidia.tensorrt.portable.7z.001)<br>[`2026-08-27-windows64.nvidia.tensorrt.portable.7z.002`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-27.2/2026-08-27-windows64.nvidia.tensorrt.portable.7z.002) |
+| Windows x64, 사용자 engine, portable | [`2026-08-27-windows64.without.engine.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-27.2/2026-08-27-windows64.without.engine.portable.zip) |
+| Windows x64, 사용자 engine, installer | [`2026-08-27-windows64.without.engine.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-27.2/2026-08-27-windows64.without.engine.installer.exe) |
+| macOS Apple Silicon, Metal | [`2026-08-27-mac-apple-silicon.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-27.2/2026-08-27-mac-apple-silicon.with-katago.dmg) |
+| macOS Intel | [`2026-08-27-mac-intel.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-27.2/2026-08-27-mac-intel.with-katago.dmg) |
+| Linux x64, CPU fallback | [`2026-08-27-linux64.with-katago.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-27.2/2026-08-27-linux64.with-katago.zip) |
+| Linux x64, OpenCL | [`2026-08-27-linux64.opencl.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-27.2/2026-08-27-linux64.opencl.zip) |
+| Linux x64, NVIDIA CUDA | [`2026-08-27-linux64.nvidia.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-27.2/2026-08-27-linux64.nvidia.zip) |
+
+### 테스트할 이유
+
+- Windows 11, RTX 3070 실기기에서 packaged Java와 B11 OpenCL을 검증했습니다. 정상 20수 SGF가 열렸고 quick win-rate curve는 약 10초에 완료되었으며 `Ctrl+B` Flash Analysis는 오류 없이 foreground analysis로 돌아왔습니다.
+- 약 22k visits가 cache된 국면에서 Kata 형세를 켜자 약 1.3초 뒤 ownership이 나타났습니다. GTP는 `ownership true movesOwnership true`를 기록했고 primary KataGo process는 하나만 유지되었습니다.
+- 최신 main 통합 후 full suite는 3395 tests, 0 failures, 0 errors, 15 skipped입니다. Maven package, Windows launcher audit, `git diff --check`, PR required checks가 모두 통과했습니다.
+- macOS, Linux, RTX 40/50, DirectML, OpenVINO, ROCm은 이번 cycle에서 새로 hardware-tested로 표시하지 않았습니다. 각 backend의 Flash Analysis와 AI 코치 feedback을 환영합니다.
+
+### 연락처
+
+- QQ 그룹: `299419120`
+
+---
+
+## ภาษาไทย
+
+นี่คือ public preview ที่เน้นความน่าเชื่อถือของ analysis, ประสบการณ์ AI Coach และ engine workflow แก้ปัญหา rank ของการประเมินฝีมือถูกรวมเป็นค่าเดียว, Flash Analysis ขึ้น error, Kata Position ไม่แสดงหลังมี cache และกราฟอัตราชนะหายไปใน live mode ของ AI Coach
+
+### ไฮไลต์ของเวอร์ชันนี้
+
+- การประเมินฝีมือไม่รวมระดับต่างกันเป็น "1.0 ดั้ง" เดียวอีกต่อไป โดยคงความแตกต่างของระดับคิว ดั้งสมัครเล่น และดั้งอาชีพ พร้อมชื่อที่อ่านง่าย
+- Flash Analysis เลือก engine/model, ล้าง lease และคืน foreground analysis ได้เสถียรขึ้น เมื่อ quick data ครบแล้วจะจบตามปกติ ไม่ขึ้น error หรือทิ้ง analysis หลักไว้ในสถานะ pause
+- AI Coach ตัด training report และปุ่มยอมแพ้ที่ซ้ำซ้อนออก review mode กลับสู่ main board โดยตรง ส่วน live mode แสดงจุดแนะนำและกราฟอัตราชนะตามปกติ และยังทบทวนเกมต่อได้หลังจบ
+- เมื่อมี cache ที่ visits สูง Kata Position จะเติมเฉพาะ ownership ที่เพิ่งขอ พร้อมเก็บ visits, candidate และ engine metadata ที่แข็งแรงกว่าไว้ทั้ง primary และ secondary engine
+- engine game แยก cold start กับ warm restart อีกครั้งและทิ้ง exclusive-lease dialog เก่าหลัง restart แก้การบันทึก New Game settings, checkmark การซ่อน toolbar, markup ที่เหลือ และทางเข้าหน้า settings ใหม่
+- การตรวจ update แบบ manual แสดงผลว่าเป็นเวอร์ชันล่าสุด พบ update หรือเกิดข้อผิดพลาดอย่างสม่ำเสมอ release asset ยังสร้างจาก topology เดียวและตรวจ multi-platform แบบ fail-closed
+- แก้ปัญหา Bash 3.2 ที่มากับ macOS ไม่รองรับ `mapfile` ของ Bash 4 จน asset validation ล้มเหลวผิดพลาดหลัง DMG ลงนามและ notarize แล้ว พร้อมรองรับ CRLF จาก native Windows Python ใน Git Bash
+
+### ก่อนดาวน์โหลด
+
+- ผู้ใช้ Windows ที่ติดตั้ง complete bundle `next-2026-08-26.1` แล้ว ใช้ `windows64.core-update.zip` เพื่อรับเฉพาะการแก้ไข app ครั้งนี้ได้ โดยไม่แทนที่ weight, engine, TensorRT หรือ `user-data`
+- ผู้ใช้ใหม่ควรดาวน์โหลด full bundle ที่ตรงกับเครื่อง ซึ่งยังมี KataGo v1.18.1 และ B11 เป็นค่าเริ่มต้น หากให้ความสำคัญกับ throughput มากกว่า ให้เลือก B10 ใน Auto Setup อย่างชัดเจน
+- RTX 20/30/40/50 ยังคงใช้ `windows64.nvidia` CUDA package เดียวกัน TensorRT เป็นตัวเลือกสำหรับ RTX 30 series และรุ่นก่อนหน้าเท่านั้น
+- นี่คือ pre-release ควรทดสอบใน folder แยกก่อน และ backup `user-data`, weight และ game records
+- DirectML, OpenVINO และ ROCm ยังเป็น experimental และเราไม่อ้างว่าผ่าน hardware test บนอุปกรณ์ที่ไม่มีในเครื่องทดสอบ
+
+### คู่มือดาวน์โหลด
+
+| คอมพิวเตอร์ของคุณ | ดาวน์โหลดไฟล์นี้ |
+| --- | --- |
+| Windows x64, OpenCL portable ที่แนะนำ | [`2026-08-27-windows64.opencl.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-27.2/2026-08-27-windows64.opencl.portable.zip) |
+| Windows portable เดิม, อัปเดตเฉพาะ app | [`2026-08-27-windows64.core-update.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-27.2/2026-08-27-windows64.core-update.zip) |
+| Windows x64, OpenCL installer | [`2026-08-27-windows64.opencl.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-27.2/2026-08-27-windows64.opencl.installer.exe) |
+| Windows x64, CPU fallback portable | [`2026-08-27-windows64.with-katago.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-27.2/2026-08-27-windows64.with-katago.portable.zip) |
+| Windows x64, CPU fallback installer | [`2026-08-27-windows64.with-katago.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-27.2/2026-08-27-windows64.with-katago.installer.exe) |
+| Windows x64, RTX 20/30/40/50 NVIDIA CUDA portable | [`2026-08-27-windows64.nvidia.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-27.2/2026-08-27-windows64.nvidia.portable.zip) |
+| Windows x64, RTX 20/30/40/50 NVIDIA CUDA installer | [`2026-08-27-windows64.nvidia.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-27.2/2026-08-27-windows64.nvidia.installer.exe) |
+| Windows DirectML experimental | [`2026-08-27-windows64.experimental.directml.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-27.2/2026-08-27-windows64.experimental.directml.portable.zip) |
+| Windows Intel OpenVINO experimental | [`2026-08-27-windows64.experimental.openvino.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-27.2/2026-08-27-windows64.experimental.openvino.portable.zip) |
+| Windows AMD RX 6000 ROCm experimental | [`2026-08-27-windows64.experimental.rocm.gfx103x.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-27.2/2026-08-27-windows64.experimental.rocm.gfx103x.portable.zip) |
+| Windows AMD RX 7000 ROCm experimental | [`2026-08-27-windows64.experimental.rocm.gfx110x.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-27.2/2026-08-27-windows64.experimental.rocm.gfx110x.portable.zip) |
+| Windows AMD Ryzen AI Max ROCm experimental | [`2026-08-27-windows64.experimental.rocm.gfx1151.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-27.2/2026-08-27-windows64.experimental.rocm.gfx1151.portable.zip) |
+| Windows AMD RX 9000 ROCm experimental | [`2026-08-27-windows64.experimental.rocm.gfx120x.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-27.2/2026-08-27-windows64.experimental.rocm.gfx120x.portable.zip) |
+| TensorRT สำหรับ RTX 30 และรุ่นก่อนหน้า, ดาวน์โหลดทั้งสอง part | [`2026-08-27-windows64.nvidia.tensorrt.portable.7z.001`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-27.2/2026-08-27-windows64.nvidia.tensorrt.portable.7z.001)<br>[`2026-08-27-windows64.nvidia.tensorrt.portable.7z.002`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-27.2/2026-08-27-windows64.nvidia.tensorrt.portable.7z.002) |
+| Windows x64, ใช้ engine ของคุณเอง, portable | [`2026-08-27-windows64.without.engine.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-27.2/2026-08-27-windows64.without.engine.portable.zip) |
+| Windows x64, ใช้ engine ของคุณเอง, installer | [`2026-08-27-windows64.without.engine.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-27.2/2026-08-27-windows64.without.engine.installer.exe) |
+| macOS Apple Silicon, Metal | [`2026-08-27-mac-apple-silicon.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-27.2/2026-08-27-mac-apple-silicon.with-katago.dmg) |
+| macOS Intel | [`2026-08-27-mac-intel.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-27.2/2026-08-27-mac-intel.with-katago.dmg) |
+| Linux x64, CPU fallback | [`2026-08-27-linux64.with-katago.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-27.2/2026-08-27-linux64.with-katago.zip) |
+| Linux x64, OpenCL | [`2026-08-27-linux64.opencl.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-27.2/2026-08-27-linux64.opencl.zip) |
+| Linux x64, NVIDIA CUDA | [`2026-08-27-linux64.nvidia.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-27.2/2026-08-27-linux64.nvidia.zip) |
+
+### เหตุผลที่ควรทดสอบ
+
+- ทดสอบจริงบน Windows 11 และ RTX 3070 ด้วย packaged Java กับ B11 OpenCL ไฟล์ SGF ที่ถูกต้อง 20 ตาเปิดได้ปกติ quick win-rate curve เสร็จในประมาณ 10 วินาที และ `Ctrl+B` Flash Analysis กลับสู่ foreground analysis โดยไม่มี error
+- เมื่อเปิด Kata Position ในตำแหน่งที่มี cache ราว 22k visits ownership แสดงในประมาณ 1.3 วินาที GTP บันทึก `ownership true movesOwnership true` และเหลือ primary KataGo process เพียงหนึ่งตัว
+- หลังรวม main ล่าสุด full suite รัน 3395 tests โดย 0 failures, 0 errors, 15 skipped และ Maven package, Windows launcher audit, `git diff --check` กับ PR required checks ผ่านทั้งหมด
+- macOS, Linux, RTX 40/50, DirectML, OpenVINO และ ROCm ไม่ได้ถูกระบุว่าเพิ่งผ่าน hardware test ในรอบนี้ ยินดีรับ feedback เรื่อง Flash Analysis และ AI Coach บน backend ต่าง ๆ
+
+### ติดต่อ
+
+- QQ group: `299419120`

--- a/.github/release-requests/next-2026-08-27.2.json
+++ b/.github/release-requests/next-2026-08-27.2.json
@@ -1,0 +1,7 @@
+{
+  "date_tag": "2026-08-27",
+  "release_tag": "next-2026-08-27.2",
+  "title": "LizzieYzy Next next-2026-08-27.2",
+  "prerelease": true,
+  "notes_file": ".github/release-notes/next-2026-08-27.2.md"
+}


### PR DESCRIPTION
## Summary

- request the reviewed 
ext-2026-08-27.2 public pre-release
- retain all six-language product notes and add the macOS Bash 3.2 release-validator fix
- publish only after exact Windows, Linux, macOS Intel, and macOS Apple Silicon workflows and all 26 public assets succeed

## Why .2

The .1 attempt remained an unpublished draft after Apple Silicon successfully built, signed, notarized, and validated its Metal DMG, but the final asset inventory step used the Bash 4-only mapfile builtin. PR #344 replaced that command, added Windows CRLF normalization, and passed Linux/Windows CI.

## Validation

- PR #344 CI: Linux build and Windows full verification succeeded
- Maven: 3395 tests, 0 failures, 0 errors, 15 skipped
- release contract suite: 137 tests, 0 failures, 0 errors, 2 platform-specific skips
- release request/notes suite: 10 tests, 0 failures
- Maven package, Bash syntax, line-ending policy, release-notes validator, and diff checks: success