### PR TITLE
Fix Linux bottom toolbar / goban-edge clip

### DIFF
--- a/src/main/java/featurecat/lizzie/gui/LizzieFrame.java
+++ b/src/main/java/featurecat/lizzie/gui/LizzieFrame.java
@@ -12338,11 +12338,87 @@ public class LizzieFrame extends JFrame {
             + System.getProperty("os.version", "unknown"));
   }
 
+  static int nativeMenuBarReserve(
+      boolean usesNativeMenuBar, int menuBarHeight, int preferredMenuBarHeight) {
+    if (!usesNativeMenuBar) {
+      return 0;
+    }
+    if (menuBarHeight > 0) {
+      return menuBarHeight;
+    }
+    return Math.max(0, preferredMenuBarHeight);
+  }
+
+  static int resolvedContentLength(
+      int laidOutLength, int frameLength, int insetStart, int insetEnd, int extraChrome) {
+    if (laidOutLength > 0) {
+      return laidOutLength;
+    }
+    return Math.max(
+        0,
+        frameLength - Math.max(0, insetStart) - Math.max(0, insetEnd) - Math.max(0, extraChrome));
+  }
+
+  static int preferLaidOutLength(int primary, int secondary) {
+    if (primary > 0) {
+      return primary;
+    }
+    return Math.max(0, secondary);
+  }
+
+  static final class MainContentLayout {
+    final Rectangle mainPanel;
+    final Rectangle toolbar;
+    final Rectangle trainingBar;
+
+    MainContentLayout(Rectangle mainPanel, Rectangle toolbar, Rectangle trainingBar) {
+      this.mainPanel = mainPanel;
+      this.toolbar = toolbar;
+      this.trainingBar = trainingBar;
+    }
+  }
+
+  static MainContentLayout layoutMainContent(
+      int contentWidth,
+      int contentHeight,
+      int windowMenuHeight,
+      int topPanelHeight,
+      boolean includeTopPanelInBoard,
+      int toolbarHeight,
+      int trainingBarHeight) {
+    int width = Math.max(0, contentWidth);
+    int height = Math.max(0, contentHeight);
+    int top =
+        Math.max(0, windowMenuHeight) + (includeTopPanelInBoard ? Math.max(0, topPanelHeight) : 0);
+    int toolbarH = Math.max(0, toolbarHeight);
+    int trainingH = Math.max(0, trainingBarHeight);
+    int boardHeight = Math.max(0, height - top - toolbarH - trainingH);
+    return new MainContentLayout(
+        new Rectangle(0, top, width, boardHeight),
+        new Rectangle(0, height - toolbarH, width, toolbarH),
+        new Rectangle(0, height - toolbarH - trainingH, width, trainingH));
+  }
+
+  private int currentNativeMenuBarReserve() {
+    JMenuBar bar = getJMenuBar();
+    int height = bar == null ? 0 : bar.getHeight();
+    int preferred =
+        bar == null || bar.getPreferredSize() == null ? 0 : bar.getPreferredSize().height;
+    return nativeMenuBarReserve(menuPresentationMode.usesNativeMenuBar(), height, preferred);
+  }
+
   public void reSetLoc() {
     SwingUtilities.invokeLater(
         new Thread() {
           public void run() {
-            int width = getWidth() - getInsets().left - getInsets().right;
+            Insets insets = getInsets();
+            int width =
+                resolvedContentLength(
+                    preferLaidOutLength(basePanel.getWidth(), getContentPane().getWidth()),
+                    getWidth(),
+                    insets.left,
+                    insets.right,
+                    0);
             if (menuPresentationMode.usesNativeMenuBar()) {
               windowMenuHeight = 0;
               windowMenuStrip.setVisible(false);
@@ -12392,35 +12468,29 @@ public class LizzieFrame extends JFrame {
               topPanel.setVisible(false);
             }
             int trainingBarHeight = humanSlTrainingBar.isVisible() ? 58 : 0;
+            int contentHeight =
+                resolvedContentLength(
+                    preferLaidOutLength(basePanel.getHeight(), getContentPane().getHeight()),
+                    getHeight(),
+                    insets.top,
+                    insets.bottom,
+                    currentNativeMenuBarReserve());
+            MainContentLayout layout =
+                layoutMainContent(
+                    width,
+                    contentHeight,
+                    windowMenuHeight,
+                    topPanelHeight,
+                    Lizzie.config.showDoubleMenu,
+                    toolbarHeight,
+                    trainingBarHeight);
             mainPanel.setBounds(
-                0,
-                windowMenuHeight + (Lizzie.config.showDoubleMenu ? topPanelHeight : 0),
-                Utils.zoomOut(width),
-                Utils.zoomOut(
-                    Lizzie.frame.getHeight()
-                        - Lizzie.frame.getInsets().top
-                        - Lizzie.frame.getInsets().bottom
-                        - windowMenuHeight
-                        - toolbarHeight
-                        - trainingBarHeight
-                        - (Lizzie.config.showDoubleMenu ? topPanelHeight : 0)));
-            humanSlTrainingBar.setBounds(
-                0,
-                Lizzie.frame.getHeight()
-                    - Lizzie.frame.getInsets().top
-                    - Lizzie.frame.getInsets().bottom
-                    - toolbarHeight
-                    - trainingBarHeight,
-                width,
-                trainingBarHeight);
-            toolbar.setBounds(
-                0,
-                Lizzie.frame.getHeight()
-                    - Lizzie.frame.getInsets().top
-                    - Lizzie.frame.getInsets().bottom
-                    - toolbarHeight,
-                width,
-                toolbarHeight);
+                layout.mainPanel.x,
+                layout.mainPanel.y,
+                Utils.zoomOut(layout.mainPanel.width),
+                Utils.zoomOut(layout.mainPanel.height));
+            humanSlTrainingBar.setBounds(layout.trainingBar);
+            toolbar.setBounds(layout.toolbar);
             layoutEngineStartupStatus(width);
             if (toolbar.showDetail) toolbar.setDetailIcon();
             toolbar.reSetButtonLocation();
@@ -15390,7 +15460,14 @@ public class LizzieFrame extends JFrame {
     }
     Dimension preferred = engineStartupStatusButton.getPreferredSize();
     int width = Math.min(Math.max(180, preferred.width + 8), Math.max(180, availableWidth - 20));
-    int contentHeight = getHeight() - getInsets().top - getInsets().bottom;
+    Insets insets = getInsets();
+    int contentHeight =
+        resolvedContentLength(
+            preferLaidOutLength(basePanel.getHeight(), getContentPane().getHeight()),
+            getHeight(),
+            insets.top,
+            insets.bottom,
+            currentNativeMenuBarReserve());
     int y = Math.max(windowMenuHeight + topPanelHeight + 4, contentHeight - toolbarHeight - 48);
     engineStartupStatusButton.setBounds(10, y, width, 32);
   }

--- a/src/test/java/featurecat/lizzie/gui/LizzieFrameBottomToolbarLayoutTest.java
+++ b/src/test/java/featurecat/lizzie/gui/LizzieFrameBottomToolbarLayoutTest.java
@@ -1,0 +1,157 @@
+package featurecat.lizzie.gui;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.awt.Rectangle;
+import org.junit.jupiter.api.Test;
+
+class LizzieFrameBottomToolbarLayoutTest {
+
+  private static final int MAXIMIZED_WIDTH = 1920;
+  private static final int MAXIMIZED_FRAME_HEIGHT = 1052;
+  private static final int RESTORED_WIDTH = 1065;
+  private static final int RESTORED_FRAME_HEIGHT = 700;
+  private static final int INSET_TOP = 28;
+  private static final int INSET_BOTTOM = 0;
+  private static final int NATIVE_MENU_HEIGHT = 28;
+  private static final int TOP_PANEL_HEIGHT = 32;
+
+  @Test
+  void shownContractStaysTwentySixAndHiddenStaysZero() {
+    assertEquals(26, Menu.BOTTOM_TOOLBAR_SHOWN_HEIGHT);
+    assertEquals(0, Menu.BOTTOM_TOOLBAR_HIDDEN_HEIGHT);
+  }
+
+  @Test
+  void fallbackContentHeightReservesNativeMenuBar() {
+    assertEquals(
+        996,
+        LizzieFrame.resolvedContentLength(
+            0, MAXIMIZED_FRAME_HEIGHT, INSET_TOP, INSET_BOTTOM, NATIVE_MENU_HEIGHT));
+  }
+
+  @Test
+  void laidOutContentPaneWinsOverFrameMinusInsets() {
+    assertEquals(
+        996,
+        LizzieFrame.resolvedContentLength(996, MAXIMIZED_FRAME_HEIGHT, INSET_TOP, INSET_BOTTOM, 0));
+  }
+
+  @Test
+  void parentPanelSizeIsPreferredOverALargerContentPane() {
+    assertEquals(996, LizzieFrame.preferLaidOutLength(996, 1024));
+    assertEquals(996, LizzieFrame.preferLaidOutLength(0, 996));
+    assertEquals(0, LizzieFrame.preferLaidOutLength(0, 0));
+  }
+
+  @Test
+  void nativeMenuReserveIsZeroForCustomStrip() {
+    assertEquals(0, LizzieFrame.nativeMenuBarReserve(false, 28, 28));
+  }
+
+  @Test
+  void nativeMenuReserveUsesRealHeightThenPreferred() {
+    assertEquals(28, LizzieFrame.nativeMenuBarReserve(true, 28, 34));
+    assertEquals(34, LizzieFrame.nativeMenuBarReserve(true, 0, 34));
+    assertEquals(0, LizzieFrame.nativeMenuBarReserve(true, 0, 0));
+  }
+
+  @Test
+  void shownToolbarFitsInsideMaximizedLinuxContentPane() {
+    LizzieFrame.MainContentLayout layout =
+        layoutFor(MAXIMIZED_WIDTH, maximizedContentHeight(), Menu.BOTTOM_TOOLBAR_SHOWN_HEIGHT);
+
+    assertToolbarFullyInside(layout, maximizedContentHeight());
+    assertEquals(Menu.BOTTOM_TOOLBAR_SHOWN_HEIGHT, layout.toolbar.height);
+    assertEquals(maximizedContentHeight() - Menu.BOTTOM_TOOLBAR_SHOWN_HEIGHT, layout.toolbar.y);
+    assertEquals(
+        remainingBoardHeight(maximizedContentHeight(), Menu.BOTTOM_TOOLBAR_SHOWN_HEIGHT),
+        layout.mainPanel.height);
+  }
+
+  @Test
+  void hidingToolbarGivesTheBoardTheReservedBand() {
+    int contentHeight = maximizedContentHeight();
+    LizzieFrame.MainContentLayout shown =
+        layoutFor(MAXIMIZED_WIDTH, contentHeight, Menu.BOTTOM_TOOLBAR_SHOWN_HEIGHT);
+    LizzieFrame.MainContentLayout hidden =
+        layoutFor(MAXIMIZED_WIDTH, contentHeight, Menu.BOTTOM_TOOLBAR_HIDDEN_HEIGHT);
+
+    assertEquals(Menu.BOTTOM_TOOLBAR_HIDDEN_HEIGHT, hidden.toolbar.height);
+    assertEquals(contentHeight, hidden.toolbar.y);
+    assertEquals(
+        shown.mainPanel.height + Menu.BOTTOM_TOOLBAR_SHOWN_HEIGHT, hidden.mainPanel.height);
+    assertEquals(contentHeight, hidden.mainPanel.y + hidden.mainPanel.height);
+    assertToolbarFullyInside(hidden, contentHeight);
+  }
+
+  @Test
+  void restoredWindowUsesTheSameReserveAndRestoreMath() {
+    int contentHeight =
+        LizzieFrame.resolvedContentLength(
+            0, RESTORED_FRAME_HEIGHT, INSET_TOP, 4, NATIVE_MENU_HEIGHT);
+    LizzieFrame.MainContentLayout shown =
+        layoutFor(RESTORED_WIDTH, contentHeight, Menu.BOTTOM_TOOLBAR_SHOWN_HEIGHT);
+    LizzieFrame.MainContentLayout hidden =
+        layoutFor(RESTORED_WIDTH, contentHeight, Menu.BOTTOM_TOOLBAR_HIDDEN_HEIGHT);
+
+    assertEquals(640, contentHeight);
+    assertToolbarFullyInside(shown, contentHeight);
+    assertEquals(Menu.BOTTOM_TOOLBAR_SHOWN_HEIGHT, shown.toolbar.height);
+    assertEquals(
+        shown.mainPanel.height + Menu.BOTTOM_TOOLBAR_SHOWN_HEIGHT, hidden.mainPanel.height);
+    assertEquals(
+        contentHeight, hidden.mainPanel.y + hidden.mainPanel.height + hidden.toolbar.height);
+  }
+
+  @Test
+  void customStripFallbackDoesNotReserveANativeMenuBar() {
+    int contentHeight =
+        LizzieFrame.resolvedContentLength(
+            0, MAXIMIZED_FRAME_HEIGHT, INSET_TOP, INSET_BOTTOM, 0);
+    LizzieFrame.MainContentLayout shown =
+        layoutFor(MAXIMIZED_WIDTH, contentHeight, Menu.BOTTOM_TOOLBAR_SHOWN_HEIGHT);
+
+    assertEquals(1024, contentHeight);
+    assertEquals(0, LizzieFrame.nativeMenuBarReserve(false, 28, 28));
+    assertToolbarFullyInside(shown, contentHeight);
+    assertEquals(Menu.BOTTOM_TOOLBAR_SHOWN_HEIGHT, shown.toolbar.height);
+  }
+
+  @Test
+  void oldFrameMinusInsetsMathPutsTheShownBarPastTheContentPane() {
+    int oldContentHeight = MAXIMIZED_FRAME_HEIGHT - INSET_TOP - INSET_BOTTOM;
+    int contentHeight = maximizedContentHeight();
+    LizzieFrame.MainContentLayout oldLayout =
+        LizzieFrame.layoutMainContent(
+            MAXIMIZED_WIDTH, oldContentHeight, 0, TOP_PANEL_HEIGHT, true, 26, 0);
+
+    assertTrue(
+        oldLayout.toolbar.y + oldLayout.toolbar.height > contentHeight,
+        "frame height minus window insets still places the bar below the content pane");
+  }
+
+  private static int maximizedContentHeight() {
+    return LizzieFrame.resolvedContentLength(
+        0, MAXIMIZED_FRAME_HEIGHT, INSET_TOP, INSET_BOTTOM, NATIVE_MENU_HEIGHT);
+  }
+
+  private static LizzieFrame.MainContentLayout layoutFor(
+      int width, int contentHeight, int toolbarHeight) {
+    return LizzieFrame.layoutMainContent(
+        width, contentHeight, 0, TOP_PANEL_HEIGHT, true, toolbarHeight, 0);
+  }
+
+  private static int remainingBoardHeight(int contentHeight, int toolbarHeight) {
+    return contentHeight - TOP_PANEL_HEIGHT - toolbarHeight;
+  }
+
+  private static void assertToolbarFullyInside(
+      LizzieFrame.MainContentLayout layout, int contentHeight) {
+    Rectangle bar = layout.toolbar;
+    assertTrue(bar.y >= 0, "toolbar y is above the content pane");
+    assertTrue(bar.y + bar.height <= contentHeight, "toolbar extends past the content pane");
+    assertEquals(contentHeight - bar.height, bar.y);
+  }
+}


### PR DESCRIPTION
## Repro
Linux x64, maximize. Show the bottom toolbar: bar or buttons can clip at the window edge. Hide the toolbar: A–T / rank coordinates and text under the board can stay cut off. Reporter package `2026-08-27-linux64.nvidia.zip` / `next-2026-08-27.2`.

## Cause
`reSetLoc` sized the board and toolbar from `frame height - insets` and missed the native Swing menu bar used on Linux Wayland. That left the shown 26px bar short of the window edge, and hide could leave a leftover reserved band so coordinates stayed clipped.

## Fix
- Size board and toolbar against the real content pane, including the native menu bar on Linux Wayland.
- Shown stays the existing 26px bar, placed fully inside content height.
- Hidden uses height 0 and gives that band back to `mainPanel`.
- Fallback (before the content pane is laid out) subtracts native menu-bar height from `frame height - insets`. Laid-out `basePanel` size is preferred when available.
- No new shrink-toolbar preference. `Utils.zoomOut` kept. `showStatus` is not the toolbar. Checkmark wiring unchanged.

## Verification
Headless: `LizzieFrameBottomToolbarLayoutTest` plus existing toolbar height/visibility tests. Parent Linux desktop screenshots (Visible / Hidden) follow this PR.

Fixes #351
