### PR TITLE
Align Windows downloads with CUDA-first guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,9 @@
 
 > [!IMPORTANT]
 > 如果你只想先下对版本，先记住这几句：
-> - Windows 大多数用户：到 [正式版下载页](https://goagent.top/download/) 下载 `*windows64.opencl.portable.zip`
-> - RTX 20/30/40/50 NVIDIA 显卡：统一下载 `*windows64.nvidia.portable.zip`，内置 CUDA 12.8 + cuDNN 9.8
+> - RTX 20/30/40/50 NVIDIA 显卡：到 [正式版下载页](https://goagent.top/download/) 下载 `*windows64.nvidia.portable.zip`，内置 CUDA 12.8 + cuDNN 9.8
+> - AMD、Intel 或较老的 NVIDIA 显卡：下载 `*windows64.opencl.portable.zip`
+> - 没有合适独立显卡，或 GPU 版本无法正常启动：下载 `*windows64.with-katago.portable.zip` CPU 兼容版
 > - 已经有 Windows 免安装版：日常升级优先下载 `*windows64.core-update.zip`，关闭软件后解压到旧目录覆盖，只更新主程序和启动器配置
 > - RTX 40/50 默认使用 CUDA；TensorRT 是 RTX 30 系及以下 NVIDIA 显卡的可选方案，不再作为“高级版”推荐
 > - 完整包的 CPU、OpenCL、CUDA、TensorRT、Metal 和 Linux 后端已统一升级到 KataGo `v1.18.1`；Linux NVIDIA 仍使用 CUDA 12.1 以兼顾系统运行环境
@@ -98,12 +99,12 @@
 
 | 你的情况 | 到 Releases 里找包含这个关键词的文件 |
 | --- | --- |
-| Windows 大多数用户，推荐，免安装 | `*windows64.opencl.portable.zip` |
-| Windows，OpenCL 版，想安装 | `*windows64.opencl.installer.exe` |
-| Windows，OpenCL 不稳定，CPU 兼容兜底，免安装 | `*windows64.with-katago.portable.zip` |
-| Windows，CPU 兼容兜底，想安装 | `*windows64.with-katago.installer.exe` |
-| Windows，RTX 20/30/40/50 NVIDIA 显卡，免安装 | `*windows64.nvidia.portable.zip` |
+| Windows，RTX 20/30/40/50 NVIDIA 显卡，推荐，免安装 | `*windows64.nvidia.portable.zip` |
 | Windows，RTX 20/30/40/50 NVIDIA 显卡，想安装 | `*windows64.nvidia.installer.exe` |
+| Windows，AMD / Intel / 较老 NVIDIA 显卡，免安装 | `*windows64.opencl.portable.zip` |
+| Windows，AMD / Intel / 较老 NVIDIA 显卡，想安装 | `*windows64.opencl.installer.exe` |
+| Windows，没有合适 GPU 或 GPU 版本无法启动，CPU 兼容版 | `*windows64.with-katago.portable.zip` |
+| Windows，CPU 兼容版，想安装 | `*windows64.with-katago.installer.exe` |
 | 已经有 Windows 免安装版，日常升级 | `*windows64.core-update.zip`，解压到旧目录覆盖 |
 | Windows，RTX 30 系及以下，想测试 TensorRT | 先下载统一 NVIDIA 包，再在 `KataGo 一键设置` 里选装 |
 | Windows，RTX 30 系及以下，想离线测试 TensorRT | `*windows64.nvidia.tensorrt.portable.7z.001` 起的全部分卷，先看同名 `README.txt` |
@@ -122,9 +123,10 @@ Windows `portable.zip` 是真正的免安装模式：配置、日志、保存棋
 
 如果你懒得分辨：
 
-- Windows：先下 `*windows64.opencl.portable.zip`
 - 已经有 Windows 免安装版：先下 `*windows64.core-update.zip` 覆盖旧目录，除非更新说明要求下载完整包
 - Windows + RTX 20/30/40/50 NVIDIA 显卡：统一下载 `*windows64.nvidia.portable.zip`
+- Windows + AMD、Intel 或较老 NVIDIA 显卡：下载 `*windows64.opencl.portable.zip`
+- Windows 没有合适 GPU，或 CUDA/OpenCL 无法正常启动：下载 `*windows64.with-katago.portable.zip`
 - Windows + RTX 30 系及以下想试 TensorRT：先打开统一 NVIDIA/CUDA 包，再在软件内“一键设置”按需安装；RTX 40/50 保留 CUDA
 - TensorRT 一键安装完成后会自动删除完整下载包，之前留下的下载缓存也可以在一键设置里点“清理 TensorRT 缓存”
 - Windows + RTX 30 系及以下需要离线 TensorRT：下载 `*windows64.nvidia.tensorrt.portable.7z.001/.002/...` 全部分卷后从 `.001` 解压

--- a/assets/package-guide-zh.svg
+++ b/assets/package-guide-zh.svg
@@ -21,7 +21,7 @@
   <rect width="1280" height="660" rx="36" fill="url(#bg)"/>
 
   <text x="640" y="108" text-anchor="middle" font-family="PingFang SC, Hiragino Sans GB, Microsoft YaHei, Segoe UI, Arial, sans-serif" font-size="46" font-weight="800" fill="#1A1713">先按你的系统和使用方式选包</text>
-  <text x="640" y="150" text-anchor="middle" font-family="PingFang SC, Hiragino Sans GB, Microsoft YaHei, Segoe UI, Arial, sans-serif" font-size="22" font-weight="500" fill="#735B31">大多数 Windows 用户先选 opencl portable。RTX 20/30/40/50 统一选 nvidia portable。</text>
+  <text x="640" y="150" text-anchor="middle" font-family="PingFang SC, Hiragino Sans GB, Microsoft YaHei, Segoe UI, Arial, sans-serif" font-size="22" font-weight="500" fill="#735B31">RTX 20/30/40/50 选 NVIDIA CUDA；AMD、Intel 与较老 NVIDIA 选 OpenCL。</text>
 
   <g filter="url(#shadow)">
     <rect x="92" y="210" width="336" height="272" rx="28" fill="url(#panel)" stroke="#F3E2BE"/>
@@ -30,11 +30,11 @@
   </g>
 
   <rect x="118" y="238" width="130" height="36" rx="18" fill="#1B4D3E"/>
-  <text x="183" y="261" text-anchor="middle" font-family="PingFang SC, Hiragino Sans GB, Microsoft YaHei, Segoe UI, Arial, sans-serif" font-size="18" font-weight="700" fill="#F7F0DF">最推荐</text>
-  <text x="118" y="322" font-family="Avenir Next, Segoe UI, Arial, sans-serif" font-size="34" font-weight="800" fill="#171513">with-katago</text>
-  <text x="118" y="360" font-family="PingFang SC, Hiragino Sans GB, Microsoft YaHei, Segoe UI, Arial, sans-serif" font-size="21" font-weight="700" fill="#715B33">已带好分析环境</text>
-  <text x="118" y="402" font-family="PingFang SC, Hiragino Sans GB, Microsoft YaHei, Segoe UI, Arial, sans-serif" font-size="18" font-weight="500" fill="#6F5A33">适合想省事的人，下载后更快开始</text>
-  <text x="118" y="428" font-family="PingFang SC, Hiragino Sans GB, Microsoft YaHei, Segoe UI, Arial, sans-serif" font-size="18" font-weight="500" fill="#6F5A33">抓谱、分析和复盘。</text>
+  <text x="183" y="261" text-anchor="middle" font-family="PingFang SC, Hiragino Sans GB, Microsoft YaHei, Segoe UI, Arial, sans-serif" font-size="18" font-weight="700" fill="#F7F0DF">按显卡选</text>
+  <text x="118" y="322" font-family="Avenir Next, Segoe UI, Arial, sans-serif" font-size="34" font-weight="800" fill="#171513">Windows portable</text>
+  <text x="118" y="360" font-family="PingFang SC, Hiragino Sans GB, Microsoft YaHei, Segoe UI, Arial, sans-serif" font-size="21" font-weight="700" fill="#715B33">CUDA / OpenCL / CPU</text>
+  <text x="118" y="402" font-family="PingFang SC, Hiragino Sans GB, Microsoft YaHei, Segoe UI, Arial, sans-serif" font-size="18" font-weight="500" fill="#6F5A33">RTX 20/30/40/50 选 NVIDIA，</text>
+  <text x="118" y="428" font-family="PingFang SC, Hiragino Sans GB, Microsoft YaHei, Segoe UI, Arial, sans-serif" font-size="18" font-weight="500" fill="#6F5A33">AMD、Intel 与较老显卡选 OpenCL。</text>
 
   <rect x="498" y="238" width="144" height="36" rx="18" fill="#2F4858"/>
   <text x="570" y="261" text-anchor="middle" font-family="PingFang SC, Hiragino Sans GB, Microsoft YaHei, Segoe UI, Arial, sans-serif" font-size="18" font-weight="700" fill="#F5F7FA">自己配置</text>
@@ -57,7 +57,7 @@
     <rect x="884" y="520" width="304" height="84" rx="24" fill="url(#platform)" stroke="#F1DDB6"/>
 
     <text x="218" y="554" text-anchor="middle" font-family="PingFang SC, Hiragino Sans GB, Microsoft YaHei, Segoe UI, Arial, sans-serif" font-size="18" font-weight="700" fill="#7A5926">Windows 64 位</text>
-    <text x="218" y="584" text-anchor="middle" font-family="Avenir Next, Segoe UI, Arial, sans-serif" font-size="16" font-weight="600" fill="#23201C">opencl / unified nvidia / installer 可选</text>
+    <text x="218" y="584" text-anchor="middle" font-family="Avenir Next, Segoe UI, Arial, sans-serif" font-size="16" font-weight="600" fill="#23201C">nvidia / opencl / cpu portable</text>
 
     <text x="482" y="554" text-anchor="middle" font-family="PingFang SC, Hiragino Sans GB, Microsoft YaHei, Segoe UI, Arial, sans-serif" font-size="18" font-weight="700" fill="#7A5926">macOS Apple Silicon</text>
     <text x="482" y="584" text-anchor="middle" font-family="Avenir Next, Segoe UI, Arial, sans-serif" font-size="17" font-weight="600" fill="#23201C">mac-arm64.dmg</text>

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -11,7 +11,7 @@
 
 这份安装指南对应的是当前仍在维护的 `LizzieYzy Next`，也就是很多人还在找的 `lizzieyzy 维护版 / 替代版本`。
 
-- 如果你在找 `KataGo 围棋复盘软件` 的 Windows 免安装包，先下载 `windows64.opencl.portable.zip`
+- 如果你在找 `KataGo 围棋复盘软件` 的 Windows 免安装包，先按显卡选择：RTX 20/30/40/50 用 NVIDIA CUDA，AMD/Intel/较老 NVIDIA 用 OpenCL，没有合适 GPU 再用 CPU 兼容版
 - 如果你想找 `还能继续用的 lizzieyzy 维护版`，这个项目就是现在应该优先看的版本
 - 如果你想 `输入野狐昵称后直接抓谱再复盘`，当前维护版已经支持
 - 如果你担心第一次启动要自己配很多东西，主推荐整合包已经内置 KataGo 和默认权重
@@ -21,12 +21,12 @@
 
 | 你的系统 | 推荐下载 | 内置 Java | 内置 KataGo | 适合谁 |
 | --- | --- | --- | --- | --- |
-| Windows 64 位 | `<date>-windows64.opencl.portable.zip` | 是 | 是 | 普通用户首选，免安装，解压即用 |
-| Windows 64 位 | `<date>-windows64.opencl.installer.exe` | 是 | 是 | 想保留安装流程的 OpenCL 用户 |
-| Windows 64 位 | `<date>-windows64.with-katago.portable.zip` | 是 | 是 | OpenCL 不稳定时的 CPU 兜底，免安装 |
-| Windows 64 位 | `<date>-windows64.with-katago.installer.exe` | 是 | 是 | 想安装的 CPU 兜底版 |
-| Windows 64 位 | `<date>-windows64.nvidia.portable.zip` | 是 | 是 | RTX 20/30/40/50 NVIDIA 显卡，免安装 |
+| Windows 64 位 | `<date>-windows64.nvidia.portable.zip` | 是 | 是 | RTX 20/30/40/50 NVIDIA 显卡，推荐，免安装 |
 | Windows 64 位 | `<date>-windows64.nvidia.installer.exe` | 是 | 是 | RTX 20/30/40/50 NVIDIA 显卡，想保留安装流程 |
+| Windows 64 位 | `<date>-windows64.opencl.portable.zip` | 是 | 是 | AMD、Intel 或较老 NVIDIA 显卡，免安装 |
+| Windows 64 位 | `<date>-windows64.opencl.installer.exe` | 是 | 是 | 想保留安装流程的 OpenCL 用户 |
+| Windows 64 位 | `<date>-windows64.with-katago.portable.zip` | 是 | 是 | 没有合适 GPU 或 GPU 版本无法启动时的 CPU 兜底 |
+| Windows 64 位 | `<date>-windows64.with-katago.installer.exe` | 是 | 是 | 想安装的 CPU 兜底版 |
 | Windows 64 位 | `<date>-windows64.without.engine.portable.zip` | 是 | 否 | 想自己配引擎，也不想安装 |
 | Windows 64 位 | `<date>-windows64.without.engine.installer.exe` | 是 | 否 | 想保留安装流程，但自己配引擎 |
 | macOS Apple Silicon | `<date>-mac-apple-silicon.with-katago.dmg` | App 自带运行时 | 是 | M 系列 Mac |
@@ -37,9 +37,9 @@
 
 一句话建议：
 
-- 想最省事：选 `windows64.opencl.portable.zip`
-- 如果 OpenCL 在你电脑上不稳定：改用 `windows64.with-katago.portable.zip`
-- RTX 20/30/40/50 NVIDIA 显卡想跑得更快：统一选 `windows64.nvidia.portable.zip`
+- RTX 20/30/40/50 NVIDIA 显卡：统一选 `windows64.nvidia.portable.zip`
+- AMD、Intel 或较老 NVIDIA 显卡：选 `windows64.opencl.portable.zip`
+- 没有合适 GPU，或 CUDA/OpenCL 在你电脑上无法正常启动：改用 `windows64.with-katago.portable.zip`
 - RTX 40/50 默认使用 CUDA；RTX 30 系及以下可在 `KataGo 一键设置` 中按需安装 TensorRT 作为可选方案
 - `KataGo 一键设置` 会检测 NVIDIA GPU / Compute Capability，再给出 TensorRT 推荐状态
 - NVIDIA 驱动 `570.65` 及以上直接加载；`528.33` 至 `570.64` 首次运行会执行一次轻量真实推理探测；更旧驱动会显示明确修复提示
@@ -68,14 +68,14 @@
 
 ## Windows 安装
 
-### Windows 64 位 OpenCL 免安装包（推荐）
+### Windows 64 位 OpenCL 免安装包
 
 1. 下载 `windows64.opencl.portable.zip`。
 2. 解压到普通目录，例如 `D:\LizzieYzy-Next`。
 3. 打开解压后的目录。
 4. 双击 `LizzieYzy Next OpenCL.exe`。
 
-这是当前最推荐给普通用户的 Windows 路径。
+这是 AMD、Intel 和较老 NVIDIA 显卡的兼容路径。
 OpenCL 免安装包也能直接打开 `KataGo 一键设置`，点一次“智能测速优化”，自动写入更合适的线程数。
 
 ### Windows 64 位 OpenCL 安装器
@@ -95,7 +95,7 @@ OpenCL 免安装包也能直接打开 `KataGo 一键设置`，点一次“智能
 2. 解压后运行 `LizzieYzy Next.exe`。
 3. 如果你更喜欢安装流程，再改用 `windows64.with-katago.installer.exe`。
 
-### Windows 64 位 NVIDIA 极速版
+### Windows 64 位 NVIDIA CUDA 推荐版
 
 如果你的电脑有 NVIDIA 显卡，而且你更在意分析速度：
 
@@ -113,7 +113,7 @@ OpenCL 免安装包也能直接打开 `KataGo 一键设置`，点一次“智能
 注意：
 
 - 这个版本只适合 NVIDIA 显卡电脑。
-- 如果你不确定自己是不是 NVIDIA 显卡，直接下载普通的 `windows64.opencl.portable.zip`。
+- 可在 Windows“任务管理器 -> 性能 -> GPU”查看显卡名称；RTX 20/30/40/50 选 NVIDIA 包，AMD、Intel 或较老 NVIDIA 选 OpenCL 包。
 
 ### Windows 64 位统一 NVIDIA CUDA 和 TensorRT 可选方案
 

--- a/docs/PACKAGES.md
+++ b/docs/PACKAGES.md
@@ -12,7 +12,9 @@
 
 - 当前维护版公开主推 13 个首次下载稳定资产，另有 6 个 Windows 实验便携包和 1 个 Windows 免安装小更新包
 - Windows 默认优先推荐 `portable.zip`
-- 大多数普通用户先下 `windows64.opencl.portable.zip`
+- RTX 20/30/40/50 NVIDIA 用户优先下载 `windows64.nvidia.portable.zip`
+- AMD、Intel 或较老 NVIDIA 显卡用户下载 `windows64.opencl.portable.zip`
+- 没有合适 GPU，或 GPU 版本无法正常启动时，使用 `windows64.with-katago.portable.zip` CPU 兼容版
 - 已有 Windows 免安装版的老用户，日常升级优先下载 `windows64.core-update.zip` 覆盖旧目录，只更新主程序和启动器配置
 - OpenCL 表现不好时改用 `windows64.with-katago.portable.zip`
 - RTX 20/30/40/50 NVIDIA 显卡统一使用 CUDA 12.8 的 `windows64.nvidia.portable.zip`
@@ -36,12 +38,12 @@
 
 | 包类型 | 典型文件名 | 适合谁 |
 | --- | --- | --- |
-| Windows 64 位 OpenCL 免安装包 | `<date>-windows64.opencl.portable.zip` | 普通用户首选，解压后直接运行 |
-| Windows 64 位 OpenCL 安装器 | `<date>-windows64.opencl.installer.exe` | 想保留安装流程的 OpenCL 用户 |
-| Windows 64 位 CPU 兜底免安装包 | `<date>-windows64.with-katago.portable.zip` | OpenCL 表现不好时切换使用 |
-| Windows 64 位 CPU 兜底安装器 | `<date>-windows64.with-katago.installer.exe` | 想安装的 CPU 兜底用户 |
-| Windows 64 位 NVIDIA CUDA 免安装包 | `<date>-windows64.nvidia.portable.zip` | RTX 20/30/40/50 NVIDIA 显卡，解压即用 |
+| Windows 64 位 NVIDIA CUDA 免安装包 | `<date>-windows64.nvidia.portable.zip` | RTX 20/30/40/50 NVIDIA 显卡，推荐，解压即用 |
 | Windows 64 位 NVIDIA CUDA 安装器 | `<date>-windows64.nvidia.installer.exe` | RTX 20/30/40/50 NVIDIA 显卡，想保留安装流程 |
+| Windows 64 位 OpenCL 免安装包 | `<date>-windows64.opencl.portable.zip` | AMD、Intel 或较老 NVIDIA 显卡，解压后直接运行 |
+| Windows 64 位 OpenCL 安装器 | `<date>-windows64.opencl.installer.exe` | 想保留安装流程的 OpenCL 用户 |
+| Windows 64 位 CPU 兜底免安装包 | `<date>-windows64.with-katago.portable.zip` | 没有合适 GPU 或 GPU 版本无法启动时使用 |
+| Windows 64 位 CPU 兜底安装器 | `<date>-windows64.with-katago.installer.exe` | 想安装的 CPU 兜底用户 |
 | Windows 免安装小更新包 | `<date>-windows64.core-update.zip` | 已经有旧版免安装目录，只想日常升级主程序的用户 |
 | Windows 64 位 TensorRT 可选分卷包 | `<date>-windows64.nvidia.tensorrt.portable.7z.001` 等全部分卷 | 熟悉 7-Zip、想离线使用 TensorRT 的 RTX 30 系及以下用户 |
 | Windows 64 位无引擎便携包 | `<date>-windows64.without.engine.portable.zip` | 想自己配置分析引擎 |
@@ -101,8 +103,9 @@
 
 如果你只想尽快开始：
 
-- Windows：选 `windows64.opencl.portable.zip`
 - Windows + RTX 20/30/40/50 NVIDIA 显卡：统一选 `windows64.nvidia.portable.zip`
+- Windows + AMD、Intel 或较老 NVIDIA 显卡：选 `windows64.opencl.portable.zip`
+- Windows 没有合适 GPU，或 CUDA/OpenCL 无法正常启动：选 `windows64.with-katago.portable.zip`
 - macOS：按芯片选对应的 `with-katago.dmg`
 - Linux：选 `linux64.with-katago.zip`
 

--- a/docs/PACKAGES_EN.md
+++ b/docs/PACKAGES_EN.md
@@ -12,7 +12,9 @@ This page describes the public release layout of the maintained `LizzieYzy Next`
 
 - The maintained release page centers on 13 stable first-download assets, plus 6 Windows experimental portable packages
 - On Windows, the default recommendation is now `portable.zip`
-- Most regular users should start with `windows64.opencl.portable.zip`
+- RTX 20/30/40/50 NVIDIA users should start with `windows64.nvidia.portable.zip`
+- AMD, Intel, and older NVIDIA users should choose `windows64.opencl.portable.zip`
+- PCs without a suitable GPU, or where GPU builds cannot start, should use the `windows64.with-katago.portable.zip` CPU compatibility build
 - If OpenCL behaves poorly, switch to `windows64.with-katago.portable.zip`
 - RTX 20/30/40/50 NVIDIA users share the CUDA 12.8 `windows64.nvidia.portable.zip`
 - RTX 40/50 should use CUDA by default; TensorRT is an optional alternative for RTX 30 series and earlier
@@ -23,12 +25,12 @@ This page describes the public release layout of the maintained `LizzieYzy Next`
 
 | Package type | Typical filename | Best for |
 | --- | --- | --- |
-| Windows x64 OpenCL portable | `<date>-windows64.opencl.portable.zip` | Main recommendation for regular users |
-| Windows x64 OpenCL installer | `<date>-windows64.opencl.installer.exe` | OpenCL users who prefer an installer |
-| Windows x64 CPU fallback portable | `<date>-windows64.with-katago.portable.zip` | CPU fallback when OpenCL behaves badly |
-| Windows x64 CPU fallback installer | `<date>-windows64.with-katago.installer.exe` | CPU fallback with installer flow |
-| Windows x64 NVIDIA CUDA portable | `<date>-windows64.nvidia.portable.zip` | RTX 20/30/40/50 NVIDIA users, unzip and run |
+| Windows x64 NVIDIA CUDA portable | `<date>-windows64.nvidia.portable.zip` | Recommended for RTX 20/30/40/50 NVIDIA users |
 | Windows x64 NVIDIA CUDA installer | `<date>-windows64.nvidia.installer.exe` | RTX 20/30/40/50 NVIDIA users who prefer an installer |
+| Windows x64 OpenCL portable | `<date>-windows64.opencl.portable.zip` | AMD, Intel, and older NVIDIA GPUs |
+| Windows x64 OpenCL installer | `<date>-windows64.opencl.installer.exe` | OpenCL users who prefer an installer |
+| Windows x64 CPU fallback portable | `<date>-windows64.with-katago.portable.zip` | PCs without a suitable GPU or when GPU builds cannot start |
+| Windows x64 CPU fallback installer | `<date>-windows64.with-katago.installer.exe` | CPU fallback with installer flow |
 | Windows x64 no-engine portable | `<date>-windows64.without.engine.portable.zip` | Custom KataGo setup |
 | Windows x64 no-engine installer | `<date>-windows64.without.engine.installer.exe` | Users who want installer flow with their own engine |
 | macOS Apple Silicon bundle | `<date>-mac-apple-silicon.with-katago.dmg` | M-series Macs |
@@ -81,8 +83,9 @@ Each experimental package still contains KataGo v1.18.1, the B11 default weight,
 
 If you just want the shortest path:
 
-- Windows: choose `windows64.opencl.portable.zip`
 - Windows with an RTX 20/30/40/50 NVIDIA GPU: choose the unified `windows64.nvidia.portable.zip`
+- Windows with an AMD, Intel, or older NVIDIA GPU: choose `windows64.opencl.portable.zip`
+- Windows without a suitable GPU, or when CUDA/OpenCL cannot start: choose `windows64.with-katago.portable.zip`
 - macOS: choose the correct `with-katago.dmg` for your chip
 - Linux: choose `linux64.with-katago.zip`
 

--- a/docs/RELEASE_NOTES_TEMPLATE.md
+++ b/docs/RELEASE_NOTES_TEMPLATE.md
@@ -12,9 +12,9 @@
 
 ## 下载前先看这几句
 
-- Windows 用户先下载 `<date>-windows64.opencl.portable.zip`
-- 如果 OpenCL 在你的电脑上表现不好，就改用 `<date>-windows64.with-katago.portable.zip`
 - RTX 20/30/40/50 NVIDIA 显卡统一下载 `<date>-windows64.nvidia.portable.zip`，内置 CUDA 12.8 + cuDNN 9.8
+- AMD、Intel 或较老 NVIDIA 显卡下载 `<date>-windows64.opencl.portable.zip`
+- 没有合适 GPU，或 CUDA/OpenCL 无法正常启动时，使用 `<date>-windows64.with-katago.portable.zip` CPU 兼容版
 - RTX 40/50 默认推荐 CUDA；TensorRT 是 RTX 30 系及以下 NVIDIA 显卡的软件内可选方案
 - 推荐完整包默认内置官方 B11 旗舰 Transformer：单次判断更强、复杂局面效果更好，但搜索可能比 B10 慢；追求速度可在一键设置中切换 B10
 - 抓野狐棋谱时直接输入“野狐昵称”，程序会自动找到账号并抓最近公开棋谱
@@ -35,12 +35,12 @@
 
 | 你的系统 | 直接下载这个 | 说明 |
 | --- | --- | --- |
-| Windows 64 位 | `<date>-windows64.opencl.portable.zip` | 主推荐，解压后直接运行 |
-| Windows 64 位 | `<date>-windows64.opencl.installer.exe` | 想保留安装流程时再选 |
+| Windows 64 位，RTX 20/30/40/50 NVIDIA | `<date>-windows64.nvidia.portable.zip` | 推荐 CUDA 12.8 包，免安装 |
+| Windows 64 位，RTX 20/30/40/50 NVIDIA | `<date>-windows64.nvidia.installer.exe` | 推荐 CUDA 12.8 包，安装器 |
+| Windows 64 位，AMD / Intel / 较老 NVIDIA | `<date>-windows64.opencl.portable.zip` | OpenCL 兼容版，免安装 |
+| Windows 64 位，AMD / Intel / 较老 NVIDIA | `<date>-windows64.opencl.installer.exe` | OpenCL 兼容版，安装器 |
 | Windows 64 位 | `<date>-windows64.with-katago.portable.zip` | OpenCL 表现不好时的 CPU 兜底免安装版 |
 | Windows 64 位 | `<date>-windows64.with-katago.installer.exe` | 想安装的 CPU 兜底版 |
-| Windows 64 位，RTX 20/30/40/50 NVIDIA | `<date>-windows64.nvidia.portable.zip` | 统一 CUDA 12.8 包，免安装 |
-| Windows 64 位，RTX 20/30/40/50 NVIDIA | `<date>-windows64.nvidia.installer.exe` | 统一 CUDA 12.8 包，安装器 |
 | Windows 64 位，RTX 30 系及以下 TensorRT | 先下载统一 NVIDIA 包 | 打开后在 `KataGo 一键设置` 里按需安装 |
 | Windows 64 位 | `<date>-windows64.without.engine.portable.zip` | 想自己决定分析引擎时再选 |
 | Windows 64 位 | `<date>-windows64.without.engine.installer.exe` | 想保留安装流程，但自己决定分析引擎 |
@@ -66,12 +66,12 @@
 
 ## Download quick guide
 
-- Windows x64: choose `<date>-windows64.opencl.portable.zip`
+- Windows x64 with RTX 20/30/40/50 NVIDIA GPU: choose `<date>-windows64.nvidia.portable.zip`
+- Windows x64 NVIDIA installer alternative: choose `<date>-windows64.nvidia.installer.exe`
+- Windows x64 with AMD, Intel, or older NVIDIA GPU: choose `<date>-windows64.opencl.portable.zip`
 - Windows x64 OpenCL installer alternative: choose `<date>-windows64.opencl.installer.exe`
 - Windows x64 CPU fallback: choose `<date>-windows64.with-katago.portable.zip`
 - Windows x64 CPU fallback installer: choose `<date>-windows64.with-katago.installer.exe`
-- Windows x64 with RTX 20/30/40/50 NVIDIA GPU: choose the unified `<date>-windows64.nvidia.portable.zip`
-- Windows x64 NVIDIA installer alternative: choose `<date>-windows64.nvidia.installer.exe`
 - Windows x64 RTX 30 series and earlier TensorRT: start with the unified NVIDIA package, then install TensorRT from KataGo Auto Setup
 - Windows x64 custom engine: choose `<date>-windows64.without.engine.portable.zip`
 - Windows x64 custom engine installer: choose `<date>-windows64.without.engine.installer.exe`

--- a/scripts/generate_release_notes.py
+++ b/scripts/generate_release_notes.py
@@ -434,6 +434,168 @@ def add_nvidia50_download_rows(
             before_items.append(note)
 
 
+def apply_current_windows_download_guidance(
+    sections: list[dict[str, object]],
+    assets_cn: dict[str, str],
+    assets: dict[str, str],
+) -> None:
+    """Keep current/future notes hardware-specific without rewriting historical tags."""
+
+    language_keys = {
+        '中文': 'zh',
+        '繁體中文': 'zh_hant',
+        'English': 'en',
+        '日本語': 'ja',
+        '한국어': 'ko',
+        'ภาษาไทย': 'th',
+    }
+    before_templates = {
+        '中文': (
+            'RTX 20/30/40/50 NVIDIA 显卡优先下载 {nvidia}。',
+            'AMD、Intel 或较老 NVIDIA 显卡下载 {opencl}。',
+            '没有合适 GPU，或 CUDA/OpenCL 无法正常启动时，使用 {cpu} CPU 兼容版。',
+        ),
+        '繁體中文': (
+            'RTX 20/30/40/50 NVIDIA 顯示卡優先下載 {nvidia}。',
+            'AMD、Intel 或較舊 NVIDIA 顯示卡下載 {opencl}。',
+            '沒有合適 GPU，或 CUDA/OpenCL 無法正常啟動時，使用 {cpu} CPU 相容版。',
+        ),
+        'English': (
+            'RTX 20/30/40/50 NVIDIA users should choose {nvidia}.',
+            'AMD, Intel, and older NVIDIA users should choose {opencl}.',
+            'Use the {cpu} CPU compatibility build when no suitable GPU backend can start.',
+        ),
+        '日本語': (
+            'RTX 20/30/40/50 NVIDIA GPU では {nvidia} を選んでください。',
+            'AMD、Intel、旧 NVIDIA GPU では {opencl} を選んでください。',
+            '適切な GPU backend を起動できない場合は {cpu} CPU 互換版を使用してください。',
+        ),
+        '한국어': (
+            'RTX 20/30/40/50 NVIDIA GPU 사용자는 {nvidia} 를 선택하세요.',
+            'AMD, Intel, 구형 NVIDIA GPU 사용자는 {opencl} 를 선택하세요.',
+            '적합한 GPU backend 를 시작할 수 없으면 {cpu} CPU 호환판을 사용하세요.',
+        ),
+        'ภาษาไทย': (
+            'ผู้ใช้ NVIDIA RTX 20/30/40/50 ควรเลือก {nvidia}',
+            'ผู้ใช้ AMD, Intel หรือ NVIDIA รุ่นเก่าควรเลือก {opencl}',
+            'หากไม่มี GPU backend ที่เหมาะสมหรือเปิดไม่ได้ ให้ใช้ {cpu} รุ่น CPU compatibility',
+        ),
+    }
+    why_items = {
+        '中文': (
+            'Windows 现在按硬件明确区分 CUDA、OpenCL 和 CPU 兼容版，下载时不再猜。',
+            'RTX 20/30/40/50 统一使用 NVIDIA CUDA；AMD、Intel 和较老 NVIDIA 使用 OpenCL。',
+        ),
+        '繁體中文': (
+            'Windows 現在依硬體清楚區分 CUDA、OpenCL 與 CPU 相容版，下載時不用再猜。',
+            'RTX 20/30/40/50 統一使用 NVIDIA CUDA；AMD、Intel 與較舊 NVIDIA 使用 OpenCL。',
+        ),
+        'English': (
+            'Windows downloads are now clearly separated into CUDA, OpenCL, and CPU compatibility paths by hardware.',
+            'RTX 20/30/40/50 use NVIDIA CUDA; AMD, Intel, and older NVIDIA GPUs use OpenCL.',
+        ),
+        '日本語': (
+            'Windows のダウンロードを、hardware に応じて CUDA、OpenCL、CPU 互換版へ明確に分けました。',
+            'RTX 20/30/40/50 は NVIDIA CUDA、AMD、Intel、旧 NVIDIA は OpenCL を使用します。',
+        ),
+        '한국어': (
+            'Windows 다운로드를 하드웨어에 따라 CUDA, OpenCL, CPU 호환 경로로 명확히 나눴습니다.',
+            'RTX 20/30/40/50은 NVIDIA CUDA, AMD, Intel, 구형 NVIDIA는 OpenCL을 사용합니다.',
+        ),
+        'ภาษาไทย': (
+            'แยกดาวน์โหลด Windows เป็น CUDA, OpenCL และ CPU compatibility ตาม hardware อย่างชัดเจน',
+            'RTX 20/30/40/50 ใช้ NVIDIA CUDA ส่วน AMD, Intel และ NVIDIA รุ่นเก่าใช้ OpenCL',
+        ),
+    }
+    legacy_why_markers = (
+        'OpenCL 版现在放到推荐位',
+        'OpenCL 版放到推薦位',
+        'OpenCL 版現在放到推薦位',
+        'OpenCL Windows bundle is now the main recommended',
+        'OpenCL build is the recommended Windows',
+        'OpenCL 版を推奨',
+        'OpenCL 版は Windows の推奨',
+        'OpenCL 빌드를 추천',
+        'OpenCL 빌드는 더 빠른 분석 속도를 위한 Windows 추천',
+        'แนะนำ OpenCL build เป็นตัวหลัก',
+        'OpenCL build เป็นตัวแนะนำหลัก',
+    )
+
+    for section in sections:
+        language = str(section['language'])
+        label_key = language_keys.get(language, 'en')
+        localized_assets = assets_cn if language in ('中文', '繁體中文') else assets
+        selected_assets = {
+            localized_assets['windows_nvidia_portable'],
+            localized_assets['windows_nvidia_installer'],
+            localized_assets['windows_opencl_portable'],
+            localized_assets['windows_opencl_installer'],
+            localized_assets['windows_portable'],
+            localized_assets['windows_installer'],
+        }
+
+        before = section['before']
+        assert isinstance(before, dict)
+        before_items = before['items']
+        assert isinstance(before_items, list)
+        before['items'] = [
+            item
+            for item in before_items
+            if not any(asset in str(item) for asset in selected_assets)
+            and not any(marker in str(item) for marker in legacy_why_markers)
+        ]
+        guidance = [
+            template.format(
+                nvidia=localized_assets['windows_nvidia_portable'],
+                opencl=localized_assets['windows_opencl_portable'],
+                cpu=localized_assets['windows_portable'],
+            )
+            for template in before_templates.get(language, before_templates['English'])
+        ]
+        before['items'] = guidance + before['items']
+
+        download = section['download']
+        assert isinstance(download, dict)
+        rows = download['rows']
+        assert isinstance(rows, list)
+        table_keys = [asset.key for asset in topology.release_notes_table_assets()]
+        preferred_keys = [
+            'windows_nvidia_portable',
+            'windows_nvidia_installer',
+            'windows_opencl_portable',
+            'windows_opencl_installer',
+            'windows_portable',
+            'windows_installer',
+        ]
+        ordered_keys = preferred_keys + [
+            key for key in table_keys if key not in preferred_keys
+        ]
+        managed_assets = {localized_assets[key] for key in table_keys}
+        remaining_rows = [
+            row
+            for row in rows
+            if not (isinstance(row, tuple) and row[1] in managed_assets)
+        ]
+        labels = STANDARD_DOWNLOAD_LABELS[label_key]
+        download['rows'] = [
+            (labels[key], localized_assets[key])
+            for key in ordered_keys
+        ] + [
+            *remaining_rows,
+        ]
+
+        why = section['why']
+        assert isinstance(why, dict)
+        why_items_existing = why['items']
+        assert isinstance(why_items_existing, list)
+        why['items'] = [
+            item
+            for item in why_items_existing
+            if not any(marker in str(item) for marker in legacy_why_markers)
+        ]
+        why['items'][3:3] = list(why_items.get(language, why_items['English']))
+
+
 def add_tensorrt_split_download_row(
     sections: list[dict[str, object]],
     assets_cn: dict[str, str],
@@ -514,12 +676,12 @@ def standard_download_rows(labels: dict[str, str], localized_assets: dict[str, s
 
 STANDARD_DOWNLOAD_LABELS = {
     'zh': {
-        'windows_opencl_portable': 'Windows 64 位，OpenCL 版，推荐更快，免安装',
-        'windows_opencl_installer': 'Windows 64 位，OpenCL 版，想安装',
+        'windows_opencl_portable': 'Windows 64 位，AMD / Intel / 较老 NVIDIA，OpenCL 兼容版，免安装',
+        'windows_opencl_installer': 'Windows 64 位，AMD / Intel / 较老 NVIDIA，OpenCL 兼容安装版',
         'windows_portable': 'Windows 64 位，CPU 兼容版，免安装',
         'windows_installer': 'Windows 64 位，CPU 兼容版，想安装',
-        'windows_nvidia_portable': 'Windows 64 位，NVIDIA 显卡，免安装',
-        'windows_nvidia_installer': 'Windows 64 位，NVIDIA 显卡，想安装',
+        'windows_nvidia_portable': 'Windows 64 位，RTX 20/30/40/50，NVIDIA CUDA 推荐版，免安装',
+        'windows_nvidia_installer': 'Windows 64 位，RTX 20/30/40/50，NVIDIA CUDA 推荐安装版',
         'windows_directml_experimental': 'Windows 64 位，DirectML 实验版，DirectX 12 GPU',
         'windows_openvino_experimental': 'Windows 64 位，OpenVINO 实验版，Intel GPU/NPU',
         'windows_rocm_gfx103x_experimental': 'Windows 64 位，ROCm 实验版，AMD RX 6000',
@@ -535,12 +697,12 @@ STANDARD_DOWNLOAD_LABELS = {
         'linux64_nvidia': 'Linux 64 位，NVIDIA CUDA 版',
     },
     'zh_hant': {
-        'windows_opencl_portable': 'Windows 64 位，OpenCL 版，推薦更快，免安裝',
-        'windows_opencl_installer': 'Windows 64 位，OpenCL 版，想安裝',
+        'windows_opencl_portable': 'Windows 64 位，AMD / Intel / 較舊 NVIDIA，OpenCL 相容版，免安裝',
+        'windows_opencl_installer': 'Windows 64 位，AMD / Intel / 較舊 NVIDIA，OpenCL 相容安裝版',
         'windows_portable': 'Windows 64 位，CPU 相容版，免安裝',
         'windows_installer': 'Windows 64 位，CPU 相容版，想安裝',
-        'windows_nvidia_portable': 'Windows 64 位，NVIDIA 顯示卡，免安裝',
-        'windows_nvidia_installer': 'Windows 64 位，NVIDIA 顯示卡，想安裝',
+        'windows_nvidia_portable': 'Windows 64 位，RTX 20/30/40/50，NVIDIA CUDA 建議版，免安裝',
+        'windows_nvidia_installer': 'Windows 64 位，RTX 20/30/40/50，NVIDIA CUDA 建議安裝版',
         'windows_directml_experimental': 'Windows 64 位，DirectML 實驗版，DirectX 12 GPU',
         'windows_openvino_experimental': 'Windows 64 位，OpenVINO 實驗版，Intel GPU/NPU',
         'windows_rocm_gfx103x_experimental': 'Windows 64 位，ROCm 實驗版，AMD RX 6000',
@@ -556,12 +718,12 @@ STANDARD_DOWNLOAD_LABELS = {
         'linux64_nvidia': 'Linux 64 位，NVIDIA CUDA 版',
     },
     'en': {
-        'windows_opencl_portable': 'Windows 64-bit, OpenCL, recommended and faster, no install',
-        'windows_opencl_installer': 'Windows 64-bit, OpenCL, installer',
+        'windows_opencl_portable': 'Windows 64-bit, AMD / Intel / older NVIDIA, OpenCL compatibility, no install',
+        'windows_opencl_installer': 'Windows 64-bit, AMD / Intel / older NVIDIA, OpenCL compatibility installer',
         'windows_portable': 'Windows 64-bit, CPU compatible build, no install',
         'windows_installer': 'Windows 64-bit, CPU compatible build, installer',
-        'windows_nvidia_portable': 'Windows 64-bit, NVIDIA GPU, no install',
-        'windows_nvidia_installer': 'Windows 64-bit, NVIDIA GPU, installer',
+        'windows_nvidia_portable': 'Windows 64-bit, RTX 20/30/40/50, recommended NVIDIA CUDA, no install',
+        'windows_nvidia_installer': 'Windows 64-bit, RTX 20/30/40/50, recommended NVIDIA CUDA installer',
         'windows_directml_experimental': 'Windows 64-bit, DirectML experimental, DirectX 12 GPU',
         'windows_openvino_experimental': 'Windows 64-bit, OpenVINO experimental, Intel GPU/NPU',
         'windows_rocm_gfx103x_experimental': 'Windows 64-bit, ROCm experimental, AMD RX 6000',
@@ -577,12 +739,12 @@ STANDARD_DOWNLOAD_LABELS = {
         'linux64_nvidia': 'Linux 64-bit, NVIDIA CUDA',
     },
     'ja': {
-        'windows_opencl_portable': 'Windows 64-bit、OpenCL 推奨高速版、インストール不要',
-        'windows_opencl_installer': 'Windows 64-bit、OpenCL 版、インストーラ',
+        'windows_opencl_portable': 'Windows 64-bit、AMD / Intel / 旧 NVIDIA、OpenCL 互換版、インストール不要',
+        'windows_opencl_installer': 'Windows 64-bit、AMD / Intel / 旧 NVIDIA、OpenCL 互換版、インストーラ',
         'windows_portable': 'Windows 64-bit、CPU 互換版、インストール不要',
         'windows_installer': 'Windows 64-bit、CPU 互換版、インストーラ',
-        'windows_nvidia_portable': 'Windows 64-bit、NVIDIA GPU、インストール不要',
-        'windows_nvidia_installer': 'Windows 64-bit、NVIDIA GPU、インストーラ',
+        'windows_nvidia_portable': 'Windows 64-bit、RTX 20/30/40/50、推奨 NVIDIA CUDA、インストール不要',
+        'windows_nvidia_installer': 'Windows 64-bit、RTX 20/30/40/50、推奨 NVIDIA CUDA、インストーラ',
         'windows_directml_experimental': 'Windows 64-bit、DirectML experimental、DirectX 12 GPU',
         'windows_openvino_experimental': 'Windows 64-bit、OpenVINO experimental、Intel GPU/NPU',
         'windows_rocm_gfx103x_experimental': 'Windows 64-bit、ROCm experimental、AMD RX 6000',
@@ -598,12 +760,12 @@ STANDARD_DOWNLOAD_LABELS = {
         'linux64_nvidia': 'Linux 64-bit、NVIDIA CUDA',
     },
     'ko': {
-        'windows_opencl_portable': 'Windows 64-bit, OpenCL 추천 고속판, 무설치',
-        'windows_opencl_installer': 'Windows 64-bit, OpenCL, 설치형',
+        'windows_opencl_portable': 'Windows 64-bit, AMD / Intel / 구형 NVIDIA, OpenCL 호환판, 무설치',
+        'windows_opencl_installer': 'Windows 64-bit, AMD / Intel / 구형 NVIDIA, OpenCL 호환 설치형',
         'windows_portable': 'Windows 64-bit, CPU 호환 빌드, 무설치',
         'windows_installer': 'Windows 64-bit, CPU 호환 빌드, 설치형',
-        'windows_nvidia_portable': 'Windows 64-bit, NVIDIA GPU, 무설치',
-        'windows_nvidia_installer': 'Windows 64-bit, NVIDIA GPU, 설치형',
+        'windows_nvidia_portable': 'Windows 64-bit, RTX 20/30/40/50, 권장 NVIDIA CUDA, 무설치',
+        'windows_nvidia_installer': 'Windows 64-bit, RTX 20/30/40/50, 권장 NVIDIA CUDA 설치형',
         'windows_directml_experimental': 'Windows 64-bit, DirectML experimental, DirectX 12 GPU',
         'windows_openvino_experimental': 'Windows 64-bit, OpenVINO experimental, Intel GPU/NPU',
         'windows_rocm_gfx103x_experimental': 'Windows 64-bit, ROCm experimental, AMD RX 6000',
@@ -619,12 +781,12 @@ STANDARD_DOWNLOAD_LABELS = {
         'linux64_nvidia': 'Linux 64-bit, NVIDIA CUDA',
     },
     'th': {
-        'windows_opencl_portable': 'Windows 64-bit, OpenCL, แนะนำและเร็วกว่า, ไม่ต้องติดตั้ง',
-        'windows_opencl_installer': 'Windows 64-bit, OpenCL, แบบติดตั้ง',
+        'windows_opencl_portable': 'Windows 64-bit, AMD / Intel / NVIDIA รุ่นเก่า, OpenCL compatibility, ไม่ต้องติดตั้ง',
+        'windows_opencl_installer': 'Windows 64-bit, AMD / Intel / NVIDIA รุ่นเก่า, OpenCL compatibility installer',
         'windows_portable': 'Windows 64-bit, CPU compatible build, ไม่ต้องติดตั้ง',
         'windows_installer': 'Windows 64-bit, CPU compatible build, แบบติดตั้ง',
-        'windows_nvidia_portable': 'Windows 64-bit, การ์ดจอ NVIDIA, ไม่ต้องติดตั้ง',
-        'windows_nvidia_installer': 'Windows 64-bit, การ์ดจอ NVIDIA, แบบติดตั้ง',
+        'windows_nvidia_portable': 'Windows 64-bit, RTX 20/30/40/50, NVIDIA CUDA ที่แนะนำ, ไม่ต้องติดตั้ง',
+        'windows_nvidia_installer': 'Windows 64-bit, RTX 20/30/40/50, NVIDIA CUDA installer ที่แนะนำ',
         'windows_directml_experimental': 'Windows 64-bit, DirectML experimental, DirectX 12 GPU',
         'windows_openvino_experimental': 'Windows 64-bit, OpenVINO experimental, Intel GPU/NPU',
         'windows_rocm_gfx103x_experimental': 'Windows 64-bit, ROCm experimental, AMD RX 6000',
@@ -4254,15 +4416,15 @@ def build_release_notes(asset_map: dict[str, str | None], bundle: dict[str, str]
             'before': {
                 'heading': '下载前先看这几句',
                 'items': [
-                    f'Windows 普通用户直接下载 {assets_cn["windows_opencl_portable"]}，这是 **OpenCL 版（推荐，免安装）**。',
-                    f'如果 OpenCL 在你的电脑上跑得不好，再改用 {assets_cn["windows_portable"]}。',
-                    f'如果你的电脑是 **英伟达显卡**，优先下载 {assets_cn["windows_nvidia_portable"]}。',
+                    f'RTX 20/30/40/50 NVIDIA 显卡优先下载 {assets_cn["windows_nvidia_portable"]}。',
+                    f'AMD、Intel 或较老 NVIDIA 显卡下载 {assets_cn["windows_opencl_portable"]}。',
+                    f'没有合适 GPU，或 CUDA/OpenCL 无法正常启动时，使用 {assets_cn["windows_portable"]} CPU 兼容版。',
                     '如果你更喜欢安装流程，再选同系列的 `installer.exe`。',
                     '野狐棋谱和腾讯棋谱现在是两个入口：野狐输入野狐昵称，腾讯输入腾讯昵称或数字 UID。',
                     f'主推荐整合包已内置 KataGo `{katago_version}` 和默认权重 `{model_source}`。',
                     'Windows OpenCL 版也支持 **智能优化**，可以自动写入更合适的线程设置。',
-                    'Windows 现在把 OpenCL 版放到推荐位，优先照顾更快的分析速度。',
-                    'CPU 版继续保留，作为 OpenCL 不稳定时的兼容兜底。',
+                    'Windows 按显卡类型推荐 CUDA、OpenCL 或 CPU 兼容版，不再笼统推荐同一个包。',
+                    'CPU 版继续保留，作为没有合适 GPU 或 GPU 后端无法启动时的兼容兜底。',
                     'Windows NVIDIA 整合包已内置官方运行库，首启可离线使用。',
                 ],
             },
@@ -4270,12 +4432,12 @@ def build_release_notes(asset_map: dict[str, str | None], bundle: dict[str, str]
                 'heading': '下载建议',
                 'headers': ('你的电脑', '直接下载这个'),
                 'rows': [
-                    ('Windows 64 位，OpenCL 版，推荐更快，免安装', assets_cn['windows_opencl_portable']),
-                    ('Windows 64 位，OpenCL 版，想安装', assets_cn['windows_opencl_installer']),
-                    ('Windows 64 位，CPU 版，兼容兜底，免安装', assets_cn['windows_portable']),
-                    ('Windows 64 位，CPU 版，兼容兜底，想安装', assets_cn['windows_installer']),
-                    ('Windows 64 位，英伟达显卡，想更快，免安装', assets_cn['windows_nvidia_portable']),
-                    ('Windows 64 位，英伟达显卡，想更快，也想安装', assets_cn['windows_nvidia_installer']),
+                    ('Windows 64 位，RTX 20/30/40/50 NVIDIA CUDA 推荐版，免安装', assets_cn['windows_nvidia_portable']),
+                    ('Windows 64 位，RTX 20/30/40/50 NVIDIA CUDA 推荐安装版', assets_cn['windows_nvidia_installer']),
+                    ('Windows 64 位，AMD / Intel / 较老 NVIDIA OpenCL 兼容版，免安装', assets_cn['windows_opencl_portable']),
+                    ('Windows 64 位，AMD / Intel / 较老 NVIDIA OpenCL 兼容安装版', assets_cn['windows_opencl_installer']),
+                    ('Windows 64 位，CPU 兼容版，免安装', assets_cn['windows_portable']),
+                    ('Windows 64 位，CPU 兼容安装版', assets_cn['windows_installer']),
                     ('Windows 64 位，想自己配引擎', assets_cn['windows_no_engine_portable']),
                     ('Windows 64 位，想自己配引擎，也想安装器', assets_cn['windows_no_engine_installer']),
                     ('macOS Apple Silicon', assets_cn['mac_arm64']),
@@ -4291,11 +4453,9 @@ def build_release_notes(asset_map: dict[str, str | None], bundle: dict[str, str]
                     '野狐抓谱链路继续可用，并新增腾讯棋谱入口，常见公开棋谱来源更完整。',
                     '腾讯棋谱支持昵称/数字 UID 搜索、列表分页、双击或“打开”直接加载到主棋盘。',
                     'Windows 现在把 `.portable.zip` 放到推荐位，解压后更符合多数用户习惯。',
-                    'Windows 现在同时提供 OpenCL 版和 CPU 版，下载时更容易按“速度优先”还是“兼容优先”来选。',
-                    'Windows OpenCL 版现在放到推荐位，优先照顾更快的分析速度。',
                     'Windows OpenCL 版也支持智能优化，测速后会自动保存推荐线程数。',
                     'Windows CPU 版继续保留，适合 OpenCL 表现不理想的机器。',
-                    '对有 NVIDIA 独显的 Windows 用户，额外提供官方 CUDA 版 KataGo 的极速整合包，并且把官方运行库一起打进包里。',
+                    'NVIDIA CUDA 整合包内置官方运行库，支持 RTX 20/30/40/50 离线启动。',
                     'macOS 继续提供 Apple Silicon / Intel 两种 `.dmg`。',
                     '整合包继续内置 KataGo 与默认权重，打开后更快进入分析。',
                 ],
@@ -4651,6 +4811,7 @@ def build_release_notes(asset_map: dict[str, str | None], bundle: dict[str, str]
 
     add_nvidia50_download_rows(sections, assets_cn, assets)
     add_tensorrt_split_download_row(sections, assets_cn, assets, asset_map)
+    apply_current_windows_download_guidance(sections, assets_cn, assets)
     validate_release_sections(sections)
 
     return release_heading(release_tag) + '\n\n' + '\n\n---\n\n'.join(

--- a/scripts/package_windows_exe.sh
+++ b/scripts/package_windows_exe.sh
@@ -899,27 +899,27 @@ EOF
   if [[ "$has_with_katago" == "true" ]]; then
     cat >>"$note_file" <<EOF
 - ${DATE_TAG}-${ARCH_TAG}.with-katago.installer.exe
-  CPU fallback build. Use this if OpenCL runs poorly on your PC and you need the safer compatibility option.
+  CPU compatibility build. Use this when the PC has no suitable GPU, or when both CUDA and OpenCL are unavailable.
 - ${DATE_TAG}-${ARCH_TAG}.with-katago.portable.zip
-  CPU fallback portable build. Use this if you do not want the installer and prefer the safer compatibility option.
+  CPU compatibility portable build. Unzip it when you need the no-install CPU fallback.
 EOF
   fi
 
   if [[ "$has_opencl_katago" == "true" ]]; then
     cat >>"$note_file" <<EOF
 - ${DATE_TAG}-${OPENCL_ARCH_TAG}.installer.exe
-  Recommended Windows build for most users who want better KataGo speed. Choose this first if your PC can run OpenCL normally.
+  OpenCL compatibility build for AMD, Intel, and older NVIDIA GPUs.
 - ${DATE_TAG}-${OPENCL_ARCH_TAG}.portable.zip
-  Recommended OpenCL portable build. Unzip it and open ${OPENCL_APP_NAME}.exe.
+  OpenCL compatibility portable build. Unzip it and open ${OPENCL_APP_NAME}.exe.
 EOF
   fi
 
   if [[ "$has_nvidia_katago" == "true" ]]; then
     cat >>"$note_file" <<EOF
 - ${DATE_TAG}-${NVIDIA_ARCH_TAG}.installer.exe
-  Unified CUDA 12.8 package for RTX 20/30/40/50 series. This is the default NVIDIA choice.
+  Recommended CUDA 12.8 package for RTX 20/30/40/50 series.
 - ${DATE_TAG}-${NVIDIA_ARCH_TAG}.portable.zip
-  NVIDIA-only portable build. Unzip it and open ${NVIDIA_APP_NAME}.exe.
+  Recommended NVIDIA portable build. Unzip it and open ${NVIDIA_APP_NAME}.exe.
   RTX 40/50 users should stay on CUDA. RTX 30 series and earlier may optionally try TensorRT.
 EOF
   fi
@@ -979,8 +979,8 @@ EOF
   if [[ "$has_opencl_katago" == "true" ]]; then
     cat >>"$note_file" <<'EOF'
 - The OpenCL assets include the official KataGo OpenCL Windows build.
-- The OpenCL package is now the main recommended Windows choice for users who want better analysis speed.
-- If OpenCL behaves badly on your PC, switch to the CPU package instead.
+- Choose OpenCL for AMD, Intel, or older NVIDIA GPUs that are not covered by the RTX CUDA package.
+- If OpenCL behaves badly on your PC, switch to the CPU compatibility package instead.
 EOF
   fi
 
@@ -1004,7 +1004,7 @@ EOF
 
   if [[ "$has_nvidia_katago" == "true" ]]; then
     cat >>"$note_file" <<'EOF'
-- Only choose an NVIDIA package if your PC has an NVIDIA GPU. If you are not sure, use the regular with-katago installer instead.
+- Use the NVIDIA CUDA package for RTX 20/30/40/50. Use OpenCL for AMD, Intel, or older NVIDIA GPUs, and use the CPU package when no suitable GPU backend is available.
 EOF
   fi
 

--- a/scripts/test_windows_download_guidance.py
+++ b/scripts/test_windows_download_guidance.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""Regression tests for hardware-specific Windows download guidance."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTES_PATH = ROOT / "scripts" / "generate_release_notes.py"
+SPEC = importlib.util.spec_from_file_location("generate_release_notes", NOTES_PATH)
+if SPEC is None or SPEC.loader is None:
+    raise RuntimeError(f"Unable to load {NOTES_PATH}")
+NOTES = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(NOTES)
+
+
+class WindowsDownloadGuidanceTest(unittest.TestCase):
+    def test_current_user_guides_do_not_recommend_opencl_to_everyone(self) -> None:
+        files = (
+            ROOT / "README.md",
+            ROOT / "docs" / "INSTALL.md",
+            ROOT / "docs" / "PACKAGES.md",
+            ROOT / "docs" / "PACKAGES_EN.md",
+            ROOT / "docs" / "RELEASE_NOTES_TEMPLATE.md",
+            ROOT / "assets" / "package-guide-zh.svg",
+            ROOT / "scripts" / "package_windows_exe.sh",
+        )
+        combined = "\n".join(path.read_text(encoding="utf-8") for path in files)
+
+        forbidden = (
+            "Windows 大多数用户",
+            "大多数普通用户先下 `windows64.opencl.portable.zip`",
+            "Windows：先下 `*windows64.opencl.portable.zip`",
+            "Windows 用户先下载 `<date>-windows64.opencl.portable.zip`",
+            "Most regular users should start with `windows64.opencl.portable.zip`",
+            "Windows: choose `windows64.opencl.portable.zip`",
+            "Recommended Windows build for most users",
+            "main recommended Windows choice",
+            "大多数 Windows 用户先选 opencl portable",
+        )
+        for phrase in forbidden:
+            self.assertNotIn(phrase, combined)
+
+        self.assertIn("RTX 20/30/40/50 NVIDIA", combined)
+        self.assertIn("AMD、Intel 或较老 NVIDIA", combined)
+        self.assertIn("CPU 兼容版", combined)
+
+    def test_future_release_notes_put_cuda_before_opencl(self) -> None:
+        date_tag = "2026-08-27"
+        asset_map = {
+            asset.key: asset.filename.render(date_tag)
+            for asset in NOTES.topology.assets()
+        }
+        asset_map["windows_tensorrt_split_parts"] = [
+            NOTES.topology.asset("windows_tensorrt_split_001").filename.render(date_tag),
+            NOTES.topology.asset("windows_tensorrt_split_002").filename.render(date_tag),
+        ]
+        notes = NOTES.build_release_notes(
+            asset_map,
+            {
+                "katago_version": "v1.18.1",
+                "model_source": "b11c768h12nbt3tflrs-fson-silu.bin.gz",
+            },
+            "wimi321/lizzieyzy-next",
+            "next-2099-01-01.1",
+        )
+
+        forbidden = (
+            "recommended no-install OpenCL build",
+            "main recommended Windows choice",
+            "推奨 OpenCL 版",
+            "추천 OpenCL 무설치",
+            "OpenCL รุ่นแนะนำ",
+            "OpenCL 版（推荐，免安装）",
+            "OpenCL 版（推薦，免安裝）",
+        )
+        for phrase in forbidden:
+            self.assertNotIn(phrase, notes)
+
+        for language in NOTES.RELEASE_LANGUAGES:
+            start = notes.index(f"## {language}\n")
+            next_heading = notes.find("\n## ", start + 1)
+            section = notes[start:] if next_heading < 0 else notes[start:next_heading]
+            self.assertLess(
+                section.index("windows64.nvidia.portable.zip"),
+                section.index("windows64.opencl.portable.zip"),
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- recommends the NVIDIA CUDA package for RTX 20/30/40/50 users
- keeps OpenCL as the compatibility path for AMD, Intel, and older NVIDIA GPUs
- keeps the CPU package as the fallback when no suitable GPU backend can start
- aligns README, package docs, release-note generation, Windows package notes, and the visual package guide
- adds regression coverage so future release notes cannot silently restore the old OpenCL-first wording

## Validation

- 3407 Maven tests passed with 0 failures and 0 errors
- 128 release-script tests passed
- shaded JAR package succeeded
- generated six-language release notes validated successfully
- Markdown links, shell syntax, Python syntax, and git diff checks passed
- package-guide SVG was rendered locally and checked for clipping

## Platform note

Windows packaging and asset integrity will be validated by GitHub Actions. No Windows real-desktop UI claim is made for this documentation and release-pipeline change.