### PR TITLE
fix(engine): rebind bundled KataGo and keep UI with no engine

### DIFF
--- a/src/main/java/featurecat/lizzie/Config.java
+++ b/src/main/java/featurecat/lizzie/Config.java
@@ -396,10 +396,7 @@ public class Config {
     Path workingDirectory = Path.of(System.getProperty("user.dir", ".")).toAbsolutePath();
     Optional<Path> commandAppRoot =
         bundledAppRootForExecutable(workingDirectory, commandParts.get(0));
-    Optional<Path> activeAppRoot = findBundledAppRoot();
-    if (!commandAppRoot.isPresent()
-        || !activeAppRoot.isPresent()
-        || !samePath(commandAppRoot.get(), activeAppRoot.get())) {
+    if (!commandAppRoot.isPresent()) {
       return false;
     }
     String modelToken = modelToken(command);
@@ -467,17 +464,6 @@ public class Config {
     return path.isAbsolute()
         ? path.toAbsolutePath().normalize()
         : workingDirectory.resolve(path).toAbsolutePath().normalize();
-  }
-
-  private static boolean samePath(Path first, Path second) {
-    if (first == null || second == null) {
-      return false;
-    }
-    try {
-      return Files.isSameFile(first, second);
-    } catch (IOException e) {
-      return first.toAbsolutePath().normalize().equals(second.toAbsolutePath().normalize());
-    }
   }
 
   private static String modelToken(String command) {
@@ -662,15 +648,15 @@ public class Config {
       }
       String name = engineInfo.optString("name", "");
       String command = engineInfo.optString("command", "");
-      boolean managedDefaultCommand = isManagedBundledDefaultCommand(command);
+      boolean managedDefaultCommand =
+          !engineInfo.optBoolean("useJavaSSH", false)
+              && isManagedBundledDefaultCommand(command);
       if (autoSetupIndex < 0 && "KataGo Auto Setup".equals(name) && managedDefaultCommand) {
         autoSetupIndex = i;
       }
       if (bundledIndex < 0
           && managedDefaultCommand
-          && (BUNDLED_ENGINE_NAME.equals(name)
-              || "KataGo Auto Setup".equals(name)
-              || isBundledKataGoCommand(command))) {
+          && (BUNDLED_ENGINE_NAME.equals(name) || "KataGo Auto Setup".equals(name))) {
         bundledIndex = i;
       }
     }
@@ -719,7 +705,9 @@ public class Config {
                 ui.optBoolean("analysis-engine-command-customized", false),
                 ui.optString("analysis-engine-command", ""));
         String analysisCommand = ui.optString("analysis-engine-command", "");
-        if ((!analysisCustomized && isManagedBundledDefaultCommand(analysisCommand))
+        if ((!analysisCustomized
+                && !analysisCommandUsesJavaSsh(leelaz)
+                && isManagedBundledDefaultCommand(analysisCommand))
             || isClearlyBrokenJavaJarCommand(analysisCommand)) {
           ui.put("analysis-engine-command", bundledConfig.analysisCommand);
           ui.put("analysis-engine-command-customized", false);
@@ -801,6 +789,14 @@ public class Config {
       writeConfig(this.config, new File(configFilename));
     }
     return changed;
+  }
+
+  private static boolean analysisCommandUsesJavaSsh(JSONObject leelaz) {
+    if (leelaz == null) {
+      return false;
+    }
+    JSONObject sshInfo = leelaz.optJSONObject("analysis-engine-ssh-info");
+    return sshInfo != null && sshInfo.optBoolean("useJavaSSH", false);
   }
 
   public boolean moveListTopCurNode = false;

--- a/src/main/java/featurecat/lizzie/Lizzie.java
+++ b/src/main/java/featurecat/lizzie/Lizzie.java
@@ -1412,8 +1412,16 @@ public class Lizzie {
   }
 
   public static void shutdown() {
+    shutdown(System::exit);
+  }
+
+  static void shutdown(IntConsumer exit) {
     logShutdownRequested();
-    if (config.autoSaveOnExit) frame.saveAutoGame(1);
+    try {
+      if (config.autoSaveOnExit) frame.saveAutoGame(1);
+    } catch (Exception e) {
+      APP.error("failed to auto-save on shutdown", e);
+    }
     if (Lizzie.config.uiConfig.optBoolean("autoload-last", false)) {
       Lizzie.config.uiConfig.put("last-engine", EngineManager.currentEngineNo);
     }
@@ -1475,7 +1483,7 @@ public class Lizzie {
         e.printStackTrace();
       }
     }
-    shutdownLoggingThenExit(System::exit);
+    shutdownLoggingThenExit(exit);
   }
 
   public static void shutdownLoggingThenExit(IntConsumer exit) {

--- a/src/main/java/featurecat/lizzie/gui/LizzieFrame.java
+++ b/src/main/java/featurecat/lizzie/gui/LizzieFrame.java
@@ -7333,7 +7333,7 @@ public class LizzieFrame extends JFrame {
     boolean isKataStyle = false;
     if (curData.isKataData
         || curData.isSaiData
-        || (Lizzie.leelaz.isKatago && !EngineManager.isEmpty)
+        || (Lizzie.leelaz != null && Lizzie.leelaz.isKatago && !EngineManager.isEmpty)
         || (EngineManager.isEngineGame
             && (Lizzie.engineManager.engineList.get(EngineManager.engineGameInfo.blackEngineIndex)
                     .isKatago
@@ -7371,7 +7371,7 @@ public class LizzieFrame extends JFrame {
                 + String.format(Locale.ENGLISH, "%.1f", scoreStdev)
                 + " ";
     }
-    if (Lizzie.leelaz.isColorEngine) {
+    if (Lizzie.leelaz != null && Lizzie.leelaz.isColorEngine) {
       // "阶段:""贴目:"
       text =
           text
@@ -7546,7 +7546,8 @@ public class LizzieFrame extends JFrame {
                   .usingSpecificRules
               > 0) return true;
     }
-    if (Lizzie.leelaz.isKatago && Lizzie.leelaz.usingSpecificRules > 0) return true;
+    if (Lizzie.leelaz != null && Lizzie.leelaz.isKatago && Lizzie.leelaz.usingSpecificRules > 0)
+      return true;
     return false;
   }
 
@@ -7787,7 +7788,7 @@ public class LizzieFrame extends JFrame {
               : Lizzie.engineManager.engineList.get(EngineManager.engineGameInfo.whiteEngineIndex);
     else leela = Lizzie.leelaz;
     // ||(Lizzie.engineManager.isEngineGame&&Lizzie.engineManager.engineGameInfo.isGenmove)
-    if (leela.isKatago && !EngineManager.isEmpty) {
+    if (leela != null && leela.isKatago && !EngineManager.isEmpty) {
       switch (leela.usingSpecificRules) {
         case 1:
           moveOrRules = Lizzie.resourceBundle.getString("LizzieFrame.currentRules.chinese");
@@ -9225,7 +9226,7 @@ public class LizzieFrame extends JFrame {
               Lizzie.board.getHistory().getCurrentHistoryNode().previous().get().getData().comment;
         else {
           if (Lizzie.board.getHistory().getData().comment.equals("")) {
-            if ((Lizzie.leelaz.isPondering()
+            if (((Lizzie.leelaz != null && Lizzie.leelaz.isPondering())
                     || EngineManager.isEngineGame
                     || Lizzie.frame.isPlayingAgainstLeelaz)
                 && Lizzie.config.appendWinrateToComment

--- a/src/main/java/featurecat/lizzie/rules/SGFParser.java
+++ b/src/main/java/featurecat/lizzie/rules/SGFParser.java
@@ -1177,7 +1177,7 @@ public class SGFParser {
             }
           }
         } else {
-          if (Lizzie.leelaz.isKatago && !fromAutoSave) {
+          if (Lizzie.leelaz != null && Lizzie.leelaz.isKatago && !fromAutoSave) {
             String rules = "";
             boolean usingSpecificRues = false;
             if (Lizzie.leelaz.isKatago) {
@@ -1263,7 +1263,7 @@ public class SGFParser {
                     "KM[%s]PW[%s]PB[%s]DT[%s]DZ[Y]AP[LizzieYzy Next: %s]RE[%s]SZ[%s]CA[UTF-8]",
                     komi, playerW, playerB, date, Lizzie.nextVersion, result, boardSizeTag));
         } else {
-          if (Lizzie.leelaz.isKatago || Lizzie.board.isKataBoard)
+          if ((Lizzie.leelaz != null && Lizzie.leelaz.isKatago) || Lizzie.board.isKataBoard)
             generalProps.append(
                 String.format(
                     "KM[%s]PW[%s]PB[%s]DT[%s]DZ[G]AP[LizzieYzy Next: %s]RE[%s]SZ[%s]CA[UTF-8]",

--- a/src/test/java/featurecat/lizzie/ConfigBundledKataGoDefaultsTest.java
+++ b/src/test/java/featurecat/lizzie/ConfigBundledKataGoDefaultsTest.java
@@ -439,6 +439,228 @@ public class ConfigBundledKataGoDefaultsTest {
   }
 
   @Test
+  void copiedBundledDefaultSlotRebindsToCurrentPackageWhileOldBundleStillExists() throws Exception {
+    Path currentRoot = Files.createTempDirectory("lizzie-current-package");
+    Path previousRoot = Files.createTempDirectory("lizzie-previous-package");
+    Files.writeString(currentRoot.resolve("config.txt"), "{}");
+    createBundledKataGoAssets(currentRoot);
+    createBundledKataGoAssets(previousRoot);
+
+    String previousCommand = bundledGtpCommand(previousRoot);
+    String previousAnalysis = bundledAnalysisCommand(previousRoot);
+    String currentCommand = bundledGtpCommand(currentRoot);
+    String currentAnalysis = bundledAnalysisCommand(currentRoot);
+
+    Config config = ConfigTestHelper.createForTests(currentRoot);
+    JSONObject ui =
+        new JSONObject()
+            .put("first-time-load", false)
+            .put("autoload-default", false)
+            .put("autoload-last", false)
+            .put("autoload-empty", true)
+            .put("default-engine", 0)
+            .put("analysis-engine-command", previousAnalysis)
+            .put("analysis-engine-command-customized", false);
+    JSONObject bundledEngine =
+        new JSONObject()
+            .put("name", "KataGo Auto Setup")
+            .put("command", previousCommand)
+            .put("isDefault", true);
+    JSONObject leelaz =
+        new JSONObject().put("engine-settings-list", new JSONArray().put(bundledEngine));
+    config.config = new JSONObject().put("ui", ui).put("leelaz", leelaz);
+
+    withUserDir(currentRoot, () -> applyBundledKataGoDefaults(config));
+
+    JSONObject storedEngine = leelaz.getJSONArray("engine-settings-list").getJSONObject(0);
+    assertEquals(currentCommand, storedEngine.getString("command"));
+    assertEquals(currentAnalysis, ui.getString("analysis-engine-command"));
+    assertFalse(ui.getBoolean("analysis-engine-command-customized"));
+    assertTrue(ui.getBoolean("autoload-empty"));
+    assertFalse(ui.getBoolean("autoload-default"));
+    assertTrue(Files.isRegularFile(bundledExecutable(previousRoot)));
+  }
+
+  @Test
+  void movedBundledDefaultSlotRebindsWhenOldExecutableIsGone() throws Exception {
+    Path currentRoot = Files.createTempDirectory("lizzie-moved-current-package");
+    Path previousRoot = Files.createTempDirectory("lizzie-moved-previous-package");
+    Files.writeString(currentRoot.resolve("config.txt"), "{}");
+    createBundledKataGoAssets(currentRoot);
+    String previousCommand = bundledGtpCommand(previousRoot);
+    String previousAnalysis = bundledAnalysisCommand(previousRoot);
+    Files.deleteIfExists(previousRoot);
+
+    Config config = ConfigTestHelper.createForTests(currentRoot);
+    JSONObject ui =
+        new JSONObject()
+            .put("first-time-load", false)
+            .put("autoload-empty", true)
+            .put("default-engine", 0)
+            .put("analysis-engine-command", previousAnalysis)
+            .put("analysis-engine-command-customized", false);
+    JSONObject leelaz =
+        new JSONObject()
+            .put(
+                "engine-settings-list",
+                new JSONArray()
+                    .put(
+                        new JSONObject()
+                            .put("name", "KataGo Bundled")
+                            .put("command", previousCommand)
+                            .put("isDefault", true)));
+    config.config = new JSONObject().put("ui", ui).put("leelaz", leelaz);
+
+    withUserDir(currentRoot, () -> applyBundledKataGoDefaults(config));
+
+    assertEquals(
+        bundledGtpCommand(currentRoot),
+        leelaz.getJSONArray("engine-settings-list").getJSONObject(0).getString("command"));
+    assertEquals(bundledAnalysisCommand(currentRoot), ui.getString("analysis-engine-command"));
+    assertTrue(ui.getBoolean("autoload-empty"));
+    assertFalse(Files.isRegularFile(bundledExecutable(previousRoot)));
+  }
+
+  @Test
+  void customizedAnalysisCommandSurvivesCopiedBundledDefaultRebind() throws Exception {
+    Path currentRoot = Files.createTempDirectory("lizzie-copied-custom-analysis");
+    Path previousRoot = Files.createTempDirectory("lizzie-copied-custom-analysis-old");
+    Files.writeString(currentRoot.resolve("config.txt"), "{}");
+    createBundledKataGoAssets(currentRoot);
+    createBundledKataGoAssets(previousRoot);
+    String customAnalysis = "\"/opt/custom/katago\" analysis --keep-mine true";
+
+    Config config = ConfigTestHelper.createForTests(currentRoot);
+    JSONObject ui =
+        new JSONObject()
+            .put("first-time-load", false)
+            .put("autoload-empty", true)
+            .put("analysis-engine-command", customAnalysis)
+            .put("analysis-engine-command-customized", true);
+    JSONObject leelaz =
+        new JSONObject()
+            .put(
+                "engine-settings-list",
+                new JSONArray()
+                    .put(
+                        new JSONObject()
+                            .put("name", "KataGo Bundled")
+                            .put("command", bundledGtpCommand(previousRoot))
+                            .put("isDefault", true)));
+    config.config = new JSONObject().put("ui", ui).put("leelaz", leelaz);
+
+    withUserDir(currentRoot, () -> applyBundledKataGoDefaults(config));
+
+    assertEquals(
+        bundledGtpCommand(currentRoot),
+        leelaz.getJSONArray("engine-settings-list").getJSONObject(0).getString("command"));
+    assertEquals(customAnalysis, ui.getString("analysis-engine-command"));
+    assertTrue(ui.getBoolean("analysis-engine-command-customized"));
+  }
+
+  @Test
+  void sshRemoteAndJavaSshCommandsAreNotReboundToCurrentPackage() throws Exception {
+    Path currentRoot = Files.createTempDirectory("lizzie-copied-remote-engines");
+    Files.writeString(currentRoot.resolve("config.txt"), "{}");
+    createBundledKataGoAssets(currentRoot);
+    String sshCommand = "ssh user@host ./katago gtp";
+    String javaSshCommand = "katago gtp -model /opt/remote.bin.gz";
+
+    Config config = ConfigTestHelper.createForTests(currentRoot);
+    JSONObject ui =
+        new JSONObject()
+            .put("first-time-load", false)
+            .put("autoload-empty", true)
+            .put("default-engine", 0)
+            .put("analysis-engine-command", RemoteComputeConfig.COMMAND_ZHIZI)
+            .put("analysis-engine-command-customized", false);
+    JSONObject sshEngine =
+        new JSONObject()
+            .put("name", "KataGo Bundled")
+            .put("command", sshCommand)
+            .put("useJavaSSH", false)
+            .put("ip", "192.0.2.10")
+            .put("isDefault", true);
+    JSONObject remoteEngine =
+        new JSONObject()
+            .put("name", "Zhizi Cloud")
+            .put("command", RemoteComputeConfig.COMMAND_ZHIZI)
+            .put("isDefault", false);
+    JSONObject javaSshEngine =
+        new JSONObject()
+            .put("name", "Java SSH")
+            .put("command", javaSshCommand)
+            .put("useJavaSSH", true)
+            .put("ip", "192.0.2.11")
+            .put("isDefault", false);
+    JSONObject leelaz =
+        new JSONObject()
+            .put(
+                "engine-settings-list",
+                new JSONArray().put(sshEngine).put(remoteEngine).put(javaSshEngine));
+    config.config = new JSONObject().put("ui", ui).put("leelaz", leelaz);
+
+    withUserDir(currentRoot, () -> applyBundledKataGoDefaults(config));
+
+    JSONArray engines = leelaz.getJSONArray("engine-settings-list");
+    assertEquals(sshCommand, engines.getJSONObject(0).getString("command"));
+    assertEquals(RemoteComputeConfig.COMMAND_ZHIZI, engines.getJSONObject(1).getString("command"));
+    assertEquals(javaSshCommand, engines.getJSONObject(2).getString("command"));
+    assertEquals(RemoteComputeConfig.COMMAND_ZHIZI, ui.getString("analysis-engine-command"));
+    assertTrue(ui.getBoolean("autoload-empty"));
+  }
+
+  @Test
+  void javaSshDefaultNamedBundledLayoutCommandIsNotRebound() throws Exception {
+    Path currentRoot = Files.createTempDirectory("lizzie-java-ssh-bundled-layout");
+    Path remoteRoot = Files.createTempDirectory("lizzie-java-ssh-remote-bundle");
+    Files.writeString(currentRoot.resolve("config.txt"), "{}");
+    createBundledKataGoAssets(currentRoot);
+    createBundledKataGoAssets(remoteRoot);
+    String remoteCommand = bundledGtpCommand(remoteRoot);
+    String remoteAnalysis = bundledAnalysisCommand(remoteRoot);
+
+    Config config = ConfigTestHelper.createForTests(currentRoot);
+    JSONObject ui =
+        new JSONObject()
+            .put("first-time-load", false)
+            .put("autoload-empty", true)
+            .put("default-engine", 0)
+            .put("analysis-engine-command", remoteAnalysis)
+            .put("analysis-engine-command-customized", false);
+    JSONObject javaSshEngine =
+        new JSONObject()
+            .put("name", "KataGo Bundled")
+            .put("command", remoteCommand)
+            .put("useJavaSSH", true)
+            .put("ip", "192.0.2.20")
+            .put("port", "22")
+            .put("userName", "katago")
+            .put("isDefault", true);
+    JSONObject leelaz =
+        new JSONObject()
+            .put("engine-settings-list", new JSONArray().put(javaSshEngine))
+            .put(
+                "analysis-engine-ssh-info",
+                new JSONObject()
+                    .put("useJavaSSH", true)
+                    .put("ip", "192.0.2.20")
+                    .put("port", "22")
+                    .put("userName", "katago"));
+    config.config = new JSONObject().put("ui", ui).put("leelaz", leelaz);
+
+    withUserDir(currentRoot, () -> applyBundledKataGoDefaults(config));
+
+    JSONObject storedEngine = leelaz.getJSONArray("engine-settings-list").getJSONObject(0);
+    assertEquals(remoteCommand, storedEngine.getString("command"));
+    assertTrue(storedEngine.getBoolean("useJavaSSH"));
+    assertEquals("192.0.2.20", storedEngine.getString("ip"));
+    assertEquals(remoteAnalysis, ui.getString("analysis-engine-command"));
+    assertTrue(ui.getBoolean("autoload-empty"));
+  }
+
+
+  @Test
   void customCommandInDefaultSlotSurvivesRestart() throws Exception {
     Path tempRoot = Files.createTempDirectory("lizzie-bundled-katago-custom");
     Files.writeString(tempRoot.resolve("config.txt"), "{}");
@@ -710,38 +932,39 @@ public class ConfigBundledKataGoDefaultsTest {
   }
 
   @Test
-  void completeExternalBundleIsNeverTreatedAsTheRunningBundle() throws Exception {
+  void completeExternalBundleInNonDefaultSlotIsNotRebound() throws Exception {
     Path currentRoot = Files.createTempDirectory("lizzie-current-bundle");
     Path externalRoot = Files.createTempDirectory("lizzie-external-bundle");
-    createBundledKataGoAssets(currentRoot, "b10c512h8nbt3tflrs-fson-silu-rsnh.bin.gz");
-    createBundledKataGoAssets(externalRoot, "b10c512h8nbt3tflrs-fson-silu-rsnh.bin.gz");
-    String externalCommand =
-        quote(bundledExecutable(externalRoot))
-            + " gtp -model "
-            + quote(externalRoot.resolve("weights").resolve("default.bin.gz"))
-            + " -config "
-            + quote(
-                externalRoot
-                    .resolve("engines")
-                    .resolve("katago")
-                    .resolve("configs")
-                    .resolve("gtp.cfg"));
-    String externalCommandWithoutModel =
-        quote(bundledExecutable(externalRoot))
-            + " gtp -config "
-            + quote(
-                externalRoot
-                    .resolve("engines")
-                    .resolve("katago")
-                    .resolve("configs")
-                    .resolve("gtp.cfg"));
+    Files.writeString(currentRoot.resolve("config.txt"), "{}");
+    createBundledKataGoAssets(currentRoot);
+    createBundledKataGoAssets(externalRoot);
+    String externalCommand = bundledGtpCommand(externalRoot);
 
-    withUserDir(
-        currentRoot,
-        () -> {
-          assertFalse(Config.isManagedBundledDefaultCommand(externalCommand));
-          assertFalse(Config.isManagedBundledDefaultCommand(externalCommandWithoutModel));
-        });
+    Config config = ConfigTestHelper.createForTests(currentRoot);
+    JSONObject ui =
+        new JSONObject()
+            .put("first-time-load", false)
+            .put("autoload-empty", true)
+            .put("default-engine", 0);
+    JSONObject leelaz =
+        new JSONObject()
+            .put(
+                "engine-settings-list",
+                new JSONArray()
+                    .put(
+                        new JSONObject()
+                            .put("name", "External KataGo")
+                            .put("command", externalCommand)
+                            .put("isDefault", true)));
+    config.config = new JSONObject().put("ui", ui).put("leelaz", leelaz);
+
+    withUserDir(currentRoot, () -> applyBundledKataGoDefaults(config));
+
+    JSONArray engines = leelaz.getJSONArray("engine-settings-list");
+    assertEquals("External KataGo", engines.getJSONObject(0).getString("name"));
+    assertEquals(externalCommand, engines.getJSONObject(0).getString("command"));
+    assertTrue(engines.getJSONObject(0).getBoolean("isDefault"));
+    assertTrue(ui.getBoolean("autoload-empty"));
   }
 
   @Test
@@ -1050,6 +1273,24 @@ public class ConfigBundledKataGoDefaultsTest {
         System.setProperty("user.dir", previousUserDir);
       }
     }
+  }
+
+  private static String bundledGtpCommand(Path root) {
+    return quote(bundledExecutable(root))
+        + " gtp -model "
+        + quote(root.resolve("weights").resolve("default.bin.gz"))
+        + " -config "
+        + quote(root.resolve("engines").resolve("katago").resolve("configs").resolve("gtp.cfg"));
+  }
+
+  private static String bundledAnalysisCommand(Path root) {
+    return quote(bundledExecutable(root))
+        + " analysis -model "
+        + quote(root.resolve("weights").resolve("default.bin.gz"))
+        + " -config "
+        + quote(
+            root.resolve("engines").resolve("katago").resolve("configs").resolve("analysis.cfg"))
+        + " -quit-without-waiting";
   }
 
   private static void createBundledKataGoAssets(Path root) throws Exception {

--- a/src/test/java/featurecat/lizzie/LizzieShutdownTest.java
+++ b/src/test/java/featurecat/lizzie/LizzieShutdownTest.java
@@ -1,0 +1,177 @@
+package featurecat.lizzie;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import featurecat.lizzie.analysis.EngineManager;
+import featurecat.lizzie.analysis.Leelaz;
+import featurecat.lizzie.gui.LizzieFrame;
+import featurecat.lizzie.gui.web.WebBoardManager;
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.json.JSONObject;
+import org.junit.jupiter.api.Test;
+
+class LizzieShutdownTest {
+  @Test
+  void autosaveRuntimeFailureStillPersistsConfigKillsEnginesAndExits() throws Exception {
+    try (Harness harness = Harness.open()) {
+      harness.frame.autoSaveFailure = new IllegalStateException("autosave failed");
+      harness.config.autoSaveOnExit = true;
+      AtomicInteger exitCode = new AtomicInteger(-1);
+
+      Lizzie.shutdown(exitCode::set);
+
+      assertEquals(1, harness.frame.autoSaveCalls);
+      assertTrue(harness.config.persistCalled, "UI persist must run after autosave failure");
+      assertTrue(harness.config.saveCalled, "config save must run after autosave failure");
+      assertEquals(1, harness.engine.forceQuitCount);
+      assertEquals(0, exitCode.get());
+    }
+  }
+
+  @Test
+  void closingWithoutExitAutosaveStillPersistsConfigKillsEnginesAndExits() throws Exception {
+    try (Harness harness = Harness.open()) {
+      harness.config.autoSaveOnExit = false;
+      AtomicInteger exitCode = new AtomicInteger(-1);
+
+      Lizzie.shutdown(exitCode::set);
+
+      assertEquals(0, harness.frame.autoSaveCalls);
+      assertTrue(harness.config.persistCalled);
+      assertTrue(harness.config.saveCalled);
+      assertEquals(1, harness.engine.forceQuitCount);
+      assertEquals(0, exitCode.get());
+    }
+  }
+
+  private static final class Harness implements AutoCloseable {
+    private final Config previousConfig;
+    private final LizzieFrame previousFrame;
+    private final EngineManager previousEngineManager;
+    private final Leelaz previousEngine;
+    private final WebBoardManager previousWebBoardManager;
+    private final RecordingConfig config;
+    private final RecordingFrame frame;
+    private final RecordingLeelaz engine;
+
+    private Harness(
+        Config previousConfig,
+        LizzieFrame previousFrame,
+        EngineManager previousEngineManager,
+        Leelaz previousEngine,
+        WebBoardManager previousWebBoardManager,
+        RecordingConfig config,
+        RecordingFrame frame,
+        RecordingLeelaz engine) {
+      this.previousConfig = previousConfig;
+      this.previousFrame = previousFrame;
+      this.previousEngineManager = previousEngineManager;
+      this.previousEngine = previousEngine;
+      this.previousWebBoardManager = previousWebBoardManager;
+      this.config = config;
+      this.frame = frame;
+      this.engine = engine;
+    }
+
+    private static Harness open() throws Exception {
+      RecordingConfig config = allocate(RecordingConfig.class);
+      config.autoSaveOnExit = true;
+      config.uiConfig = new JSONObject();
+      RecordingFrame frame = allocate(RecordingFrame.class);
+      RecordingLeelaz engine = new RecordingLeelaz();
+      EngineManager engineManager = allocate(EngineManager.class);
+      engineManager.engineList = new ArrayList<>();
+      engineManager.engineList.add(engine);
+      Harness harness =
+          new Harness(
+              Lizzie.config,
+              Lizzie.frame,
+              Lizzie.engineManager,
+              Lizzie.leelaz,
+              Lizzie.webBoardManager,
+              config,
+              frame,
+              engine);
+      Lizzie.config = config;
+      Lizzie.frame = frame;
+      Lizzie.engineManager = engineManager;
+      Lizzie.leelaz = null;
+      Lizzie.webBoardManager = null;
+      return harness;
+    }
+
+    @Override
+    public void close() {
+      Lizzie.config = previousConfig;
+      Lizzie.frame = previousFrame;
+      Lizzie.engineManager = previousEngineManager;
+      Lizzie.leelaz = previousEngine;
+      Lizzie.webBoardManager = previousWebBoardManager;
+    }
+  }
+
+  private static final class RecordingConfig extends Config {
+    private RecordingConfig() throws IOException {}
+
+    boolean persistCalled;
+    boolean saveCalled;
+
+    @Override
+    public void persist() {
+      persistCalled = true;
+    }
+
+    @Override
+    public void save() {
+      saveCalled = true;
+    }
+  }
+
+  private static final class RecordingFrame extends LizzieFrame {
+    int autoSaveCalls;
+    RuntimeException autoSaveFailure;
+
+    @Override
+    public void saveAutoGame(int index) {
+      autoSaveCalls++;
+      if (autoSaveFailure != null) {
+        throw autoSaveFailure;
+      }
+    }
+
+    @Override
+    public void closeContributeEngine() {}
+
+    @Override
+    public void shutdownClockHelper() {}
+  }
+
+  private static final class RecordingLeelaz extends Leelaz {
+    int forceQuitCount;
+
+    private RecordingLeelaz() throws IOException {
+      super("");
+    }
+
+    @Override
+    public boolean isStarted() {
+      return true;
+    }
+
+    @Override
+    public void forceQuit() {
+      forceQuitCount++;
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  private static <T> T allocate(Class<T> type) throws Exception {
+    Field field = sun.misc.Unsafe.class.getDeclaredField("theUnsafe");
+    field.setAccessible(true);
+    return (T) ((sun.misc.Unsafe) field.get(null)).allocateInstance(type);
+  }
+}

--- a/src/test/java/featurecat/lizzie/gui/LizzieFrameRegressionTest.java
+++ b/src/test/java/featurecat/lizzie/gui/LizzieFrameRegressionTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import featurecat.lizzie.Config;
@@ -39,6 +40,7 @@ import java.io.BufferedOutputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -94,6 +96,42 @@ class LizzieFrameRegressionTest {
       allocate(LizzieFrame.class).toggleShowKataEstimate();
     } finally {
       Lizzie.leelaz = previousEngine;
+    }
+  }
+
+  @Test
+  void captureRulesPaintDoesNotThrowWithoutAForegroundEngine() throws Exception {
+    Font previousFont = LizzieFrame.uiFont;
+    try (TestEnvironment env = TestEnvironment.open()) {
+      EmptyEngineUiFrame frame = prepareEmptyEngineUiFrame();
+      LizzieFrame.uiFont = new Font(Font.SANS_SERIF, Font.PLAIN, 12);
+      BufferedImage image = new BufferedImage(200, 120, BufferedImage.TYPE_INT_ARGB);
+      Graphics2D graphics = image.createGraphics();
+      try {
+        assertDoesNotThrow(() -> invokeDrawCaptured(frame, graphics, 0, 0, 200, 120, false));
+        assertDoesNotThrow(() -> invokeDrawMoveStatistics(frame, graphics, 0, 0, 200, 120));
+      } finally {
+        graphics.dispose();
+      }
+    } finally {
+      LizzieFrame.uiFont = previousFont;
+    }
+  }
+
+  @Test
+  void commentSetAndRefreshDoNotTreatAMissingEngineAsLoading() throws Exception {
+    try (TestEnvironment env = TestEnvironment.open()) {
+      EmptyEngineUiFrame frame = prepareEmptyEngineUiFrame();
+
+      assertDoesNotThrow(() -> invokeSetComment(frame, false));
+      assertDoesNotThrow(() -> frame.appendComment());
+      assertDoesNotThrow(() -> frame.refresh());
+
+      String comment = String.valueOf(getField(frame, "cachedComment"));
+      assertEquals("", comment);
+      assertFalse(
+          comment.contains(Lizzie.resourceBundle.getString("LizzieFrame.display.loading")),
+          "an absent foreground engine is idle, not still loading");
     }
   }
 
@@ -2160,6 +2198,80 @@ class LizzieFrameRegressionTest {
     assertSame(frame.replacementReadBoard, frame.readBoard);
   }
 
+  private static EmptyEngineUiFrame prepareEmptyEngineUiFrame() throws Exception {
+    Config config = allocate(Config.class);
+    config.showComment = true;
+    config.commentFontSize = 16;
+    config.uiFontName = Font.SANS_SERIF;
+    config.appendWinrateToComment = false;
+    config.UsePlayMode = false;
+    Lizzie.config = config;
+    installEmptyBoard();
+    EmptyEngineUiFrame frame = allocate(EmptyEngineUiFrame.class);
+    setField(frame, "cachedComment", "");
+    Lizzie.frame = frame;
+    Lizzie.leelaz = null;
+    EngineManager.isEmpty = true;
+    EngineManager.isEngineGame = false;
+    EngineManager.isPreEngineGame = false;
+    return frame;
+  }
+
+  private static void invokeDrawCaptured(
+      LizzieFrame frame, Graphics2D graphics, int x, int y, int width, int height, boolean small)
+      throws Exception {
+    Method method =
+        LizzieFrame.class.getDeclaredMethod(
+            "drawCaptured",
+            Graphics2D.class,
+            int.class,
+            int.class,
+            int.class,
+            int.class,
+            boolean.class);
+    method.setAccessible(true);
+    invokeUnchecked(method, frame, graphics, x, y, width, height, small);
+  }
+
+  private static void invokeDrawMoveStatistics(
+      LizzieFrame frame, Graphics2D graphics, int x, int y, int width, int height)
+      throws Exception {
+    Method method =
+        LizzieFrame.class.getDeclaredMethod(
+            "drawMoveStatistics",
+            Graphics2D.class,
+            int.class,
+            int.class,
+            int.class,
+            int.class);
+    method.setAccessible(true);
+    invokeUnchecked(method, frame, graphics, x, y, width, height);
+  }
+
+  private static void invokeSetComment(LizzieFrame frame, boolean needReaddText) throws Exception {
+    Method method = LizzieFrame.class.getDeclaredMethod("setComment", boolean.class);
+    method.setAccessible(true);
+    invokeUnchecked(method, frame, needReaddText);
+  }
+
+  private static void invokeUnchecked(Method method, Object target, Object... arguments) {
+    try {
+      method.invoke(target, arguments);
+    } catch (InvocationTargetException e) {
+      Throwable cause = e.getCause();
+      if (cause instanceof RuntimeException) {
+        throw (RuntimeException) cause;
+      }
+      if (cause instanceof Error) {
+        throw (Error) cause;
+      }
+      throw new RuntimeException(cause);
+    } catch (ReflectiveOperationException e) {
+      throw new AssertionError(e);
+    }
+  }
+
+
   private static boolean invokeShouldAutoQuickAnalyze(LizzieFrame frame) throws Exception {
     Method method = LizzieFrame.class.getDeclaredMethod("shouldAutoQuickAnalyzeLoadedGame");
     method.setAccessible(true);
@@ -2500,6 +2612,14 @@ class LizzieFrameRegressionTest {
     Field field = Leelaz.class.getDeclaredField(name);
     field.setAccessible(true);
     field.set(engine, value);
+  }
+
+  private static final class EmptyEngineUiFrame extends LizzieFrame {
+    @Override
+    public void requestProblemListRefresh() {}
+
+    @Override
+    public void repaint() {}
   }
 
   private static final class TestEnvironment implements AutoCloseable {

--- a/src/test/java/featurecat/lizzie/rules/SGFParserEmptyEngineSaveTest.java
+++ b/src/test/java/featurecat/lizzie/rules/SGFParserEmptyEngineSaveTest.java
@@ -1,0 +1,60 @@
+package featurecat.lizzie.rules;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import featurecat.lizzie.Lizzie;
+import featurecat.lizzie.analysis.EngineManager;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class SGFParserEmptyEngineSaveTest {
+  @Test
+  void ordinarySaveAllowsAMissingForegroundEngineAndWritesANonKataHeader() throws Exception {
+    try (RulesLayerTestHarness env = RulesLayerTestHarness.open()) {
+      clearForegroundEngine();
+      Lizzie.board.isKataBoard = false;
+
+      String sgf = assertDoesNotThrow(() -> SGFParser.saveToString(false));
+
+      assertFalse(
+          sgf.contains("DZ[G]"),
+          "a non-Kata board with no foreground engine must not write a Kata header");
+      assertTrue(sgf.contains("AP[LizzieYzy Next"), "ordinary save still writes the app header");
+    }
+  }
+
+  @Test
+  void autosaveAllowsAMissingForegroundEngine(@TempDir Path tempDir) throws Exception {
+    try (RulesLayerTestHarness env = RulesLayerTestHarness.open()) {
+      clearForegroundEngine();
+      Path sgfFile = tempDir.resolve("auto.sgf");
+
+      assertDoesNotThrow(() -> SGFParser.save(Lizzie.board, sgfFile.toString(), true));
+      assertTrue(sgfFile.toFile().isFile(), "autosave should still write an SGF file");
+    }
+  }
+
+  @Test
+  void saveUsesTheBoardKataMarkerWhenTheForegroundEngineIsMissing() throws Exception {
+    try (RulesLayerTestHarness env = RulesLayerTestHarness.open()) {
+      clearForegroundEngine();
+      Lizzie.board.isKataBoard = true;
+
+      String sgf = assertDoesNotThrow(() -> SGFParser.saveToString(false));
+
+      assertTrue(
+          sgf.contains("DZ[G]"),
+          "an already-Kata board must keep its Kata header without a live engine");
+    }
+  }
+
+  private static void clearForegroundEngine() {
+    Lizzie.leelaz = null;
+    EngineManager.isEmpty = true;
+    EngineManager.isEngineGame = false;
+    EngineManager.isPreEngineGame = false;
+  }
+}


### PR DESCRIPTION
## Summary

- After a Windows portable folder is moved or copied, config load rebinds the bundled KataGo default slot (and an uncustomized analysis command) to the running package instead of the old absolute path.
- When there is no current primary engine, the main window still paints and refreshes, SGF save does not throw, and shutdown still persists UI, saves config, stops engines, and exits if autosave fails.

Fixes #342

## Type Of Change

- [x] Bug fix
- [ ] Feature
- [ ] Packaging / release update
- [ ] Docs / translation
- [ ] Refactor

## Testing

- [x] Tested locally
- [ ] Verified package contents if packaging changed
- [ ] Verified Fox sync flow if related
- [ ] Added screenshots if UI changed
- [ ] Updated README / docs if user-facing behavior changed
- [x] Noted affected platforms if the change is platform-specific
- [x] Verified there is no unrelated formatting or line-ending churn
- [ ] Ran `python3 scripts/check_line_endings.py` (or equivalent `python` on Windows)

Ticket 01: `ConfigBundledKataGoDefaultsTest` 36/0.
Ticket 02: focused paint/comment, empty-engine SGF save, and shutdown tests passed.
Combined SHA focused: 116/0 (`ConfigBundledKataGoDefaultsTest`, `LizzieShutdownTest`, `SGFParserEmptyEngineSaveTest`, `LizzieFrameRegressionTest`).
Windows Maven `-DskipTests package` SUCCESS on `b5a8c4ea`.

Windows desktop (SHA `b5a8c4ea01fcd17669b6c6f1971f2bba4241b399`):

- Source shaded JAR: main window paints with no primary engine loaded; close via the title-bar X exits the process.
- NVIDIA portable layout from `2026-08-25-windows64.nvidia.portable.zip` with this SHA's shaded JAR: first launch from directory A starts bundled KataGo; after moving the folder to B, bundled KataGo runs from the new folder's `app/engines/katago/windows-x64/katago.exe` and `app/weights/default.bin.gz`; custom engine slots keep their original commands; close from B exits the process.

7 PASS, 0 FAIL, 1 NOT RUN (source JAR autoload-empty, so the "engine already up" check did not apply).

## Notes

Windows portable. Custom weights, customized analysis commands, Java SSH, remote compute, and non-default slots that point at another complete bundle keep their saved commands. Failed engine start still rolls the primary slot back to empty; this change only makes that state drawable and closable.

Reviewers: two commits on `7c35a947` (`fix(config): rebind bundled KataGo default to current package`, `fix(gui): keep the main window usable without a foreground engine`).
