### PR TITLE
Mirror AMD RX 9000 experimental package on R2

### DIFF
--- a/docs/PACKAGES.md
+++ b/docs/PACKAGES.md
@@ -227,7 +227,7 @@ OUT_DIR=dist/perf SCENARIO=startup DURATION_SECONDS=45 \
 - Windows 64 位无引擎包同时提供安装器和 `.portable.zip`
 - 当前公开 release 主列表固定为 13 个首次下载稳定资产；另有 6 个 DirectML/OpenVINO/ROCm 实验便携包；`windows64.core-update.zip` 是已有 Windows 免安装用户的小更新资产；TensorRT 分卷不替代软件内断点续传安装
 - 旧的兼容 zip 只作为历史 tag 说明保留，不再放进主推荐区
-- R2 只镜像当前正式版的 Windows 免安装包、小更新包、两款 macOS DMG 和 TensorRT 分卷；完整策略与维护流程见 [Cloudflare R2 正式版下载与升级](R2_RELEASES.md)
+- R2 只镜像当前正式版的 Windows 常用免安装包、RX 9000 ROCm 实验包、小更新包、两款 macOS DMG 和 TensorRT 分卷；其他 AMD ROCm 架构继续从 GitHub 下载。完整策略与维护流程见 [Cloudflare R2 正式版下载与升级](R2_RELEASES.md)
 
 ## 相关文档
 

--- a/docs/R2_RELEASES.md
+++ b/docs/R2_RELEASES.md
@@ -14,14 +14,16 @@
 ## 固定资源范围
 
 R2 桶名固定为 `lizzieyzy-next-downloads`，只保留一个正式版。发布脚本要求每个正式版恰好
-包含以下 12 个镜像对象，数量或名称不一致会直接停止：
+包含以下 13 个镜像对象，数量或名称不一致会直接停止：
 
 - 4 个 Windows 免安装包：OpenCL、CPU、统一 NVIDIA CUDA、无引擎
 - `windows64.core-update.zip`
 - macOS Apple Silicon 与 Intel 两个 DMG
+- Windows AMD RX 9000 / RDNA4 `gfx120x` ROCm 实验免安装包
 - TensorRT `.7z.001`、`.7z.002`、README、manifest、SHA-256 文件
 
-Windows 安装器、Linux 包、pre-release 和历史版本不占用 R2。版本化对象位于
+Windows 安装器、Linux 包、其他 AMD ROCm 架构、pre-release 和历史版本不占用 R2。
+RX 6000、RX 7000 与 Ryzen AI Max 的实验包继续由 GitHub Release 提供。版本化对象位于
 `releases/<tag>/`，稳定频道使用：
 
 - `channels/stable/update-envelope.json`
@@ -105,7 +107,7 @@ Ed25519 私钥只能存在于 GitHub Secret；应用内只包含公钥。更换�
 - `https://goagent.top/download/` 显示正确 stable tag，且没有 pre-release。
 - `https://www.goagent.top/download/`、`https://download.goagent.top/` 与
   `https://download.goagent.top/index.html` 均以 301 跳到统一官网下载页。
-- 12 个对象均返回 HTTPS 200、正确 `Content-Length`、`Accept-Ranges: bytes`、
+- 13 个对象均返回 HTTPS 200、正确 `Content-Length`、`Accept-Ranges: bytes`、
   `Content-Disposition: attachment` 和 immutable 缓存策略。
 - `Range: bytes=0-0` 返回 206 和正确 `Content-Range`。
 - R2 对象总量小于 9 GB，`releases/` 下不存在旧正式版目录。

