### PR TITLE
Wrap Problem moves empty-state subtitle so it stays inside the card

### DIFF
--- a/src/main/java/featurecat/lizzie/gui/BlunderListPanel.java
+++ b/src/main/java/featurecat/lizzie/gui/BlunderListPanel.java
@@ -19,6 +19,14 @@ public class BlunderListPanel extends JPanel implements Scrollable {
   private static final int CARD_HEIGHT = 64;
   private static final int PADDING = 10;
   private static final int DEFAULT_CARD_CORNER_RADIUS = 10;
+  static final int EMPTY_STATE_MAX_BOX_WIDTH = 220;
+  static final int EMPTY_STATE_MIN_BOX_HEIGHT = 86;
+  static final int EMPTY_STATE_MARGIN = 12;
+  static final int EMPTY_STATE_TEXT_INSET = 16;
+  static final int EMPTY_STATE_TITLE_SUBTITLE_GAP = 8;
+  static final String EMPTY_STATE_TITLE = "当前无问题手";
+  static final String EMPTY_STATE_ANALYZING_TITLE = "⏳ 正在整理问题手...";
+  static final String EMPTY_STATE_SUBTITLE = "全盘分析后，这里会列出掉胜率较多的问题手";
 
   private static final Color COLOR_DANGER = new Color(0xEF, 0x44, 0x44); // 🔴
   private static final Color COLOR_WARNING = new Color(0xF9, 0x73, 0x16); // 🟧
@@ -205,26 +213,34 @@ public class BlunderListPanel extends JPanel implements Scrollable {
   private void drawEmptyState(Graphics g) {
     Graphics2D g2 = (Graphics2D) g.create();
     g2.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
-    g2.setFont(new Font(Lizzie.config.uiFontName, Font.PLAIN, 14));
-    String text =
-        currentSnapshot != null && currentSnapshot.analysisRunning ? "⏳ 正在整理问题手..." : "当前无问题手";
-    FontMetrics fm = g2.getFontMetrics();
+    String fontName =
+        Lizzie.config != null && Lizzie.config.uiFontName != null
+            ? Lizzie.config.uiFontName
+            : Font.SANS_SERIF;
+    Font titleFont = new Font(fontName, Font.PLAIN, 14);
+    Font subtitleFont = new Font(fontName, Font.PLAIN, 12);
+    EmptyStateLayout layout =
+        layoutEmptyState(
+            Math.max(1, getWidth()),
+            Math.max(1, getHeight()),
+            g2.getFontMetrics(titleFont),
+            g2.getFontMetrics(subtitleFont),
+            currentSnapshot != null && currentSnapshot.analysisRunning);
     // Both styles use a dark sidebar surface, so the boxed empty state works for both.
-    int boxW = Math.min(getWidth() - 24, 220);
-    int boxH = 86;
-    int boxX = Math.max(12, (getWidth() - boxW) / 2);
-    int boxY = Math.max(12, (getHeight() - boxH) / 2 - 12);
     g2.setColor(new Color(255, 255, 255, 14));
-    g2.fillRoundRect(boxX, boxY, boxW, boxH, 18, 18);
+    g2.fillRoundRect(layout.boxX, layout.boxY, layout.boxW, layout.boxH, 18, 18);
     g2.setColor(new Color(255, 255, 255, 24));
-    g2.drawRoundRect(boxX, boxY, boxW - 1, boxH - 1, 18, 18);
+    g2.drawRoundRect(layout.boxX, layout.boxY, layout.boxW - 1, layout.boxH - 1, 18, 18);
+    g2.setFont(titleFont);
     g2.setColor(TEXT_PRIMARY);
-    g2.drawString(text, boxX + (boxW - fm.stringWidth(text)) / 2, boxY + 34);
+    for (EmptyStateLine line : layout.titleLines) {
+      g2.drawString(line.text, line.x, line.baselineY);
+    }
+    g2.setFont(subtitleFont);
     g2.setColor(TEXT_SECONDARY);
-    String sub = "全盘分析后，这里会列出掉胜率较多的问题手";
-    g2.setFont(new Font(Lizzie.config.uiFontName, Font.PLAIN, 12));
-    FontMetrics subFm = g2.getFontMetrics();
-    g2.drawString(sub, boxX + (boxW - subFm.stringWidth(sub)) / 2, boxY + 58);
+    for (EmptyStateLine line : layout.subtitleLines) {
+      g2.drawString(line.text, line.x, line.baselineY);
+    }
     g2.dispose();
   }
 
@@ -438,5 +454,130 @@ public class BlunderListPanel extends JPanel implements Scrollable {
   private Color withAlpha(Color color, int alpha) {
     return new Color(
         color.getRed(), color.getGreen(), color.getBlue(), Math.max(0, Math.min(255, alpha)));
+  }
+
+  static int emptyStateBoxWidth(int panelWidth) {
+    return Math.max(1, Math.min(panelWidth - EMPTY_STATE_MARGIN * 2, EMPTY_STATE_MAX_BOX_WIDTH));
+  }
+
+  static List<String> wrapToWidth(FontMetrics metrics, String text, int maxWidth) {
+    List<String> lines = new ArrayList<>();
+    if (text == null || text.isEmpty()) {
+      return lines;
+    }
+    int limit = Math.max(1, maxWidth);
+    StringBuilder line = new StringBuilder();
+    int index = 0;
+    while (index < text.length()) {
+      int next = index + Character.charCount(text.codePointAt(index));
+      String ch = text.substring(index, next);
+      if (line.length() > 0 && metrics.stringWidth(line.toString() + ch) > limit) {
+        lines.add(line.toString());
+        line.setLength(0);
+      }
+      line.append(ch);
+      index = next;
+    }
+    if (line.length() > 0) {
+      lines.add(line.toString());
+    }
+    return lines;
+  }
+
+  static EmptyStateLayout layoutEmptyState(
+      int panelWidth,
+      int panelHeight,
+      FontMetrics titleMetrics,
+      FontMetrics subtitleMetrics,
+      boolean analysisRunning) {
+    String title = analysisRunning ? EMPTY_STATE_ANALYZING_TITLE : EMPTY_STATE_TITLE;
+    int boxW = emptyStateBoxWidth(panelWidth);
+    int boxX = Math.max(EMPTY_STATE_MARGIN, (panelWidth - boxW) / 2);
+    int innerWidth = Math.max(1, boxW - EMPTY_STATE_TEXT_INSET * 2);
+    List<String> wrappedTitle = wrapToWidth(titleMetrics, title, innerWidth);
+    List<String> wrappedSubtitle = wrapToWidth(subtitleMetrics, EMPTY_STATE_SUBTITLE, innerWidth);
+    int titleBlockHeight =
+        Math.max(titleMetrics.getHeight(), wrappedTitle.size() * titleMetrics.getHeight());
+    int subtitleBlockHeight =
+        Math.max(subtitleMetrics.getHeight(), wrappedSubtitle.size() * subtitleMetrics.getHeight());
+    int contentHeight = titleBlockHeight + EMPTY_STATE_TITLE_SUBTITLE_GAP + subtitleBlockHeight;
+    int boxH = Math.max(EMPTY_STATE_MIN_BOX_HEIGHT, contentHeight + EMPTY_STATE_TEXT_INSET * 2);
+    int boxY = Math.max(EMPTY_STATE_MARGIN, (panelHeight - boxH) / 2 - EMPTY_STATE_MARGIN);
+    int contentTop = boxY + Math.max(EMPTY_STATE_TEXT_INSET, (boxH - contentHeight) / 2);
+
+    List<EmptyStateLine> titleLines = new ArrayList<>();
+    int titleBaseline = contentTop + titleMetrics.getAscent();
+    for (String line : wrappedTitle) {
+      int width = titleMetrics.stringWidth(line);
+      titleLines.add(
+          new EmptyStateLine(
+              line,
+              boxX + (boxW - width) / 2,
+              titleBaseline,
+              width,
+              titleMetrics.getAscent(),
+              titleMetrics.getDescent()));
+      titleBaseline += titleMetrics.getHeight();
+    }
+
+    List<EmptyStateLine> subtitleLines = new ArrayList<>();
+    int subtitleBaseline =
+        contentTop + titleBlockHeight + EMPTY_STATE_TITLE_SUBTITLE_GAP + subtitleMetrics.getAscent();
+    for (String line : wrappedSubtitle) {
+      int width = subtitleMetrics.stringWidth(line);
+      subtitleLines.add(
+          new EmptyStateLine(
+              line,
+              boxX + (boxW - width) / 2,
+              subtitleBaseline,
+              width,
+              subtitleMetrics.getAscent(),
+              subtitleMetrics.getDescent()));
+      subtitleBaseline += subtitleMetrics.getHeight();
+    }
+
+    return new EmptyStateLayout(boxX, boxY, boxW, boxH, titleLines, subtitleLines);
+  }
+
+  static final class EmptyStateLine {
+    final String text;
+    final int x;
+    final int baselineY;
+    final int width;
+    final int ascent;
+    final int descent;
+
+    EmptyStateLine(String text, int x, int baselineY, int width, int ascent, int descent) {
+      this.text = text;
+      this.x = x;
+      this.baselineY = baselineY;
+      this.width = width;
+      this.ascent = ascent;
+      this.descent = descent;
+    }
+  }
+
+  static final class EmptyStateLayout {
+    final int boxX;
+    final int boxY;
+    final int boxW;
+    final int boxH;
+    final List<EmptyStateLine> titleLines;
+    final List<EmptyStateLine> subtitleLines;
+
+    EmptyStateLayout(
+        int boxX,
+        int boxY,
+        int boxW,
+        int boxH,
+        List<EmptyStateLine> titleLines,
+        List<EmptyStateLine> subtitleLines) {
+      this.boxX = boxX;
+      this.boxY = boxY;
+      this.boxW = boxW;
+      this.boxH = boxH;
+      this.titleLines = Collections.unmodifiableList(new ArrayList<>(titleLines));
+      this.subtitleLines = Collections.unmodifiableList(new ArrayList<>(subtitleLines));
+    }
   }
 }

--- a/src/main/java/featurecat/lizzie/gui/BlunderListPanel.java
+++ b/src/main/java/featurecat/lizzie/gui/BlunderListPanel.java
@@ -146,11 +146,37 @@ public class BlunderListPanel extends JPanel implements Scrollable {
     return !getVisibleBlackEntries().isEmpty() || !getVisibleWhiteEntries().isEmpty();
   }
 
+  private boolean showingEmptyState() {
+    return currentSnapshot == null || !hasVisibleEntries();
+  }
+
+  private String emptyStateFontName() {
+    return Lizzie.config != null && Lizzie.config.uiFontName != null
+        ? Lizzie.config.uiFontName
+        : Font.SANS_SERIF;
+  }
+
+  private int emptyStatePreferredHeight(int panelWidth) {
+    Font titleFont = new Font(emptyStateFontName(), Font.PLAIN, 14);
+    Font subtitleFont = new Font(emptyStateFontName(), Font.PLAIN, 12);
+    EmptyStateLayout layout =
+        layoutEmptyState(
+            panelWidth,
+            1,
+            getFontMetrics(titleFont),
+            getFontMetrics(subtitleFont),
+            currentSnapshot != null && currentSnapshot.analysisRunning);
+    return layout.boxH + EMPTY_STATE_MARGIN * 2;
+  }
+
   @Override
   public Dimension getPreferredSize() {
-    int rows = currentSnapshot == null ? 0 : getMergedEntries().size();
-    int height = currentSnapshot == null ? 1 : HEADER_HEIGHT + rows * CARD_HEIGHT + PADDING;
-    return new Dimension(preferredViewportWidth(), Math.max(1, height));
+    int width = preferredViewportWidth();
+    if (showingEmptyState()) {
+      return new Dimension(width, Math.max(1, emptyStatePreferredHeight(width)));
+    }
+    int rows = getMergedEntries().size();
+    return new Dimension(width, Math.max(1, HEADER_HEIGHT + rows * CARD_HEIGHT + PADDING));
   }
 
   @Override
@@ -197,7 +223,7 @@ public class BlunderListPanel extends JPanel implements Scrollable {
   @Override
   protected void paintComponent(Graphics g) {
     super.paintComponent(g);
-    if (currentSnapshot == null || !hasVisibleEntries()) {
+    if (showingEmptyState()) {
       drawEmptyState(g);
       return;
     }
@@ -213,12 +239,8 @@ public class BlunderListPanel extends JPanel implements Scrollable {
   private void drawEmptyState(Graphics g) {
     Graphics2D g2 = (Graphics2D) g.create();
     g2.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
-    String fontName =
-        Lizzie.config != null && Lizzie.config.uiFontName != null
-            ? Lizzie.config.uiFontName
-            : Font.SANS_SERIF;
-    Font titleFont = new Font(fontName, Font.PLAIN, 14);
-    Font subtitleFont = new Font(fontName, Font.PLAIN, 12);
+    Font titleFont = new Font(emptyStateFontName(), Font.PLAIN, 14);
+    Font subtitleFont = new Font(emptyStateFontName(), Font.PLAIN, 12);
     EmptyStateLayout layout =
         layoutEmptyState(
             Math.max(1, getWidth()),
@@ -460,6 +482,27 @@ public class BlunderListPanel extends JPanel implements Scrollable {
     return Math.max(1, Math.min(panelWidth - EMPTY_STATE_MARGIN * 2, EMPTY_STATE_MAX_BOX_WIDTH));
   }
 
+  static int lineHeight(FontMetrics metrics) {
+    return Math.max(metrics.getHeight(), metrics.getAscent() + metrics.getDescent());
+  }
+
+  static int emptyStateCardHeight(
+      FontMetrics titleMetrics,
+      FontMetrics subtitleMetrics,
+      int boxW,
+      boolean analysisRunning) {
+    String title = analysisRunning ? EMPTY_STATE_ANALYZING_TITLE : EMPTY_STATE_TITLE;
+    int innerWidth = Math.max(1, boxW - EMPTY_STATE_TEXT_INSET * 2);
+    int titleLines = Math.max(1, wrapToWidth(titleMetrics, title, innerWidth).size());
+    int subtitleLines =
+        Math.max(1, wrapToWidth(subtitleMetrics, EMPTY_STATE_SUBTITLE, innerWidth).size());
+    int contentHeight =
+        titleLines * lineHeight(titleMetrics)
+            + EMPTY_STATE_TITLE_SUBTITLE_GAP
+            + subtitleLines * lineHeight(subtitleMetrics);
+    return Math.max(EMPTY_STATE_MIN_BOX_HEIGHT, contentHeight + EMPTY_STATE_TEXT_INSET * 2);
+  }
+
   static List<String> wrapToWidth(FontMetrics metrics, String text, int maxWidth) {
     List<String> lines = new ArrayList<>();
     if (text == null || text.isEmpty()) {
@@ -496,13 +539,17 @@ public class BlunderListPanel extends JPanel implements Scrollable {
     int innerWidth = Math.max(1, boxW - EMPTY_STATE_TEXT_INSET * 2);
     List<String> wrappedTitle = wrapToWidth(titleMetrics, title, innerWidth);
     List<String> wrappedSubtitle = wrapToWidth(subtitleMetrics, EMPTY_STATE_SUBTITLE, innerWidth);
-    int titleBlockHeight =
-        Math.max(titleMetrics.getHeight(), wrappedTitle.size() * titleMetrics.getHeight());
+    int titleLineHeight = lineHeight(titleMetrics);
+    int subtitleLineHeight = lineHeight(subtitleMetrics);
+    int titleBlockHeight = Math.max(titleLineHeight, wrappedTitle.size() * titleLineHeight);
     int subtitleBlockHeight =
-        Math.max(subtitleMetrics.getHeight(), wrappedSubtitle.size() * subtitleMetrics.getHeight());
+        Math.max(subtitleLineHeight, wrappedSubtitle.size() * subtitleLineHeight);
     int contentHeight = titleBlockHeight + EMPTY_STATE_TITLE_SUBTITLE_GAP + subtitleBlockHeight;
-    int boxH = Math.max(EMPTY_STATE_MIN_BOX_HEIGHT, contentHeight + EMPTY_STATE_TEXT_INSET * 2);
+    int boxH = emptyStateCardHeight(titleMetrics, subtitleMetrics, boxW, analysisRunning);
     int boxY = Math.max(EMPTY_STATE_MARGIN, (panelHeight - boxH) / 2 - EMPTY_STATE_MARGIN);
+    if (boxY + boxH + EMPTY_STATE_MARGIN > panelHeight) {
+      boxY = EMPTY_STATE_MARGIN;
+    }
     int contentTop = boxY + Math.max(EMPTY_STATE_TEXT_INSET, (boxH - contentHeight) / 2);
 
     List<EmptyStateLine> titleLines = new ArrayList<>();
@@ -517,7 +564,7 @@ public class BlunderListPanel extends JPanel implements Scrollable {
               width,
               titleMetrics.getAscent(),
               titleMetrics.getDescent()));
-      titleBaseline += titleMetrics.getHeight();
+      titleBaseline += titleLineHeight;
     }
 
     List<EmptyStateLine> subtitleLines = new ArrayList<>();
@@ -533,8 +580,15 @@ public class BlunderListPanel extends JPanel implements Scrollable {
               width,
               subtitleMetrics.getAscent(),
               subtitleMetrics.getDescent()));
-      subtitleBaseline += subtitleMetrics.getHeight();
+      subtitleBaseline += subtitleLineHeight;
     }
+
+    int contentBottom =
+        subtitleLines.isEmpty()
+            ? contentTop + contentHeight
+            : subtitleLines.get(subtitleLines.size() - 1).baselineY
+                + subtitleLines.get(subtitleLines.size() - 1).descent;
+    boxH = Math.max(boxH, contentBottom + EMPTY_STATE_TEXT_INSET - boxY);
 
     return new EmptyStateLayout(boxX, boxY, boxW, boxH, titleLines, subtitleLines);
   }

--- a/src/main/java/featurecat/lizzie/gui/BlunderListPanel.java
+++ b/src/main/java/featurecat/lizzie/gui/BlunderListPanel.java
@@ -156,24 +156,11 @@ public class BlunderListPanel extends JPanel implements Scrollable {
         : Font.SANS_SERIF;
   }
 
-  private int emptyStatePreferredHeight(int panelWidth) {
-    Font titleFont = new Font(emptyStateFontName(), Font.PLAIN, 14);
-    Font subtitleFont = new Font(emptyStateFontName(), Font.PLAIN, 12);
-    EmptyStateLayout layout =
-        layoutEmptyState(
-            panelWidth,
-            1,
-            getFontMetrics(titleFont),
-            getFontMetrics(subtitleFont),
-            currentSnapshot != null && currentSnapshot.analysisRunning);
-    return layout.boxH + EMPTY_STATE_MARGIN * 2;
-  }
-
   @Override
   public Dimension getPreferredSize() {
     int width = preferredViewportWidth();
     if (showingEmptyState()) {
-      return new Dimension(width, Math.max(1, emptyStatePreferredHeight(width)));
+      return new Dimension(width, 1);
     }
     int rows = getMergedEntries().size();
     return new Dimension(width, Math.max(1, HEADER_HEIGHT + rows * CARD_HEIGHT + PADDING));
@@ -204,6 +191,9 @@ public class BlunderListPanel extends JPanel implements Scrollable {
 
   @Override
   public boolean getScrollableTracksViewportHeight() {
+    if (showingEmptyState()) {
+      return true;
+    }
     Container parent = getParent();
     return parent instanceof JViewport
         && ((JViewport) parent).getHeight() > getPreferredSize().height;
@@ -239,26 +229,24 @@ public class BlunderListPanel extends JPanel implements Scrollable {
   private void drawEmptyState(Graphics g) {
     Graphics2D g2 = (Graphics2D) g.create();
     g2.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
-    Font titleFont = new Font(emptyStateFontName(), Font.PLAIN, 14);
-    Font subtitleFont = new Font(emptyStateFontName(), Font.PLAIN, 12);
     EmptyStateLayout layout =
-        layoutEmptyState(
+        fitEmptyState(
             Math.max(1, getWidth()),
             Math.max(1, getHeight()),
-            g2.getFontMetrics(titleFont),
-            g2.getFontMetrics(subtitleFont),
-            currentSnapshot != null && currentSnapshot.analysisRunning);
+            emptyStateFontName(),
+            currentSnapshot != null && currentSnapshot.analysisRunning,
+            g2);
     // Both styles use a dark sidebar surface, so the boxed empty state works for both.
     g2.setColor(new Color(255, 255, 255, 14));
     g2.fillRoundRect(layout.boxX, layout.boxY, layout.boxW, layout.boxH, 18, 18);
     g2.setColor(new Color(255, 255, 255, 24));
     g2.drawRoundRect(layout.boxX, layout.boxY, layout.boxW - 1, layout.boxH - 1, 18, 18);
-    g2.setFont(titleFont);
+    g2.setFont(layout.titleFont);
     g2.setColor(TEXT_PRIMARY);
     for (EmptyStateLine line : layout.titleLines) {
       g2.drawString(line.text, line.x, line.baselineY);
     }
-    g2.setFont(subtitleFont);
+    g2.setFont(layout.subtitleFont);
     g2.setColor(TEXT_SECONDARY);
     for (EmptyStateLine line : layout.subtitleLines) {
       g2.drawString(line.text, line.x, line.baselineY);
@@ -486,23 +474,6 @@ public class BlunderListPanel extends JPanel implements Scrollable {
     return Math.max(metrics.getHeight(), metrics.getAscent() + metrics.getDescent());
   }
 
-  static int emptyStateCardHeight(
-      FontMetrics titleMetrics,
-      FontMetrics subtitleMetrics,
-      int boxW,
-      boolean analysisRunning) {
-    String title = analysisRunning ? EMPTY_STATE_ANALYZING_TITLE : EMPTY_STATE_TITLE;
-    int innerWidth = Math.max(1, boxW - EMPTY_STATE_TEXT_INSET * 2);
-    int titleLines = Math.max(1, wrapToWidth(titleMetrics, title, innerWidth).size());
-    int subtitleLines =
-        Math.max(1, wrapToWidth(subtitleMetrics, EMPTY_STATE_SUBTITLE, innerWidth).size());
-    int contentHeight =
-        titleLines * lineHeight(titleMetrics)
-            + EMPTY_STATE_TITLE_SUBTITLE_GAP
-            + subtitleLines * lineHeight(subtitleMetrics);
-    return Math.max(EMPTY_STATE_MIN_BOX_HEIGHT, contentHeight + EMPTY_STATE_TEXT_INSET * 2);
-  }
-
   static List<String> wrapToWidth(FontMetrics metrics, String text, int maxWidth) {
     List<String> lines = new ArrayList<>();
     if (text == null || text.isEmpty()) {
@@ -527,16 +498,73 @@ public class BlunderListPanel extends JPanel implements Scrollable {
     return lines;
   }
 
+  static EmptyStateLayout fitEmptyState(
+      int panelWidth,
+      int panelHeight,
+      String fontName,
+      boolean analysisRunning,
+      Graphics2D graphics) {
+    String family = fontName != null ? fontName : Font.SANS_SERIF;
+    int[] titleSizes = {14, 13, 12, 11, 10, 9};
+    int[] subtitleSizes = {12, 11, 10, 9, 8, 7};
+    int[] insets = {16, 12, 8, 6, 4};
+    EmptyStateLayout fallback = null;
+    for (int inset : insets) {
+      for (int i = 0; i < titleSizes.length; i++) {
+        Font titleFont = new Font(family, Font.PLAIN, titleSizes[i]);
+        Font subtitleFont = new Font(family, Font.PLAIN, subtitleSizes[i]);
+        EmptyStateLayout layout =
+            layoutEmptyState(
+                panelWidth,
+                panelHeight,
+                graphics.getFontMetrics(titleFont),
+                graphics.getFontMetrics(subtitleFont),
+                analysisRunning,
+                inset,
+                titleFont,
+                subtitleFont);
+        if (layout.fitsInPanel(panelWidth, panelHeight)) {
+          return layout;
+        }
+        fallback = layout;
+      }
+    }
+    return fallback;
+  }
+
   static EmptyStateLayout layoutEmptyState(
       int panelWidth,
       int panelHeight,
       FontMetrics titleMetrics,
       FontMetrics subtitleMetrics,
       boolean analysisRunning) {
+    Font titleFont = new Font(Font.SANS_SERIF, Font.PLAIN, 14);
+    Font subtitleFont = new Font(Font.SANS_SERIF, Font.PLAIN, 12);
+    return layoutEmptyState(
+        panelWidth,
+        panelHeight,
+        titleMetrics,
+        subtitleMetrics,
+        analysisRunning,
+        EMPTY_STATE_TEXT_INSET,
+        titleFont,
+        subtitleFont);
+  }
+
+  static EmptyStateLayout layoutEmptyState(
+      int panelWidth,
+      int panelHeight,
+      FontMetrics titleMetrics,
+      FontMetrics subtitleMetrics,
+      boolean analysisRunning,
+      int textInset,
+      Font titleFont,
+      Font subtitleFont) {
     String title = analysisRunning ? EMPTY_STATE_ANALYZING_TITLE : EMPTY_STATE_TITLE;
+    int inset = Math.max(4, textInset);
     int boxW = emptyStateBoxWidth(panelWidth);
-    int boxX = Math.max(EMPTY_STATE_MARGIN, (panelWidth - boxW) / 2);
-    int innerWidth = Math.max(1, boxW - EMPTY_STATE_TEXT_INSET * 2);
+    int boxX = Math.max(Math.min(EMPTY_STATE_MARGIN, panelWidth / 8), (panelWidth - boxW) / 2);
+    int innerWidth = Math.max(1, boxW - inset * 2);
     List<String> wrappedTitle = wrapToWidth(titleMetrics, title, innerWidth);
     List<String> wrappedSubtitle = wrapToWidth(subtitleMetrics, EMPTY_STATE_SUBTITLE, innerWidth);
     int titleLineHeight = lineHeight(titleMetrics);
@@ -545,12 +573,15 @@ public class BlunderListPanel extends JPanel implements Scrollable {
     int subtitleBlockHeight =
         Math.max(subtitleLineHeight, wrappedSubtitle.size() * subtitleLineHeight);
     int contentHeight = titleBlockHeight + EMPTY_STATE_TITLE_SUBTITLE_GAP + subtitleBlockHeight;
-    int boxH = emptyStateCardHeight(titleMetrics, subtitleMetrics, boxW, analysisRunning);
-    int boxY = Math.max(EMPTY_STATE_MARGIN, (panelHeight - boxH) / 2 - EMPTY_STATE_MARGIN);
-    if (boxY + boxH + EMPTY_STATE_MARGIN > panelHeight) {
-      boxY = EMPTY_STATE_MARGIN;
+    int maxBoxH = Math.max(1, panelHeight);
+    int desiredH = contentHeight + inset * 2;
+    int minH = Math.min(EMPTY_STATE_MIN_BOX_HEIGHT, maxBoxH);
+    int boxH = Math.min(maxBoxH, Math.max(minH, desiredH));
+    int boxY = Math.max(0, (panelHeight - boxH) / 2);
+    if (panelHeight >= boxH + EMPTY_STATE_MARGIN * 2) {
+      boxY = Math.max(EMPTY_STATE_MARGIN, (panelHeight - boxH) / 2 - EMPTY_STATE_MARGIN);
     }
-    int contentTop = boxY + Math.max(EMPTY_STATE_TEXT_INSET, (boxH - contentHeight) / 2);
+    int contentTop = boxY + Math.max(inset, (boxH - contentHeight) / 2);
 
     List<EmptyStateLine> titleLines = new ArrayList<>();
     int titleBaseline = contentTop + titleMetrics.getAscent();
@@ -588,9 +619,13 @@ public class BlunderListPanel extends JPanel implements Scrollable {
             ? contentTop + contentHeight
             : subtitleLines.get(subtitleLines.size() - 1).baselineY
                 + subtitleLines.get(subtitleLines.size() - 1).descent;
-    boxH = Math.max(boxH, contentBottom + EMPTY_STATE_TEXT_INSET - boxY);
+    boxH = Math.min(maxBoxH, Math.max(boxH, contentBottom + inset - boxY));
+    if (boxY + boxH > panelHeight) {
+      boxY = Math.max(0, panelHeight - boxH);
+    }
 
-    return new EmptyStateLayout(boxX, boxY, boxW, boxH, titleLines, subtitleLines);
+    return new EmptyStateLayout(
+        boxX, boxY, boxW, boxH, inset, titleFont, subtitleFont, titleLines, subtitleLines);
   }
 
   static final class EmptyStateLine {
@@ -616,6 +651,9 @@ public class BlunderListPanel extends JPanel implements Scrollable {
     final int boxY;
     final int boxW;
     final int boxH;
+    final int textInset;
+    final Font titleFont;
+    final Font subtitleFont;
     final List<EmptyStateLine> titleLines;
     final List<EmptyStateLine> subtitleLines;
 
@@ -624,14 +662,51 @@ public class BlunderListPanel extends JPanel implements Scrollable {
         int boxY,
         int boxW,
         int boxH,
+        int textInset,
+        Font titleFont,
+        Font subtitleFont,
         List<EmptyStateLine> titleLines,
         List<EmptyStateLine> subtitleLines) {
       this.boxX = boxX;
       this.boxY = boxY;
       this.boxW = boxW;
       this.boxH = boxH;
+      this.textInset = textInset;
+      this.titleFont = titleFont;
+      this.subtitleFont = subtitleFont;
       this.titleLines = Collections.unmodifiableList(new ArrayList<>(titleLines));
       this.subtitleLines = Collections.unmodifiableList(new ArrayList<>(subtitleLines));
+    }
+
+    boolean fitsInPanel(int panelWidth, int panelHeight) {
+      if (boxX < 0 || boxY < 0 || boxW < 1 || boxH < 1) {
+        return false;
+      }
+      if (boxX + boxW > panelWidth || boxY + boxH > panelHeight) {
+        return false;
+      }
+      int innerWidth = Math.max(1, boxW - textInset * 2);
+      for (EmptyStateLine line : titleLines) {
+        if (!lineFits(line, innerWidth)) {
+          return false;
+        }
+      }
+      for (EmptyStateLine line : subtitleLines) {
+        if (!lineFits(line, innerWidth)) {
+          return false;
+        }
+      }
+      return true;
+    }
+
+    private boolean lineFits(EmptyStateLine line, int innerWidth) {
+      if (line.x < boxX || line.x + line.width > boxX + boxW) {
+        return false;
+      }
+      if (line.baselineY - line.ascent < boxY || line.baselineY + line.descent > boxY + boxH) {
+        return false;
+      }
+      return line.text.codePointCount(0, line.text.length()) <= 1 || line.width <= innerWidth;
     }
   }
 }

--- a/src/test/java/featurecat/lizzie/gui/BlunderListPanelLayoutTest.java
+++ b/src/test/java/featurecat/lizzie/gui/BlunderListPanelLayoutTest.java
@@ -58,11 +58,43 @@ class BlunderListPanelLayoutTest {
 
   @Test
   void emptyStateSubtitleStaysInsideCardAfterWrap() {
+    assertEmptyStateFitsInsideCard(100, 86, false);
+    assertEmptyStateFitsInsideCard(120, 86, false);
     assertEmptyStateFitsInsideCard(160, 280, false);
     assertEmptyStateFitsInsideCard(244, 320, false);
     assertEmptyStateFitsInsideCard(400, 320, false);
+    assertEmptyStateFitsInsideCard(120, 86, true);
     assertEmptyStateFitsInsideCard(160, 280, true);
     assertEmptyStateFitsInsideCard(244, 320, true);
+  }
+
+  @Test
+  void emptyStatePreferredHeightGrowsOnNarrowViewportInsteadOfClipping() {
+    BlunderListPanel panel = new BlunderListPanel();
+    JScrollPane scrollPane = new JScrollPane(panel);
+    scrollPane.setSize(120, 86);
+    scrollPane.getViewport().setSize(new Dimension(120, 86));
+    panel.updateSnapshot(emptySnapshot(false));
+
+    BufferedImage image = new BufferedImage(1, 1, BufferedImage.TYPE_INT_ARGB);
+    Graphics2D graphics = image.createGraphics();
+    try {
+      FontMetrics titleMetrics = graphics.getFontMetrics(new Font(Font.SANS_SERIF, Font.PLAIN, 14));
+      FontMetrics subtitleMetrics =
+          graphics.getFontMetrics(new Font(Font.SANS_SERIF, Font.PLAIN, 12));
+      BlunderListPanel.EmptyStateLayout layout =
+          BlunderListPanel.layoutEmptyState(120, 86, titleMetrics, subtitleMetrics, false);
+      assertTrue(
+          layout.boxH > BlunderListPanel.EMPTY_STATE_MIN_BOX_HEIGHT,
+          "narrow wrap must grow the card instead of keeping a too-short height");
+      assertTrue(panel.getPreferredSize().height > 86);
+      assertTrue(
+          panel.getPreferredSize().height
+              >= layout.boxH + BlunderListPanel.EMPTY_STATE_MARGIN * 2);
+      assertFalse(panel.getScrollableTracksViewportHeight());
+    } finally {
+      graphics.dispose();
+    }
   }
 
   private static void assertEmptyStateFitsInsideCard(
@@ -89,6 +121,9 @@ class BlunderListPanelLayoutTest {
       assertEquals(BlunderListPanel.EMPTY_STATE_SUBTITLE, joinedText(layout.subtitleLines));
       assertTrue(layout.boxW <= BlunderListPanel.EMPTY_STATE_MAX_BOX_WIDTH);
       assertTrue(layout.boxH >= BlunderListPanel.EMPTY_STATE_MIN_BOX_HEIGHT);
+      assertTrue(
+          panel.getPreferredSize().height
+              >= layout.boxH + BlunderListPanel.EMPTY_STATE_MARGIN * 2);
 
       int innerWidth = Math.max(1, layout.boxW - BlunderListPanel.EMPTY_STATE_TEXT_INSET * 2);
       int fullSubtitleWidth = subtitleMetrics.stringWidth(BlunderListPanel.EMPTY_STATE_SUBTITLE);
@@ -108,7 +143,16 @@ class BlunderListPanelLayoutTest {
         assertLineInsideCard(layout, line, innerWidth);
       }
 
-      panel.paint(graphics);
+      int paintHeight = Math.max(panelHeight, panel.getPreferredSize().height);
+      panel.setSize(panelWidth, paintHeight);
+      BufferedImage paintImage =
+          new BufferedImage(panelWidth, paintHeight, BufferedImage.TYPE_INT_ARGB);
+      Graphics2D paintGraphics = paintImage.createGraphics();
+      try {
+        panel.paint(paintGraphics);
+      } finally {
+        paintGraphics.dispose();
+      }
     } finally {
       graphics.dispose();
     }

--- a/src/test/java/featurecat/lizzie/gui/BlunderListPanelLayoutTest.java
+++ b/src/test/java/featurecat/lizzie/gui/BlunderListPanelLayoutTest.java
@@ -5,7 +5,11 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.awt.Dimension;
+import java.awt.Font;
+import java.awt.FontMetrics;
+import java.awt.Graphics2D;
 import java.awt.Rectangle;
+import java.awt.image.BufferedImage;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -50,6 +54,95 @@ class BlunderListPanelLayoutTest {
 
     assertEquals(32, panel.getScrollableUnitIncrement(visible, SwingConstants.VERTICAL, 1));
     assertEquals(256, panel.getScrollableBlockIncrement(visible, SwingConstants.VERTICAL, 1));
+  }
+
+  @Test
+  void emptyStateSubtitleStaysInsideCardAfterWrap() {
+    assertEmptyStateFitsInsideCard(160, 280, false);
+    assertEmptyStateFitsInsideCard(244, 320, false);
+    assertEmptyStateFitsInsideCard(400, 320, false);
+    assertEmptyStateFitsInsideCard(160, 280, true);
+    assertEmptyStateFitsInsideCard(244, 320, true);
+  }
+
+  private static void assertEmptyStateFitsInsideCard(
+      int panelWidth, int panelHeight, boolean analysisRunning) {
+    BlunderListPanel panel = new BlunderListPanel();
+    panel.updateSnapshot(emptySnapshot(analysisRunning));
+    panel.setSize(panelWidth, panelHeight);
+
+    BufferedImage image = new BufferedImage(panelWidth, panelHeight, BufferedImage.TYPE_INT_ARGB);
+    Graphics2D graphics = image.createGraphics();
+    try {
+      FontMetrics titleMetrics = graphics.getFontMetrics(new Font(Font.SANS_SERIF, Font.PLAIN, 14));
+      FontMetrics subtitleMetrics =
+          graphics.getFontMetrics(new Font(Font.SANS_SERIF, Font.PLAIN, 12));
+      BlunderListPanel.EmptyStateLayout layout =
+          BlunderListPanel.layoutEmptyState(
+              panelWidth, panelHeight, titleMetrics, subtitleMetrics, analysisRunning);
+
+      String expectedTitle =
+          analysisRunning
+              ? BlunderListPanel.EMPTY_STATE_ANALYZING_TITLE
+              : BlunderListPanel.EMPTY_STATE_TITLE;
+      assertEquals(expectedTitle, joinedText(layout.titleLines));
+      assertEquals(BlunderListPanel.EMPTY_STATE_SUBTITLE, joinedText(layout.subtitleLines));
+      assertTrue(layout.boxW <= BlunderListPanel.EMPTY_STATE_MAX_BOX_WIDTH);
+      assertTrue(layout.boxH >= BlunderListPanel.EMPTY_STATE_MIN_BOX_HEIGHT);
+
+      int innerWidth = Math.max(1, layout.boxW - BlunderListPanel.EMPTY_STATE_TEXT_INSET * 2);
+      int fullSubtitleWidth = subtitleMetrics.stringWidth(BlunderListPanel.EMPTY_STATE_SUBTITLE);
+      if (fullSubtitleWidth > innerWidth) {
+        assertTrue(
+            layout.subtitleLines.size() > 1,
+            "subtitle must wrap when it is wider than the card inner width");
+        assertTrue(
+            layout.boxH > BlunderListPanel.EMPTY_STATE_MIN_BOX_HEIGHT,
+            "card height must grow after the subtitle wraps");
+      }
+
+      for (BlunderListPanel.EmptyStateLine line : layout.titleLines) {
+        assertLineInsideCard(layout, line, innerWidth);
+      }
+      for (BlunderListPanel.EmptyStateLine line : layout.subtitleLines) {
+        assertLineInsideCard(layout, line, innerWidth);
+      }
+
+      panel.paint(graphics);
+    } finally {
+      graphics.dispose();
+    }
+  }
+
+  private static void assertLineInsideCard(
+      BlunderListPanel.EmptyStateLayout layout,
+      BlunderListPanel.EmptyStateLine line,
+      int innerWidth) {
+    assertTrue(line.x >= layout.boxX, line.text);
+    assertTrue(line.x + line.width <= layout.boxX + layout.boxW, line.text);
+    assertTrue(line.baselineY - line.ascent >= layout.boxY, line.text);
+    assertTrue(line.baselineY + line.descent <= layout.boxY + layout.boxH, line.text);
+    if (line.text.codePointCount(0, line.text.length()) > 1) {
+      assertTrue(line.width <= innerWidth, line.text + " width=" + line.width);
+    }
+  }
+
+  private static String joinedText(List<BlunderListPanel.EmptyStateLine> lines) {
+    StringBuilder text = new StringBuilder();
+    for (BlunderListPanel.EmptyStateLine line : lines) {
+      text.append(line.text);
+    }
+    return text.toString();
+  }
+
+  private static ProblemListSnapshot emptySnapshot(boolean analysisRunning) {
+    return new ProblemListSnapshot(
+        ProblemListMetric.WINRATE_LOSS,
+        Collections.emptyList(),
+        Collections.emptyList(),
+        0,
+        0,
+        analysisRunning);
   }
 
   private static ProblemListSnapshot snapshotWithBlackRows(int rows) {

--- a/src/test/java/featurecat/lizzie/gui/BlunderListPanelLayoutTest.java
+++ b/src/test/java/featurecat/lizzie/gui/BlunderListPanelLayoutTest.java
@@ -6,7 +6,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.awt.Dimension;
 import java.awt.Font;
-import java.awt.FontMetrics;
 import java.awt.Graphics2D;
 import java.awt.Rectangle;
 import java.awt.image.BufferedImage;
@@ -60,6 +59,7 @@ class BlunderListPanelLayoutTest {
   void emptyStateSubtitleStaysInsideCardAfterWrap() {
     assertEmptyStateFitsInsideCard(100, 86, false);
     assertEmptyStateFitsInsideCard(120, 86, false);
+    assertEmptyStateFitsInsideCard(120, 200, false);
     assertEmptyStateFitsInsideCard(160, 280, false);
     assertEmptyStateFitsInsideCard(244, 320, false);
     assertEmptyStateFitsInsideCard(400, 320, false);
@@ -69,29 +69,27 @@ class BlunderListPanelLayoutTest {
   }
 
   @Test
-  void emptyStatePreferredHeightGrowsOnNarrowViewportInsteadOfClipping() {
+  void emptyStateFitsNarrowViewportWithoutScrolling() {
     BlunderListPanel panel = new BlunderListPanel();
     JScrollPane scrollPane = new JScrollPane(panel);
     scrollPane.setSize(120, 86);
     scrollPane.getViewport().setSize(new Dimension(120, 86));
     panel.updateSnapshot(emptySnapshot(false));
 
-    BufferedImage image = new BufferedImage(1, 1, BufferedImage.TYPE_INT_ARGB);
+    assertTrue(
+        panel.getScrollableTracksViewportHeight(),
+        "empty state must fill the viewport instead of introducing an inner scrollbar");
+
+    BufferedImage image = new BufferedImage(120, 86, BufferedImage.TYPE_INT_ARGB);
     Graphics2D graphics = image.createGraphics();
     try {
-      FontMetrics titleMetrics = graphics.getFontMetrics(new Font(Font.SANS_SERIF, Font.PLAIN, 14));
-      FontMetrics subtitleMetrics =
-          graphics.getFontMetrics(new Font(Font.SANS_SERIF, Font.PLAIN, 12));
       BlunderListPanel.EmptyStateLayout layout =
-          BlunderListPanel.layoutEmptyState(120, 86, titleMetrics, subtitleMetrics, false);
+          BlunderListPanel.fitEmptyState(120, 86, Font.SANS_SERIF, false, graphics);
       assertTrue(
-          layout.boxH > BlunderListPanel.EMPTY_STATE_MIN_BOX_HEIGHT,
-          "narrow wrap must grow the card instead of keeping a too-short height");
-      assertTrue(panel.getPreferredSize().height > 86);
-      assertTrue(
-          panel.getPreferredSize().height
-              >= layout.boxH + BlunderListPanel.EMPTY_STATE_MARGIN * 2);
-      assertFalse(panel.getScrollableTracksViewportHeight());
+          layout.fitsInPanel(120, 86),
+          "wrapped empty-state text must stay inside the visible card without scrolling");
+      panel.setSize(120, 86);
+      panel.paint(graphics);
     } finally {
       graphics.dispose();
     }
@@ -106,12 +104,9 @@ class BlunderListPanelLayoutTest {
     BufferedImage image = new BufferedImage(panelWidth, panelHeight, BufferedImage.TYPE_INT_ARGB);
     Graphics2D graphics = image.createGraphics();
     try {
-      FontMetrics titleMetrics = graphics.getFontMetrics(new Font(Font.SANS_SERIF, Font.PLAIN, 14));
-      FontMetrics subtitleMetrics =
-          graphics.getFontMetrics(new Font(Font.SANS_SERIF, Font.PLAIN, 12));
       BlunderListPanel.EmptyStateLayout layout =
-          BlunderListPanel.layoutEmptyState(
-              panelWidth, panelHeight, titleMetrics, subtitleMetrics, analysisRunning);
+          BlunderListPanel.fitEmptyState(
+              panelWidth, panelHeight, Font.SANS_SERIF, analysisRunning, graphics);
 
       String expectedTitle =
           analysisRunning
@@ -120,20 +115,25 @@ class BlunderListPanelLayoutTest {
       assertEquals(expectedTitle, joinedText(layout.titleLines));
       assertEquals(BlunderListPanel.EMPTY_STATE_SUBTITLE, joinedText(layout.subtitleLines));
       assertTrue(layout.boxW <= BlunderListPanel.EMPTY_STATE_MAX_BOX_WIDTH);
-      assertTrue(layout.boxH >= BlunderListPanel.EMPTY_STATE_MIN_BOX_HEIGHT);
       assertTrue(
-          panel.getPreferredSize().height
-              >= layout.boxH + BlunderListPanel.EMPTY_STATE_MARGIN * 2);
+          layout.fitsInPanel(panelWidth, panelHeight),
+          "empty-state card and wrapped text must stay inside the panel");
 
-      int innerWidth = Math.max(1, layout.boxW - BlunderListPanel.EMPTY_STATE_TEXT_INSET * 2);
-      int fullSubtitleWidth = subtitleMetrics.stringWidth(BlunderListPanel.EMPTY_STATE_SUBTITLE);
+      int innerWidth = Math.max(1, layout.boxW - layout.textInset * 2);
+      int fullSubtitleWidth =
+          graphics
+              .getFontMetrics(layout.subtitleFont)
+              .stringWidth(BlunderListPanel.EMPTY_STATE_SUBTITLE);
       if (fullSubtitleWidth > innerWidth) {
         assertTrue(
             layout.subtitleLines.size() > 1,
             "subtitle must wrap when it is wider than the card inner width");
-        assertTrue(
-            layout.boxH > BlunderListPanel.EMPTY_STATE_MIN_BOX_HEIGHT,
-            "card height must grow after the subtitle wraps");
+        if (panelHeight > BlunderListPanel.EMPTY_STATE_MIN_BOX_HEIGHT + 40) {
+          assertTrue(
+              layout.boxH > BlunderListPanel.EMPTY_STATE_MIN_BOX_HEIGHT
+                  || layout.boxY + layout.boxH <= panelHeight,
+              "card height must grow after wrap when the viewport has room");
+        }
       }
 
       for (BlunderListPanel.EmptyStateLine line : layout.titleLines) {
@@ -143,16 +143,7 @@ class BlunderListPanelLayoutTest {
         assertLineInsideCard(layout, line, innerWidth);
       }
 
-      int paintHeight = Math.max(panelHeight, panel.getPreferredSize().height);
-      panel.setSize(panelWidth, paintHeight);
-      BufferedImage paintImage =
-          new BufferedImage(panelWidth, paintHeight, BufferedImage.TYPE_INT_ARGB);
-      Graphics2D paintGraphics = paintImage.createGraphics();
-      try {
-        panel.paint(paintGraphics);
-      } finally {
-        paintGraphics.dispose();
-      }
+      panel.paint(graphics);
     } finally {
       graphics.dispose();
     }


### PR DESCRIPTION
## Repro
Open the left analysis 问题手 / Problem moves tab with no detected blunders. The subtitle 「全盘分析后，这里会列出掉胜率较多的问题手」 is drawn as one unwrapped centered line on a 220×86 card and overflows left/right. On a ~120px-wide left column, wrap without growing the preferred height still clipped the subtitle; growing height then introduced an inner scrollbar and the viewport still clipped.

## Cause
`BlunderListPanel.drawEmptyState` used a fixed 86px card and `drawString` with no wrap. After wrap, preferred height and the comments viewport still did not keep the full subtitle visible without scrolling.

## Fix
- Wrap title and subtitle to the card inner width with padding.
- Empty state fills the viewport; tighten inset/font only as needed so the full subtitle stays visible without scrolling on a ~120px column.
- Strings stay hardcoded. List layout, sidebar header, and language packs unchanged.
- Headless `BlunderListPanelLayoutTest` covers narrow (~120px) and wide panels, including the analyzing title.

## Verification
`mvn -B -Djava.awt.headless=true -Dtest=BlunderListPanelLayoutTest test`. Parent Linux desktop size and locale shots follow this PR.

Fixes #360
