### PR TITLE
修复 AI 陪练结束后的智子云恢复与自动复盘曲线

### DIFF
--- a/src/main/java/featurecat/lizzie/analysis/ExactSnapshotEngineRestore.java
+++ b/src/main/java/featurecat/lizzie/analysis/ExactSnapshotEngineRestore.java
@@ -82,6 +82,24 @@ public final class ExactSnapshotEngineRestore {
     }
   }
 
+  /**
+   * Captures an exact restore plan for a displayed history position.
+   *
+   * <p>Unlike {@link #prepare(Leelaz.ExactSnapshotRestoreAdmission, BoardHistoryNode)}, this
+   * variant treats an ordinary empty history root as a replay origin. That gives remote engines a
+   * real move tail that preserves side-to-play without inventing a pass, while retaining strict
+   * GTP acknowledgements for resource handoffs.
+   */
+  public static PreparedRestore prepareCurrentHistoryPosition(
+      Leelaz.ExactSnapshotRestoreAdmission admission, BoardHistoryNode target) {
+    try {
+      return new PreparedRestore(RestorePlan.captureCurrentHistory(admission, target));
+    } catch (RuntimeException | Error failure) {
+      admission.completeBoardSync();
+      throw failure;
+    }
+  }
+
   private static void validateCurrentPosition(BoardData sourceData) {
     if (sourceData == null) {
       throw new IllegalArgumentException("positionData");
@@ -561,9 +579,22 @@ public final class ExactSnapshotEngineRestore {
     private static Optional<RestorePlan> capture(
         Leelaz.ExactSnapshotRestoreAdmission admission,
         BoardHistoryNode target) {
+      return capture(admission, target, false);
+    }
+
+    private static RestorePlan captureCurrentHistory(
+        Leelaz.ExactSnapshotRestoreAdmission admission, BoardHistoryNode target) {
+      return capture(admission, target, true)
+          .orElseThrow(() -> new IllegalStateException("History position has no replay origin."));
+    }
+
+    private static Optional<RestorePlan> capture(
+        Leelaz.ExactSnapshotRestoreAdmission admission,
+        BoardHistoryNode target,
+        boolean allowHistoryOrigin) {
       if (admission == null) {
         throw new IllegalArgumentException("admission");
-    }
+      }
       Leelaz engine = admission.authority();
       Leelaz mirrorEngine = admission.mirror();
       requireEngine(engine);
@@ -572,6 +603,12 @@ public final class ExactSnapshotEngineRestore {
         throw new IllegalArgumentException("target");
       }
       SnapshotAnchor anchor = findSnapshotAnchor(target);
+      if (anchor == null && allowHistoryOrigin) {
+        BoardHistoryNode origin = findHistoryOrigin(target);
+        BoardData originData = origin.getData();
+        validateCurrentPosition(originData);
+        anchor = new SnapshotAnchor(origin, originData);
+      }
       if (anchor == null) {
         return Optional.empty();
       }
@@ -582,6 +619,14 @@ public final class ExactSnapshotEngineRestore {
       Double restoreKomi = captureHistoryKomi();
       return Optional.of(
           new RestorePlan(engine, mirrorEngine, snapshotData, tail, restoreKomi, admission));
+    }
+
+    private static BoardHistoryNode findHistoryOrigin(BoardHistoryNode target) {
+      BoardHistoryNode origin = target;
+      while (origin.previous().isPresent()) {
+        origin = origin.previous().get();
+      }
+      return origin;
     }
 
     private static RestorePlan capture(

--- a/src/main/java/featurecat/lizzie/gui/HumanSlGameController.java
+++ b/src/main/java/featurecat/lizzie/gui/HumanSlGameController.java
@@ -753,10 +753,10 @@ public final class HumanSlGameController {
     Runnable uiCompletion =
         () -> {
           Lizzie.frame.hideHumanSlTrainingBar(this);
-          Lizzie.frame.refresh();
           if (Lizzie.frame.humanSlGame == this) {
             Lizzie.frame.humanSlGame = null;
           }
+          Lizzie.frame.refresh();
         };
     Runnable completionOverride = successfulExitCompletionOverride;
     beginExitLifecycle(
@@ -982,6 +982,34 @@ public final class HumanSlGameController {
     }
     if (continuation != null) {
       runExitContinuation(continuation);
+    } else {
+      startPostGameAnalysisAfterSuccessfulExit();
+    }
+  }
+
+  private void startPostGameAnalysisAfterSuccessfulExit() {
+    if (config.mode.isLiveAnalysis() || Lizzie.frame == null) {
+      return;
+    }
+    Runnable start =
+        () -> {
+          if (Lizzie.frame == null || Lizzie.frame.humanSlGame != null) {
+            return;
+          }
+          try {
+            Lizzie.frame.ensureAnalysisResumedAfterLoad();
+          } catch (RuntimeException | Error failure) {
+            logExitFailure("post-game analysis start", failure);
+          }
+        };
+    if (SwingUtilities.isEventDispatchThread()) {
+      start.run();
+    } else {
+      try {
+        SwingUtilities.invokeLater(start);
+      } catch (RuntimeException | Error failure) {
+        logExitFailure("post-game analysis dispatch", failure);
+      }
     }
   }
 

--- a/src/main/java/featurecat/lizzie/gui/Menu.java
+++ b/src/main/java/featurecat/lizzie/gui/Menu.java
@@ -10625,10 +10625,19 @@ public class Menu extends JMenuBar {
   }
 
   private void configureAiFeatureButton(JFontButton button) {
-    Dimension natural = button.getPreferredSize();
-    int minWidth = Lizzie.config.isChinese ? Config.menuHeight * 4 : Config.menuHeight * 5;
+    configureAiFeatureButton(button, Lizzie.config.isChinese, Config.menuHeight);
+  }
+
+  static void configureAiFeatureButton(
+      JFontButton button, boolean useCompactMinimum, int menuHeight) {
+    Dimension natural =
+        button.getUI() == null ? null : button.getUI().getPreferredSize(button);
+    if (natural == null) {
+      natural = button.getMinimumSize();
+    }
+    int minWidth = useCompactMinimum ? menuHeight * 4 : menuHeight * 5;
     button.setPreferredSize(
-        new Dimension(Math.max(minWidth, natural.width + 14), Math.max(26, Config.menuHeight - 2)));
+        new Dimension(Math.max(minWidth, natural.width + 14), Math.max(26, menuHeight - 2)));
     button.setMinimumSize(new Dimension(Math.min(84, button.getPreferredSize().width), 24));
   }
 

--- a/src/main/java/featurecat/lizzie/gui/NewHumanSlGameDialog.java
+++ b/src/main/java/featurecat/lizzie/gui/NewHumanSlGameDialog.java
@@ -9,6 +9,7 @@ import featurecat.lizzie.rules.BoardData;
 import featurecat.lizzie.rules.BoardHistoryList;
 import featurecat.lizzie.rules.BoardHistoryNode;
 import featurecat.lizzie.training.HumanSlTrainingConfig;
+import featurecat.lizzie.training.HumanSlTrainingPreferences;
 import featurecat.lizzie.training.HumanSlTrainingSession;
 import featurecat.lizzie.training.OpponentPreset;
 import featurecat.lizzie.training.TrainingMode;
@@ -32,6 +33,7 @@ import java.awt.event.KeyEvent;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
 import java.io.IOException;
+import java.math.BigDecimal;
 import java.nio.file.Path;
 import java.text.MessageFormat;
 import java.time.Duration;
@@ -160,6 +162,7 @@ public final class NewHumanSlGameDialog extends JDialog {
     contentScroll.setHorizontalScrollBarPolicy(JScrollPane.HORIZONTAL_SCROLLBAR_AS_NEEDED);
     contentScroll.setVerticalScrollBarPolicy(JScrollPane.VERTICAL_SCROLLBAR_AS_NEEDED);
     setContentPane(contentScroll);
+    restoreLastStartedSettings();
     installBehavior();
     refreshModelStatus();
     pack();
@@ -608,6 +611,54 @@ public final class NewHumanSlGameDialog extends JDialog {
     komiField.setText(handicap >= 2 ? "0" : "7.5");
   }
 
+  private void restoreLastStartedSettings() {
+    HumanSlTrainingPreferences.SavedSettings saved =
+        HumanSlTrainingPreferences.load(Lizzie.config == null ? null : Lizzie.config.uiConfig);
+    HumanSlTrainingConfig config = saved.config();
+
+    trainingModeBox.setSelectedIndex(config.mode.isLiveAnalysis() ? 1 : 0);
+    boolean rankPreset = config.opponentPreset == OpponentPreset.RANK;
+    rankPresetButton.setSelected(rankPreset);
+    proPresetButton.setSelected(!rankPreset);
+    showOpponentCard(rankPreset ? "rank" : "pro");
+
+    danButton.setSelected(config.danRank);
+    kyuButton.setSelected(!config.danRank);
+    updateRankModel(config.danRank);
+    rankSpinner.setValue(config.rank);
+    proStyleBox.setSelectedIndex(config.opponentPreset == OpponentPreset.ONLINE_9D ? 1 : 0);
+
+    colorBox.setSelectedIndex(playerColorIndex(config.playerColor));
+    timeBox.setSelectedIndex(moveTimeIndex(config.moveTimeSeconds));
+    handicapBox.setSelectedItem(config.handicap);
+    komiField.setText(BigDecimal.valueOf(config.komi).stripTrailingZeros().toPlainString());
+    moreButton.setSelected(saved.advancedVisible());
+    updateTrainingSummary();
+  }
+
+  private static int moveTimeIndex(int seconds) {
+    if (seconds == 30) {
+      return 1;
+    }
+    if (seconds == 60) {
+      return 2;
+    }
+    if (seconds == 24 * 60 * 60) {
+      return 3;
+    }
+    return 0;
+  }
+
+  private static int playerColorIndex(HumanSlTrainingConfig.PlayerColor color) {
+    if (color == HumanSlTrainingConfig.PlayerColor.BLACK) {
+      return 1;
+    }
+    if (color == HumanSlTrainingConfig.PlayerColor.WHITE) {
+      return 2;
+    }
+    return 0;
+  }
+
   private void onPrimaryAction() {
     if (downloading) {
       return;
@@ -759,6 +810,7 @@ public final class NewHumanSlGameDialog extends JDialog {
       return;
     }
     HumanSlTrainingConfig config = selectedConfig();
+    boolean advancedVisible = moreButton.isSelected();
     BoardHistoryNode readinessNode =
         config.fromCurrentPosition
             ? Lizzie.board.getHistory().getCurrentHistoryNode()
@@ -797,11 +849,14 @@ public final class NewHumanSlGameDialog extends JDialog {
                         ENGINE_READY_TIMEOUT,
                         pauseSettled);
                 dispatchRunnerPreparationCompletion(
-                    () -> completeRunnerPreparation(preparedRunner, config, outcome),
+                    () ->
+                        completeRunnerPreparation(
+                            preparedRunner, config, advancedVisible, outcome),
                     dispatchFailure ->
                         completeRunnerPreparation(
                             preparedRunner,
                             config,
+                            advancedVisible,
                             new RunnerPreparationOutcome(
                                 false, appendFailure(outcome.failure(), dispatchFailure))),
                     SwingUtilities::invokeLater);
@@ -1015,6 +1070,7 @@ public final class NewHumanSlGameDialog extends JDialog {
   private void completeRunnerPreparation(
       HumanSlAnalysisRunner runner,
       HumanSlTrainingConfig config,
+      boolean advancedVisible,
       RunnerPreparationOutcome outcome) {
     // closeDialog or an earlier completion may already own this runner's one-shot cleanup.
     if (preparingRunner != runner || !runnerCleanupClaim.claim()) {
@@ -1063,6 +1119,7 @@ public final class NewHumanSlGameDialog extends JDialog {
             });
     if (handoffFailure == null) {
       cancelled = false;
+      rememberLastStartedSettings(config, advancedVisible);
       return;
     }
 
@@ -1086,6 +1143,20 @@ public final class NewHumanSlGameDialog extends JDialog {
                 return null;
               });
       logLifecycleFailure("failed handoff dialog restore", visibilityFailure);
+    }
+  }
+
+  private void rememberLastStartedSettings(
+      HumanSlTrainingConfig config, boolean advancedVisible) {
+    if (Lizzie.config == null || Lizzie.config.uiConfig == null) {
+      return;
+    }
+    try {
+      HumanSlTrainingPreferences.store(Lizzie.config.uiConfig, config, advancedVisible);
+      Lizzie.config.save();
+    } catch (IOException | RuntimeException failure) {
+      // A preference write must never turn a successfully started coaching game into a failure.
+      LOG.warn("Failed to remember the last AI Coach settings", failure);
     }
   }
 

--- a/src/main/java/featurecat/lizzie/rules/Board.java
+++ b/src/main/java/featurecat/lizzie/rules/Board.java
@@ -1973,7 +1973,10 @@ public class Board {
       Leelaz.ExactSnapshotRestoreAdmission admission =
           engine.captureHistoryNavigationExactSnapshotRestoreAdmission();
       ExactSnapshotEngineRestore.PreparedRestore prepared =
-          ExactSnapshotEngineRestore.prepareCurrentPosition(admission, position);
+          engine.useRemoteCompute
+              ? ExactSnapshotEngineRestore.prepareCurrentHistoryPosition(
+                  admission, capturedCurrentNode)
+              : ExactSnapshotEngineRestore.prepareCurrentPosition(admission, position);
       if (Lizzie.board != owner
           || Lizzie.capturePrimaryEngineGeneration(engine) != primaryGeneration) {
         prepared.discard();

--- a/src/main/java/featurecat/lizzie/training/HumanSlTrainingPreferences.java
+++ b/src/main/java/featurecat/lizzie/training/HumanSlTrainingPreferences.java
@@ -1,0 +1,100 @@
+package featurecat.lizzie.training;
+
+import java.util.Objects;
+import org.json.JSONObject;
+
+/** Locale-independent persistence for the most recently started AI Coach game. */
+public final class HumanSlTrainingPreferences {
+  public static final String UI_CONFIG_KEY = "human-sl-training-last-settings";
+  private static final int UNLIMITED_MOVE_TIME_SECONDS = 24 * 60 * 60;
+
+  private HumanSlTrainingPreferences() {}
+
+  public record SavedSettings(HumanSlTrainingConfig config, boolean advancedVisible) {
+    public SavedSettings {
+      Objects.requireNonNull(config, "config");
+    }
+  }
+
+  public static SavedSettings load(JSONObject uiConfig) {
+    HumanSlTrainingConfig defaults = HumanSlTrainingConfig.builder().build();
+    if (uiConfig == null) {
+      return new SavedSettings(defaults, false);
+    }
+    JSONObject saved = uiConfig.optJSONObject(UI_CONFIG_KEY);
+    if (saved == null) {
+      return new SavedSettings(defaults, false);
+    }
+
+    TrainingMode mode = enumValue(saved, "mode", TrainingMode.class, defaults.mode);
+    if (mode.isLiveAnalysis()) {
+      mode = TrainingMode.LIVE_ANALYSIS;
+    }
+    OpponentPreset opponent =
+        enumValue(saved, "opponent-preset", OpponentPreset.class, defaults.opponentPreset);
+    HumanSlTrainingConfig.PlayerColor color =
+        enumValue(
+            saved,
+            "player-color",
+            HumanSlTrainingConfig.PlayerColor.class,
+            defaults.playerColor);
+    boolean danRank = saved.optBoolean("dan-rank", defaults.danRank);
+    int rank = saved.optInt("rank", defaults.rank);
+    int moveTime = normalizeMoveTime(saved.optInt("move-time-seconds", defaults.moveTimeSeconds));
+    int handicap = saved.optInt("handicap", defaults.handicap);
+    double komi = saved.optDouble("komi", defaults.komi);
+    if (!Double.isFinite(komi)) {
+      komi = defaults.komi;
+    }
+
+    HumanSlTrainingConfig config =
+        HumanSlTrainingConfig.builder()
+            .mode(mode)
+            .opponentPreset(opponent)
+            .rank(rank, danRank)
+            .playerColor(color)
+            .moveTimeSeconds(moveTime)
+            .handicap(handicap)
+            .komi(komi)
+            // Starting from the current board is an action for one game, not a durable default.
+            .fromCurrentPosition(false)
+            .build();
+    return new SavedSettings(config, saved.optBoolean("advanced-visible", false));
+  }
+
+  public static void store(
+      JSONObject uiConfig, HumanSlTrainingConfig config, boolean advancedVisible) {
+    Objects.requireNonNull(uiConfig, "uiConfig");
+    Objects.requireNonNull(config, "config");
+    JSONObject saved = new JSONObject();
+    saved.put("mode", config.mode.name());
+    saved.put("opponent-preset", config.opponentPreset.name());
+    saved.put("rank", config.rank);
+    saved.put("dan-rank", config.danRank);
+    saved.put("player-color", config.playerColor.name());
+    saved.put("move-time-seconds", config.moveTimeSeconds);
+    saved.put("handicap", config.handicap);
+    saved.put("komi", config.komi);
+    saved.put("advanced-visible", advancedVisible);
+    uiConfig.put(UI_CONFIG_KEY, saved);
+  }
+
+  private static int normalizeMoveTime(int seconds) {
+    return seconds == 10 || seconds == 30 || seconds == 60 || seconds == UNLIMITED_MOVE_TIME_SECONDS
+        ? seconds
+        : 10;
+  }
+
+  private static <E extends Enum<E>> E enumValue(
+      JSONObject saved, String key, Class<E> type, E fallback) {
+    String value = saved.optString(key, "").trim();
+    if (value.isEmpty()) {
+      return fallback;
+    }
+    try {
+      return Enum.valueOf(type, value);
+    } catch (IllegalArgumentException ignored) {
+      return fallback;
+    }
+  }
+}

--- a/src/test/java/featurecat/lizzie/analysis/ExactSnapshotEngineRestoreContractTest.java
+++ b/src/test/java/featurecat/lizzie/analysis/ExactSnapshotEngineRestoreContractTest.java
@@ -686,6 +686,38 @@ class ExactSnapshotEngineRestoreContractTest {
   }
 
   @Test
+  void currentHistoryRestoreReplaysRealTailToPreserveRemoteWhiteToPlay() throws Exception {
+    try (TestHarness harness = TestHarness.open(false)) {
+      BoardHistoryList history = new BoardHistoryList(BoardData.empty(BOARD_SIZE, BOARD_SIZE));
+      history.add(moveNode(2, 2, Stone.BLACK, false, 1));
+      Lizzie.board.setHistory(history);
+
+      Leelaz engine = new Leelaz("");
+      engine.useRemoteCompute = true;
+      ExactSnapshotRestoreProtocolFixture.Transport transport =
+          ExactSnapshotRestoreProtocolFixture.install(
+              engine, command -> ExactSnapshotRestoreProtocolFixture.Response.success());
+      Leelaz.ExactSnapshotRestoreAdmission admission =
+          engine.captureExactSnapshotRestoreAdmission(
+              Leelaz.ExactSnapshotRestoreOwner.ORDINARY,
+              null,
+              engine.resolveLoadSgfMirrorEngine());
+
+      ExactSnapshotEngineRestore.prepareCurrentHistoryPosition(
+              admission, history.getCurrentHistoryNode())
+          .execute();
+
+      assertTrue(
+          transport.commands().stream()
+              .anyMatch(ExactSnapshotEngineRestoreContractTest::isSetPositionCommand));
+      assertEquals(
+          List.of("play B " + Board.convertCoordinatesToName(2, 2)),
+          collectPlayCommands(transport.commands()),
+          "remote restore must use the real move tail to establish white-to-play");
+    }
+  }
+
+  @Test
   void historyTargetCaptureUsesCurrentGameKomi() throws Exception {
     try (TestHarness harness = TestHarness.open(false)) {
       BoardHistoryList history = new BoardHistoryList(snapshotRoot());

--- a/src/test/java/featurecat/lizzie/gui/HumanSlGameControllerIntegrationTest.java
+++ b/src/test/java/featurecat/lizzie/gui/HumanSlGameControllerIntegrationTest.java
@@ -893,6 +893,91 @@ class HumanSlGameControllerIntegrationTest {
   }
 
   @Test
+  void postGameReviewStartsNormalAnalysisOnlyAfterSuccessfulDetach() throws Exception {
+    try (CoachEnvironment env = CoachEnvironment.open()) {
+      CoachFrame frame = (CoachFrame) Lizzie.frame;
+      HumanSlTrainingSession session = new HumanSlTrainingSession();
+      HumanSlGameController controller =
+          new HumanSlGameController(
+              new BlockingHumanSlRunner(),
+              HumanSlTrainingConfig.builder()
+                  .mode(TrainingMode.POST_GAME_REVIEW)
+                  .playerColor(HumanSlTrainingConfig.PlayerColor.BLACK)
+                  .fromCurrentPosition(false)
+                  .moveTimeSeconds(2)
+                  .build(),
+              session);
+      controller.setExitLifecycleForTesting(Runnable::run, Runnable::run, () -> true, null);
+      session.setState(HumanSlTrainingSession.State.PLAYING);
+      frame.humanSlGame = controller;
+
+      controller.finishAndReturnToBoard();
+      SwingUtilities.invokeAndWait(() -> {});
+
+      assertTrue(controller.isFinished());
+      assertNull(frame.humanSlGame);
+      assertEquals(1, frame.analysisResumeRequests);
+      assertTrue(frame.detachedWhenAnalysisResumed);
+    }
+  }
+
+  @Test
+  void liveAnalysisFinishDoesNotStartPostGameCurve() throws Exception {
+    try (CoachEnvironment env = CoachEnvironment.open()) {
+      CoachFrame frame = (CoachFrame) Lizzie.frame;
+      HumanSlTrainingSession session = new HumanSlTrainingSession();
+      HumanSlGameController controller =
+          new HumanSlGameController(
+              new BlockingHumanSlRunner(),
+              HumanSlTrainingConfig.builder()
+                  .mode(TrainingMode.LIVE_ANALYSIS)
+                  .playerColor(HumanSlTrainingConfig.PlayerColor.BLACK)
+                  .fromCurrentPosition(false)
+                  .moveTimeSeconds(2)
+                  .build(),
+              session);
+      controller.setExitLifecycleForTesting(Runnable::run, Runnable::run, () -> true, null);
+      session.setState(HumanSlTrainingSession.State.PLAYING);
+      frame.humanSlGame = controller;
+
+      controller.finishAndReturnToBoard();
+      SwingUtilities.invokeAndWait(() -> {});
+
+      assertTrue(controller.isFinished());
+      assertEquals(0, frame.analysisResumeRequests);
+    }
+  }
+
+  @Test
+  void modeTransitionAfterCoachExitDoesNotStartPostGameCurve() throws Exception {
+    try (CoachEnvironment env = CoachEnvironment.open()) {
+      CoachFrame frame = (CoachFrame) Lizzie.frame;
+      HumanSlTrainingSession session = new HumanSlTrainingSession();
+      HumanSlGameController controller =
+          new HumanSlGameController(
+              new BlockingHumanSlRunner(),
+              HumanSlTrainingConfig.builder()
+                  .mode(TrainingMode.POST_GAME_REVIEW)
+                  .playerColor(HumanSlTrainingConfig.PlayerColor.BLACK)
+                  .fromCurrentPosition(false)
+                  .moveTimeSeconds(2)
+                  .build(),
+              session);
+      controller.setExitLifecycleForTesting(Runnable::run, Runnable::run, () -> true, null);
+      session.setState(HumanSlTrainingSession.State.PLAYING);
+      frame.humanSlGame = controller;
+      AtomicInteger transitions = new AtomicInteger();
+
+      controller.abortAndThen(transitions::incrementAndGet);
+      SwingUtilities.invokeAndWait(() -> {});
+
+      assertTrue(controller.isFinished());
+      assertEquals(1, transitions.get());
+      assertEquals(0, frame.analysisResumeRequests);
+    }
+  }
+
+  @Test
   void exitFailuresKeepForegroundLeasePendingAndNeverResumeEarly() throws Exception {
     for (String failingPhase : List.of("close", "resync", "restore")) {
       try (CoachEnvironment env = CoachEnvironment.open()) {
@@ -1665,6 +1750,9 @@ class HumanSlGameControllerIntegrationTest {
   }
 
   private static class CoachFrame extends LizzieFrame {
+    private int analysisResumeRequests;
+    private boolean detachedWhenAnalysisResumed;
+
     @Override
     public void clearKataEstimate() {}
 
@@ -1694,6 +1782,13 @@ class HumanSlGameControllerIntegrationTest {
 
     @Override
     public void setResult(String result) {}
+
+    @Override
+    public boolean ensureAnalysisResumedAfterLoad() {
+      analysisResumeRequests++;
+      detachedWhenAnalysisResumed = humanSlGame == null;
+      return true;
+    }
   }
 
   private static final class ThrowingStartCoachFrame extends CoachFrame {

--- a/src/test/java/featurecat/lizzie/gui/MenuAiFeatureButtonLayoutTest.java
+++ b/src/test/java/featurecat/lizzie/gui/MenuAiFeatureButtonLayoutTest.java
@@ -1,0 +1,47 @@
+package featurecat.lizzie.gui;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.awt.Dimension;
+import javax.swing.SwingUtilities;
+import org.junit.jupiter.api.Test;
+
+class MenuAiFeatureButtonLayoutTest {
+  @Test
+  void repeatedStateRefreshDoesNotGrowButton() throws Exception {
+    SwingUtilities.invokeAndWait(
+        () -> {
+          JFontButton button = new JFontButton("AI Coach");
+
+          Menu.configureAiFeatureButton(button, false, 34);
+          Dimension first = new Dimension(button.getPreferredSize());
+
+          for (int refresh = 0; refresh < 20; refresh++) {
+            Menu.configureAiFeatureButton(button, false, 34);
+          }
+
+          assertEquals(first, button.getPreferredSize());
+        });
+  }
+
+  @Test
+  void returningToIdleRestoresOriginalWidthAfterLongStatus() throws Exception {
+    SwingUtilities.invokeAndWait(
+        () -> {
+          JFontButton button = new JFontButton("AI Coach");
+          Menu.configureAiFeatureButton(button, false, 34);
+          Dimension idle = new Dimension(button.getPreferredSize());
+
+          button.setText("AI Coach is preparing the training session");
+          Menu.configureAiFeatureButton(button, false, 34);
+          int preparingWidth = button.getPreferredSize().width;
+
+          button.setText("AI Coach");
+          Menu.configureAiFeatureButton(button, false, 34);
+
+          assertTrue(preparingWidth > idle.width);
+          assertEquals(idle, button.getPreferredSize());
+        });
+  }
+}

--- a/src/test/java/featurecat/lizzie/rules/BoardPrimaryEngineSyncTest.java
+++ b/src/test/java/featurecat/lizzie/rules/BoardPrimaryEngineSyncTest.java
@@ -8,6 +8,7 @@ import featurecat.lizzie.Config;
 import featurecat.lizzie.ExtraMode;
 import featurecat.lizzie.Lizzie;
 import featurecat.lizzie.analysis.EngineManager;
+import featurecat.lizzie.analysis.ExactSnapshotRestoreProtocolFixture;
 import featurecat.lizzie.analysis.Leelaz;
 import featurecat.lizzie.gui.GtpConsolePane;
 import featurecat.lizzie.gui.LizzieFrame;
@@ -290,6 +291,34 @@ class BoardPrimaryEngineSyncTest {
               .recaptureCurrentPositionForSamePrimary()
               .orElseThrow()
               .matchesCurrentBoardAndPrimary());
+    }
+  }
+
+  @Test
+  void frozenExactRestorePreservesRemoteWhiteToPlayWithRealHistoryTail() throws Exception {
+    try (TestHarness harness = TestHarness.open()) {
+      Board board = Lizzie.board;
+      BoardHistoryList history = new BoardHistoryList(BoardData.empty(BOARD_SIZE, BOARD_SIZE));
+      history.add(moveNode(0, 0, Stone.BLACK, false, 1));
+      board.setHistory(history);
+
+      Leelaz engine = new Leelaz("");
+      engine.useRemoteCompute = true;
+      engine.isLoaded = true;
+      setStarted(engine, true);
+      ExactSnapshotRestoreProtocolFixture.Transport transport =
+          ExactSnapshotRestoreProtocolFixture.install(
+              engine, command -> ExactSnapshotRestoreProtocolFixture.Response.success());
+      Lizzie.leelaz = engine;
+
+      Board.FrozenPrimaryPosition frozen =
+          board.freezeCurrentPositionForPrimaryEngineExactRestore().orElseThrow();
+
+      assertTrue(frozen.execute());
+      assertEquals(
+          List.of("play B A3"),
+          transport.commands().stream().filter(command -> command.startsWith("play ")).toList());
+      assertTrue(frozen.matchesCurrentBoardAndPrimary());
     }
   }
 

--- a/src/test/java/featurecat/lizzie/training/HumanSlTrainingPreferencesTest.java
+++ b/src/test/java/featurecat/lizzie/training/HumanSlTrainingPreferencesTest.java
@@ -1,0 +1,102 @@
+package featurecat.lizzie.training;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import featurecat.lizzie.training.HumanSlTrainingConfig.PlayerColor;
+import org.json.JSONObject;
+import org.junit.jupiter.api.Test;
+
+class HumanSlTrainingPreferencesTest {
+  @Test
+  void roundTripsEveryDurableCoachChoice() {
+    JSONObject ui = new JSONObject().put("unrelated-setting", 42);
+    HumanSlTrainingConfig selected =
+        HumanSlTrainingConfig.builder()
+            .mode(TrainingMode.LIVE_ANALYSIS)
+            .opponentPreset(OpponentPreset.ONLINE_9D)
+            .rank(12, false)
+            .playerColor(PlayerColor.WHITE)
+            .moveTimeSeconds(60)
+            .handicap(2)
+            .komi(0.5)
+            .fromCurrentPosition(true)
+            .build();
+
+    HumanSlTrainingPreferences.store(ui, selected, true);
+    HumanSlTrainingPreferences.SavedSettings restored = HumanSlTrainingPreferences.load(ui);
+
+    assertEquals(42, ui.getInt("unrelated-setting"));
+    assertEquals(TrainingMode.LIVE_ANALYSIS, restored.config().mode);
+    assertEquals(OpponentPreset.ONLINE_9D, restored.config().opponentPreset);
+    assertEquals(12, restored.config().rank);
+    assertFalse(restored.config().danRank);
+    assertEquals(PlayerColor.WHITE, restored.config().playerColor);
+    assertEquals(60, restored.config().moveTimeSeconds);
+    assertEquals(2, restored.config().handicap);
+    assertEquals(0.5, restored.config().komi);
+    assertFalse(restored.config().fromCurrentPosition);
+    assertTrue(restored.advancedVisible());
+  }
+
+  @Test
+  void missingSettingsUseTheProductDefaults() {
+    HumanSlTrainingPreferences.SavedSettings restored =
+        HumanSlTrainingPreferences.load(new JSONObject());
+
+    assertEquals(TrainingMode.POST_GAME_REVIEW, restored.config().mode);
+    assertEquals(OpponentPreset.RANK, restored.config().opponentPreset);
+    assertEquals(3, restored.config().rank);
+    assertTrue(restored.config().danRank);
+    assertEquals(PlayerColor.RANDOM, restored.config().playerColor);
+    assertEquals(10, restored.config().moveTimeSeconds);
+    assertEquals(0, restored.config().handicap);
+    assertEquals(7.5, restored.config().komi);
+    assertFalse(restored.advancedVisible());
+  }
+
+  @Test
+  void legacyLiveCorrectionSettingsRestoreAsLiveAnalysis() {
+    JSONObject saved =
+        new JSONObject()
+            .put("mode", "LIVE_CORRECTION")
+            .put("opponent-preset", "MODERN_PRO")
+            .put("player-color", "BLACK");
+    JSONObject ui = new JSONObject().put(HumanSlTrainingPreferences.UI_CONFIG_KEY, saved);
+
+    HumanSlTrainingPreferences.SavedSettings restored = HumanSlTrainingPreferences.load(ui);
+
+    assertEquals(TrainingMode.LIVE_ANALYSIS, restored.config().mode);
+    assertEquals(OpponentPreset.MODERN_PRO, restored.config().opponentPreset);
+    assertEquals(PlayerColor.BLACK, restored.config().playerColor);
+  }
+
+  @Test
+  void corruptOrFutureValuesFallBackWithoutBreakingTheDialog() {
+    JSONObject saved =
+        new JSONObject()
+            .put("mode", "FUTURE_MODE")
+            .put("opponent-preset", "UNKNOWN_STYLE")
+            .put("rank", 99)
+            .put("dan-rank", false)
+            .put("player-color", "PURPLE")
+            .put("move-time-seconds", 17)
+            .put("handicap", 99)
+            .put("komi", "not-a-number")
+            .put("advanced-visible", true);
+    JSONObject ui = new JSONObject().put(HumanSlTrainingPreferences.UI_CONFIG_KEY, saved);
+
+    HumanSlTrainingPreferences.SavedSettings restored = HumanSlTrainingPreferences.load(ui);
+
+    assertEquals(TrainingMode.POST_GAME_REVIEW, restored.config().mode);
+    assertEquals(OpponentPreset.RANK, restored.config().opponentPreset);
+    assertEquals(20, restored.config().rank);
+    assertFalse(restored.config().danRank);
+    assertEquals(PlayerColor.RANDOM, restored.config().playerColor);
+    assertEquals(10, restored.config().moveTimeSeconds);
+    assertEquals(9, restored.config().handicap);
+    assertEquals(7.5, restored.config().komi);
+    assertTrue(restored.advancedVisible());
+  }
+}


### PR DESCRIPTION
## 修复内容

- 智子云作为前台引擎时，AI 陪练结束改为基于真实主线回放恢复棋盘，保留准确的行棋方，不再因空回放尾无法表达白方行棋而进入恢复失败状态。
- “实战后复盘”仅在陪练进程关闭、棋盘精确同步、前台引擎租约和界面清理全部成功后，自动启动已有的快速胜率曲线流程。
- “边下边分析”和切换到其他模式不额外启动复盘任务；本地引擎继续使用原有完整快照恢复语义。
- 增加远程白方行棋恢复、Board 集成、复盘/实时/模式切换生命周期回归测试。

## 自动化验证

- `mvn -B -Djava.awt.headless=true -Dfmt.skip=true test`: 3509 tests, 0 failures, 0 errors, 14 skipped
- 关键回归复跑: 100 tests, 0 failures, 0 errors, 0 skipped
- `mvn -B -Djava.awt.headless=true -Dfmt.skip=true -DskipTests package`: BUILD SUCCESS
- `python scripts/test_windows_launcher_packaging.py`: passed
- `git diff --check`: passed
- `python scripts/check_line_endings.py`: passed

## Windows 真机验收

使用隔离的 `next-2026-08-27.5` NVIDIA portable，替换本 PR 构建的 shaded JAR 后真实启动 EXE：

- 智子云 + 实战后复盘，奇数手结束：无恢复失败弹窗，3 秒出现曲线，8 秒完成评估并恢复前台候选点分析。
- 智子云 + 用户落子后立即结束（偶数手/并发取消）：曲线完成，陪练进程退出，前台分析恢复。
- 智子云 + 边下边分析：结束后不启动重复复盘任务，前台引擎可继续工作。
- 本地 NVIDIA + 实战后复盘：3 秒内曲线和评估完成，陪练 KataGo 回收，只保留一个前台 KataGo。
- 修复版会话中未再出现 `UNSUPPORTED_REMOTE_POSITION` 或 `HumanSL exit phase=... failed`。