### PR TITLE
Fix Chinese coordinate validation in AI commentary

### DIFF
--- a/src/main/java/featurecat/lizzie/teacher/TeachingEvidenceBuilder.java
+++ b/src/main/java/featurecat/lizzie/teacher/TeachingEvidenceBuilder.java
@@ -693,7 +693,9 @@ public final class TeachingEvidenceBuilder {
   static List<String> extractCoordinates(String markdown) {
     Set<String> result = new HashSet<>();
     if (markdown == null) return new ArrayList<>(result);
-    Matcher mt = Pattern.compile("\\b([A-HJ-T](?:1?\\d|2[0-5]))\\b").matcher(markdown);
+    Matcher mt =
+        Pattern.compile("(?<![A-Za-z0-9])([A-HJ-T](?:1?\\d|2[0-5]))(?![A-Za-z0-9])")
+            .matcher(markdown);
     while (mt.find()) result.add(mt.group(1).toUpperCase());
     return new ArrayList<>(result);
   }


### PR DESCRIPTION
## Summary

- Fixes AI commentary evidence validation when a Go coordinate directly follows Chinese text, such as `推荐T19`.
- Replaces English word-boundary matching with explicit ASCII token boundaries so unsupported recommendations are detected consistently across languages.
- Restores the AI commentary quality gate before the next stable release.

## Validation

- `mvn -B -Dfmt.skip=true -Dtest=TeachingEvidenceBuilderTest,QualityGateTest test`: 12 passed
- `mvn -B -Dfmt.skip=true test`: 3407 tests, 0 failures, 0 errors, 2 skipped
- `mvn -B -Dfmt.skip=true -DskipTests package`: passed
- `git diff --check`: passed
