### PR TITLE
feat(comments): divide personal notes from auto match info

### DIFF
--- a/src/main/java/featurecat/lizzie/gui/LizzieFrame.java
+++ b/src/main/java/featurecat/lizzie/gui/LizzieFrame.java
@@ -9786,6 +9786,10 @@ public class LizzieFrame extends JFrame {
             + "px;}");
     styleSheet.addRule(".ai-commentary-title {margin:2px 0 6px 0;}");
     styleSheet.addRule(".comment-spacer {height:6px;}");
+    styleSheet.addRule(
+        ".match-info-divider {height:1px; margin:6px 0; padding:0; border:none; overflow:hidden; font-size:1px; line-height:1px; background-color:"
+            + foreground
+            + ";}");
     styleSheet.addRule("table {border-collapse:collapse; margin:4px 0;}");
     styleSheet.addRule(
         "th, td {border:1px solid " + foreground + "; padding:3px 6px; text-align:left;}");

--- a/src/main/java/featurecat/lizzie/gui/LizzieFrame.java
+++ b/src/main/java/featurecat/lizzie/gui/LizzieFrame.java
@@ -9740,9 +9740,30 @@ public class LizzieFrame extends JFrame {
   }
 
   private void setCommentText(String comment) {
-    String rendered = CommentDisplayRenderer.render(comment);
+    String rendered =
+        CommentDisplayRenderer.render(comment, shouldSeparateOrdinaryAnalysisMatchInfo());
     setRenderedComment(commentTextArea, rendered);
     setRenderedComment(commentTextPane, rendered);
+  }
+
+  private static boolean shouldSeparateOrdinaryAnalysisMatchInfo() {
+    Board board = Lizzie.board;
+    if (board == null) {
+      return true;
+    }
+    if (EngineGamePresentation.current().playing()) {
+      return false;
+    }
+    if (board.isPkBoard || board.isGameBoard) {
+      return false;
+    }
+    if (board.getHistory() != null) {
+      GameInfo info = board.getHistory().getGameInfo();
+      if (info != null && info.hasEngineGameHistory()) {
+        return false;
+      }
+    }
+    return true;
   }
 
   private JPaintTextPane createCommentDisplayPane(HTMLDocument document) {

--- a/src/main/java/featurecat/lizzie/rules/SGFParser.java
+++ b/src/main/java/featurecat/lizzie/rules/SGFParser.java
@@ -1960,6 +1960,97 @@ public class SGFParser {
     return curComment;
   }
 
+  /** Personal commentary plus the current-language formatComment match-info block. */
+  public static final class WinrateCommentSplit {
+    public final String personalComment;
+    public final String matchInfo;
+
+    private WinrateCommentSplit(String personalComment, String matchInfo) {
+      this.personalComment = personalComment;
+      this.matchInfo = matchInfo;
+    }
+  }
+
+  /**
+   * Splits a stored ordinary-analysis comment into personal text and the writer match-info block
+   * using the same language-dependent pattern the writer already uses.
+   */
+  public static WinrateCommentSplit splitWinrateComment(String comment) {
+    if (comment == null || comment.isEmpty() || Lizzie.resourceBundle == null) {
+      return new WinrateCommentSplit(comment == null ? "" : comment, "");
+    }
+    boolean[][] variants = {{true, false}, {true, true}, {false, false}};
+    for (boolean[] variant : variants) {
+      String wp = winrateCommentRegexForDisplay(variant[0], variant[1]);
+      if (comment.matches("(?s).*" + wp + "(?s).*")) {
+        Matcher matcher = Pattern.compile(wp).matcher(comment);
+        if (matcher.find()) {
+          return new WinrateCommentSplit(
+              comment.replaceAll(wp, "").trim(), matcher.group().trim());
+        }
+      }
+    }
+    return new WinrateCommentSplit(comment, "");
+  }
+
+  private static String winrateCommentRegexForDisplay(boolean isKataData, boolean isSaiData) {
+    boolean leadWithKomi =
+        Lizzie.config != null && Lizzie.config.showKataGoScoreLeadWithKomi;
+    String lead =
+        leadWithKomi
+            ? Lizzie.resourceBundle.getString("SGFParse.leadWithKomi")
+            : Lizzie.resourceBundle.getString("SGFParse.leadJustScore");
+    if (!isKataData) {
+      return "("
+          + Lizzie.resourceBundle.getString("SGFParse.black")
+          + " |"
+          + Lizzie.resourceBundle.getString("SGFParse.white")
+          + " )"
+          + Lizzie.resourceBundle.getString("SGFParse.winrate")
+          + " [0-9\\.\\-]+%* \\(*[0-9.\\-+]*%*\\)*\n\\("
+          + ".*"
+          + " / [0-9\\.]*[kmKM]* "
+          + Lizzie.resourceBundle.getString("SGFParse.playouts")
+          + "\\)\\n"
+          + Lizzie.resourceBundle.getString("SGFParse.komi")
+          + ".*";
+    }
+    if (isSaiData) {
+      return "("
+          + Lizzie.resourceBundle.getString("SGFParse.black")
+          + " |"
+          + Lizzie.resourceBundle.getString("SGFParse.white")
+          + " )"
+          + Lizzie.resourceBundle.getString("SGFParse.winrate")
+          + " [0-9\\.\\-]+%* \\(*[0-9.\\-+]*%*\\)*\n"
+          + lead
+          + " [0-9\\.\\-+]* \\(*[0-9.\\-+]*\\)*\n\\("
+          + ".*"
+          + " / [0-9\\.]*[kmKM]* "
+          + Lizzie.resourceBundle.getString("SGFParse.playouts")
+          + "\\)\\n"
+          + Lizzie.resourceBundle.getString("SGFParse.komi")
+          + ".*";
+    }
+    return "("
+        + Lizzie.resourceBundle.getString("SGFParse.black")
+        + " |"
+        + Lizzie.resourceBundle.getString("SGFParse.white")
+        + " )"
+        + Lizzie.resourceBundle.getString("SGFParse.winrate")
+        + " [0-9\\.\\-]+%* \\(*[0-9.\\-+]*%*\\)*\n"
+        + lead
+        + " [0-9\\.\\-+]* \\(*[0-9.\\-+]*\\)* "
+        + Lizzie.resourceBundle.getString("SGFParse.stdev")
+        + " [0-9\\.\\-+]*\n\\("
+        + ".*"
+        + " / [0-9\\.]*[kmKM]* "
+        + Lizzie.resourceBundle.getString("SGFParse.playouts")
+        + "\\)\\n"
+        + Lizzie.resourceBundle.getString("SGFParse.komi")
+        + ".*";
+  }
+
   /**
    * Format Comment with following format: Move <Move number> <Winrate> (<Last Move Rate
    * Difference>) (<Weight name> / <Playouts>)

--- a/src/main/java/featurecat/lizzie/rules/SGFParser.java
+++ b/src/main/java/featurecat/lizzie/rules/SGFParser.java
@@ -1896,64 +1896,7 @@ public class SGFParser {
 
   private static String removeWinrateComment(
       boolean isKataData, boolean isSaiData, String curComment) {
-    String wp = "";
-    if (!isKataData) {
-      wp =
-          "("
-              + Lizzie.resourceBundle.getString("SGFParse.black")
-              + " |"
-              + Lizzie.resourceBundle.getString("SGFParse.white")
-              + " )"
-              + Lizzie.resourceBundle.getString("SGFParse.winrate")
-              + " [0-9\\.\\-]+%* \\(*[0-9.\\-+]*%*\\)*\n\\("
-              + ".*"
-              + " / [0-9\\.]*[kmKM]* "
-              + Lizzie.resourceBundle.getString("SGFParse.playouts")
-              + "\\)\\n"
-              + Lizzie.resourceBundle.getString("SGFParse.komi")
-              + ".*";
-    } else {
-      if (isSaiData)
-        wp =
-            "("
-                + Lizzie.resourceBundle.getString("SGFParse.black")
-                + " |"
-                + Lizzie.resourceBundle.getString("SGFParse.white")
-                + " )"
-                + Lizzie.resourceBundle.getString("SGFParse.winrate")
-                + " [0-9\\.\\-]+%* \\(*[0-9.\\-+]*%*\\)*\n"
-                + (Lizzie.config.showKataGoScoreLeadWithKomi
-                    ? Lizzie.resourceBundle.getString("SGFParse.leadWithKomi")
-                    : Lizzie.resourceBundle.getString("SGFParse.leadJustScore"))
-                + " [0-9\\.\\-+]* \\(*[0-9.\\-+]*\\)*\n\\("
-                + ".*"
-                + " / [0-9\\.]*[kmKM]* "
-                + Lizzie.resourceBundle.getString("SGFParse.playouts")
-                + "\\)\\n"
-                + Lizzie.resourceBundle.getString("SGFParse.komi")
-                + ".*";
-      else
-        wp =
-            "("
-                + Lizzie.resourceBundle.getString("SGFParse.black")
-                + " |"
-                + Lizzie.resourceBundle.getString("SGFParse.white")
-                + " )"
-                + Lizzie.resourceBundle.getString("SGFParse.winrate")
-                + " [0-9\\.\\-]+%* \\(*[0-9.\\-+]*%*\\)*\n"
-                + (Lizzie.config.showKataGoScoreLeadWithKomi
-                    ? Lizzie.resourceBundle.getString("SGFParse.leadWithKomi")
-                    : Lizzie.resourceBundle.getString("SGFParse.leadJustScore"))
-                + " [0-9\\.\\-+]* \\(*[0-9.\\-+]*\\)* "
-                + Lizzie.resourceBundle.getString("SGFParse.stdev")
-                + " [0-9\\.\\-+]*\n\\("
-                + ".*"
-                + " / [0-9\\.]*[kmKM]* "
-                + Lizzie.resourceBundle.getString("SGFParse.playouts")
-                + "\\)\\n"
-                + Lizzie.resourceBundle.getString("SGFParse.komi")
-                + ".*";
-    }
+    String wp = winrateCommentRegex(isKataData, isSaiData);
     if (curComment.matches("(?s).*" + wp + "(?s).*")) {
       return curComment.replaceAll(wp, "");
     }
@@ -1981,7 +1924,7 @@ public class SGFParser {
     }
     boolean[][] variants = {{true, false}, {true, true}, {false, false}};
     for (boolean[] variant : variants) {
-      String wp = winrateCommentRegexForDisplay(variant[0], variant[1]);
+      String wp = winrateCommentRegex(variant[0], variant[1]);
       if (comment.matches("(?s).*" + wp + "(?s).*")) {
         Matcher matcher = Pattern.compile(wp).matcher(comment);
         if (matcher.find()) {
@@ -1993,7 +1936,7 @@ public class SGFParser {
     return new WinrateCommentSplit(comment, "");
   }
 
-  private static String winrateCommentRegexForDisplay(boolean isKataData, boolean isSaiData) {
+  private static String winrateCommentRegex(boolean isKataData, boolean isSaiData) {
     boolean leadWithKomi =
         Lizzie.config != null && Lizzie.config.showKataGoScoreLeadWithKomi;
     String lead =
@@ -2230,65 +2173,7 @@ public class SGFParser {
     }
 
     if (!data.comment.isEmpty()) {
-      // [^\\(\\)/]*
-      String wp = "";
-      if (!data.isKataData) {
-        wp =
-            "("
-                + Lizzie.resourceBundle.getString("SGFParse.black")
-                + " |"
-                + Lizzie.resourceBundle.getString("SGFParse.white")
-                + " )"
-                + Lizzie.resourceBundle.getString("SGFParse.winrate")
-                + " [0-9\\.\\-]+%* \\(*[0-9.\\-+]*%*\\)*\n\\("
-                + ".*"
-                + " / [0-9\\.]*[kmKM]* "
-                + Lizzie.resourceBundle.getString("SGFParse.playouts")
-                + "\\)\\n"
-                + Lizzie.resourceBundle.getString("SGFParse.komi")
-                + ".*";
-      } else {
-        if (data.isSaiData)
-          wp =
-              "("
-                  + Lizzie.resourceBundle.getString("SGFParse.black")
-                  + " |"
-                  + Lizzie.resourceBundle.getString("SGFParse.white")
-                  + " )"
-                  + Lizzie.resourceBundle.getString("SGFParse.winrate")
-                  + " [0-9\\.\\-]+%* \\(*[0-9.\\-+]*%*\\)*\n"
-                  + (Lizzie.config.showKataGoScoreLeadWithKomi
-                      ? Lizzie.resourceBundle.getString("SGFParse.leadWithKomi")
-                      : Lizzie.resourceBundle.getString("SGFParse.leadJustScore"))
-                  + " [0-9\\.\\-+]* \\(*[0-9.\\-+]*\\)*\n\\("
-                  + ".*"
-                  + " / [0-9\\.]*[kmKM]* "
-                  + Lizzie.resourceBundle.getString("SGFParse.playouts")
-                  + "\\)\\n"
-                  + Lizzie.resourceBundle.getString("SGFParse.komi")
-                  + ".*";
-        else
-          wp =
-              "("
-                  + Lizzie.resourceBundle.getString("SGFParse.black")
-                  + " |"
-                  + Lizzie.resourceBundle.getString("SGFParse.white")
-                  + " )"
-                  + Lizzie.resourceBundle.getString("SGFParse.winrate")
-                  + " [0-9\\.\\-]+%* \\(*[0-9.\\-+]*%*\\)*\n"
-                  + (Lizzie.config.showKataGoScoreLeadWithKomi
-                      ? Lizzie.resourceBundle.getString("SGFParse.leadWithKomi")
-                      : Lizzie.resourceBundle.getString("SGFParse.leadJustScore"))
-                  + " [0-9\\.\\-+]* \\(*[0-9.\\-+]*\\)* "
-                  + Lizzie.resourceBundle.getString("SGFParse.stdev")
-                  + " [0-9\\.\\-+]*\n\\("
-                  + ".*"
-                  + " / [0-9\\.]*[kmKM]* "
-                  + Lizzie.resourceBundle.getString("SGFParse.playouts")
-                  + "\\)\\n"
-                  + Lizzie.resourceBundle.getString("SGFParse.komi")
-                  + ".*";
-      }
+      String wp = winrateCommentRegex(data.isKataData, data.isSaiData);
       // if (Lizzie.leelaz.isKatago) wp = wp + "\n.*";
       if (data.comment.matches("(?s).*" + wp + "(?s).*")) {
         nc = data.comment.replaceAll(wp, nc);
@@ -2619,65 +2504,7 @@ public class SGFParser {
     }
 
     if (!data.comment.isEmpty() && !isEngineGameHistory()) {
-      // [^\\(\\)/]*
-      String wp = "";
-      if (!data.isKataData) {
-        wp =
-            "("
-                + Lizzie.resourceBundle.getString("SGFParse.black")
-                + " |"
-                + Lizzie.resourceBundle.getString("SGFParse.white")
-                + " )"
-                + Lizzie.resourceBundle.getString("SGFParse.winrate")
-                + " [0-9\\.\\-]+%* \\(*[0-9.\\-+]*%*\\)*\n\\("
-                + ".*"
-                + " / [0-9\\.]*[kmKM]* "
-                + Lizzie.resourceBundle.getString("SGFParse.playouts")
-                + "\\)\\n"
-                + Lizzie.resourceBundle.getString("SGFParse.komi")
-                + ".*";
-      } else {
-        if (data.isSaiData)
-          wp =
-              "("
-                  + Lizzie.resourceBundle.getString("SGFParse.black")
-                  + " |"
-                  + Lizzie.resourceBundle.getString("SGFParse.white")
-                  + " )"
-                  + Lizzie.resourceBundle.getString("SGFParse.winrate")
-                  + " [0-9\\.\\-]+%* \\(*[0-9.\\-+]*%*\\)*\n"
-                  + (Lizzie.config.showKataGoScoreLeadWithKomi
-                      ? Lizzie.resourceBundle.getString("SGFParse.leadWithKomi")
-                      : Lizzie.resourceBundle.getString("SGFParse.leadJustScore"))
-                  + " [0-9\\.\\-+]* \\(*[0-9.\\-+]*\\)*\n\\("
-                  + ".*"
-                  + " / [0-9\\.]*[kmKM]* "
-                  + Lizzie.resourceBundle.getString("SGFParse.playouts")
-                  + "\\)\\n"
-                  + Lizzie.resourceBundle.getString("SGFParse.komi")
-                  + ".*";
-        else
-          wp =
-              "("
-                  + Lizzie.resourceBundle.getString("SGFParse.black")
-                  + " |"
-                  + Lizzie.resourceBundle.getString("SGFParse.white")
-                  + " )"
-                  + Lizzie.resourceBundle.getString("SGFParse.winrate")
-                  + " [0-9\\.\\-]+%* \\(*[0-9.\\-+]*%*\\)*\n"
-                  + (Lizzie.config.showKataGoScoreLeadWithKomi
-                      ? Lizzie.resourceBundle.getString("SGFParse.leadWithKomi")
-                      : Lizzie.resourceBundle.getString("SGFParse.leadJustScore"))
-                  + " [0-9\\.\\-+]* \\(*[0-9.\\-+]*\\)* "
-                  + Lizzie.resourceBundle.getString("SGFParse.stdev")
-                  + " [0-9\\.\\-+]*\n\\("
-                  + ".*"
-                  + " / [0-9\\.]*[kmKM]* "
-                  + Lizzie.resourceBundle.getString("SGFParse.playouts")
-                  + "\\)\\n"
-                  + Lizzie.resourceBundle.getString("SGFParse.komi")
-                  + ".*";
-      }
+      String wp = winrateCommentRegex(data.isKataData, data.isSaiData);
       // if (Lizzie.leelaz.isKatago) wp = wp + "\n.*";
       if (data.comment.matches("(?s).*" + wp + "(?s).*")) {
         nc = data.comment.replaceAll(wp, nc);
@@ -2858,65 +2685,7 @@ public class SGFParser {
     }
 
     if (!data.comment.isEmpty()) {
-      // [^\\(\\)/]*
-      String wp = "";
-      if (!data.isKataData) {
-        wp =
-            "("
-                + Lizzie.resourceBundle.getString("SGFParse.black")
-                + " |"
-                + Lizzie.resourceBundle.getString("SGFParse.white")
-                + " )"
-                + Lizzie.resourceBundle.getString("SGFParse.winrate")
-                + " [0-9\\.\\-]+%* \\(*[0-9.\\-+]*%*\\)*\n\\("
-                + ".*"
-                + " / [0-9\\.]*[kmKM]* "
-                + Lizzie.resourceBundle.getString("SGFParse.playouts")
-                + "\\)\\n"
-                + Lizzie.resourceBundle.getString("SGFParse.komi")
-                + ".*";
-      } else {
-        if (data.isSaiData)
-          wp =
-              "("
-                  + Lizzie.resourceBundle.getString("SGFParse.black")
-                  + " |"
-                  + Lizzie.resourceBundle.getString("SGFParse.white")
-                  + " )"
-                  + Lizzie.resourceBundle.getString("SGFParse.winrate")
-                  + " [0-9\\.\\-]+%* \\(*[0-9.\\-+]*%*\\)*\n"
-                  + (Lizzie.config.showKataGoScoreLeadWithKomi
-                      ? Lizzie.resourceBundle.getString("SGFParse.leadWithKomi")
-                      : Lizzie.resourceBundle.getString("SGFParse.leadJustScore"))
-                  + " [0-9\\.\\-+]* \\(*[0-9.\\-+]*\\)*\n\\("
-                  + ".*"
-                  + " / [0-9\\.]*[kmKM]* "
-                  + Lizzie.resourceBundle.getString("SGFParse.playouts")
-                  + "\\)\\n"
-                  + Lizzie.resourceBundle.getString("SGFParse.komi")
-                  + ".*";
-        else
-          wp =
-              "("
-                  + Lizzie.resourceBundle.getString("SGFParse.black")
-                  + " |"
-                  + Lizzie.resourceBundle.getString("SGFParse.white")
-                  + " )"
-                  + Lizzie.resourceBundle.getString("SGFParse.winrate")
-                  + " [0-9\\.\\-]+%* \\(*[0-9.\\-+]*%*\\)*\n"
-                  + (Lizzie.config.showKataGoScoreLeadWithKomi
-                      ? Lizzie.resourceBundle.getString("SGFParse.leadWithKomi")
-                      : Lizzie.resourceBundle.getString("SGFParse.leadJustScore"))
-                  + " [0-9\\.\\-+]* \\(*[0-9.\\-+]*\\)* "
-                  + Lizzie.resourceBundle.getString("SGFParse.stdev")
-                  + " [0-9\\.\\-+]*\n\\("
-                  + ".*"
-                  + " / [0-9\\.]*[kmKM]* "
-                  + Lizzie.resourceBundle.getString("SGFParse.playouts")
-                  + "\\)\\n"
-                  + Lizzie.resourceBundle.getString("SGFParse.komi")
-                  + ".*";
-      }
+      String wp = winrateCommentRegex(data.isKataData, data.isSaiData);
       // if (Lizzie.leelaz.isKatago) wp = wp + "\n.*";
       if (data.comment.matches("(?s).*" + wp + "(?s).*")) {
         nc = data.comment.replaceAll(wp, nc);

--- a/src/main/java/featurecat/lizzie/teacher/CommentDisplayRenderer.java
+++ b/src/main/java/featurecat/lizzie/teacher/CommentDisplayRenderer.java
@@ -1,5 +1,11 @@
 package featurecat.lizzie.teacher;
 
+import featurecat.lizzie.Lizzie;
+import featurecat.lizzie.analysis.GameInfo;
+import featurecat.lizzie.enginegame.EngineGamePresentation;
+import featurecat.lizzie.rules.Board;
+import featurecat.lizzie.rules.SGFParser;
+import featurecat.lizzie.rules.SGFParser.WinrateCommentSplit;
 import java.util.Optional;
 
 /** Builds trusted HTML for displaying user SGF comments and stored AI commentary. */
@@ -9,14 +15,26 @@ public final class CommentDisplayRenderer {
   public static String render(String rawComment) {
     String userComment = TeacherCommentCodec.removeBlocks(rawComment);
     Optional<String> aiCommentary = TeacherCommentCodec.extract(rawComment);
-    StringBuilder body = new StringBuilder("<html><body>");
-    if (!userComment.isEmpty()) {
-      body.append("<div class='sgf-comment'>")
-          .append(SafeMarkdownRenderer.plainTextToBodyHtml(userComment))
-          .append("</div>");
+    String personalComment = userComment;
+    String matchInfo = "";
+    if (shouldSplitOrdinaryAnalysisMatchInfo()) {
+      WinrateCommentSplit split = SGFParser.splitWinrateComment(userComment);
+      personalComment = split.personalComment;
+      matchInfo = split.matchInfo;
     }
+    StringBuilder body = new StringBuilder("<html><body>");
+    if (!personalComment.isEmpty()) {
+      appendSgfComment(body, personalComment);
+    }
+    if (!personalComment.isEmpty() && !matchInfo.isEmpty()) {
+      body.append("<div class='match-info-divider'>&nbsp;</div>");
+    }
+    if (!matchInfo.isEmpty()) {
+      appendSgfComment(body, matchInfo);
+    }
+    boolean hasSgfText = !personalComment.isEmpty() || !matchInfo.isEmpty();
     if (aiCommentary.isPresent()) {
-      if (!userComment.isEmpty()) {
+      if (hasSgfText) {
         body.append("<div class='comment-spacer'>&nbsp;</div>");
       }
       body.append("<div class='ai-commentary'>")
@@ -29,5 +47,31 @@ public final class CommentDisplayRenderer {
           .append("</div>");
     }
     return body.append("</body></html>").toString();
+  }
+
+  private static void appendSgfComment(StringBuilder body, String text) {
+    body.append("<div class='sgf-comment'>")
+        .append(SafeMarkdownRenderer.plainTextToBodyHtml(text))
+        .append("</div>");
+  }
+
+  private static boolean shouldSplitOrdinaryAnalysisMatchInfo() {
+    Board board = Lizzie.board;
+    if (board == null) {
+      return true;
+    }
+    if (EngineGamePresentation.current().playing()) {
+      return false;
+    }
+    if (board.isPkBoard || board.isGameBoard) {
+      return false;
+    }
+    if (board.getHistory() != null) {
+      GameInfo info = board.getHistory().getGameInfo();
+      if (info != null && info.hasEngineGameHistory()) {
+        return false;
+      }
+    }
+    return true;
   }
 }

--- a/src/main/java/featurecat/lizzie/teacher/CommentDisplayRenderer.java
+++ b/src/main/java/featurecat/lizzie/teacher/CommentDisplayRenderer.java
@@ -1,9 +1,5 @@
 package featurecat.lizzie.teacher;
 
-import featurecat.lizzie.Lizzie;
-import featurecat.lizzie.analysis.GameInfo;
-import featurecat.lizzie.enginegame.EngineGamePresentation;
-import featurecat.lizzie.rules.Board;
 import featurecat.lizzie.rules.SGFParser;
 import featurecat.lizzie.rules.SGFParser.WinrateCommentSplit;
 import java.util.Optional;
@@ -13,11 +9,15 @@ public final class CommentDisplayRenderer {
   private CommentDisplayRenderer() {}
 
   public static String render(String rawComment) {
+    return render(rawComment, false);
+  }
+
+  public static String render(String rawComment, boolean separateMatchInfo) {
     String userComment = TeacherCommentCodec.removeBlocks(rawComment);
     Optional<String> aiCommentary = TeacherCommentCodec.extract(rawComment);
     String personalComment = userComment;
     String matchInfo = "";
-    if (shouldSplitOrdinaryAnalysisMatchInfo()) {
+    if (separateMatchInfo) {
       WinrateCommentSplit split = SGFParser.splitWinrateComment(userComment);
       personalComment = split.personalComment;
       matchInfo = split.matchInfo;
@@ -53,25 +53,5 @@ public final class CommentDisplayRenderer {
     body.append("<div class='sgf-comment'>")
         .append(SafeMarkdownRenderer.plainTextToBodyHtml(text))
         .append("</div>");
-  }
-
-  private static boolean shouldSplitOrdinaryAnalysisMatchInfo() {
-    Board board = Lizzie.board;
-    if (board == null) {
-      return true;
-    }
-    if (EngineGamePresentation.current().playing()) {
-      return false;
-    }
-    if (board.isPkBoard || board.isGameBoard) {
-      return false;
-    }
-    if (board.getHistory() != null) {
-      GameInfo info = board.getHistory().getGameInfo();
-      if (info != null && info.hasEngineGameHistory()) {
-        return false;
-      }
-    }
-    return true;
   }
 }

--- a/src/test/java/featurecat/lizzie/teacher/CommentDisplayRendererTest.java
+++ b/src/test/java/featurecat/lizzie/teacher/CommentDisplayRendererTest.java
@@ -3,6 +3,9 @@ package featurecat.lizzie.teacher;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import featurecat.lizzie.AppLocale;
+import featurecat.lizzie.Lizzie;
+import java.util.ResourceBundle;
 import org.junit.jupiter.api.Test;
 
 class CommentDisplayRendererTest {
@@ -62,5 +65,95 @@ class CommentDisplayRendererTest {
     assertTrue(html.contains("<table><thead><tr><th>Move</th><th>Review</th></tr></thead>"));
     assertTrue(html.contains("<td>D4</td><td><strong>Good</strong> &amp; &lt;img src=x&gt;</td>"));
     assertFalse(html.contains("<img"));
+  }
+
+  @Test
+  void separatesEnglishPersonalCommentaryFromMatchInfoWithDivider() {
+    String html =
+        renderWithBundle(
+            AppLocale.ENGLISH.loadBundle(),
+            "Looks like a fight.\n\n" + ENGLISH_KATA_MATCH_INFO);
+
+    int personalAt = html.indexOf("Looks like a fight.");
+    int dividerAt = html.indexOf("match-info-divider");
+    int winRateAt = html.indexOf("win rate");
+    assertTrue(personalAt >= 0);
+    assertTrue(dividerAt > personalAt);
+    assertTrue(winRateAt > dividerAt);
+    assertTrue(html.contains("lead:"));
+    assertTrue(html.contains("visits"));
+    assertTrue(html.contains("komi:"));
+  }
+
+  @Test
+  void separatesChinesePersonalCommentaryFromMatchInfoWithDivider() {
+    String html =
+        renderWithBundle(
+            AppLocale.SIMPLIFIED_CHINESE.loadBundle(),
+            "这手可以。\n\n" + CHINESE_KATA_MATCH_INFO);
+
+    int personalAt = html.indexOf("这手可以。");
+    int dividerAt = html.indexOf("match-info-divider");
+    int winRateAt = html.indexOf("胜率");
+    assertTrue(personalAt >= 0);
+    assertTrue(dividerAt > personalAt);
+    assertTrue(winRateAt > dividerAt);
+    assertTrue(html.contains("领先"));
+    assertTrue(html.contains("计算量"));
+    assertTrue(html.contains("贴目"));
+  }
+
+  @Test
+  void rendersMatchInfoWithoutDividerWhenThereIsNoPersonalCommentary() {
+    String html = renderWithBundle(AppLocale.ENGLISH.loadBundle(), ENGLISH_KATA_MATCH_INFO);
+
+    assertTrue(html.contains("win rate"));
+    assertTrue(html.contains("lead:"));
+    assertTrue(html.contains("visits"));
+    assertTrue(html.contains("komi:"));
+    assertFalse(html.contains("match-info-divider"));
+  }
+
+  @Test
+  void keepsAiCommentaryAfterPersonalCommentaryAndMatchInfo() {
+    String stored =
+        TeacherCommentCodec.upsert(
+            "My note\n\n" + ENGLISH_KATA_MATCH_INFO, "# Review", "test-model");
+
+    String html = renderWithBundle(AppLocale.ENGLISH.loadBundle(), stored);
+
+    int personalAt = html.indexOf("My note");
+    int dividerAt = html.indexOf("match-info-divider");
+    int winRateAt = html.indexOf("win rate");
+    int aiAt = html.indexOf("ai-commentary");
+    int reviewAt = html.indexOf("<h1>Review</h1>");
+    assertTrue(personalAt >= 0);
+    assertTrue(dividerAt > personalAt);
+    assertTrue(winRateAt > dividerAt);
+    assertTrue(aiAt > winRateAt);
+    assertTrue(reviewAt > aiAt);
+    assertFalse(html.contains("LizzieYzy AI Commentary BEGIN"));
+  }
+
+  private static final String ENGLISH_KATA_MATCH_INFO =
+      "White win rate: 38.9% (-22.2%)\n"
+          + "lead: -8.9 (-2.8) stdev: 13.4\n"
+          + "(Transformer11BFlagship / 4.5k visits)\n"
+          + "komi: 7.5";
+
+  private static final String CHINESE_KATA_MATCH_INFO =
+      "白棋 胜率: 38.9% (-22.2%)\n"
+          + "领先: -8.9 (-2.8) 不确定度: 13.4\n"
+          + "(Transformer11BFlagship / 4.5k 计算量)\n"
+          + "贴目: 7.5";
+
+  private static String renderWithBundle(ResourceBundle bundle, String comment) {
+    ResourceBundle previous = Lizzie.resourceBundle;
+    Lizzie.resourceBundle = bundle;
+    try {
+      return CommentDisplayRenderer.render(comment);
+    } finally {
+      Lizzie.resourceBundle = previous;
+    }
   }
 }

--- a/src/test/java/featurecat/lizzie/teacher/CommentDisplayRendererTest.java
+++ b/src/test/java/featurecat/lizzie/teacher/CommentDisplayRendererTest.java
@@ -135,6 +135,16 @@ class CommentDisplayRendererTest {
     assertFalse(html.contains("LizzieYzy AI Commentary BEGIN"));
   }
 
+  @Test
+  void keepsMixedCommentUnsplitWhenMatchInfoSeparationIsDisabled() {
+    String mixed = "Looks like a fight.\n\n" + ENGLISH_KATA_MATCH_INFO;
+    String html = renderWithBundle(AppLocale.ENGLISH.loadBundle(), mixed, false);
+
+    assertTrue(html.contains("Looks like a fight."));
+    assertTrue(html.contains("win rate"));
+    assertFalse(html.contains("match-info-divider"));
+  }
+
   private static final String ENGLISH_KATA_MATCH_INFO =
       "White win rate: 38.9% (-22.2%)\n"
           + "lead: -8.9 (-2.8) stdev: 13.4\n"
@@ -148,10 +158,15 @@ class CommentDisplayRendererTest {
           + "贴目: 7.5";
 
   private static String renderWithBundle(ResourceBundle bundle, String comment) {
+    return renderWithBundle(bundle, comment, true);
+  }
+
+  private static String renderWithBundle(
+      ResourceBundle bundle, String comment, boolean separateMatchInfo) {
     ResourceBundle previous = Lizzie.resourceBundle;
     Lizzie.resourceBundle = bundle;
     try {
-      return CommentDisplayRenderer.render(comment);
+      return CommentDisplayRenderer.render(comment, separateMatchInfo);
     } finally {
       Lizzie.resourceBundle = previous;
     }


### PR DESCRIPTION
## Summary

- Ordinary-analysis Comments HTML now shows personal commentary above the auto-appended match-info block, with a 1px divider between them when both are present.
- Match-info-only comments stay as they are, with no divider. AI Commentary still renders as its own block after the SGF text. The comment editor and SGF write path are unchanged.

## Type Of Change

- [x] Feature

## Testing

- [x] Tested locally (`CommentDisplayRendererTest`, 9 tests)
- [ ] Verified package contents if packaging changed
- [ ] Verified Fox sync flow if related
- [ ] Added screenshots if UI changed
- [ ] Updated README / docs if user-facing behavior changed
- [ ] Noted affected platforms if the change is platform-specific
- [x] Verified there is no unrelated formatting or line-ending churn
- [x] Ran `python3 scripts/check_line_endings.py` (or equivalent `python` on Windows)

Windows Maven `-DskipTests package` succeeded for this SHA; shaded JAR was built and not launched.

## Notes

Splitter uses the existing language-dependent `formatComment` pattern. Ordinary analysis only: live/history engine games, PK boards, and analyze-mode game boards keep an unsplit remainder.

## Related

- https://github.com/wimi321/lizzieyzy-next/issues/352