### PR TITLE
feat(diagnostics): include thread snapshots in diagnostic ZIP

### DIFF
--- a/src/main/java/featurecat/lizzie/Lizzie.java
+++ b/src/main/java/featurecat/lizzie/Lizzie.java
@@ -20,6 +20,7 @@ import featurecat.lizzie.gui.LoadEngine;
 import featurecat.lizzie.gui.Menu;
 import featurecat.lizzie.gui.web.WebBoardManager;
 import featurecat.lizzie.logging.CrashHandlers;
+import featurecat.lizzie.logging.EdtHangWatchdog;
 import featurecat.lizzie.logging.LogCategories;
 import featurecat.lizzie.logging.LoggingRuntime;
 import featurecat.lizzie.logging.WorkDirectoryResolution;
@@ -475,6 +476,7 @@ public class Lizzie {
           LoggingRuntime.STDERR_PREFIX + "bootstrap " + t.getClass().getSimpleName());
     }
     CrashHandlers.install();
+    EdtHangWatchdog.installDefault();
     logStartupIdentity();
     return workDirectory;
   }
@@ -1501,6 +1503,10 @@ public class Lizzie {
   }
 
   public static void shutdownLoggingThenExit(IntConsumer exit) {
+    try {
+      EdtHangWatchdog.uninstall();
+    } catch (RuntimeException ignored) {
+    }
     try {
       LoggingRuntime.current()
           .ifPresent(

--- a/src/main/java/featurecat/lizzie/logging/DiagnosticBundleExporter.java
+++ b/src/main/java/featurecat/lizzie/logging/DiagnosticBundleExporter.java
@@ -89,11 +89,17 @@ public final class DiagnosticBundleExporter {
   private static final Pattern SAFE_CAPTURE_SEGMENT =
       Pattern.compile("[A-Za-z0-9][A-Za-z0-9._-]*");
 
+  @FunctionalInterface
+  interface ThreadSnapshotSource {
+    String capture(ExportSanitizer sanitizer);
+  }
+
   private final Path outputDirectory;
   private final DiagnosticBundleLimits limits;
   private final PartialFileObserver partialFileObserver;
   private final BundleNameSupplier bundleNameSupplier;
   private final PartialFileCleanupStrategy partialFileCleanupStrategy;
+  private ThreadSnapshotSource threadSnapshotSource = ThreadSnapshot::capture;
 
   public DiagnosticBundleExporter(Path outputDirectory) {
     this(outputDirectory, DiagnosticBundleLimits.production());
@@ -159,6 +165,10 @@ public final class DiagnosticBundleExporter {
     this.bundleNameSupplier = Objects.requireNonNull(bundleNameSupplier, "bundleNameSupplier");
     this.partialFileCleanupStrategy =
         Objects.requireNonNull(partialFileCleanupStrategy, "partialFileCleanupStrategy");
+  }
+
+  void setThreadSnapshotSourceForTests(ThreadSnapshotSource source) {
+    this.threadSnapshotSource = source == null ? ThreadSnapshot::capture : source;
   }
 
   public static Path defaultOutputDirectory(Path workDirectory) {
@@ -715,6 +725,7 @@ public final class DiagnosticBundleExporter {
         out,
         NS_SNAPSHOTS + "readboard-observed.json",
         renderObserved(request.readBoardLogging(), sanitizer).toString(2));
+    writeThreadSnapshot(out, sanitizer, sources, hostSession);
     SyncDiagnosticsExportSnapshot snapshot =
         request.snapshot() == null
             ? new SyncDiagnosticsExportSnapshot(
@@ -746,6 +757,58 @@ public final class DiagnosticBundleExporter {
             hostSession,
             "",
             false));
+  }
+
+  private void writeThreadSnapshot(
+      ZipOutputStream out,
+      ExportSanitizer sanitizer,
+      JSONObject sources,
+      String hostSession) {
+    String text;
+    String status = "included";
+    String reason = "";
+    try {
+      text = threadSnapshotSource.capture(sanitizer);
+      if (text == null) {
+        text = "";
+      }
+    } catch (RuntimeException | Error ignored) {
+      status = "failed";
+      reason = "unreadable";
+      try {
+        text = sanitizer.sanitizeText("thread snapshot failed\n");
+      } catch (RuntimeException | Error ignoredSanitizer) {
+        text = "thread snapshot failed\n";
+      }
+    }
+    try {
+      writeTextEntry(out, NS_SNAPSHOTS + ThreadSnapshot.ENTRY_NAME, text);
+      sources.put(
+          "threads",
+          sourceRecord(
+              true,
+              status,
+              text.getBytes(StandardCharsets.UTF_8).length,
+              0,
+              0,
+              NS_SNAPSHOTS,
+              hostSession,
+              reason,
+              false));
+    } catch (IOException ignoredWrite) {
+      sources.put(
+          "threads",
+          sourceRecord(
+              true,
+              "failed",
+              0,
+              0,
+              0,
+              NS_SNAPSHOTS,
+              hostSession,
+              "unreadable",
+              false));
+    }
   }
 
   private static CaptureEventSet listCurrentCaptureEvents(

--- a/src/main/java/featurecat/lizzie/logging/EdtHangWatchdog.java
+++ b/src/main/java/featurecat/lizzie/logging/EdtHangWatchdog.java
@@ -1,0 +1,198 @@
+package featurecat.lizzie.logging;
+
+import java.awt.GraphicsEnvironment;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+import java.util.function.LongSupplier;
+import java.util.function.Supplier;
+import javax.swing.SwingUtilities;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Lightweight EDT stall detector. Captures one thread snapshot when the event queue stops
+ * responding, then throttles until the EDT recovers. Never opens a dialog.
+ */
+public final class EdtHangWatchdog {
+  static final long DEFAULT_STALL_NANOS = TimeUnit.SECONDS.toNanos(5);
+  static final long DEFAULT_THROTTLE_NANOS = TimeUnit.SECONDS.toNanos(60);
+  static final long DEFAULT_POLL_NANOS = TimeUnit.SECONDS.toNanos(1);
+
+  private static final Logger DIAG = LoggerFactory.getLogger(LogCategories.DIAGNOSTICS);
+  private static final AtomicReference<EdtHangWatchdog> INSTALLED = new AtomicReference<>();
+
+  private final LongSupplier nanoTime;
+  private final long stallNanos;
+  private final long throttleNanos;
+  private final long pollNanos;
+  private final Consumer<Runnable> edtDispatcher;
+  private final Supplier<String> snapshotter;
+  private final ScheduledExecutorService scheduler;
+  private final AtomicBoolean running = new AtomicBoolean();
+  private final AtomicBoolean pingInFlight = new AtomicBoolean();
+  private final AtomicBoolean stallCaptured = new AtomicBoolean();
+  private final AtomicLong lastEdtNanos = new AtomicLong();
+  private final AtomicLong lastCaptureNanos = new AtomicLong(Long.MIN_VALUE / 2);
+  private final AtomicInteger captureCount = new AtomicInteger();
+  private volatile String lastHangDump = "";
+
+  public static void installDefault() {
+    try {
+      if (GraphicsEnvironment.isHeadless()) {
+        return;
+      }
+      EdtHangWatchdog watchdog =
+          new EdtHangWatchdog(
+              System::nanoTime,
+              DEFAULT_STALL_NANOS,
+              DEFAULT_THROTTLE_NANOS,
+              DEFAULT_POLL_NANOS,
+              SwingUtilities::invokeLater,
+              () -> ThreadSnapshot.captureRaw("edt-hang"),
+              newWatchdogScheduler());
+      if (INSTALLED.compareAndSet(null, watchdog)) {
+        watchdog.start();
+      } else {
+        watchdog.stop();
+      }
+    } catch (Throwable ignored) {
+    }
+  }
+
+  public static void uninstall() {
+    EdtHangWatchdog current = INSTALLED.getAndSet(null);
+    if (current != null) {
+      current.stop();
+    }
+  }
+
+  EdtHangWatchdog(
+      LongSupplier nanoTime,
+      long stallNanos,
+      long throttleNanos,
+      Consumer<Runnable> edtDispatcher,
+      Supplier<String> snapshotter) {
+    this(nanoTime, stallNanos, throttleNanos, DEFAULT_POLL_NANOS, edtDispatcher, snapshotter, null);
+  }
+
+  private EdtHangWatchdog(
+      LongSupplier nanoTime,
+      long stallNanos,
+      long throttleNanos,
+      long pollNanos,
+      Consumer<Runnable> edtDispatcher,
+      Supplier<String> snapshotter,
+      ScheduledExecutorService scheduler) {
+    this.nanoTime = nanoTime;
+    this.stallNanos = stallNanos;
+    this.throttleNanos = throttleNanos;
+    this.pollNanos = pollNanos;
+    this.edtDispatcher = edtDispatcher;
+    this.snapshotter = snapshotter;
+    this.scheduler = scheduler;
+  }
+
+  void start() {
+    enable();
+    if (scheduler == null) {
+      return;
+    }
+    scheduler.scheduleWithFixedDelay(
+        this::safeTick, pollNanos, pollNanos, TimeUnit.NANOSECONDS);
+  }
+
+  void enable() {
+    lastEdtNanos.set(nanoTime.getAsLong());
+    pingInFlight.set(false);
+    stallCaptured.set(false);
+    running.set(true);
+    pingEdt();
+  }
+
+  void stop() {
+    running.set(false);
+    if (scheduler != null) {
+      scheduler.shutdownNow();
+    }
+  }
+
+  void tick() {
+    if (!running.get()) {
+      return;
+    }
+    pingEdt();
+    long now = nanoTime.getAsLong();
+    long lastEdt = lastEdtNanos.get();
+    boolean stalled = now - lastEdt >= stallNanos;
+    if (!stalled) {
+      stallCaptured.set(false);
+      return;
+    }
+    if (stallCaptured.get()) {
+      return;
+    }
+    if (now - lastCaptureNanos.get() < throttleNanos) {
+      return;
+    }
+    if (!stallCaptured.compareAndSet(false, true)) {
+      return;
+    }
+    lastCaptureNanos.set(now);
+    try {
+      String dump = snapshotter.get();
+      lastHangDump = dump == null ? "" : dump;
+      ThreadSnapshot.holdRaw(lastHangDump);
+      captureCount.incrementAndGet();
+      DIAG.warn("edt hang thread snapshot captured stallMs={}", (now - lastEdt) / 1_000_000L);
+    } catch (Throwable ignored) {
+      stallCaptured.set(false);
+    }
+  }
+
+  int captureCount() {
+    return captureCount.get();
+  }
+
+  String lastHangDump() {
+    return lastHangDump == null ? "" : lastHangDump;
+  }
+
+  private void safeTick() {
+    try {
+      tick();
+    } catch (Throwable ignored) {
+    }
+  }
+
+  private void pingEdt() {
+    if (!pingInFlight.compareAndSet(false, true)) {
+      return;
+    }
+    try {
+      edtDispatcher.accept(
+          () -> {
+            lastEdtNanos.set(nanoTime.getAsLong());
+            pingInFlight.set(false);
+          });
+    } catch (Throwable ignored) {
+      pingInFlight.set(false);
+    }
+  }
+
+  private static ScheduledExecutorService newWatchdogScheduler() {
+    ThreadFactory factory =
+        runnable -> {
+          Thread thread = new Thread(runnable, "lizzie-edt-hang-watchdog");
+          thread.setDaemon(true);
+          return thread;
+        };
+    return Executors.newSingleThreadScheduledExecutor(factory);
+  }
+}

--- a/src/main/java/featurecat/lizzie/logging/ThreadSnapshot.java
+++ b/src/main/java/featurecat/lizzie/logging/ThreadSnapshot.java
@@ -154,7 +154,7 @@ public final class ThreadSnapshot {
         body.append('\n');
       }
       body.append("name=").append(name == null ? "" : name).append('\n');
-      body.append("id=").append(id).append('\n');
+      body.append("threadId=").append(id).append('\n');
       body.append("state=").append(state == null ? "" : state.name()).append('\n');
       body.append("daemon=").append(daemon).append('\n');
       body.append("priority=").append(priority).append('\n');

--- a/src/main/java/featurecat/lizzie/logging/ThreadSnapshot.java
+++ b/src/main/java/featurecat/lizzie/logging/ThreadSnapshot.java
@@ -154,6 +154,7 @@ public final class ThreadSnapshot {
         body.append('\n');
       }
       body.append("name=").append(name == null ? "" : name).append('\n');
+      // "id=" is treated as a Yike room parameter by ExportSanitizer.sanitizeText.
       body.append("threadId=").append(id).append('\n');
       body.append("state=").append(state == null ? "" : state.name()).append('\n');
       body.append("daemon=").append(daemon).append('\n');

--- a/src/main/java/featurecat/lizzie/logging/ThreadSnapshot.java
+++ b/src/main/java/featurecat/lizzie/logging/ThreadSnapshot.java
@@ -1,0 +1,434 @@
+package featurecat.lizzie.logging;
+
+import java.lang.management.ManagementFactory;
+import java.lang.management.ThreadInfo;
+import java.lang.management.ThreadMXBean;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Formats a process-wide thread snapshot for the diagnostic package {@code snapshots/threads.txt}.
+ */
+public final class ThreadSnapshot {
+  static final String ENTRY_NAME = "threads.txt";
+  private static final int MAX_STACK_FRAMES = 256;
+  private static final AtomicReference<String> HELD_RAW = new AtomicReference<>();
+
+  private ThreadSnapshot() {}
+
+  public static String capture(ExportSanitizer sanitizer) {
+    StringBuilder raw = new StringBuilder();
+    raw.append(captureRaw("export"));
+    String held = heldRaw();
+    if (held != null && !held.isEmpty()) {
+      raw.append('\n');
+      raw.append(held);
+    }
+    ExportSanitizer active = sanitizer == null ? new ExportSanitizer() : sanitizer;
+    return active.sanitizeText(raw.toString());
+  }
+
+  static String captureRaw(String reason) {
+    return render(liveRecords(), Instant.now(), reason);
+  }
+
+  static void holdRaw(String snapshot) {
+    HELD_RAW.set(snapshot);
+  }
+
+  static String heldRaw() {
+    return HELD_RAW.get();
+  }
+
+  static void resetHeldForTests() {
+    HELD_RAW.set(null);
+  }
+
+  static String render(
+      List<? extends ThreadRecord> records, Instant capturedAt, String reason) {
+    Instant at = capturedAt == null ? Instant.now() : capturedAt;
+    String why = reason == null || reason.isEmpty() ? "export" : reason;
+    List<RenderedThread> rendered = new ArrayList<>();
+    if (records != null) {
+      for (ThreadRecord record : records) {
+        rendered.add(renderOne(record));
+      }
+    }
+    rendered.sort(
+        Comparator.comparingInt((RenderedThread thread) -> thread.rank)
+            .thenComparing(thread -> thread.name, String.CASE_INSENSITIVE_ORDER)
+            .thenComparingLong(thread -> thread.id));
+
+    StringBuilder out = new StringBuilder();
+    out.append("=== Thread snapshot ===\n");
+    out.append("reason=").append(why).append('\n');
+    out.append("capturedAt=").append(at).append('\n');
+    out.append("threadCount=").append(rendered.size()).append('\n');
+    List<String> highlightedNames = new ArrayList<>();
+    int highlightedCount = 0;
+    for (RenderedThread thread : rendered) {
+      if (!thread.tags.isEmpty()) {
+        highlightedCount++;
+        highlightedNames.add(thread.name);
+      }
+    }
+    out.append("highlightedCount=").append(highlightedCount).append('\n');
+    out.append("highlightedNames=");
+    for (int i = 0; i < highlightedNames.size(); i++) {
+      if (i > 0) {
+        out.append(", ");
+      }
+      out.append(highlightedNames.get(i));
+    }
+    out.append('\n');
+    String deadlocks = deadlockIds();
+    if (!deadlocks.isEmpty()) {
+      out.append("deadlockedThreadIds=").append(deadlocks).append('\n');
+    }
+    out.append('\n');
+    for (RenderedThread thread : rendered) {
+      out.append(thread.body);
+      if (thread.body.isEmpty() || thread.body.charAt(thread.body.length() - 1) != '\n') {
+        out.append('\n');
+      }
+      out.append('\n');
+    }
+    return out.toString();
+  }
+
+  static String renderAndSanitize(
+      List<? extends ThreadRecord> records,
+      ExportSanitizer sanitizer,
+      Instant capturedAt,
+      String reason) {
+    ExportSanitizer active = sanitizer == null ? new ExportSanitizer() : sanitizer;
+    return active.sanitizeText(render(records, capturedAt, reason));
+  }
+
+  static List<ThreadRecord> liveRecords() {
+    Map<Thread, StackTraceElement[]> traces = Thread.getAllStackTraces();
+    Map<Long, ThreadInfo> infos = threadInfos();
+    List<ThreadRecord> records = new ArrayList<>(traces.size());
+    for (Map.Entry<Thread, StackTraceElement[]> entry : traces.entrySet()) {
+      Thread thread = entry.getKey();
+      if (thread == null) {
+        continue;
+      }
+      long id = -1L;
+      try {
+        id = thread.getId();
+      } catch (Throwable ignored) {
+      }
+      records.add(
+          new JdkThreadRecord(thread, entry.getValue(), id < 0 ? null : infos.get(id)));
+    }
+    return records;
+  }
+
+  private static RenderedThread renderOne(ThreadRecord record) {
+    try {
+      String name = record.name();
+      Thread.State state = record.state();
+      boolean daemon = record.daemon();
+      long id = record.id();
+      int priority = record.priority();
+      StackTraceElement[] stack = record.stack();
+      String lockName = record.lockName();
+      String lockOwnerName = record.lockOwnerName();
+      boolean inNative = record.inNative();
+      List<String> tags = highlightTags(name, stack);
+      StringBuilder body = new StringBuilder();
+      if (tags.isEmpty()) {
+        body.append("--- thread ---\n");
+      } else {
+        body.append(">>> HIGHLIGHT");
+        for (String tag : tags) {
+          body.append(' ').append(tag);
+        }
+        body.append('\n');
+      }
+      body.append("name=").append(name == null ? "" : name).append('\n');
+      body.append("id=").append(id).append('\n');
+      body.append("state=").append(state == null ? "" : state.name()).append('\n');
+      body.append("daemon=").append(daemon).append('\n');
+      body.append("priority=").append(priority).append('\n');
+      body.append("tags=");
+      for (int i = 0; i < tags.size(); i++) {
+        if (i > 0) {
+          body.append(',');
+        }
+        body.append(tags.get(i));
+      }
+      body.append('\n');
+      body.append("lock=").append(lockName == null ? "" : lockName).append('\n');
+      body.append("lockOwner=").append(lockOwnerName == null ? "" : lockOwnerName).append('\n');
+      body.append("native=").append(inNative).append('\n');
+      body.append("--- stack ---\n");
+      appendStack(body, stack);
+      return new RenderedThread(name == null ? "" : name, id, rank(tags), tags, body.toString());
+    } catch (Throwable ignored) {
+      return new RenderedThread(
+          "<unreadable>",
+          Long.MAX_VALUE,
+          99,
+          List.of(),
+          "--- thread ---\nname=<unreadable>\nstate=<unreadable>\ndaemon=<unreadable>\nerror=unreadable\n");
+    }
+  }
+
+  static List<String> highlightTags(String name, StackTraceElement[] stack) {
+    List<String> tags = new ArrayList<>();
+    String threadName = name == null ? "" : name;
+    String lower = threadName.toLowerCase(Locale.ROOT);
+    if (threadName.startsWith("AWT-EventQueue")) {
+      tags.add("edt");
+    }
+    if ("main".equals(threadName)) {
+      tags.add("main");
+    }
+    if (lower.startsWith("lizzie-log-")) {
+      tags.add("log-worker");
+    }
+    if (lower.contains("readboard")) {
+      tags.add("readboard");
+    }
+    boolean engineName = lower.contains("stdout") || lower.contains("stderr");
+    boolean engineStack = false;
+    boolean readboardStack = false;
+    boolean networkName =
+        lower.contains("websocket")
+            || lower.contains("webboard")
+            || lower.contains("zhizi")
+            || lower.contains("yike")
+            || lower.contains("network");
+    boolean networkStack = false;
+    if (stack != null) {
+      for (StackTraceElement frame : stack) {
+        if (frame == null) {
+          continue;
+        }
+        String cls = frame.getClassName();
+        String method = frame.getMethodName();
+        if (cls == null) {
+          continue;
+        }
+        if (("featurecat.lizzie.analysis.Leelaz".equals(cls)
+                || "featurecat.lizzie.analysis.AnalysisEngine".equals(cls))
+            && ("read".equals(method) || "readError".equals(method))) {
+          engineStack = true;
+        }
+        String clsLower = cls.toLowerCase(Locale.ROOT);
+        if (clsLower.contains("readboard")) {
+          readboardStack = true;
+        }
+        if (cls.contains("WebSocket")
+            || cls.contains("WebBoard")
+            || cls.startsWith("featurecat.lizzie.analysis.remote")
+            || cls.startsWith("featurecat.lizzie.gui.web")
+            || cls.startsWith("org.java_websocket")) {
+          networkStack = true;
+        }
+      }
+    }
+    if (engineName || engineStack) {
+      tags.add("engine-io");
+    }
+    if (readboardStack && !tags.contains("readboard")) {
+      tags.add("readboard");
+    }
+    if (networkName || networkStack) {
+      tags.add("network");
+    }
+    return tags;
+  }
+
+  private static int rank(List<String> tags) {
+    if (tags.contains("edt")) {
+      return 0;
+    }
+    if (tags.contains("main")) {
+      return 1;
+    }
+    if (tags.contains("engine-io")) {
+      return 2;
+    }
+    if (tags.contains("log-worker")) {
+      return 3;
+    }
+    if (tags.contains("readboard")) {
+      return 4;
+    }
+    if (tags.contains("network")) {
+      return 5;
+    }
+    return 99;
+  }
+
+  private static void appendStack(StringBuilder body, StackTraceElement[] stack) {
+    if (stack == null) {
+      body.append("(no stack)\n");
+      return;
+    }
+    if (stack.length == 0) {
+      body.append("(empty stack)\n");
+      return;
+    }
+    int limit = Math.min(stack.length, MAX_STACK_FRAMES);
+    for (int i = 0; i < limit; i++) {
+      StackTraceElement frame = stack[i];
+      if (frame == null) {
+        body.append("  at <unreadable>\n");
+      } else {
+        body.append("  at ").append(frame).append('\n');
+      }
+    }
+    if (stack.length > MAX_STACK_FRAMES) {
+      body.append("  ... ").append(stack.length - MAX_STACK_FRAMES).append(" frames omitted\n");
+    }
+  }
+
+  private static Map<Long, ThreadInfo> threadInfos() {
+    try {
+      ThreadMXBean mx = ManagementFactory.getThreadMXBean();
+      boolean monitors = mx.isObjectMonitorUsageSupported();
+      boolean synchronizers = mx.isSynchronizerUsageSupported();
+      ThreadInfo[] infos = mx.dumpAllThreads(monitors, synchronizers);
+      if (infos == null || infos.length == 0) {
+        return Map.of();
+      }
+      Map<Long, ThreadInfo> byId = new HashMap<>();
+      for (ThreadInfo info : infos) {
+        if (info != null) {
+          byId.put(info.getThreadId(), info);
+        }
+      }
+      return byId;
+    } catch (Throwable ignored) {
+      return Map.of();
+    }
+  }
+
+  private static String deadlockIds() {
+    try {
+      long[] ids = ManagementFactory.getThreadMXBean().findDeadlockedThreads();
+      if (ids == null || ids.length == 0) {
+        return "";
+      }
+      StringBuilder text = new StringBuilder();
+      for (int i = 0; i < ids.length; i++) {
+        if (i > 0) {
+          text.append(',');
+        }
+        text.append(ids[i]);
+      }
+      return text.toString();
+    } catch (Throwable ignored) {
+      return "";
+    }
+  }
+
+  interface ThreadRecord {
+    String name();
+
+    Thread.State state();
+
+    boolean daemon();
+
+    long id();
+
+    int priority();
+
+    StackTraceElement[] stack();
+
+    default String lockName() {
+      return "";
+    }
+
+    default String lockOwnerName() {
+      return "";
+    }
+
+    default boolean inNative() {
+      return false;
+    }
+  }
+
+  private static final class JdkThreadRecord implements ThreadRecord {
+    private final Thread thread;
+    private final StackTraceElement[] stack;
+    private final ThreadInfo info;
+
+    private JdkThreadRecord(Thread thread, StackTraceElement[] stack, ThreadInfo info) {
+      this.thread = thread;
+      this.stack = stack == null ? new StackTraceElement[0] : stack;
+      this.info = info;
+    }
+
+    @Override
+    public String name() {
+      return thread.getName();
+    }
+
+    @Override
+    public Thread.State state() {
+      return thread.getState();
+    }
+
+    @Override
+    public boolean daemon() {
+      return thread.isDaemon();
+    }
+
+    @Override
+    public long id() {
+      return thread.getId();
+    }
+
+    @Override
+    public int priority() {
+      return thread.getPriority();
+    }
+
+    @Override
+    public StackTraceElement[] stack() {
+      return stack;
+    }
+
+    @Override
+    public String lockName() {
+      return info == null || info.getLockName() == null ? "" : info.getLockName();
+    }
+
+    @Override
+    public String lockOwnerName() {
+      return info == null || info.getLockOwnerName() == null ? "" : info.getLockOwnerName();
+    }
+
+    @Override
+    public boolean inNative() {
+      return info != null && info.isInNative();
+    }
+  }
+
+  private static final class RenderedThread {
+    final String name;
+    final long id;
+    final int rank;
+    final List<String> tags;
+    final String body;
+
+    private RenderedThread(String name, long id, int rank, List<String> tags, String body) {
+      this.name = name;
+      this.id = id;
+      this.rank = rank;
+      this.tags = tags;
+      this.body = body;
+    }
+  }
+}

--- a/src/test/java/featurecat/lizzie/logging/DiagnosticBundleExporterTest.java
+++ b/src/test/java/featurecat/lizzie/logging/DiagnosticBundleExporterTest.java
@@ -37,6 +37,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.locks.LockSupport;
 import java.util.zip.GZIPOutputStream;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
@@ -75,6 +76,8 @@ class DiagnosticBundleExporterTest {
   @AfterEach
   void tearDown() {
     LoggingRuntime.resetForTests();
+    ThreadSnapshot.resetHeldForTests();
+    EdtHangWatchdog.uninstall();
   }
 
   @Test
@@ -128,6 +131,7 @@ class DiagnosticBundleExporterTest {
     assertTrue(names.contains("snapshots/summary.txt"));
     assertTrue(names.contains("snapshots/sync-context.json"));
     assertTrue(names.contains("snapshots/versions.json"));
+    assertTrue(names.contains("snapshots/threads.txt"));
     assertFalse(names.contains("app.log"));
     assertFalse(names.contains("crash.log"));
     assertFalse(names.contains("logs/lizzie/engine-trace.log"));
@@ -169,7 +173,79 @@ class DiagnosticBundleExporterTest {
     assertFalse(engine.has("command"));
     JSONObject versions = new JSONObject(text(entries, "snapshots/versions.json"));
     assertEquals("next-dev", versions.getString("host"));
+    String threads = text(entries, "snapshots/threads.txt");
+    assertTrue(threads.contains("name="), threads);
+    assertTrue(threads.contains("state="), threads);
+    assertTrue(threads.contains("daemon="), threads);
+    assertTrue(threads.contains("--- stack ---"), threads);
+    assertEquals("included", source(manifest, "threads").getString("status"));
     assertNoCanaries(entries, "CANARY_PASSWORD_EXPORT", "C:\\Users\\alice");
+  }
+
+  @Test
+  void exportWritesFindableEventQueueThreadSnapshotThroughSanitizer() throws Exception {
+    LoggingRuntime runtime = start();
+    CountDownLatch parked = new CountDownLatch(1);
+    CountDownLatch secretParked = new CountDownLatch(1);
+    Thread edt =
+        new Thread(
+            () -> {
+              parked.countDown();
+              LockSupport.park();
+            },
+            "AWT-EventQueue-0");
+    edt.setDaemon(true);
+    Thread secret =
+        new Thread(
+            () -> {
+              secretParked.countDown();
+              LockSupport.park();
+            },
+            "diag-worker password=CANARY_THREAD_SECRET");
+    secret.setDaemon(true);
+    edt.start();
+    secret.start();
+    assertTrue(parked.await(5, TimeUnit.SECONDS));
+    assertTrue(secretParked.await(5, TimeUnit.SECONDS));
+    try {
+      Map<String, byte[]> entries = unzipEntries(exportDefault(runtime));
+      assertTrue(entries.containsKey("snapshots/threads.txt"));
+      String threads = text(entries, "snapshots/threads.txt");
+      assertTrue(threads.contains("AWT-EventQueue-0"), threads);
+      assertTrue(threads.contains("name=AWT-EventQueue-0"), threads);
+      assertTrue(threads.contains(">>> HIGHLIGHT"), threads);
+      assertTrue(threads.contains("state="), threads);
+      assertTrue(threads.contains("--- stack ---"), threads);
+      assertFalse(threads.contains("CANARY_THREAD_SECRET"), threads);
+      assertTrue(threads.contains("password=<redacted>"), threads);
+      assertSource(source(manifest(entries), "threads"), true, true, "included", "snapshots/");
+    } finally {
+      LockSupport.unpark(edt);
+      LockSupport.unpark(secret);
+      edt.join(1_000);
+      secret.join(1_000);
+    }
+  }
+
+  @Test
+  void threadSnapshotFailureDoesNotFailThePackage() throws Exception {
+    LoggingRuntime runtime = start();
+    DiagnosticBundleExporter exporter =
+        new DiagnosticBundleExporter(DiagnosticBundleExporter.defaultOutputDirectory(tempDir));
+    exporter.setThreadSnapshotSourceForTests(
+        sanitizer -> {
+          throw new IllegalStateException("snapshot boom");
+        });
+    Path zip = exporter.export(request(runtime, EnumSet.noneOf(TraceScope.class)));
+    assertTrue(Files.isRegularFile(zip));
+    Map<String, byte[]> entries = unzipEntries(zip);
+    assertTrue(entries.containsKey("snapshots/config.json"));
+    assertTrue(entries.containsKey("snapshots/versions.json"));
+    assertTrue(entries.containsKey("snapshots/threads.txt"));
+    assertTrue(text(entries, "snapshots/threads.txt").contains("thread snapshot failed"));
+    JSONObject threads = source(manifest(entries), "threads");
+    assertSource(threads, true, false, "failed", "snapshots/");
+    assertEquals("unreadable", threads.getString("reason"));
   }
 
   @Test

--- a/src/test/java/featurecat/lizzie/logging/EdtHangWatchdogTest.java
+++ b/src/test/java/featurecat/lizzie/logging/EdtHangWatchdogTest.java
@@ -1,0 +1,115 @@
+package featurecat.lizzie.logging;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+class EdtHangWatchdogTest {
+  @AfterEach
+  void tearDown() {
+    ThreadSnapshot.resetHeldForTests();
+    EdtHangWatchdog.uninstall();
+  }
+
+  @Test
+  void stallCapturesOnceThenThrottlesUntilStop() {
+    AtomicLong now = new AtomicLong(TimeUnit.SECONDS.toNanos(10));
+    AtomicBoolean blocked = new AtomicBoolean();
+    AtomicInteger dumps = new AtomicInteger();
+    Deque<Runnable> edtQueue = new ArrayDeque<>();
+    EdtHangWatchdog watchdog =
+        new EdtHangWatchdog(
+            now::get,
+            EdtHangWatchdog.DEFAULT_STALL_NANOS,
+            EdtHangWatchdog.DEFAULT_THROTTLE_NANOS,
+            task -> edtQueue.addLast(task),
+            () -> {
+              dumps.incrementAndGet();
+              return "hang-dump-" + dumps.get();
+            });
+
+    watchdog.enable();
+    drainEdt(edtQueue, blocked);
+    watchdog.tick();
+    drainEdt(edtQueue, blocked);
+    assertEquals(0, watchdog.captureCount());
+
+    blocked.set(true);
+    now.addAndGet(EdtHangWatchdog.DEFAULT_STALL_NANOS);
+    watchdog.tick();
+    drainEdt(edtQueue, blocked);
+    assertEquals(1, watchdog.captureCount());
+    assertEquals("hang-dump-1", watchdog.lastHangDump());
+    assertEquals("hang-dump-1", ThreadSnapshot.heldRaw());
+
+    now.addAndGet(TimeUnit.SECONDS.toNanos(1));
+    watchdog.tick();
+    drainEdt(edtQueue, blocked);
+    assertEquals(1, watchdog.captureCount());
+
+    blocked.set(false);
+    now.addAndGet(TimeUnit.MILLISECONDS.toNanos(1));
+    drainEdt(edtQueue, blocked);
+    watchdog.tick();
+    drainEdt(edtQueue, blocked);
+    assertEquals(1, watchdog.captureCount());
+
+    blocked.set(true);
+    now.addAndGet(EdtHangWatchdog.DEFAULT_STALL_NANOS);
+    watchdog.tick();
+    drainEdt(edtQueue, blocked);
+    assertEquals(1, watchdog.captureCount(), "throttle must suppress the same stall window");
+
+    now.addAndGet(EdtHangWatchdog.DEFAULT_THROTTLE_NANOS);
+    watchdog.tick();
+    drainEdt(edtQueue, blocked);
+    assertEquals(2, watchdog.captureCount());
+    assertEquals("hang-dump-2", watchdog.lastHangDump());
+
+    watchdog.stop();
+    now.addAndGet(EdtHangWatchdog.DEFAULT_STALL_NANOS + EdtHangWatchdog.DEFAULT_THROTTLE_NANOS);
+    watchdog.tick();
+    assertEquals(2, watchdog.captureCount());
+    assertEquals(2, dumps.get());
+  }
+
+  private static void drainEdt(Deque<Runnable> edtQueue, AtomicBoolean blocked) {
+    if (blocked.get()) {
+      return;
+    }
+    while (!edtQueue.isEmpty()) {
+      edtQueue.removeFirst().run();
+    }
+  }
+
+  @Test
+  void stopPreventsCaptureEvenAfterStall() {
+    AtomicLong now = new AtomicLong(0L);
+    AtomicBoolean blocked = new AtomicBoolean(true);
+    EdtHangWatchdog watchdog =
+        new EdtHangWatchdog(
+            now::get,
+            TimeUnit.SECONDS.toNanos(1),
+            TimeUnit.SECONDS.toNanos(1),
+            task -> {
+              if (!blocked.get()) {
+                task.run();
+              }
+            },
+            () -> "should-not-capture");
+    watchdog.enable();
+    watchdog.stop();
+    now.addAndGet(TimeUnit.SECONDS.toNanos(5));
+    watchdog.tick();
+    assertEquals(0, watchdog.captureCount());
+    assertTrue(watchdog.lastHangDump().isEmpty());
+  }
+}

--- a/src/test/java/featurecat/lizzie/logging/ThreadSnapshotTest.java
+++ b/src/test/java/featurecat/lizzie/logging/ThreadSnapshotTest.java
@@ -1,0 +1,224 @@
+package featurecat.lizzie.logging;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Instant;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+class ThreadSnapshotTest {
+  private static final Instant CAPTURED_AT = Instant.parse("2026-08-29T12:00:00Z");
+
+  @AfterEach
+  void tearDown() {
+    ThreadSnapshot.resetHeldForTests();
+  }
+
+  @Test
+  void renderIncludesNameStateDaemonAndStackAndHighlightsKeyThreads() {
+    List<ThreadSnapshot.ThreadRecord> records =
+        List.of(
+            stub(
+                "pool-3-thread-1",
+                Thread.State.WAITING,
+                true,
+                9,
+                frame("java.lang.Object", "wait")),
+            stub(
+                "AWT-EventQueue-0",
+                Thread.State.RUNNABLE,
+                false,
+                1,
+                frame("java.awt.EventDispatchThread", "pumpOneEventForFilters")),
+            stub(
+                "main",
+                Thread.State.RUNNABLE,
+                false,
+                2,
+                frame("featurecat.lizzie.Lizzie", "main")),
+            stub(
+                "lizzie-log-app",
+                Thread.State.WAITING,
+                true,
+                3,
+                frame("featurecat.lizzie.logging.BoundedAsyncAppender", "drain")),
+            stub(
+                "ReadBoardStream",
+                Thread.State.RUNNABLE,
+                true,
+                4,
+                frame("featurecat.lizzie.analysis.ReadBoardStream", "run")),
+            stub(
+                "WebSocketConnectReadThread-1",
+                Thread.State.RUNNABLE,
+                true,
+                5,
+                frame("org.java_websocket.client.WebSocketClient", "run")),
+            stub(
+                "engine-stdout-reader",
+                Thread.State.RUNNABLE,
+                true,
+                6,
+                frame("featurecat.lizzie.analysis.Leelaz", "read")),
+            stub(
+                "engine-stderr-reader",
+                Thread.State.RUNNABLE,
+                true,
+                7,
+                frame("featurecat.lizzie.analysis.Leelaz", "readError")));
+
+    String text = ThreadSnapshot.render(records, CAPTURED_AT, "export");
+
+    assertTrue(text.contains("reason=export"), text);
+    assertTrue(text.contains("capturedAt=2026-08-29T12:00:00Z"), text);
+    assertTrue(text.contains("name=AWT-EventQueue-0"), text);
+    assertTrue(text.contains("state=RUNNABLE"), text);
+    assertTrue(text.contains("daemon=false"), text);
+    assertTrue(text.contains("daemon=true"), text);
+    assertTrue(text.contains("--- stack ---"), text);
+    assertTrue(text.contains("at java.awt.EventDispatchThread.pumpOneEventForFilters"), text);
+    assertTrue(text.contains(">>> HIGHLIGHT edt"), text);
+    assertTrue(text.contains(">>> HIGHLIGHT main"), text);
+    assertTrue(text.contains(">>> HIGHLIGHT engine-io"), text);
+    assertTrue(text.contains(">>> HIGHLIGHT log-worker"), text);
+    assertTrue(text.contains(">>> HIGHLIGHT readboard"), text);
+    assertTrue(text.contains(">>> HIGHLIGHT network"), text);
+    assertTrue(
+        text.contains(
+            "highlightedNames=AWT-EventQueue-0, main, engine-stderr-reader, engine-stdout-reader, lizzie-log-app, ReadBoardStream, WebSocketConnectReadThread-1"),
+        text);
+
+    int edt = text.indexOf("name=AWT-EventQueue-0");
+    int worker = text.indexOf("name=pool-3-thread-1");
+    assertTrue(edt >= 0 && worker > edt, text);
+  }
+
+  @Test
+  void singleThreadReadFailureKeepsRemainingThreads() {
+    ThreadSnapshot.ThreadRecord broken =
+        new ThreadSnapshot.ThreadRecord() {
+          @Override
+          public String name() {
+            throw new IllegalStateException("thread disappeared");
+          }
+
+          @Override
+          public Thread.State state() {
+            return Thread.State.RUNNABLE;
+          }
+
+          @Override
+          public boolean daemon() {
+            return false;
+          }
+
+          @Override
+          public long id() {
+            return 99L;
+          }
+
+          @Override
+          public int priority() {
+            return 5;
+          }
+
+          @Override
+          public StackTraceElement[] stack() {
+            return new StackTraceElement[0];
+          }
+        };
+    String text =
+        ThreadSnapshot.render(
+            List.of(
+                stub(
+                    "AWT-EventQueue-0",
+                    Thread.State.RUNNABLE,
+                    false,
+                    1,
+                    frame("java.awt.EventQueue", "dispatchEvent")),
+                broken),
+            CAPTURED_AT,
+            "export");
+
+    assertTrue(text.contains("name=AWT-EventQueue-0"), text);
+    assertTrue(text.contains("name=<unreadable>"), text);
+    assertTrue(text.contains("error=unreadable"), text);
+    assertTrue(text.contains("threadCount=2"), text);
+  }
+
+  @Test
+  void sanitizerIsAppliedToRenderedText() {
+    String text =
+        ThreadSnapshot.renderAndSanitize(
+            List.of(
+                stub(
+                    "worker password=CANARY_THREAD_SECRET",
+                    Thread.State.RUNNABLE,
+                    true,
+                    4,
+                    frame("java.lang.Thread", "run"))),
+            new ExportSanitizer(),
+            CAPTURED_AT,
+            "export");
+    assertFalse(text.contains("CANARY_THREAD_SECRET"), text);
+    assertTrue(text.contains("password=<redacted>"), text);
+  }
+
+  @Test
+  void captureIncludesLiveThreadsAndHeldHangDump() {
+    ThreadSnapshot.holdRaw(
+        "=== Thread snapshot ===\nreason=edt-hang\nname=AWT-EventQueue-0\nstate=RUNNABLE\n");
+    String text = ThreadSnapshot.capture(new ExportSanitizer());
+    assertTrue(text.contains("reason=export"), text);
+    assertTrue(text.contains("reason=edt-hang"), text);
+    assertTrue(text.contains("name="), text);
+    assertTrue(text.contains("state="), text);
+    assertTrue(text.contains("daemon="), text);
+    assertTrue(text.contains("--- stack ---"), text);
+  }
+
+  private static ThreadSnapshot.ThreadRecord stub(
+      String name,
+      Thread.State state,
+      boolean daemon,
+      long id,
+      StackTraceElement frame) {
+    return new ThreadSnapshot.ThreadRecord() {
+      @Override
+      public String name() {
+        return name;
+      }
+
+      @Override
+      public Thread.State state() {
+        return state;
+      }
+
+      @Override
+      public boolean daemon() {
+        return daemon;
+      }
+
+      @Override
+      public long id() {
+        return id;
+      }
+
+      @Override
+      public int priority() {
+        return 5;
+      }
+
+      @Override
+      public StackTraceElement[] stack() {
+        return new StackTraceElement[] {frame};
+      }
+    };
+  }
+
+  private static StackTraceElement frame(String className, String methodName) {
+    return new StackTraceElement(className, methodName, className.replace('.', '/') + ".java", 1);
+  }
+}


### PR DESCRIPTION
## Repro
Export a diagnostic ZIP from Help → 诊断与日志 → 导出诊断包. The pack already has `snapshots/` (config, versions, readboard, sync) but no `snapshots/threads.txt`. A UI hang or EDT stall usually throws nothing, and the crash handler only records one uncaught exception.

## Cause
`writeSnapshots` did not dump all thread stacks. There was no JDK `getAllStackTraces` / ThreadMXBean path into the existing `snapshots/` + `ExportSanitizer` flow.

## Fix
- Write `snapshots/threads.txt` from `writeSnapshots` with name, state, daemon flag, and stack, highlighted for AWT-EventQueue-0, main, engine readers, log workers, ReadBoard, Network/WebSocket.
- Run the text through `ExportSanitizer.sanitizeText`. A failed dump writes a stub and does not fail the pack.
- Optional EDT hang watchdog: one in-memory snapshot after a 5s stall, 60s throttle, no auto dialog. Manual capture is the existing Export package action.
- CrashHandlers unchanged. No heap dump. No high-frequency dumps.

## Verification
`mvn -B -Dfmt.skip=true -Dtest=ThreadSnapshotTest,EdtHangWatchdogTest,DiagnosticBundleExporterTest,LizzieShutdownTest test` — 54 tests, 0 failures. Parent Linux desktop 简体 + English dialog shots follow this PR.

Fixes #373
