### PR TITLE
Fix bundled engine fallback before release

### DIFF
--- a/.github/workflows/build-windows-release.yml
+++ b/.github/workflows/build-windows-release.yml
@@ -147,7 +147,7 @@ jobs:
           grep -q "first launch should work offline" "$note_file"
           grep -q "qiyi71w/readboard v3.0.6" "$note_file"
           grep -q "JCEF browser runtime" "$note_file"
-          grep -q "Unified CUDA 12.8 package for RTX 20/30/40/50" "$note_file"
+          grep -q "NVIDIA CUDA package for RTX 20/30/40/50" "$note_file"
           test -f "dist/windows/input-with-katago/engines/katago/windows-x64/katago.exe"
           test -f "dist/windows/input-with-katago/PROJECT_INFO.txt"
           test -f "dist/windows/input-with-katago/readboard/readboard.exe"

--- a/scripts/test_windows_download_guidance.py
+++ b/scripts/test_windows_download_guidance.py
@@ -48,6 +48,13 @@ class WindowsDownloadGuidanceTest(unittest.TestCase):
         self.assertIn("AMD、Intel 或较老 NVIDIA", combined)
         self.assertIn("CPU 兼容版", combined)
 
+        workflow = (
+            ROOT / ".github" / "workflows" / "build-windows-release.yml"
+        ).read_text(encoding="utf-8")
+        install_note_fragment = "NVIDIA CUDA package for RTX 20/30/40/50"
+        self.assertIn(install_note_fragment, combined)
+        self.assertIn(install_note_fragment, workflow)
+
     def test_future_release_notes_put_cuda_before_opencl(self) -> None:
         date_tag = "2026-08-27"
         asset_map = {

--- a/src/main/java/featurecat/lizzie/Config.java
+++ b/src/main/java/featurecat/lizzie/Config.java
@@ -254,12 +254,17 @@ public class Config {
   public int movelistSelectedIndexTop = 0;
 
   private static class BundledKataGoConfig {
+    private final Path appRoot;
     private final String engineCommand;
     private final String analysisCommand;
     private final boolean transformerDefault;
 
     private BundledKataGoConfig(
-        String engineCommand, String analysisCommand, boolean transformerDefault) {
+        Path appRoot,
+        String engineCommand,
+        String analysisCommand,
+        boolean transformerDefault) {
+      this.appRoot = appRoot;
       this.engineCommand = engineCommand;
       this.analysisCommand = analysisCommand;
       this.transformerDefault = transformerDefault;
@@ -386,6 +391,10 @@ public class Config {
   }
 
   static boolean isManagedBundledDefaultCommand(String command) {
+    return isManagedBundledDefaultCommand(command, null);
+  }
+
+  private static boolean isManagedBundledDefaultCommand(String command, Path activeAppRoot) {
     if (command == null || command.trim().isEmpty() || !isBundledKataGoCommand(command)) {
       return command == null || command.trim().isEmpty();
     }
@@ -396,12 +405,17 @@ public class Config {
     Path workingDirectory = Path.of(System.getProperty("user.dir", ".")).toAbsolutePath();
     Optional<Path> commandAppRoot =
         bundledAppRootForExecutable(workingDirectory, commandParts.get(0));
-    if (!commandAppRoot.isPresent()) {
-      return false;
-    }
     String modelToken = modelToken(command);
-    return modelToken.isEmpty()
-        || isDefaultOrLegacyBundledWeight(commandAppRoot.get(), workingDirectory, modelToken);
+    if (modelToken.isEmpty()) {
+      return commandAppRoot.isPresent();
+    }
+    if (commandAppRoot.isPresent()
+        && isDefaultOrLegacyBundledWeight(
+            commandAppRoot.get(), workingDirectory, modelToken)) {
+      return true;
+    }
+    return activeAppRoot != null
+        && isDefaultOrLegacyBundledWeight(activeAppRoot, workingDirectory, modelToken);
   }
 
   private static Optional<Path> bundledAppRootForExecutable(
@@ -603,7 +617,7 @@ public class Config {
             + quotePath(analysisConfigPath)
             + " -quit-without-waiting";
     return new BundledKataGoConfig(
-        engineCommand, analysisCommand, isBundledTransformerDefault(appRoot));
+        appRoot, engineCommand, analysisCommand, isBundledTransformerDefault(appRoot));
   }
 
   private static boolean isBundledTransformerDefault(Path appRoot) {
@@ -650,7 +664,7 @@ public class Config {
       String command = engineInfo.optString("command", "");
       boolean managedDefaultCommand =
           !engineInfo.optBoolean("useJavaSSH", false)
-              && isManagedBundledDefaultCommand(command);
+              && isManagedBundledDefaultCommand(command, bundledConfig.appRoot);
       if (autoSetupIndex < 0 && "KataGo Auto Setup".equals(name) && managedDefaultCommand) {
         autoSetupIndex = i;
       }
@@ -685,7 +699,8 @@ public class Config {
       reusedAutoSetupEntry = "KataGo Auto Setup".equals(bundledEngine.optString("name", ""));
       String existingCommand = bundledEngine.optString("command", "");
       refreshBundledCommand =
-          existingCommand.trim().isEmpty() || isManagedBundledDefaultCommand(existingCommand);
+          existingCommand.trim().isEmpty()
+              || isManagedBundledDefaultCommand(existingCommand, bundledConfig.appRoot);
     } else {
       bundledEngine = new JSONObject();
       engineSettings.put(bundledEngine);
@@ -707,7 +722,7 @@ public class Config {
         String analysisCommand = ui.optString("analysis-engine-command", "");
         if ((!analysisCustomized
                 && !analysisCommandUsesJavaSsh(leelaz)
-                && isManagedBundledDefaultCommand(analysisCommand))
+                && isManagedBundledDefaultCommand(analysisCommand, bundledConfig.appRoot))
             || isClearlyBrokenJavaJarCommand(analysisCommand)) {
           ui.put("analysis-engine-command", bundledConfig.analysisCommand);
           ui.put("analysis-engine-command-customized", false);

--- a/src/main/java/featurecat/lizzie/analysis/remote/RemoteComputeConfig.java
+++ b/src/main/java/featurecat/lizzie/analysis/remote/RemoteComputeConfig.java
@@ -4,6 +4,7 @@ import featurecat.lizzie.Config;
 import featurecat.lizzie.Lizzie;
 import featurecat.lizzie.gui.EngineData;
 import featurecat.lizzie.rules.Board;
+import featurecat.lizzie.util.KataGoRuntimeHelper;
 import featurecat.lizzie.util.Utils;
 import java.io.IOException;
 import java.net.URI;
@@ -451,12 +452,16 @@ public final class RemoteComputeConfig {
   }
 
   public static int saveLocalProviderAndDefaultEngine() {
+    ArrayList<EngineData> engines = Utils.getEngineData();
+    int localIndex = firstLocalEngineIndex(engines);
+    if (localIndex < 0) {
+      return -1;
+    }
+
     State state = load();
     state.provider = PROVIDER_LOCAL;
     save(state);
 
-    ArrayList<EngineData> engines = Utils.getEngineData();
-    int localIndex = firstLocalEngineIndex(engines);
     for (int i = 0; i < engines.size(); i++) {
       EngineData engine = engines.get(i);
       if (engine != null) {
@@ -478,11 +483,76 @@ public final class RemoteComputeConfig {
       if (engine == null || engine.commands == null || engine.commands.trim().isEmpty()) {
         continue;
       }
-      if (!isRemoteComputeEngineCommand(engine.commands)) {
+      if (isRemoteComputeEngineCommand(engine.commands)) {
+        continue;
+      }
+      if (isUsableLocalEngine(engine)) {
         return i;
       }
     }
     return -1;
+  }
+
+  private static boolean isUsableLocalEngine(EngineData engine) {
+    if (engine == null || engine.useJavaSSH) {
+      return false;
+    }
+    List<String> command = Utils.splitCommand(engine.commands);
+    if (command.isEmpty()) {
+      return false;
+    }
+    Path executable = KataGoRuntimeHelper.resolveCommandExecutable(command);
+    if (executable == null || !Files.isRegularFile(executable)) {
+      return false;
+    }
+    for (int i = 0; i < command.size(); i++) {
+      String token = command.get(i);
+      if (token == null) {
+        continue;
+      }
+      String normalized = token.toLowerCase(Locale.ROOT);
+      String referencedPath = null;
+      if ("-model".equals(normalized)
+          || "--model".equals(normalized)
+          || "-config".equals(normalized)
+          || "--config".equals(normalized)
+          || "-jar".equals(normalized)) {
+        if (i + 1 >= command.size()) {
+          return false;
+        }
+        referencedPath = command.get(++i);
+      } else if (normalized.startsWith("-model=")
+          || normalized.startsWith("--model=")
+          || normalized.startsWith("-config=")
+          || normalized.startsWith("--config=")) {
+        referencedPath = token.substring(token.indexOf('=') + 1);
+      }
+      if (referencedPath != null && !commandFileExists(referencedPath, executable.getParent())) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  private static boolean commandFileExists(String value, Path executableDirectory) {
+    if (value == null || value.trim().isEmpty()) {
+      return false;
+    }
+    try {
+      Path path = Path.of(value.trim());
+      if (path.isAbsolute()) {
+        return Files.isRegularFile(path.toAbsolutePath().normalize());
+      }
+      Path workingDirectory =
+          Path.of(System.getProperty("user.dir", ".")).toAbsolutePath().normalize();
+      if (Files.isRegularFile(workingDirectory.resolve(path).normalize())) {
+        return true;
+      }
+      return executableDirectory != null
+          && Files.isRegularFile(executableDirectory.resolve(path).normalize());
+    } catch (RuntimeException e) {
+      return false;
+    }
   }
 
   public static String displayNameForZhiziArgs(String args) {

--- a/src/main/java/featurecat/lizzie/gui/BoardRenderer.java
+++ b/src/main/java/featurecat/lizzie/gui/BoardRenderer.java
@@ -1247,7 +1247,7 @@ public class BoardRenderer {
 
   public boolean shouldShowCountBlockBelow() {
     Leelaz leelaz = this.boardIndex == 1 && Lizzie.leelaz2 != null ? Lizzie.leelaz2 : Lizzie.leelaz;
-    if (leelaz.isKatago && leelaz.iskataHeatmapShowOwner) {
+    if (leelaz != null && leelaz.isKatago && leelaz.iskataHeatmapShowOwner) {
       return Lizzie.config.showPureEstimateBigBelow;
     }
     return Lizzie.config.showKataGoEstimateBigBelow;
@@ -1255,7 +1255,7 @@ public class BoardRenderer {
 
   public boolean shouldShowCountBlockBig() {
     Leelaz leelaz = this.boardIndex == 1 && Lizzie.leelaz2 != null ? Lizzie.leelaz2 : Lizzie.leelaz;
-    if (leelaz.isKatago && leelaz.iskataHeatmapShowOwner) {
+    if (leelaz != null && leelaz.isKatago && leelaz.iskataHeatmapShowOwner) {
       return Lizzie.config.showPureEstimateBigBelow;
     }
     return Lizzie.config.showKataGoEstimateBigBelow;

--- a/src/main/java/featurecat/lizzie/gui/FloatBoardRenderer.java
+++ b/src/main/java/featurecat/lizzie/gui/FloatBoardRenderer.java
@@ -493,7 +493,7 @@ public class FloatBoardRenderer {
 
   public boolean shouldShowCountBlockBelow() {
     Leelaz leelaz = Lizzie.leelaz;
-    if (leelaz.isKatago && leelaz.iskataHeatmapShowOwner) {
+    if (leelaz != null && leelaz.isKatago && leelaz.iskataHeatmapShowOwner) {
       return Lizzie.config.showPureEstimateBigBelow;
     }
     return Lizzie.config.showKataGoEstimateBigBelow;
@@ -501,7 +501,7 @@ public class FloatBoardRenderer {
 
   public boolean shouldShowCountBlockBig() {
     Leelaz leelaz = Lizzie.leelaz;
-    if (leelaz.isKatago && leelaz.iskataHeatmapShowOwner) {
+    if (leelaz != null && leelaz.isKatago && leelaz.iskataHeatmapShowOwner) {
       return Lizzie.config.showPureEstimateBigBelow;
     }
     return Lizzie.config.showKataGoEstimateBigBelow;

--- a/src/main/java/featurecat/lizzie/gui/KomiHoldSession.java
+++ b/src/main/java/featurecat/lizzie/gui/KomiHoldSession.java
@@ -39,6 +39,7 @@ final class KomiHoldSession {
   private final int initialDelayMs;
   private final int repeatDelayMs;
   private final BooleanSupplier lifecycleReady;
+  private final boolean customLifecycleReady;
   private volatile boolean holding;
   private boolean focusManagerBound;
   private Timer timer;
@@ -144,6 +145,7 @@ final class KomiHoldSession {
     this.holdStep = Objects.requireNonNull(holdStep, "holdStep");
     this.initialDelayMs = initialDelayMs;
     this.repeatDelayMs = repeatDelayMs;
+    this.customLifecycleReady = lifecycleReady != null;
     this.lifecycleReady = lifecycleReady == null ? this::hasActiveWindow : lifecycleReady;
   }
 
@@ -265,6 +267,12 @@ final class KomiHoldSession {
 
   private void onFocusedWindowChanged(PropertyChangeEvent event) {
     if (!holding) {
+      return;
+    }
+    if (customLifecycleReady) {
+      if (!canRepeat()) {
+        stopHold();
+      }
       return;
     }
     Window ancestor = SwingUtilities.getWindowAncestor(control);

--- a/src/main/java/featurecat/lizzie/gui/LizzieFrame.java
+++ b/src/main/java/featurecat/lizzie/gui/LizzieFrame.java
@@ -1226,7 +1226,7 @@ public class LizzieFrame extends JFrame {
                   listTable.revalidate();
                 }
                 if (Lizzie.config.isShowingBlunderTabel) {
-                  if (Lizzie.leelaz.isLoaded()) {
+                  if (Lizzie.leelaz != null && Lizzie.leelaz.isLoaded()) {
                     if (Lizzie.board.isKataBoard || Lizzie.leelaz.isKatago || Lizzie.leelaz.isSai) {
                       if (scoreIsHiddenInBlunderTable) {
                         resumColumn(3, blunderTabelBlack, blunderTableColum3Width);

--- a/src/main/java/featurecat/lizzie/gui/SubBoardRenderer.java
+++ b/src/main/java/featurecat/lizzie/gui/SubBoardRenderer.java
@@ -576,7 +576,7 @@ public class SubBoardRenderer {
 
   public boolean shouldShowCountBlockBelow() {
     Leelaz leelaz = Lizzie.leelaz;
-    if (leelaz.isKatago && leelaz.iskataHeatmapShowOwner) {
+    if (leelaz != null && leelaz.isKatago && leelaz.iskataHeatmapShowOwner) {
       return Lizzie.config.showPureEstimateBigBelow;
     }
     return Lizzie.config.showKataGoEstimateBigBelow;
@@ -584,7 +584,7 @@ public class SubBoardRenderer {
 
   public boolean shouldShowCountBlockBig() {
     Leelaz leelaz = Lizzie.leelaz;
-    if (leelaz.isKatago && leelaz.iskataHeatmapShowOwner) {
+    if (leelaz != null && leelaz.isKatago && leelaz.iskataHeatmapShowOwner) {
       return Lizzie.config.showPureEstimateBigBelow;
     }
     return Lizzie.config.showKataGoEstimateBigBelow;

--- a/src/test/java/featurecat/lizzie/ConfigBundledKataGoDefaultsTest.java
+++ b/src/test/java/featurecat/lizzie/ConfigBundledKataGoDefaultsTest.java
@@ -482,6 +482,65 @@ public class ConfigBundledKataGoDefaultsTest {
   }
 
   @Test
+  void mixedBundledPathsRebindAsOneManagedProfile() throws Exception {
+    Path currentRoot = Files.createTempDirectory("lizzie-current-mixed-package");
+    Path staleRoot = Files.createTempDirectory("lizzie-stale-mixed-package");
+    Files.writeString(currentRoot.resolve("config.txt"), "{}");
+    createBundledKataGoAssets(currentRoot);
+
+    String mixedGtpCommand =
+        quote(bundledExecutable(staleRoot))
+            + " gtp -model "
+            + quote(currentRoot.resolve("weights").resolve("default.bin.gz"))
+            + " -config "
+            + quote(
+                currentRoot
+                    .resolve("engines")
+                    .resolve("katago")
+                    .resolve("configs")
+                    .resolve("gtp.cfg"));
+    String mixedAnalysisCommand =
+        quote(bundledExecutable(staleRoot))
+            + " analysis -model "
+            + quote(currentRoot.resolve("weights").resolve("default.bin.gz"))
+            + " -config "
+            + quote(
+                currentRoot
+                    .resolve("engines")
+                    .resolve("katago")
+                    .resolve("configs")
+                    .resolve("analysis.cfg"))
+            + " -quit-without-waiting";
+
+    Config config = ConfigTestHelper.createForTests(currentRoot);
+    JSONObject ui =
+        new JSONObject()
+            .put("first-time-load", false)
+            .put("autoload-default", false)
+            .put("autoload-last", false)
+            .put("autoload-empty", true)
+            .put("default-engine", 0)
+            .put("analysis-engine-command", mixedAnalysisCommand)
+            .put("analysis-engine-command-customized", false);
+    JSONObject bundledEngine =
+        new JSONObject()
+            .put("name", "KataGo Auto Setup")
+            .put("command", mixedGtpCommand)
+            .put("isDefault", true);
+    JSONObject leelaz =
+        new JSONObject().put("engine-settings-list", new JSONArray().put(bundledEngine));
+    config.config = new JSONObject().put("ui", ui).put("leelaz", leelaz);
+
+    withUserDir(currentRoot, () -> applyBundledKataGoDefaults(config));
+
+    JSONArray engines = leelaz.getJSONArray("engine-settings-list");
+    assertEquals(1, engines.length());
+    assertEquals(bundledGtpCommand(currentRoot), engines.getJSONObject(0).getString("command"));
+    assertEquals(bundledAnalysisCommand(currentRoot), ui.getString("analysis-engine-command"));
+    assertTrue(ui.getBoolean("autoload-empty"));
+  }
+
+  @Test
   void movedBundledDefaultSlotRebindsWhenOldExecutableIsGone() throws Exception {
     Path currentRoot = Files.createTempDirectory("lizzie-moved-current-package");
     Path previousRoot = Files.createTempDirectory("lizzie-moved-previous-package");

--- a/src/test/java/featurecat/lizzie/analysis/remote/RemoteComputeConfigTest.java
+++ b/src/test/java/featurecat/lizzie/analysis/remote/RemoteComputeConfigTest.java
@@ -613,9 +613,10 @@ class RemoteComputeConfigTest {
   void switchingBackToLocalPersistsLocalEngineForNextStartup() throws Exception {
     withConfig(
         () -> {
+          Path root = Files.createTempDirectory("remote-local-engine-persistence");
           ArrayList<EngineData> engines = new ArrayList<>();
           EngineData local = new EngineData();
-          local.commands = "katago.exe gtp -config default.cfg";
+          local.commands = usableKataGoCommand(root);
           local.name = "Local KataGo";
           local.isDefault = false;
           engines.add(local);
@@ -645,6 +646,82 @@ class RemoteComputeConfigTest {
   }
 
   @Test
+  void switchingBackToLocalKeepsRemoteSelectionWhenEveryLocalEngineIsStale() throws Exception {
+    withConfig(
+        () -> {
+          EngineData stale = new EngineData();
+          stale.commands = "missing-katago gtp -config missing.cfg";
+          stale.name = "Stale KataGo";
+
+          EngineData zhizi = new EngineData();
+          zhizi.commands = RemoteComputeConfig.COMMAND_ZHIZI;
+          zhizi.name = "Zhizi Cloud";
+          zhizi.isDefault = true;
+
+          Utils.saveEngineSettings(new ArrayList<>(List.of(stale, zhizi)));
+          Lizzie.config.uiConfig.put("default-engine", 1);
+          Lizzie.config.uiConfig.put("last-engine", 1);
+          RemoteComputeConfig.State state = RemoteComputeConfig.load();
+          state.provider = RemoteComputeConfig.PROVIDER_ZHIZI;
+          RemoteComputeConfig.save(state);
+
+          int localIndex = RemoteComputeConfig.saveLocalProviderAndDefaultEngine();
+
+          assertEquals(-1, localIndex);
+          assertEquals(RemoteComputeConfig.PROVIDER_ZHIZI, RemoteComputeConfig.load().provider);
+          ArrayList<EngineData> savedEngines = Utils.getEngineData();
+          assertFalse(savedEngines.get(0).isDefault);
+          assertTrue(savedEngines.get(1).isDefault);
+          assertEquals(1, Lizzie.config.uiConfig.optInt("default-engine", -1));
+          assertEquals(1, Lizzie.config.uiConfig.optInt("last-engine", -1));
+        });
+  }
+
+  @Test
+  void switchingBackToLocalPrefersAUsableEngineOverAStaleSlot() throws Exception {
+    withConfig(
+        () -> {
+          Path root = Files.createTempDirectory("remote-local-engine-selection");
+          Path executable = Files.write(root.resolve("katago"), new byte[] {1});
+          Path model = Files.write(root.resolve("default.bin.gz"), new byte[] {1});
+          Path gtpConfig = Files.write(root.resolve("gtp.cfg"), new byte[] {1});
+
+          EngineData stale = new EngineData();
+          stale.commands =
+              quote(root.resolve("missing-katago"))
+                  + " gtp -model "
+                  + quote(model)
+                  + " -config "
+                  + quote(gtpConfig);
+          stale.name = "Stale KataGo";
+
+          EngineData usable = new EngineData();
+          usable.commands =
+              quote(executable)
+                  + " gtp -model "
+                  + quote(model)
+                  + " -config "
+                  + quote(gtpConfig);
+          usable.name = "Usable KataGo";
+
+          EngineData zhizi = new EngineData();
+          zhizi.commands = RemoteComputeConfig.COMMAND_ZHIZI;
+          zhizi.name = "Zhizi Cloud";
+          zhizi.isDefault = true;
+
+          Utils.saveEngineSettings(new ArrayList<>(List.of(stale, usable, zhizi)));
+
+          int localIndex = RemoteComputeConfig.saveLocalProviderAndDefaultEngine();
+
+          assertEquals(1, localIndex);
+          ArrayList<EngineData> savedEngines = Utils.getEngineData();
+          assertFalse(savedEngines.get(0).isDefault);
+          assertTrue(savedEngines.get(1).isDefault);
+          assertFalse(savedEngines.get(2).isDefault);
+        });
+  }
+
+  @Test
   void customWebSocketUrlIsNormalizedAndRecognized() {
     assertEquals(
         "wss://example.com/katago?token=abc",
@@ -666,13 +743,15 @@ class RemoteComputeConfigTest {
   @Test
   void customWebSocketEngineCanBecomeDefaultAndLocalSwitchSkipsIt() throws Exception {
     withConfig(
-        () ->
-            withResourceBundle(
+        () -> {
+          Path root = Files.createTempDirectory("remote-custom-local-engine");
+          String localCommand = usableKataGoCommand(root);
+          withResourceBundle(
                 AppLocale.ENGLISH.loadBundle(),
                 () -> {
                   ArrayList<EngineData> engines = new ArrayList<>();
                   EngineData local = new EngineData();
-                  local.commands = "katago.exe gtp -config default.cfg";
+                  local.commands = localCommand;
                   local.name = "Local KataGo";
                   local.isDefault = false;
                   engines.add(local);
@@ -702,7 +781,8 @@ class RemoteComputeConfigTest {
                   assertTrue(savedEngines.get(0).isDefault);
                   assertFalse(savedEngines.get(customIndex).isDefault);
                   assertEquals(0, Lizzie.config.uiConfig.optInt("last-engine", -1));
-                }));
+                });
+        });
   }
 
   @Test
@@ -710,10 +790,11 @@ class RemoteComputeConfigTest {
     withConfig(
         () -> {
           RemoteComputeConfig.clearZhiziToken();
+          Path root = Files.createTempDirectory("remote-startup-local-engine");
           ArrayList<EngineData> engines = new ArrayList<>();
           EngineData local = new EngineData();
           local.index = 0;
-          local.commands = "katago.exe gtp -config default.cfg";
+          local.commands = usableKataGoCommand(root);
           local.name = "Local KataGo";
           local.isDefault = false;
           engines.add(local);
@@ -812,6 +893,21 @@ class RemoteComputeConfigTest {
 
   private static void withConfig(ThrowingRunnable action) throws Exception {
     withConfigAndStore(store -> action.run());
+  }
+
+  private static String quote(Path path) {
+    return "\"" + path.toAbsolutePath().normalize() + "\"";
+  }
+
+  private static String usableKataGoCommand(Path root) throws Exception {
+    Path executable = Files.write(root.resolve("katago"), new byte[] {1});
+    Path model = Files.write(root.resolve("default.bin.gz"), new byte[] {1});
+    Path gtpConfig = Files.write(root.resolve("gtp.cfg"), new byte[] {1});
+    return quote(executable)
+        + " gtp -model "
+        + quote(model)
+        + " -config "
+        + quote(gtpConfig);
   }
 
   private static void withConfigAndStore(ThrowingStoreRunnable action) throws Exception {

--- a/src/test/java/featurecat/lizzie/gui/LizzieFrameRegressionTest.java
+++ b/src/test/java/featurecat/lizzie/gui/LizzieFrameRegressionTest.java
@@ -100,6 +100,33 @@ class LizzieFrameRegressionTest {
   }
 
   @Test
+  void estimateRenderersUseSafeDefaultsWithoutAForegroundEngine() throws Exception {
+    Config previousConfig = Lizzie.config;
+    Leelaz previousEngine = Lizzie.leelaz;
+    try {
+      Config config = allocate(Config.class);
+      config.showKataGoEstimateBigBelow = true;
+      config.showPureEstimateBigBelow = false;
+      Lizzie.config = config;
+      Lizzie.leelaz = null;
+
+      BoardRenderer boardRenderer = allocate(BoardRenderer.class);
+      FloatBoardRenderer floatBoardRenderer = allocate(FloatBoardRenderer.class);
+      SubBoardRenderer subBoardRenderer = allocate(SubBoardRenderer.class);
+
+      assertTrue(boardRenderer.shouldShowCountBlockBelow());
+      assertTrue(boardRenderer.shouldShowCountBlockBig());
+      assertTrue(floatBoardRenderer.shouldShowCountBlockBelow());
+      assertTrue(floatBoardRenderer.shouldShowCountBlockBig());
+      assertTrue(subBoardRenderer.shouldShowCountBlockBelow());
+      assertTrue(subBoardRenderer.shouldShowCountBlockBig());
+    } finally {
+      Lizzie.config = previousConfig;
+      Lizzie.leelaz = previousEngine;
+    }
+  }
+
+  @Test
   void captureRulesPaintDoesNotThrowWithoutAForegroundEngine() throws Exception {
     Font previousFont = LizzieFrame.uiFont;
     try (TestEnvironment env = TestEnvironment.open()) {


### PR DESCRIPTION
## Summary

- rebind mixed stale bundled KataGo paths to the active app package
- skip unusable local engine entries when leaving remote compute and preserve the current provider when none are usable
- keep the main board renderable when no foreground engine is loaded
- align the Windows release audit with the CUDA-first package guidance

## Validation

- `mvn -B -Dfmt.skip=true test` (3411 tests, 0 failures, 0 errors, 2 skipped)
- `mvn -B -Dfmt.skip=true -DskipTests package`
- Windows download-guidance and launcher-packaging tests
- line-ending and `git diff --check` validation
- macOS app-image QA with bundled KataGo: stale mixed paths were rebound, analysis started from the active package, and no-engine UI ran without renderer/timer exceptions

## Platform note

Windows packaging and smoke validation will run in CI. No Windows real-desktop UI claim is made for this PR.