--- a/scripts/r2_release.py
+++ b/scripts/r2_release.py
@@ -45,6 +45,10 @@ WINDOWS_PORTABLE = re.compile(
 WINDOWS_CORE = re.compile(
     r"^(?P<date>\d{4}-\d{2}-\d{2})-windows64\.core-update\.zip$"
 )
+WINDOWS_AMD_ROCM = re.compile(
+    r"^(?P<date>\d{4}-\d{2}-\d{2})-windows64\.experimental\.rocm\.gfx120x"
+    r"\.portable\.zip$"
+)
 MAC_DMG = re.compile(
     r"^(?P<date>\d{4}-\d{2}-\d{2})-mac-"
     r"(?P<chip>apple-silicon|intel)\.with-katago\.dmg$"
@@ -121,7 +125,7 @@ def select_r2_assets(
     if not tag:
         raise ReleaseError("Release tag is missing")
     selected: list[Asset] = []
-    counts = {"windows": 0, "core": 0, "mac": 0, "tensorrt": 0}
+    counts = {"windows": 0, "core": 0, "amd_rocm": 0, "mac": 0, "tensorrt": 0}
     for raw in release_assets(release):
         name = str(raw.get("name") or "")
         match = WINDOWS_PORTABLE.fullmatch(name)
@@ -138,26 +142,34 @@ def select_r2_assets(
                 kwargs = {"flavor": "all", "arch": "x64"}
                 counts["core"] += 1
             else:
-                match = MAC_DMG.fullmatch(name)
+                match = WINDOWS_AMD_ROCM.fullmatch(name)
                 if match:
-                    category = "macos-dmg"
-                    kwargs = {
-                        "flavor": "with-katago",
-                        "arch": "arm64" if match.group("chip") == "apple-silicon" else "x64",
-                    }
-                    counts["mac"] += 1
+                    category = "amd-rocm-experimental"
+                    kwargs = {"flavor": "rocm-gfx120x", "arch": "x64"}
+                    counts["amd_rocm"] += 1
                 else:
-                    match = TENSORRT_ASSET.fullmatch(name)
+                    match = MAC_DMG.fullmatch(name)
                     if match:
-                        category = "tensorrt-optional"
-                        kwargs = {"flavor": "nvidia-tensorrt", "arch": "x64"}
-                        counts["tensorrt"] += 1
+                        category = "macos-dmg"
+                        kwargs = {
+                            "flavor": "with-katago",
+                            "arch": (
+                                "arm64" if match.group("chip") == "apple-silicon" else "x64"
+                            ),
+                        }
+                        counts["mac"] += 1
+                    else:
+                        match = TENSORRT_ASSET.fullmatch(name)
+                        if match:
+                            category = "tensorrt-optional"
+                            kwargs = {"flavor": "nvidia-tensorrt", "arch": "x64"}
+                            counts["tensorrt"] += 1
         if not category:
             continue
         asset = Asset.from_github(raw, category, **kwargs)
         selected.append(dataclasses.replace(asset, r2_key=f"releases/{tag}/{name}"))
 
-    expected = {"windows": 4, "core": 1, "mac": 2, "tensorrt": 5}
+    expected = {"windows": 4, "core": 1, "amd_rocm": 1, "mac": 2, "tensorrt": 5}
     if counts != expected:
         raise ReleaseError(f"R2 asset whitelist mismatch: expected {expected}, found {counts}")
     names = [asset.name for asset in selected]
@@ -363,6 +375,7 @@ def catalog_label(asset: Asset) -> tuple[str, str, bool]:
         "nvidia": ("Windows NVIDIA", "Windows NVIDIA", False),
         "without.engine": ("Windows 无引擎版", "Windows without engine", False),
         "nvidia-tensorrt": ("RTX 30 系及以下可选 TensorRT", "Optional TensorRT for RTX 30 and earlier", True),
+        "rocm-gfx120x": ("AMD RX 9000 ROCm 实验版", "AMD RX 9000 ROCm experimental", True),
     }
     if asset.category == "macos-dmg":
         return (

--- a/scripts/test_r2_release.py
+++ b/scripts/test_r2_release.py
@@ -29,6 +29,7 @@ def release():
         f"{DATE}-windows64.nvidia.portable.zip",
         f"{DATE}-windows64.without.engine.portable.zip",
         f"{DATE}-windows64.core-update.zip",
+        f"{DATE}-windows64.experimental.rocm.gfx120x.portable.zip",
         f"{DATE}-mac-apple-silicon.with-katago.dmg",
         f"{DATE}-mac-intel.with-katago.dmg",
         f"{DATE}-windows64.nvidia.tensorrt.portable.7z.001",
@@ -40,6 +41,9 @@ def release():
         f"{DATE}-linux64.opencl.zip",
         f"{DATE}-linux64.nvidia.zip",
         f"{DATE}-windows64.opencl.installer.exe",
+        f"{DATE}-windows64.experimental.rocm.gfx103x.portable.zip",
+        f"{DATE}-windows64.experimental.rocm.gfx110x.portable.zip",
+        f"{DATE}-windows64.experimental.rocm.gfx1151.portable.zip",
     ]
     return {
         "tag_name": TAG,
@@ -51,13 +55,24 @@ def release():
 
 
 class R2ReleaseTest(unittest.TestCase):
-    def test_whitelist_is_exact_and_excludes_installers_and_linux(self):
+    def test_whitelist_is_exact_and_excludes_installers_linux_and_older_amd(self):
         selected = r2_release.select_r2_assets(release(), r2_release.DEFAULT_PUBLIC_BASE)
 
-        self.assertEqual(12, len(selected))
-        self.assertEqual(12_000, sum(entry.size for entry in selected))
+        self.assertEqual(13, len(selected))
+        self.assertEqual(13_000, sum(entry.size for entry in selected))
         self.assertFalse(any(entry.name.endswith("installer.exe") for entry in selected))
         self.assertFalse(any("linux64" in entry.name for entry in selected))
+        self.assertEqual(
+            [f"{DATE}-windows64.experimental.rocm.gfx120x.portable.zip"],
+            [entry.name for entry in selected if entry.category == "amd-rocm-experimental"],
+        )
+        self.assertFalse(
+            any(
+                family in entry.name
+                for entry in selected
+                for family in ("gfx103x", "gfx110x", "gfx1151")
+            )
+        )
 
     def test_missing_asset_and_size_limit_fail_closed(self):
         missing = release()
@@ -66,6 +81,13 @@ class R2ReleaseTest(unittest.TestCase):
         ]
         with self.assertRaises(r2_release.ReleaseError):
             r2_release.select_r2_assets(missing, r2_release.DEFAULT_PUBLIC_BASE)
+
+        missing_amd = release()
+        missing_amd["assets"] = [
+            entry for entry in missing_amd["assets"] if "rocm.gfx120x" not in entry["name"]
+        ]
+        with self.assertRaises(r2_release.ReleaseError):
+            r2_release.select_r2_assets(missing_amd, r2_release.DEFAULT_PUBLIC_BASE)
 
         oversized = release()
         oversized["assets"][0]["size"] = r2_release.R2_SIZE_LIMIT
@@ -110,6 +132,9 @@ class R2ReleaseTest(unittest.TestCase):
         linux = next(package for package in manifest["packages"] if package["platform"] == "linux")
         self.assertTrue(linux["downloadUrl"].startswith("https://github.com/"))
         self.assertEqual([], linux["mirrorUrls"])
+        self.assertFalse(
+            any(package["flavor"] == "rocm-gfx120x" for package in manifest["packages"])
+        )
 
     def test_legacy_manifest_stays_github_only(self):
         source = release()
@@ -165,6 +190,13 @@ class R2ReleaseTest(unittest.TestCase):
             )
         )
         self.assertTrue(all(entry["mirrorUrls"] for entry in stable["assets"]))
+        amd = next(
+            entry for entry in stable["assets"] if entry["flavor"] == "rocm-gfx120x"
+        )
+        self.assertEqual("amd-rocm-experimental", amd["category"])
+        self.assertEqual("x64", amd["arch"])
+        self.assertTrue(amd["advanced"])
+        self.assertEqual("AMD RX 9000 ROCm 实验版", amd["labelZh"])
         self.assertTrue(
             all(entry["mirrorUrls"] == [] for entry in maintenance["assets"])
         )


### PR DESCRIPTION
## Summary

- mirrors only the Windows RDNA4 / RX 9000 `gfx120x` ROCm experimental portable package
- keeps older AMD architectures, installers, Linux packages, and pre-releases on GitHub only
- exposes the package in the stable download catalog without adding it to automatic updates
- raises the exact R2 asset contract from 12 to 13 while preserving the 9 GB hard limit

## Validation

- `python3 -m unittest scripts.test_r2_release` (20 passed)
- `python3 scripts/check_line_endings.py`
- `python3 scripts/check_markdown_links.py`
- `git diff --check`
- `mvn -B -Dfmt.skip=true test` (3422 tests, 0 failures, 0 errors)
- `mvn -B -Dfmt.skip=true -DskipTests package`
- real `next-2026-08-27.5` asset plan: 13 objects, 7,747,939,628 bytes

The AMD package remains experimental and is not presented as an automatic update target.