### PR TITLE
feat(humansl): log structured diagnostics on analysis resolve failure (#368)

### DIFF
--- a/src/main/java/featurecat/lizzie/util/AnalysisEngineCommandHelper.java
+++ b/src/main/java/featurecat/lizzie/util/AnalysisEngineCommandHelper.java
@@ -3,6 +3,7 @@ package featurecat.lizzie.util;
 import featurecat.lizzie.Config;
 import featurecat.lizzie.Lizzie;
 import featurecat.lizzie.gui.EngineData;
+import featurecat.lizzie.logging.LogCategories;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
@@ -12,11 +13,14 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import java.util.MissingResourceException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public final class AnalysisEngineCommandHelper {
   static final String TEMPLATE_RESOURCE = "katago/analysis_example.cfg";
   public static final String DEFAULT_ANALYSIS_COMMAND =
       "katago analysis -model model.bin.gz -config analysis.cfg -quit-without-waiting";
+  private static final Logger LOG = LoggerFactory.getLogger(LogCategories.ENGINE);
 
   private AnalysisEngineCommandHelper() {}
 
@@ -99,11 +103,16 @@ public final class AnalysisEngineCommandHelper {
    */
   public static Result resolveHumanSlCommand(String configuredCommand) {
     KataGoAutoSetupHelper.SetupSnapshot snapshot = KataGoAutoSetupHelper.inspectLocalSetup();
-    return resolveHumanSlCommand(
-        configuredCommand,
-        snapshot == null ? null : snapshot.enginePath,
-        snapshot == null ? null : snapshot.analysisConfigPath,
-        snapshot == null ? null : snapshot.activeWeightPath);
+    Result result =
+        resolveHumanSlCommand(
+            configuredCommand,
+            snapshot == null ? null : snapshot.enginePath,
+            snapshot == null ? null : snapshot.analysisConfigPath,
+            snapshot == null ? null : snapshot.activeWeightPath);
+    if (!result.isSuccess()) {
+      logHumanSlResolutionFailure(configuredCommand, snapshot);
+    }
+    return result;
   }
 
   static Result resolveHumanSlCommand(
@@ -139,6 +148,123 @@ public final class AnalysisEngineCommandHelper {
       parts.add("-quit-without-waiting");
     }
     return Result.success(buildCommandLine(parts), "", false, analysisConfigPath);
+  }
+
+  static void logHumanSlResolutionFailure(
+      String configuredCommand, KataGoAutoSetupHelper.SetupSnapshot snapshot) {
+    try {
+      LOG.warn("{}", formatHumanSlResolutionFailure(configuredCommand, snapshot));
+    } catch (RuntimeException | Error ignored) {
+      // A logging backend failure must not change resolve success or failure.
+    }
+  }
+
+  static String formatHumanSlResolutionFailure(
+      String configuredCommand, KataGoAutoSetupHelper.SetupSnapshot snapshot) {
+    boolean configuredCommandPresent =
+        configuredCommand != null && !configuredCommand.trim().isEmpty();
+    String source = KataGoAutoSetupHelper.DiscoverySource.NONE.name();
+    String packageFlavor = KataGoAutoSetupHelper.PackageFlavor.UNKNOWN.name();
+    boolean engine = false;
+    boolean analysisConfig = false;
+    boolean weight = false;
+    String missingComponents = "[]";
+    String diagnostics = "[]";
+    if (snapshot != null) {
+      engine = isRegularFile(snapshot.enginePath);
+      analysisConfig = isRegularFile(snapshot.analysisConfigPath);
+      weight = isRegularFile(snapshot.activeWeightPath);
+      KataGoAutoSetupHelper.LocalKataGoDiscoveryResult discovery = snapshot.discovery;
+      if (discovery != null) {
+        source = discovery.source.name();
+        packageFlavor = discovery.packageFlavor.name();
+        missingComponents = formatSafeList(discovery.missingComponents, snapshot);
+        diagnostics = formatSafeList(discovery.diagnostics, snapshot);
+      }
+    }
+    return "HumanSL analysis engine resolution failed:"
+        + " configuredCommandPresent="
+        + configuredCommandPresent
+        + " source="
+        + source
+        + " packageFlavor="
+        + packageFlavor
+        + " engine="
+        + engine
+        + " analysisConfig="
+        + analysisConfig
+        + " weight="
+        + weight
+        + " missingComponents="
+        + missingComponents
+        + " diagnostics="
+        + diagnostics;
+  }
+
+  private static String formatSafeList(
+      List<?> values, KataGoAutoSetupHelper.SetupSnapshot snapshot) {
+    if (values == null || values.isEmpty()) {
+      return "[]";
+    }
+    StringBuilder builder = new StringBuilder("[");
+    for (int i = 0; i < values.size(); i++) {
+      if (i > 0) {
+        builder.append(", ");
+      }
+      Object value = values.get(i);
+      builder.append(redactSnapshotPaths(value == null ? "" : String.valueOf(value), snapshot));
+    }
+    builder.append(']');
+    return builder.toString();
+  }
+
+  private static String redactSnapshotPaths(
+      String text, KataGoAutoSetupHelper.SetupSnapshot snapshot) {
+    if (text == null || text.isEmpty() || snapshot == null) {
+      return text == null ? "" : text;
+    }
+    String safe = text;
+    safe = replacePathWithFileName(safe, snapshot.enginePath);
+    safe = replacePathWithFileName(safe, snapshot.gtpConfigPath);
+    safe = replacePathWithFileName(safe, snapshot.analysisConfigPath);
+    safe = replacePathWithFileName(safe, snapshot.activeWeightPath);
+    safe = replacePathWithFileName(safe, snapshot.workingDir);
+    safe = replacePathWithFileName(safe, snapshot.appRoot);
+    if (snapshot.discovery != null) {
+      safe = replacePathWithFileName(safe, snapshot.discovery.sourceCommand);
+    }
+    return safe;
+  }
+
+  private static String replacePathWithFileName(String text, Path path) {
+    if (text == null || text.isEmpty() || path == null) {
+      return text == null ? "" : text;
+    }
+    return replaceLiteralWithFileName(text, path.toString(), path.getFileName());
+  }
+
+  private static String replacePathWithFileName(String text, String pathText) {
+    if (text == null || text.isEmpty() || pathText == null || pathText.isEmpty()) {
+      return text == null ? "" : text;
+    }
+    Path fileName;
+    try {
+      fileName = Path.of(pathText).getFileName();
+    } catch (RuntimeException e) {
+      fileName = null;
+    }
+    return replaceLiteralWithFileName(text, pathText, fileName);
+  }
+
+  private static String replaceLiteralWithFileName(String text, String literal, Path fileName) {
+    if (literal == null || literal.isEmpty() || !text.contains(literal)) {
+      return text;
+    }
+    String replacement = fileName == null ? "file" : fileName.toString();
+    if (replacement.isEmpty() || replacement.equals(literal)) {
+      return text.replace(literal, "file");
+    }
+    return text.replace(literal, replacement);
   }
 
   public static Path ensureAnalysisConfig(Path gtpConfigPath) throws IOException {

--- a/src/test/java/featurecat/lizzie/util/AnalysisEngineCommandHelperTest.java
+++ b/src/test/java/featurecat/lizzie/util/AnalysisEngineCommandHelperTest.java
@@ -370,8 +370,15 @@ class AnalysisEngineCommandHelperTest {
 
           assertFalse(result.isSuccess());
           assertTrue(result.getCommand().isEmpty());
-          assertEquals(1, events.list.size(), events.list.toString());
-          String message = events.list.get(0).getFormattedMessage();
+          List<String> messages =
+              events.list.stream()
+                  .map(ILoggingEvent::getFormattedMessage)
+                  .filter(
+                      message ->
+                          message.contains("HumanSL analysis engine resolution failed:"))
+                  .toList();
+          assertEquals(1, messages.size(), events.list.toString());
+          String message = messages.get(0);
           assertTrue(message.contains("HumanSL analysis engine resolution failed:"), message);
           assertTrue(message.contains("configuredCommandPresent=false"), message);
           assertTrue(message.contains("source=BUNDLED_PACKAGE"), message);
@@ -404,7 +411,7 @@ class AnalysisEngineCommandHelperTest {
           AnalysisEngineCommandHelper.Result result =
               AnalysisEngineCommandHelper.resolveHumanSlCommand("");
           assertFalse(result.isSuccess());
-          runtime.awaitIdle();
+          runtime.shutdown();
 
           Path zip =
               new DiagnosticBundleExporter(DiagnosticBundleExporter.defaultOutputDirectory(logHome))

--- a/src/test/java/featurecat/lizzie/util/AnalysisEngineCommandHelperTest.java
+++ b/src/test/java/featurecat/lizzie/util/AnalysisEngineCommandHelperTest.java
@@ -33,7 +33,7 @@ import java.util.Map;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 import org.json.JSONObject;
-import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.slf4j.LoggerFactory;
@@ -41,9 +41,11 @@ import org.slf4j.LoggerFactory;
 class AnalysisEngineCommandHelperTest {
   @TempDir Path tempDir;
 
-  @AfterEach
-  void tearDownLoggingRuntime() {
-    LoggingRuntime.resetForTests();
+  @BeforeAll
+  static void loadRuntimeClasses() throws ClassNotFoundException {
+    Class.forName(KataGoAutoSetupHelper.class.getName());
+    Class.forName(KataGoRuntimeHelper.class.getName());
+    Class.forName(Lizzie.class.getName());
   }
 
   @Test
@@ -399,44 +401,58 @@ class AnalysisEngineCommandHelperTest {
     Path root = tempDir.resolve("secret-katago-home-368-package");
     Path engine = writeIncompleteOpenClBundleMissingAnalysisConfig(root);
     Files.createDirectories(logHome);
-    LoggingRuntime.resetForTests();
-    LoggingRuntime runtime =
-        LoggingRuntime.initialize(
-            new WorkDirectoryResolution(logHome, List.of()),
-            new LoggingLimits(64, 32, 32, 32, 7, 1_000_000, 256_000));
+    ClassLoader previousLoader = Thread.currentThread().getContextClassLoader();
+    LoggingRuntime runtime = null;
+    try {
+      LoggingRuntime.resetForTests();
+      runtime =
+          LoggingRuntime.initialize(
+              new WorkDirectoryResolution(logHome, List.of()),
+              new LoggingLimits(64, 32, 32, 32, 7, 1_000_000, 256_000));
 
-    withUserDirAndConfig(
-        root,
-        () -> {
-          AnalysisEngineCommandHelper.Result result =
-              AnalysisEngineCommandHelper.resolveHumanSlCommand("");
-          assertFalse(result.isSuccess());
-          runtime.shutdown();
+      LoggingRuntime loggingRuntime = runtime;
+      withUserDirAndConfig(
+          root,
+          () -> {
+            AnalysisEngineCommandHelper.Result result =
+                AnalysisEngineCommandHelper.resolveHumanSlCommand("");
+            assertFalse(result.isSuccess());
+            loggingRuntime.shutdown();
 
-          Path zip =
-              new DiagnosticBundleExporter(DiagnosticBundleExporter.defaultOutputDirectory(logHome))
-                  .export(
-                      new DiagnosticBundleRequest(
-                          runtime,
-                          EnumSet.noneOf(TraceScope.class),
-                          new JSONObject(),
-                          emptySnapshot(),
-                          "next-dev"));
-          Map<String, String> entries = unzipTextEntries(zip);
-          String appLog = entries.getOrDefault("logs/lizzie/app.log", "");
-          String diagnosticLine = humanSlResolutionFailureLine(appLog);
-          assertFalse(diagnosticLine.isEmpty(), appLog);
-          assertTrue(diagnosticLine.contains("source=BUNDLED_PACKAGE"), diagnosticLine);
-          assertTrue(diagnosticLine.contains("packageFlavor=INCOMPLETE_BUNDLE"), diagnosticLine);
-          assertTrue(diagnosticLine.contains("missingComponents=[ANALYSIS_CONFIG]"), diagnosticLine);
-          assertTrue(diagnosticLine.contains("engine=true"), diagnosticLine);
-          assertTrue(diagnosticLine.contains("analysisConfig=false"), diagnosticLine);
-          assertTrue(diagnosticLine.contains("weight=true"), diagnosticLine);
-          assertFalse(
-              diagnosticLine.contains(root.toAbsolutePath().normalize().toString()),
-              diagnosticLine);
-          assertFalse(diagnosticLine.contains(engine.toString()), diagnosticLine);
-        });
+            Path zip =
+                new DiagnosticBundleExporter(
+                        DiagnosticBundleExporter.defaultOutputDirectory(logHome))
+                    .export(
+                        new DiagnosticBundleRequest(
+                            loggingRuntime,
+                            EnumSet.noneOf(TraceScope.class),
+                            new JSONObject(),
+                            emptySnapshot(),
+                            "next-dev"));
+            Map<String, String> entries = unzipTextEntries(zip);
+            String appLog = entries.getOrDefault("logs/lizzie/app.log", "");
+            String diagnosticLine = humanSlResolutionFailureLine(appLog);
+            assertFalse(diagnosticLine.isEmpty(), appLog);
+            assertTrue(diagnosticLine.contains("source=BUNDLED_PACKAGE"), diagnosticLine);
+            assertTrue(
+                diagnosticLine.contains("packageFlavor=INCOMPLETE_BUNDLE"), diagnosticLine);
+            assertTrue(
+                diagnosticLine.contains("missingComponents=[ANALYSIS_CONFIG]"), diagnosticLine);
+            assertTrue(diagnosticLine.contains("engine=true"), diagnosticLine);
+            assertTrue(diagnosticLine.contains("analysisConfig=false"), diagnosticLine);
+            assertTrue(diagnosticLine.contains("weight=true"), diagnosticLine);
+            assertFalse(
+                diagnosticLine.contains(root.toAbsolutePath().normalize().toString()),
+                diagnosticLine);
+            assertFalse(diagnosticLine.contains(engine.toString()), diagnosticLine);
+          });
+    } finally {
+      if (runtime != null) {
+        runtime.shutdown();
+      }
+      LoggingRuntime.resetForTests();
+      Thread.currentThread().setContextClassLoader(previousLoader);
+    }
   }
 
   @Test
@@ -512,7 +528,6 @@ class AnalysisEngineCommandHelperTest {
   }
 
   private static ListAppender<ILoggingEvent> attachEngineLog() {
-    LoggingRuntime.resetForTests();
     Logger engine = (Logger) LoggerFactory.getLogger(LogCategories.ENGINE);
     engine.setLevel(Level.INFO);
     ListAppender<ILoggingEvent> appender = new ListAppender<>();

--- a/src/test/java/featurecat/lizzie/util/AnalysisEngineCommandHelperTest.java
+++ b/src/test/java/featurecat/lizzie/util/AnalysisEngineCommandHelperTest.java
@@ -5,17 +5,46 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import featurecat.lizzie.Config;
+import featurecat.lizzie.ConfigTestHelper;
+import featurecat.lizzie.Lizzie;
+import featurecat.lizzie.analysis.SyncDiagnosticsExportSnapshot;
 import featurecat.lizzie.gui.EngineData;
+import featurecat.lizzie.logging.DiagnosticBundleExporter;
+import featurecat.lizzie.logging.DiagnosticBundleRequest;
+import featurecat.lizzie.logging.LogCategories;
+import featurecat.lizzie.logging.LoggingLimits;
+import featurecat.lizzie.logging.LoggingRuntime;
+import featurecat.lizzie.logging.TraceScope;
+import featurecat.lizzie.logging.WorkDirectoryResolution;
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+import org.json.JSONObject;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.slf4j.LoggerFactory;
 
 class AnalysisEngineCommandHelperTest {
   @TempDir Path tempDir;
+
+  @AfterEach
+  void tearDownLoggingRuntime() {
+    LoggingRuntime.resetForTests();
+  }
 
   @Test
   void convertsSavedKataGoEngineAndCreatesMissingAnalysisConfig() throws Exception {
@@ -327,6 +356,114 @@ class AnalysisEngineCommandHelperTest {
   }
 
   @Test
+  void humanSlFailedResolveLogsSourceFlavorAndMissingComponentsWithoutFullPaths()
+      throws Exception {
+    Path root = tempDir.resolve("secret-katago-home-368");
+    Path engine = writeIncompleteOpenClBundleMissingAnalysisConfig(root);
+    ListAppender<ILoggingEvent> events = attachEngineLog();
+
+    withUserDirAndConfig(
+        root,
+        () -> {
+          AnalysisEngineCommandHelper.Result result =
+              AnalysisEngineCommandHelper.resolveHumanSlCommand("");
+
+          assertFalse(result.isSuccess());
+          assertTrue(result.getCommand().isEmpty());
+          assertEquals(1, events.list.size(), events.list.toString());
+          String message = events.list.get(0).getFormattedMessage();
+          assertTrue(message.contains("HumanSL analysis engine resolution failed:"), message);
+          assertTrue(message.contains("configuredCommandPresent=false"), message);
+          assertTrue(message.contains("source=BUNDLED_PACKAGE"), message);
+          assertTrue(message.contains("packageFlavor=INCOMPLETE_BUNDLE"), message);
+          assertTrue(message.contains("engine=true"), message);
+          assertTrue(message.contains("analysisConfig=false"), message);
+          assertTrue(message.contains("weight=true"), message);
+          assertTrue(message.contains("missingComponents=[ANALYSIS_CONFIG]"), message);
+          assertTrue(message.contains("diagnostics="), message);
+          assertFalse(message.contains(root.toAbsolutePath().normalize().toString()), message);
+          assertFalse(message.contains(engine.toString()), message);
+        });
+  }
+
+  @Test
+  void humanSlFailedResolveDiagnosticAppearsInDiagnosticPackage() throws Exception {
+    Path logHome = tempDir.resolve("logging-home");
+    Path root = tempDir.resolve("secret-katago-home-368-package");
+    Path engine = writeIncompleteOpenClBundleMissingAnalysisConfig(root);
+    Files.createDirectories(logHome);
+    LoggingRuntime.resetForTests();
+    LoggingRuntime runtime =
+        LoggingRuntime.initialize(
+            new WorkDirectoryResolution(logHome, List.of()),
+            new LoggingLimits(64, 32, 32, 32, 7, 1_000_000, 256_000));
+
+    withUserDirAndConfig(
+        root,
+        () -> {
+          AnalysisEngineCommandHelper.Result result =
+              AnalysisEngineCommandHelper.resolveHumanSlCommand("");
+          assertFalse(result.isSuccess());
+          runtime.awaitIdle();
+
+          Path zip =
+              new DiagnosticBundleExporter(DiagnosticBundleExporter.defaultOutputDirectory(logHome))
+                  .export(
+                      new DiagnosticBundleRequest(
+                          runtime,
+                          EnumSet.noneOf(TraceScope.class),
+                          new JSONObject(),
+                          emptySnapshot(),
+                          "next-dev"));
+          Map<String, String> entries = unzipTextEntries(zip);
+          String appLog = entries.getOrDefault("logs/lizzie/app.log", "");
+          String diagnosticLine = humanSlResolutionFailureLine(appLog);
+          assertFalse(diagnosticLine.isEmpty(), appLog);
+          assertTrue(diagnosticLine.contains("source=BUNDLED_PACKAGE"), diagnosticLine);
+          assertTrue(diagnosticLine.contains("packageFlavor=INCOMPLETE_BUNDLE"), diagnosticLine);
+          assertTrue(diagnosticLine.contains("missingComponents=[ANALYSIS_CONFIG]"), diagnosticLine);
+          assertTrue(diagnosticLine.contains("engine=true"), diagnosticLine);
+          assertTrue(diagnosticLine.contains("analysisConfig=false"), diagnosticLine);
+          assertTrue(diagnosticLine.contains("weight=true"), diagnosticLine);
+          assertFalse(
+              diagnosticLine.contains(root.toAbsolutePath().normalize().toString()),
+              diagnosticLine);
+          assertFalse(diagnosticLine.contains(engine.toString()), diagnosticLine);
+        });
+  }
+
+  @Test
+  void humanSlSuccessfulResolveDoesNotLogResolutionFailure() throws Exception {
+    Path engine = writeFile(tempDir.resolve("自定义引擎/katago"));
+    Path config = writeFile(tempDir.resolve("自定义引擎/analysis.cfg"));
+    Path weight = writeFile(tempDir.resolve("自定义权重/model.bin.gz"));
+    String customCommand =
+        quote(engine)
+            + " analysis -model "
+            + quote(weight)
+            + " -config "
+            + quote(config);
+    ListAppender<ILoggingEvent> events = attachEngineLog();
+
+    withUserDirAndConfig(
+        tempDir.resolve("unused-bundle"),
+        () -> {
+          AnalysisEngineCommandHelper.Result result =
+              AnalysisEngineCommandHelper.resolveHumanSlCommand(customCommand);
+
+          assertTrue(result.isSuccess(), result.getMessage());
+          assertEquals(customCommand, result.getCommand());
+          assertTrue(
+              events.list.stream()
+                  .noneMatch(
+                      event ->
+                          event.getFormattedMessage()
+                              .contains("HumanSL analysis engine resolution failed:")),
+              events.list.toString());
+        });
+  }
+
+  @Test
   void bundledAnalysisConfigTemplateIsAvailable() throws Exception {
     assertNotNull(
         AnalysisEngineCommandHelperTest.class
@@ -348,5 +485,105 @@ class AnalysisEngineCommandHelperTest {
   private static Path writeFile(Path path) throws Exception {
     Files.createDirectories(path.getParent());
     return Files.write(path, new byte[] {1});
+  }
+
+  private static Path writeIncompleteOpenClBundleMissingAnalysisConfig(Path root) throws Exception {
+    Files.createDirectories(root);
+    Files.writeString(
+        root.resolve("lizzieyzy-next-installed-manifest.json"),
+        "{\"platform\":\"linux\",\"flavor\":\"opencl\"}");
+    Path engine =
+        writeFile(
+            root.resolve("engines")
+                .resolve("katago")
+                .resolve(detectTestPlatformDir())
+                .resolve(testKataGoBinaryName()));
+    Files.createDirectories(root.resolve("engines").resolve("katago").resolve("configs"));
+    writeFile(root.resolve("engines").resolve("katago").resolve("configs").resolve("gtp.cfg"));
+    writeFile(root.resolve("weights").resolve("default.bin.gz"));
+    return engine.toAbsolutePath().normalize();
+  }
+
+  private static ListAppender<ILoggingEvent> attachEngineLog() {
+    LoggingRuntime.resetForTests();
+    Logger engine = (Logger) LoggerFactory.getLogger(LogCategories.ENGINE);
+    engine.setLevel(Level.INFO);
+    ListAppender<ILoggingEvent> appender = new ListAppender<>();
+    appender.start();
+    engine.addAppender(appender);
+    return appender;
+  }
+
+  private static void withUserDirAndConfig(Path userDir, ThrowingRunnable action) throws Exception {
+    Files.createDirectories(userDir);
+    String previousUserDir = System.getProperty("user.dir");
+    Config previousConfig = Lizzie.config;
+    try {
+      System.setProperty("user.dir", userDir.toString());
+      Lizzie.config = ConfigTestHelper.createForTests(userDir);
+      Lizzie.config.config = new JSONObject();
+      Lizzie.config.leelazConfig = new JSONObject();
+      Lizzie.config.uiConfig = new JSONObject();
+      action.run();
+    } finally {
+      if (previousUserDir == null) {
+        System.clearProperty("user.dir");
+      } else {
+        System.setProperty("user.dir", previousUserDir);
+      }
+      Lizzie.config = previousConfig;
+    }
+  }
+
+  private static String detectTestPlatformDir() {
+    String osName = System.getProperty("os.name", "").toLowerCase();
+    String arch = System.getProperty("os.arch", "").toLowerCase();
+    boolean isArm = arch.contains("aarch64") || arch.contains("arm64");
+    boolean is64 = arch.contains("64");
+    if (osName.contains("win")) {
+      return is64 ? "windows-x64" : "windows-x86";
+    }
+    if (osName.contains("mac") || osName.contains("darwin")) {
+      return isArm ? "macos-arm64" : "macos-amd64";
+    }
+    return is64 ? "linux-x64" : "linux-x86";
+  }
+
+  private static String testKataGoBinaryName() {
+    return System.getProperty("os.name", "").toLowerCase().contains("win")
+        ? "katago.exe"
+        : "katago";
+  }
+
+  private static SyncDiagnosticsExportSnapshot emptySnapshot() {
+    return new SyncDiagnosticsExportSnapshot(
+        1L, null, List.of(), List.of(), List.of(), null);
+  }
+
+  private static String humanSlResolutionFailureLine(String appLog) {
+    if (appLog == null || appLog.isEmpty()) {
+      return "";
+    }
+    for (String line : appLog.split("\\R")) {
+      if (line.contains("HumanSL analysis engine resolution failed:")) {
+        return line;
+      }
+    }
+    return "";
+  }
+
+  private static Map<String, String> unzipTextEntries(Path zip) throws IOException {
+    Map<String, String> entries = new LinkedHashMap<>();
+    try (ZipInputStream input = new ZipInputStream(Files.newInputStream(zip))) {
+      ZipEntry entry;
+      while ((entry = input.getNextEntry()) != null) {
+        entries.put(entry.getName(), new String(input.readAllBytes(), StandardCharsets.UTF_8));
+      }
+    }
+    return entries;
+  }
+
+  private interface ThrowingRunnable {
+    void run() throws Exception;
   }
 }


### PR DESCRIPTION
## Repro
Start AI Coach / HumanSL when `resolveHumanSlCommand()` cannot build an analysis command. The dialog shows a generic “No engine selected” (or the no-command fallback) and returns before `HumanSlAnalysisRunner` is created. A diagnostic package has no structured entry explaining why (empty command vs missing analysis.cfg vs stale bundled path vs missing weight).

## Cause
`resolveHumanSlCommand` already calls `KataGoAutoSetupHelper.inspectLocalSetup()` but only forwards engine/config/weight paths and does not log. The dialog returns on `!commandResult.isSuccess()` before the runner exists, so lifecycle logs never see the failure.

## Fix
- On resolve failure only, write one structured diagnostic through the existing logger / diagnostic-package path.
- Fields: `configuredCommandPresent`, `source`, `packageFlavor`, engine/analysisConfig/weight booleans, `missingComponents`, `diagnostics`.
- No full local paths, no complete engine command. Filenames only if a name is required.
- Success path, dialog strings, and runner lifecycle logs unchanged. No debug toggle.

## Verification
`mvn -B -Dfmt.skip=true -Dtest=AnalysisEngineCommandHelperTest,HumanSlAnalysisRunnerTest,HumanSlGameControllerIntegrationTest,HumanSlGameControllerLabelTest,HumanSlTrainingSessionTest,HumanSlTrainingConfigTest,HumanSlTrainingBarTest,HumanSlDialogBoundsTest test` — 89 tests, 0 failures. New coverage checks source / flavor / missing components without a full path, and that the entry appears in a diagnostic package.

Fixes #368
