### PR TITLE
docs: unify diagnostic pack guidance in troubleshooting and issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -76,7 +76,7 @@ body:
     id: logs
     attributes:
       label: Logs
-      description: 可填。帮助 → 诊断与日志 → 导出诊断包，把 zip 附到本 issue；打不开软件时附 logs/app.log。 / Optional. Help → Diagnostics and Logs → Export package, then attach the zip.
+      description: 可填。如果程序能启动，打开 帮助 → 诊断与日志 → 导出诊断包，把 ZIP 附到本 issue（诊断包经过隐私脱敏）。无法启动时附 logs/app.log，以及存在时的 logs/crash.log。 / Optional. If the app can start, open Help → Diagnostics and Logs → Export package and attach the ZIP (privacy-sanitized). If it cannot start, attach logs/app.log and logs/crash.log if present.
       placeholder: Optional
   - type: textarea
     id: evidence

--- a/.github/ISSUE_TEMPLATE/installation_report.yml
+++ b/.github/ISSUE_TEMPLATE/installation_report.yml
@@ -85,7 +85,7 @@ body:
     id: evidence
     attributes:
       label: Screenshot / Log / Extra Evidence
-      description: 可贴截图、报错文本、录屏链接或日志片段。
+      description: 可填。程序能启动时优先附上诊断包：帮助 → 诊断与日志 → 导出诊断包（经过隐私脱敏）。无法启动时附 logs/app.log，以及存在时的 logs/crash.log。也可贴截图、报错文本或录屏链接。 / Optional. If the app can start, prefer the diagnostic ZIP from Help → Diagnostics and Logs → Export package (privacy-sanitized). If it cannot start, attach logs/app.log and logs/crash.log if present. Screenshots, error text, or a recording link are also welcome.
   - type: checkboxes
     id: acknowledgement
     attributes:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,8 +34,7 @@ This project is a maintained fork. We care about practical fixes, clear packagin
 - 下载的安装包文件名
 - 是否内置引擎版本
 - 问题出现时的操作步骤
-- 截图或录屏
-- 报错文本
+- 如果程序能启动，优先附上 **帮助 → 诊断与日志 → 导出诊断包** 生成的 ZIP（经过隐私脱敏）；无法启动时附 `logs/app.log`，以及存在时的 `logs/crash.log`；截图或录屏、报错文本也有帮助
 - 如果和野狐抓谱相关，请写清楚你输入的野狐昵称，以及返回结果
 - 如果能复现，请写出稳定复现步骤
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -25,7 +25,7 @@ If you need help with `LizzieYzy Next`, start with the closest path below. Clear
 - 机器架构：Windows x64 / macOS Apple Silicon / macOS Intel / Linux x64
 - 是否使用普通 `with-katago`、`nvidia`，还是 `without.engine`
 - 如果问题和野狐抓谱相关，请提供你输入的 **野狐昵称**
-- 错误截图、日志、系统安全提示
+- 错误截图、系统安全提示；如果程序能启动，优先附上 **帮助 → 诊断与日志 → 导出诊断包** 生成的 ZIP（经过隐私脱敏）；无法启动时附 `logs/app.log`，以及存在时的 `logs/crash.log`
 
 ## Fastest Path For Common Cases
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -96,6 +96,8 @@ chmod +x start-linux64.sh
 - 是否是普通 `with-katago`、`nvidia`，还是 `without.engine`
 - 完整报错截图或复现步骤
 
+如果程序能够正常启动，请打开 **帮助 → 诊断与日志 → 导出诊断包**，并将生成的 ZIP 附加到 Issue 中。诊断包会经过现有隐私脱敏处理。如果程序无法启动，请提供 `logs/app.log`，以及存在时的 `logs/crash.log`。
+
 相关入口：
 
 - [安装指南](INSTALL.md)

--- a/docs/TROUBLESHOOTING_EN.md
+++ b/docs/TROUBLESHOOTING_EN.md
@@ -96,6 +96,8 @@ The most useful items are:
 - whether you used the regular `with-katago`, `nvidia`, or `without.engine` package
 - a full screenshot or exact reproduction steps
 
+If the app can start, open **Help → Diagnostics and Logs → Export package** and attach the ZIP to the issue. The package is privacy-sanitized. If the app cannot start, attach `logs/app.log`, and `logs/crash.log` if present.
+
 Related docs:
 
 - [Installation Guide](INSTALL_EN.md)


### PR DESCRIPTION
## Repro
Troubleshooting ZH/EN section 6, Installation Report evidence, SUPPORT.md, and CONTRIBUTING.md tell users to attach screenshots or scattered logs. Bug Report Logs already has the menu path and `logs/app.log` but omits `logs/crash.log`, and ZH/EN meaning does not match.

## Cause
Runtime-failure docs and templates were written separately, so the attach path (Help → 诊断与日志 → 导出诊断包 vs raw logs) is not the same everywhere.

## Fix
- Unify: if the app can start, Help → 诊断与日志 → 导出诊断包 (EN: Help → Diagnostics and Logs → Export package) and attach the ZIP. The pack is privacy-sanitized. Fields stay optional.
- If the app cannot start, attach `logs/app.log` and `logs/crash.log` if present.
- Touched TROUBLESHOOTING.md / TROUBLESHOOTING_EN.md section 6, Bug Report Logs, Installation Report evidence, SUPPORT.md, CONTRIBUTING.md.
- Docs and templates only. No Menu.java, exporter, or logging-runtime change.

## Verification
Issue Form YAML parses. Markdown and ZH/EN wording aligned. Menu names match current UI. No Java tests required.

Fixes #378
