### PR TITLE
feat(engine): log structured startup bootstrap diagnostics (#376)

### DIFF
--- a/src/main/java/featurecat/lizzie/analysis/AnalysisResourceCoordinator.java
+++ b/src/main/java/featurecat/lizzie/analysis/AnalysisResourceCoordinator.java
@@ -1,5 +1,6 @@
 package featurecat.lizzie.analysis;
 
+import featurecat.lizzie.logging.EngineBootstrapFacts;
 import featurecat.lizzie.logging.EngineObservation;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -85,14 +86,18 @@ public final class AnalysisResourceCoordinator {
     }
     String purposeName = normalizedPurpose(purpose).name();
     if (process == null) {
-      EngineObservation.ensureStarted(owner, purposeName);
-      if (EngineObservation.engineDiagnosticsEnabled()) {
-        EngineObservation.recordProcessDetails(
-            EngineObservation.identityFor(owner),
-            "process-started",
-            purposeName,
-            -1L,
-            diagnosticCommand(command));
+      try {
+        EngineBootstrapFacts facts = EngineStartupBootstrap.factsFor(command, purposeName);
+        EngineObservation.ensureStarted(owner, purposeName, facts);
+        if (EngineObservation.engineDiagnosticsEnabled()) {
+          EngineObservation.recordProcessDetails(
+              EngineObservation.identityFor(owner),
+              "process-started",
+              purposeName,
+              -1L,
+              diagnosticCommand(command));
+        }
+      } catch (RuntimeException ignored) {
       }
       return;
     }
@@ -104,12 +109,16 @@ public final class AnalysisResourceCoordinator {
       }
       REGISTERED_PROCESSES.put(owner, new ProcessRegistration(process, pid));
     }
-    String engineId = EngineObservation.restartInstance(owner, purposeName);
-    if (!EngineObservation.engineDiagnosticsEnabled()) {
-      return;
+    try {
+      EngineBootstrapFacts facts = EngineStartupBootstrap.factsFor(command, purposeName);
+      String engineId = EngineObservation.restartInstance(owner, purposeName, facts);
+      EngineObservation.markStartupStage(engineId, EngineObservation.STAGE_PROCESS_STARTED);
+      if (EngineObservation.engineDiagnosticsEnabled()) {
+        EngineObservation.recordProcessDetails(
+            engineId, "process-started", purposeName, pid, diagnosticCommand(command));
+      }
+    } catch (RuntimeException ignored) {
     }
-    EngineObservation.recordProcessDetails(
-        engineId, "process-started", purposeName, pid, diagnosticCommand(command));
   }
 
   public static void processStopped(Object owner, Purpose purpose, Process process) {

--- a/src/main/java/featurecat/lizzie/analysis/EngineStartupBootstrap.java
+++ b/src/main/java/featurecat/lizzie/analysis/EngineStartupBootstrap.java
@@ -1,0 +1,63 @@
+package featurecat.lizzie.analysis;
+
+import featurecat.lizzie.logging.EngineBootstrapFacts;
+import featurecat.lizzie.util.KataGoRuntimeHelper;
+import featurecat.lizzie.util.Utils;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Locale;
+
+/** Builds engine bootstrap facts using bundled/backend helpers already used at launch. */
+final class EngineStartupBootstrap {
+  private EngineStartupBootstrap() {}
+
+  static EngineBootstrapFacts factsFor(String command, String purpose) {
+    EngineBootstrapFacts parsed = EngineBootstrapFacts.fromCommand(command, purpose);
+    try {
+      List<String> parts = Utils.splitCommand(command == null ? "" : command);
+      Path executable = KataGoRuntimeHelper.resolveCommandExecutable(parts);
+      String nvidia = KataGoRuntimeHelper.resolveNvidiaBackend(executable);
+      String backend = parsed.backend();
+      String onnxProvider = parsed.onnxProvider();
+      if (nvidia != null && !nvidia.isEmpty()) {
+        backend = nvidia;
+      } else if (KataGoRuntimeHelper.isBundledOpenClPath(executable)) {
+        backend = "opencl";
+      } else {
+        String marker = KataGoRuntimeHelper.readEngineBackendMarker(executable);
+        if (marker != null && !marker.trim().isEmpty()) {
+          String normalized = marker.trim().toLowerCase(Locale.ROOT);
+          if ("opencl".equals(normalized)) {
+            backend = "opencl";
+          } else if ("directml".equals(normalized)
+              || "openvino".equals(normalized)
+              || "openvino-npu".equals(normalized)) {
+            backend = "onnx";
+            if (EngineBootstrapFacts.UNKNOWN.equals(onnxProvider)) {
+              onnxProvider = normalized;
+            }
+          }
+        }
+      }
+      if (backend.equals(parsed.backend()) && onnxProvider.equals(parsed.onnxProvider())) {
+        return parsed;
+      }
+      return EngineBootstrapFacts.of(
+          parsed.engineType(),
+          parsed.version(),
+          parsed.purpose(),
+          parsed.source(),
+          backend,
+          onnxProvider,
+          parsed.model(),
+          parsed.config());
+    } catch (RuntimeException ignored) {
+      return parsed;
+    } catch (Error error) {
+      if (error instanceof VirtualMachineError) {
+        throw error;
+      }
+      return parsed;
+    }
+  }
+}

--- a/src/main/java/featurecat/lizzie/analysis/Leelaz.java
+++ b/src/main/java/featurecat/lizzie/analysis/Leelaz.java
@@ -3762,39 +3762,68 @@ public class Leelaz {
   }
 
   private void noteEngineStarted() {
-    String id = EngineObservation.identityFor(this);
-    if (id == null) {
-      id = EngineObservation.ensureStarted(this, "MAIN_BOARD");
+    try {
+      String id = EngineObservation.identityFor(this);
+      if (id == null) {
+        id =
+            EngineObservation.ensureStarted(
+                this, "MAIN_BOARD", EngineStartupBootstrap.factsFor(engineCommand, "MAIN_BOARD"));
+      }
+      loggingEngineId = id;
+    } catch (RuntimeException ignored) {
     }
-    loggingEngineId = id;
   }
 
   private void noteEngineStopped() {
-    if (EngineObservation.engineDiagnosticsEnabled()) {
-      EngineObservation.recordRecentStderr(
-          loggingEngineId, snapshotRecentLines(recentStderrLines));
+    try {
+      if (EngineObservation.engineDiagnosticsEnabled()) {
+        EngineObservation.recordRecentStderr(
+            loggingEngineId, snapshotRecentLines(recentStderrLines));
+      }
+      EngineObservation.ensureStopped(this, "stopped");
+    } catch (RuntimeException ignored) {
     }
-    EngineObservation.ensureStopped(this, "stopped");
     loggingEngineId = null;
   }
 
   private void noteEngineFailed(String reason) {
-    loggingEngineId = EngineObservation.mintIdentity(this);
-    if (EngineObservation.engineDiagnosticsEnabled()) {
-      EngineObservation.recordRecentStderr(
-          loggingEngineId, snapshotRecentLines(recentStderrLines));
+    try {
+      String id = EngineObservation.identityFor(this);
+      if (id == null) {
+        id = EngineObservation.mintIdentity(this);
+        EngineObservation.recordBootstrap(
+            id, EngineStartupBootstrap.factsFor(engineCommand, "MAIN_BOARD"));
+      }
+      loggingEngineId = id;
+      try {
+        if (EngineObservation.engineDiagnosticsEnabled()) {
+          EngineObservation.recordRecentStderr(
+              loggingEngineId, snapshotRecentLines(recentStderrLines));
+        }
+        EngineObservation.recordFailed(loggingEngineId, reason);
+      } finally {
+        EngineObservation.discardIdentity(this);
+        loggingEngineId = null;
+      }
+    } catch (RuntimeException ignored) {
+      loggingEngineId = null;
     }
-    EngineObservation.recordFailed(loggingEngineId, reason);
-    EngineObservation.discardIdentity(this);
-    loggingEngineId = null;
   }
 
   private void markEngineLoaded() {
     boolean already = isLoaded;
     isLoaded = true;
     if (!already) {
-      EngineObservation.recordReady(loggingEngineId);
+      try {
+        EngineObservation.recordReady(currentObservationIdentity());
+      } catch (RuntimeException ignored) {
+      }
     }
+  }
+
+  private String currentObservationIdentity() {
+    String id = loggingEngineId;
+    return id != null ? id : EngineObservation.identityFor(this);
   }
 
   private boolean isFailedTrackingStreamCleanupInProgress() {
@@ -5326,6 +5355,11 @@ public class Leelaz {
         canAddPlayer = true;
       }
       isCheckingName = false;
+      try {
+        EngineObservation.markStartupStage(
+            currentObservationIdentity(), EngineObservation.STAGE_GTP_NAME);
+      } catch (RuntimeException ignored) {
+      }
     } else if (isCheckingVersion && !isLeela0110) {
       if (isKatago) {
         String[] ver = params[1].split("\\.");
@@ -5369,6 +5403,11 @@ public class Leelaz {
                 suppressGlobalPresentation);
         isTuning = false;
         // Lizzie.initializeAfterVersionCheck();
+      }
+      try {
+        EngineObservation.markStartupStage(
+            currentObservationIdentity(), EngineObservation.STAGE_GTP_VERSION);
+      } catch (RuntimeException ignored) {
       }
     }
     return startupCommandAction;
@@ -9305,6 +9344,9 @@ public class Leelaz {
                 ? "unexpected-eof"
                 : terminalFailure instanceof IOException ? "io-error" : "reader-error",
             terminalFailure);
+        if (!isLoaded) {
+          noteEngineFailed("exit-before-ready");
+        }
       }
       try {
         shutdownReaderTransport(binding);
@@ -18597,6 +18639,13 @@ public class Leelaz {
         lines.removeFirst();
       }
       lines.addLast(line);
+    }
+    if (lines == recentStderrLines) {
+      try {
+        EngineObservation.markStartupStage(
+            currentObservationIdentity(), EngineObservation.STAGE_FIRST_STDERR);
+      } catch (RuntimeException ignored) {
+      }
     }
   }
 

--- a/src/main/java/featurecat/lizzie/logging/EngineBootstrapFacts.java
+++ b/src/main/java/featurecat/lizzie/logging/EngineBootstrapFacts.java
@@ -1,0 +1,413 @@
+package featurecat.lizzie.logging;
+
+import featurecat.lizzie.Config;
+import featurecat.lizzie.util.Utils;
+import featurecat.lizzie.util.katago.tuning.KataGoCommandSpec;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Structured engine-startup facts for {@link EngineObservation}. Values are log tokens only: no
+ * full command lines and no absolute paths.
+ *
+ * <p>Bundled vs user-configured comes from {@link Config#isBundledKataGoCommand}. Backend detection
+ * reuses the same NVIDIA path markers, OpenCL marker file, and {@code
+ * lizzieyzy-next-engine-backend.txt} conventions as {@code KataGoRuntimeHelper}.
+ */
+public final class EngineBootstrapFacts {
+  public static final String UNKNOWN = "unknown";
+  public static final String SOURCE_BUNDLED = "bundled";
+  public static final String SOURCE_USER_CONFIGURED = "user-configured";
+
+  private static final int TOKEN_MAX_LENGTH = 96;
+  private static final String ENGINE_BACKEND_MARKER_NAME = "lizzieyzy-next-engine-backend.txt";
+  private static final String NVIDIA_ENGINE_DIR = "windows-x64-nvidia";
+  private static final String NVIDIA50_CUDA_ENGINE_DIR = "windows-x64-nvidia50-cuda";
+  private static final String NVIDIA_TRT_ENGINE_DIR = "windows-x64-nvidia-tensorrt";
+  private static final String NVIDIA50_TRT_ENGINE_DIR = "windows-x64-nvidia50-trt";
+  private static final String NVIDIA_BACKEND = "nvidia";
+  private static final String NVIDIA50_CUDA_BACKEND = "nvidia50-cuda";
+  private static final String NVIDIA_TRT_BACKEND = "nvidia-tensorrt";
+  private static final String NVIDIA50_TRT_BACKEND = "nvidia50-trt";
+  private static final String OPENCL_BACKEND = "opencl";
+  private static final String HUMAN_SL_CUDA_COMPANION_NAME = "katago-human-sl-cuda.exe";
+  private static final Pattern ONNX_PROVIDER =
+      Pattern.compile("(?i)(?:^|[,\\s])onnxProvider=([^,\\s\"]+)");
+  private static final Pattern SAFE_TOKEN = Pattern.compile("[^A-Za-z0-9._+-]+");
+
+  private final String engineType;
+  private final String version;
+  private final String purpose;
+  private final String source;
+  private final String backend;
+  private final String onnxProvider;
+  private final String model;
+  private final String config;
+
+  private EngineBootstrapFacts(
+      String engineType,
+      String version,
+      String purpose,
+      String source,
+      String backend,
+      String onnxProvider,
+      String model,
+      String config) {
+    this.engineType = engineType;
+    this.version = version;
+    this.purpose = purpose;
+    this.source = source;
+    this.backend = backend;
+    this.onnxProvider = onnxProvider;
+    this.model = model;
+    this.config = config;
+  }
+
+  public static EngineBootstrapFacts unknown(String purpose) {
+    return new EngineBootstrapFacts(
+        UNKNOWN,
+        UNKNOWN,
+        safePurpose(purpose),
+        SOURCE_USER_CONFIGURED,
+        UNKNOWN,
+        UNKNOWN,
+        UNKNOWN,
+        UNKNOWN);
+  }
+
+  public static EngineBootstrapFacts of(
+      String engineType,
+      String version,
+      String purpose,
+      String source,
+      String backend,
+      String onnxProvider,
+      String model,
+      String config) {
+    return new EngineBootstrapFacts(
+        safeToken(engineType),
+        safeToken(version),
+        safePurpose(purpose),
+        safeToken(source),
+        safeToken(backend),
+        safeToken(onnxProvider),
+        safeToken(model),
+        safeToken(config));
+  }
+
+  public static EngineBootstrapFacts fromCommand(String command, String purpose) {
+    try {
+      return parseCommand(command, purpose);
+    } catch (RuntimeException ignored) {
+      return unknown(purpose);
+    } catch (Error error) {
+      if (error instanceof VirtualMachineError) {
+        throw error;
+      }
+      return unknown(purpose);
+    }
+  }
+
+  public String engineType() {
+    return engineType;
+  }
+
+  public String version() {
+    return version;
+  }
+
+  public String purpose() {
+    return purpose;
+  }
+
+  public String source() {
+    return source;
+  }
+
+  public String backend() {
+    return backend;
+  }
+
+  public String onnxProvider() {
+    return onnxProvider;
+  }
+
+  public String model() {
+    return model;
+  }
+
+  public String config() {
+    return config;
+  }
+
+  String formatLogLine(String stageFragment) {
+    StringBuilder line = new StringBuilder("engine event=bootstrap");
+    appendField(line, "engineType", engineType);
+    appendField(line, "version", version);
+    appendField(line, "purpose", purpose);
+    appendField(line, "source", source);
+    appendField(line, "backend", backend);
+    appendField(line, "onnxProvider", onnxProvider);
+    appendField(line, "model", model);
+    appendField(line, "config", config);
+    if (stageFragment != null && !stageFragment.isEmpty()) {
+      line.append(stageFragment);
+    }
+    return line.toString();
+  }
+
+  private static EngineBootstrapFacts parseCommand(String command, String purpose) {
+    List<String> parts = Utils.splitCommand(command == null ? "" : command);
+    boolean bundled = Config.isBundledKataGoCommand(command);
+    String source = bundled ? SOURCE_BUNDLED : SOURCE_USER_CONFIGURED;
+    Path executable = executablePath(parts);
+    String onnxProvider = resolveOnnxProvider(parts, command, executable);
+    String backend = resolveBackend(executable, onnxProvider);
+    return new EngineBootstrapFacts(
+        inferEngineType(parts, bundled),
+        UNKNOWN,
+        safePurpose(purpose),
+        source,
+        backend,
+        onnxProvider,
+        fileIdentity(optionValue(parts, "-model", "--model", "-weights", "--weights")),
+        fileIdentity(optionValue(parts, "-config", "--config")));
+  }
+
+  private static Path executablePath(List<String> parts) {
+    if (parts == null || parts.isEmpty() || parts.get(0) == null || parts.get(0).trim().isEmpty()) {
+      return null;
+    }
+    try {
+      return Path.of(parts.get(0).trim());
+    } catch (RuntimeException ignored) {
+      return null;
+    }
+  }
+
+  private static String inferEngineType(List<String> parts, boolean bundled) {
+    if (bundled) {
+      return "katago";
+    }
+    if (parts == null || parts.isEmpty()) {
+      return UNKNOWN;
+    }
+    String executable = fileIdentity(parts.get(0)).toLowerCase(Locale.ROOT);
+    if (executable.contains("katago")) {
+      return "katago";
+    }
+    if (executable.contains("leelaz") || executable.contains("leela")) {
+      return "leela";
+    }
+    return UNKNOWN;
+  }
+
+  private static String resolveBackend(Path executable, String onnxProvider) {
+    String nvidia = resolveNvidiaBackendFromPath(executable);
+    if (nvidia != null) {
+      return nvidia;
+    }
+    String marker = readBackendMarker(executable);
+    if (OPENCL_BACKEND.equals(marker)) {
+      return OPENCL_BACKEND;
+    }
+    if (isOnnxExecutionProvider(marker)) {
+      return "onnx";
+    }
+    if (!UNKNOWN.equals(marker)) {
+      return marker;
+    }
+    if (isOnnxExecutionProvider(onnxProvider)) {
+      return "onnx";
+    }
+    return UNKNOWN;
+  }
+
+  /**
+   * Mirrors {@code KataGoRuntimeHelper.resolveNvidiaBackend} path and marker rules without loading
+   * that class from logging tests.
+   */
+  private static String resolveNvidiaBackendFromPath(Path enginePath) {
+    if (enginePath == null) {
+      return null;
+    }
+    Path fileName = enginePath.getFileName();
+    if (fileName != null && HUMAN_SL_CUDA_COMPANION_NAME.equalsIgnoreCase(fileName.toString())) {
+      return NVIDIA50_CUDA_BACKEND;
+    }
+    String normalized = enginePath.toString().replace('\\', '/').toLowerCase(Locale.ROOT);
+    if (normalized.contains("/" + NVIDIA_TRT_ENGINE_DIR + "/")
+        || normalized.contains("/" + NVIDIA50_TRT_ENGINE_DIR + "/")) {
+      return NVIDIA_TRT_BACKEND;
+    }
+    if (normalized.contains("/" + NVIDIA50_CUDA_ENGINE_DIR + "/")) {
+      return NVIDIA50_CUDA_BACKEND;
+    }
+    if (normalized.contains("/" + NVIDIA_ENGINE_DIR + "/")) {
+      return NVIDIA_BACKEND;
+    }
+    String marker = readBackendMarker(enginePath);
+    if (NVIDIA_TRT_BACKEND.equals(marker) || NVIDIA50_TRT_BACKEND.equals(marker)) {
+      return NVIDIA_TRT_BACKEND;
+    }
+    if (NVIDIA50_CUDA_BACKEND.equals(marker)) {
+      return NVIDIA50_CUDA_BACKEND;
+    }
+    if (NVIDIA_BACKEND.equals(marker)) {
+      return NVIDIA_BACKEND;
+    }
+    if (marker.startsWith("nvidia")) {
+      return marker;
+    }
+    return null;
+  }
+
+  private static String resolveOnnxProvider(List<String> parts, String command, Path executable) {
+    String fromOverride = overrideOnnxProvider(parts);
+    if (!UNKNOWN.equals(fromOverride)) {
+      return fromOverride;
+    }
+    Matcher matcher = ONNX_PROVIDER.matcher(command == null ? "" : command);
+    if (matcher.find()) {
+      return safeToken(matcher.group(1));
+    }
+    String marker = readBackendMarker(executable);
+    if (isOnnxExecutionProvider(marker)) {
+      return marker;
+    }
+    return UNKNOWN;
+  }
+
+  private static String overrideOnnxProvider(List<String> parts) {
+    if (parts == null || parts.isEmpty()) {
+      return UNKNOWN;
+    }
+    try {
+      Map<String, String> overrides = KataGoCommandSpec.parse(parts).effectiveOverrides();
+      for (Map.Entry<String, String> entry : overrides.entrySet()) {
+        if (entry.getKey() != null && "onnxprovider".equalsIgnoreCase(entry.getKey().trim())) {
+          return safeToken(entry.getValue());
+        }
+      }
+    } catch (RuntimeException ignored) {
+    }
+    return UNKNOWN;
+  }
+
+  private static String readBackendMarker(Path executable) {
+    if (executable == null) {
+      return UNKNOWN;
+    }
+    try {
+      Path engineDir = executable.toAbsolutePath().normalize().getParent();
+      if (engineDir == null) {
+        return UNKNOWN;
+      }
+      Path markerPath = engineDir.resolve(ENGINE_BACKEND_MARKER_NAME);
+      if (!Files.isRegularFile(markerPath)) {
+        return UNKNOWN;
+      }
+      String marker =
+          Files.readString(markerPath, StandardCharsets.UTF_8).trim().toLowerCase(Locale.ROOT);
+      return marker.isEmpty() ? UNKNOWN : safeToken(marker);
+    } catch (Exception ignored) {
+      return UNKNOWN;
+    }
+  }
+
+  private static boolean isOnnxExecutionProvider(String value) {
+    if (value == null || UNKNOWN.equals(value)) {
+      return false;
+    }
+    String normalized = value.toLowerCase(Locale.ROOT);
+    return "directml".equals(normalized)
+        || "openvino".equals(normalized)
+        || "openvino-npu".equals(normalized);
+  }
+
+  private static String optionValue(List<String> parts, String... flags) {
+    if (parts == null || flags == null) {
+      return null;
+    }
+    for (int i = 0; i < parts.size(); i++) {
+      String token = parts.get(i);
+      if (token == null) {
+        continue;
+      }
+      for (String flag : flags) {
+        if (flag.equals(token)) {
+          return i + 1 < parts.size() ? parts.get(i + 1) : null;
+        }
+        String prefix = flag + "=";
+        if (token.startsWith(prefix)) {
+          return token.substring(prefix.length());
+        }
+      }
+    }
+    return null;
+  }
+
+  static String fileIdentity(String raw) {
+    if (raw == null) {
+      return UNKNOWN;
+    }
+    String trimmed = stripQuotes(raw.trim());
+    if (trimmed.isEmpty()) {
+      return UNKNOWN;
+    }
+    String normalized = trimmed.replace('\\', '/');
+    int separator = normalized.lastIndexOf('/');
+    String fileName = separator >= 0 ? normalized.substring(separator + 1) : normalized;
+    return safeToken(fileName);
+  }
+
+  static String safeToken(String raw) {
+    if (raw == null) {
+      return UNKNOWN;
+    }
+    String trimmed = stripQuotes(raw.trim());
+    if (trimmed.isEmpty()) {
+      return UNKNOWN;
+    }
+    String collapsed = SAFE_TOKEN.matcher(trimmed).replaceAll("_");
+    while (collapsed.startsWith("_")) {
+      collapsed = collapsed.substring(1);
+    }
+    while (collapsed.endsWith("_")) {
+      collapsed = collapsed.substring(0, collapsed.length() - 1);
+    }
+    if (collapsed.isEmpty() || ".".equals(collapsed) || "..".equals(collapsed)) {
+      return UNKNOWN;
+    }
+    if (collapsed.length() > TOKEN_MAX_LENGTH) {
+      collapsed = collapsed.substring(0, TOKEN_MAX_LENGTH);
+    }
+    return collapsed;
+  }
+
+  private static String safePurpose(String purpose) {
+    String token = safeToken(purpose);
+    return UNKNOWN.equals(token) ? UNKNOWN : token;
+  }
+
+  private static String stripQuotes(String value) {
+    if (value.length() >= 2) {
+      char first = value.charAt(0);
+      char last = value.charAt(value.length() - 1);
+      if (first == last && (first == '"' || first == '\'')) {
+        return value.substring(1, value.length() - 1);
+      }
+    }
+    return value;
+  }
+
+  private static void appendField(StringBuilder line, String name, String value) {
+    line.append(' ').append(name).append('=').append(value == null ? UNKNOWN : value);
+  }
+}

--- a/src/main/java/featurecat/lizzie/logging/EngineObservation.java
+++ b/src/main/java/featurecat/lizzie/logging/EngineObservation.java
@@ -3,15 +3,35 @@ package featurecat.lizzie.logging;
 import java.io.IOException;
 import java.util.Optional;
 import java.util.WeakHashMap;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public final class EngineObservation {
+  public static final String STAGE_PROCESS_STARTED = "process-started";
+  public static final String STAGE_FIRST_STDERR = "first-stderr";
+  public static final String STAGE_GTP_NAME = "gtp-name";
+  public static final String STAGE_GTP_VERSION = "gtp-version";
+  public static final String STAGE_READY = "ready";
+  public static final String STAGE_FAILED = "failed";
+
+  private static final String[] STARTUP_STAGE_ORDER = {
+    STAGE_PROCESS_STARTED,
+    STAGE_FIRST_STDERR,
+    STAGE_GTP_NAME,
+    STAGE_GTP_VERSION,
+    STAGE_READY,
+    STAGE_FAILED
+  };
+
   private static final Logger ENGINE = LoggerFactory.getLogger(LogCategories.ENGINE);
   private static final Logger GTP = LoggerFactory.getLogger(LogCategories.GTP);
   private static final Logger TRACE = LoggerFactory.getLogger(LogCategories.ENGINE_TRACE);
   private static final Object IDENTITY_LOCK = new Object();
   private static final WeakHashMap<Object, String> ENGINE_IDS = new WeakHashMap<>();
+  private static final ConcurrentHashMap<String, StartupState> STARTUPS = new ConcurrentHashMap<>();
 
   private EngineObservation() {}
 
@@ -38,16 +58,24 @@ public final class EngineObservation {
   }
 
   public static String ensureStarted(Object owner, String purpose) {
+    return ensureStarted(owner, purpose, null);
+  }
+
+  public static String ensureStarted(Object owner, String purpose, EngineBootstrapFacts facts) {
     String existing = identityFor(owner);
     if (existing != null) {
       return existing;
     }
-    return startInstance(owner, purpose);
+    return startInstance(owner, purpose, facts);
   }
 
   public static String restartInstance(Object owner, String purpose) {
+    return restartInstance(owner, purpose, null);
+  }
+
+  public static String restartInstance(Object owner, String purpose, EngineBootstrapFacts facts) {
     ensureStopped(owner, "replaced");
-    return startInstance(owner, purpose);
+    return startInstance(owner, purpose, facts);
   }
 
   public static void ensureStopped(Object owner, String reason) {
@@ -56,9 +84,7 @@ public final class EngineObservation {
       return;
     }
     recordStopped(id, reason);
-    synchronized (IDENTITY_LOCK) {
-      ENGINE_IDS.remove(owner);
-    }
+    discardIdentity(owner);
   }
 
   public static String commandName(String command) {
@@ -85,19 +111,47 @@ public final class EngineObservation {
     if (protocolId >= 0) {
       return Integer.toString(protocolId);
     }
-    return LoggingRuntime.current()
-        .map(LoggingRuntime::newCommandIdentity)
-        .orElse("cmd-none");
+    return LoggingRuntime.current().map(LoggingRuntime::newCommandIdentity).orElse("cmd-none");
   }
 
   public static void recordStarted(String engineId, String purpose) {
-    if (!runtimeActive() || !ENGINE.isInfoEnabled()) {
-      return;
+    try {
+      if (!runtimeActive() || !ENGINE.isInfoEnabled()) {
+        return;
+      }
+      inContext(
+          engineId,
+          null,
+          () ->
+              ENGINE.info(
+                  "engine event=started purpose={}", purpose == null ? "unknown" : purpose));
+    } catch (RuntimeException ignored) {
     }
-    inContext(
-        engineId,
-        null,
-        () -> ENGINE.info("engine event=started purpose={}", purpose == null ? "unknown" : purpose));
+  }
+
+  public static void recordBootstrap(String engineId, EngineBootstrapFacts facts) {
+    try {
+      if (!runtimeActive() || !ENGINE.isInfoEnabled() || engineId == null) {
+        return;
+      }
+      StartupState state = STARTUPS.computeIfAbsent(engineId, ignored -> new StartupState());
+      if (!state.bootstrapRecorded.compareAndSet(false, true)) {
+        return;
+      }
+      EngineBootstrapFacts safe = facts == null ? EngineBootstrapFacts.unknown(null) : facts;
+      inContext(engineId, null, () -> ENGINE.info("{}", safe.formatLogLine(state.formatStages())));
+    } catch (RuntimeException ignored) {
+    }
+  }
+
+  public static void markStartupStage(String engineId, String stage) {
+    try {
+      if (engineId == null || stage == null || stage.isEmpty()) {
+        return;
+      }
+      STARTUPS.computeIfAbsent(engineId, ignored -> new StartupState()).mark(stage);
+    } catch (RuntimeException ignored) {
+    }
   }
 
   public static void recordStopped(String engineId, String reason) {
@@ -111,20 +165,32 @@ public final class EngineObservation {
   }
 
   public static void recordReady(String engineId) {
-    if (!runtimeActive() || !ENGINE.isInfoEnabled()) {
-      return;
+    try {
+      if (!runtimeActive() || !ENGINE.isInfoEnabled()) {
+        return;
+      }
+      markStartupStage(engineId, STAGE_READY);
+      String stages = formatKnownStages(engineId);
+      inContext(engineId, null, () -> ENGINE.info("engine event=ready{}", stages));
+    } catch (RuntimeException ignored) {
     }
-    inContext(engineId, null, () -> ENGINE.info("engine event=ready"));
   }
 
   public static void recordFailed(String engineId, String reason) {
-    if (!runtimeActive() || !ENGINE.isWarnEnabled()) {
-      return;
+    try {
+      if (!runtimeActive() || !ENGINE.isWarnEnabled()) {
+        return;
+      }
+      markStartupStage(engineId, STAGE_FAILED);
+      String stages = formatKnownStages(engineId);
+      inContext(
+          engineId,
+          null,
+          () ->
+              ENGINE.warn(
+                  "engine event=failed reason={}{}", reason == null ? "unknown" : reason, stages));
+    } catch (RuntimeException ignored) {
     }
-    inContext(
-        engineId,
-        null,
-        () -> ENGINE.warn("engine event=failed reason={}", reason == null ? "unknown" : reason));
   }
 
   public static void recordTransportFailure(
@@ -218,10 +284,7 @@ public final class EngineObservation {
     if (!gtpDiagnosticsEnabled()) {
       return;
     }
-    inContext(
-        engineId,
-        commandId,
-        () -> GTP.debug("gtp command={} outcome={}", name, "sent"));
+    inContext(engineId, commandId, () -> GTP.debug("gtp command={} outcome={}", name, "sent"));
   }
 
   public static void recordCommandOutcome(
@@ -232,9 +295,7 @@ public final class EngineObservation {
     inContext(
         engineId,
         commandId,
-        () ->
-            GTP.debug(
-                "gtp command={} outcome={} latencyMs={}", name, outcome, latencyMs));
+        () -> GTP.debug("gtp command={} outcome={} latencyMs={}", name, outcome, latencyMs));
   }
 
   public static void traceRawCommand(String engineId, String commandId, String command) {
@@ -271,8 +332,7 @@ public final class EngineObservation {
     if (action == null) {
       return;
     }
-    String trace =
-        LoggingRuntime.current().map(LoggingRuntime::currentTraceSessionId).orElse(null);
+    String trace = LoggingRuntime.current().map(LoggingRuntime::currentTraceSessionId).orElse(null);
     try (CorrelationContext.Scope scope =
         CorrelationContext.openScope().installEngine(engineId).installCommand(commandId)) {
       if (trace != null) {
@@ -299,15 +359,16 @@ public final class EngineObservation {
   }
 
   public static String mintIdentity(Object owner) {
-    String id =
-        LoggingRuntime.current()
-            .map(LoggingRuntime::newEngineIdentity)
-            .orElse("eng-none");
+    String id = LoggingRuntime.current().map(LoggingRuntime::newEngineIdentity).orElse("eng-none");
     if (owner != null) {
       synchronized (IDENTITY_LOCK) {
-        ENGINE_IDS.put(owner, id);
+        String previous = ENGINE_IDS.put(owner, id);
+        if (previous != null && !previous.equals(id)) {
+          STARTUPS.remove(previous);
+        }
       }
     }
+    STARTUPS.put(id, new StartupState());
     return id;
   }
 
@@ -315,8 +376,12 @@ public final class EngineObservation {
     if (owner == null) {
       return;
     }
+    String removed;
     synchronized (IDENTITY_LOCK) {
-      ENGINE_IDS.remove(owner);
+      removed = ENGINE_IDS.remove(owner);
+    }
+    if (removed != null) {
+      STARTUPS.remove(removed);
     }
   }
 
@@ -330,13 +395,53 @@ public final class EngineObservation {
         return false;
       }
       ENGINE_IDS.remove(owner);
-      return true;
     }
+    STARTUPS.remove(expectedIdentity);
+    return true;
   }
 
-  private static String startInstance(Object owner, String purpose) {
+  private static String startInstance(Object owner, String purpose, EngineBootstrapFacts facts) {
     String id = allocateIdentity(owner);
-    recordStarted(id, purpose);
+    try {
+      EngineBootstrapFacts safe = facts == null ? EngineBootstrapFacts.unknown(purpose) : facts;
+      recordBootstrap(id, safe);
+      recordStarted(id, purpose);
+    } catch (RuntimeException ignored) {
+    }
     return id;
+  }
+
+  private static String formatKnownStages(String engineId) {
+    if (engineId == null) {
+      return "";
+    }
+    StartupState state = STARTUPS.get(engineId);
+    return state == null ? "" : state.formatStages();
+  }
+
+  private static final class StartupState {
+    private final long startNanos = System.nanoTime();
+    private final ConcurrentHashMap<String, Long> stages = new ConcurrentHashMap<>();
+    private final AtomicBoolean bootstrapRecorded = new AtomicBoolean();
+
+    private void mark(String stage) {
+      stages.putIfAbsent(stage, elapsedMs());
+    }
+
+    private long elapsedMs() {
+      return TimeUnit.NANOSECONDS.toMillis(Math.max(0L, System.nanoTime() - startNanos));
+    }
+
+    private String formatStages() {
+      StringBuilder rendered = new StringBuilder();
+      for (String stage : STARTUP_STAGE_ORDER) {
+        Long elapsed = stages.get(stage);
+        if (elapsed == null) {
+          continue;
+        }
+        rendered.append(' ').append(stage).append('=').append(elapsed).append("ms");
+      }
+      return rendered.toString();
+    }
   }
 }

--- a/src/main/java/featurecat/lizzie/util/KataGoRuntimeHelper.java
+++ b/src/main/java/featurecat/lizzie/util/KataGoRuntimeHelper.java
@@ -687,7 +687,7 @@ public final class KataGoRuntimeHelper {
     return OPENCL_BACKEND.equals(readEngineBackendMarker(enginePath));
   }
 
-  private static String resolveNvidiaBackend(Path enginePath) {
+  public static String resolveNvidiaBackend(Path enginePath) {
     if (enginePath == null) {
       return null;
     }
@@ -728,7 +728,7 @@ public final class KataGoRuntimeHelper {
     return null;
   }
 
-  private static String readEngineBackendMarker(Path enginePath) {
+  public static String readEngineBackendMarker(Path enginePath) {
     if (enginePath == null) {
       return "";
     }

--- a/src/test/java/featurecat/lizzie/analysis/AnalysisResourceCoordinatorTest.java
+++ b/src/test/java/featurecat/lizzie/analysis/AnalysisResourceCoordinatorTest.java
@@ -174,6 +174,11 @@ class AnalysisResourceCoordinatorTest {
     awaitIdle.invoke(runtime);
 
     String app = Files.readString(tempDir.resolve("logs/app.log"), StandardCharsets.UTF_8);
+    assertTrue(app.contains("engine event=bootstrap"), app);
+    assertTrue(app.contains("engineType=katago"), app);
+    assertTrue(app.contains("source=user-configured"), app);
+    assertTrue(app.contains("backend=unknown"), app);
+    assertTrue(app.contains("model=model.bin.gz"), app);
     assertTrue(app.contains("engine event=started"), app);
     assertTrue(app.contains("engine event=process-started"), app);
     assertTrue(app.contains("engine event=dynamic-parameter"), app);

--- a/src/test/java/featurecat/lizzie/analysis/EngineGtpLoggingTest.java
+++ b/src/test/java/featurecat/lizzie/analysis/EngineGtpLoggingTest.java
@@ -1,5 +1,6 @@
 package featurecat.lizzie.analysis;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -18,6 +19,7 @@ import featurecat.lizzie.logging.LoggingSettings;
 import featurecat.lizzie.logging.TraceScope;
 import featurecat.lizzie.logging.WorkDirectoryResolution;
 import featurecat.lizzie.rules.Board;
+import featurecat.lizzie.util.KataGoRuntimeHelper;
 import java.io.ByteArrayOutputStream;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
@@ -69,10 +71,12 @@ class EngineGtpLoggingTest {
 
     assertNotEquals(first, second);
     String app = readApp();
+    assertTrue(app.contains("engine event=bootstrap"), app);
     assertTrue(app.contains("engine event=started"), app);
     assertTrue(app.contains("engine event=ready"), app);
     assertTrue(app.contains("engine=" + first), app);
     assertTrue(app.contains("engine=" + second), app);
+    assertTrue(app.contains("purpose=MAIN_BOARD"), app);
     assertFalse(app.contains("gtp raw"), app);
   }
 
@@ -80,14 +84,107 @@ class EngineGtpLoggingTest {
   void startupFailureAllocatesEngineIdentityWithoutStartedEvent() throws Exception {
     LoggingRuntime runtime = startRuntime();
     Leelaz engine = prepareEngine();
+    engine.setEngineCommand(
+        "\"C:\\\\Users\\\\Player\\\\secret\\\\katago.exe\" gtp "
+            + "-model \"C:\\\\Users\\\\Player\\\\secret\\\\model.bin.gz\"");
     Method fail = Leelaz.class.getDeclaredMethod("noteEngineFailed", String.class);
     fail.setAccessible(true);
     fail.invoke(engine, "ssh login failed");
     awaitLogs(runtime);
     String app = readApp();
     assertTrue(app.contains("engine event=failed reason=ssh login failed"), app);
+    assertTrue(app.contains("engine event=bootstrap"), app);
+    assertTrue(app.contains("engineType=katago"), app);
+    assertTrue(app.contains("source=user-configured"), app);
+    assertTrue(app.contains("purpose=MAIN_BOARD"), app);
+    assertTrue(app.contains("model=model.bin.gz"), app);
     assertFalse(app.contains("engine event=started"), app);
+    assertFalse(app.contains("Player"), app);
+    assertFalse(app.contains("secret"), app);
+    assertSameEngineIdentity(app, "event=bootstrap", "event=failed");
     assertTrue(app.contains("engine=eng-"), app);
+  }
+
+  @Test
+  void processStartFailureKeepsBootstrapIdentityWithoutStartedEvent() throws Exception {
+    LoggingRuntime runtime = startRuntime();
+    Leelaz engine = prepareEngine();
+    Method fail = Leelaz.class.getDeclaredMethod("noteEngineFailed", String.class);
+    fail.setAccessible(true);
+    fail.invoke(engine, "process start failed");
+    awaitLogs(runtime);
+    String app = readApp();
+    assertTrue(app.contains("engine event=bootstrap"), app);
+    assertTrue(app.contains("engine event=failed reason=process start failed"), app);
+    assertTrue(app.contains("engineType=unknown"), app);
+    assertTrue(app.contains("backend=unknown"), app);
+    assertTrue(app.contains("onnxProvider=unknown"), app);
+    assertFalse(app.contains("engine event=started"), app);
+    assertSameEngineIdentity(app, "event=bootstrap", "event=failed");
+  }
+
+  @Test
+  void exitBeforeReadyReusesBootstrapIdentity() throws Exception {
+    LoggingRuntime runtime = startRuntime();
+    Leelaz engine = prepareEngine();
+    Method started = Leelaz.class.getDeclaredMethod("noteEngineStarted");
+    started.setAccessible(true);
+    started.invoke(engine);
+    String identity = EngineObservation.identityFor(engine);
+    Method fail = Leelaz.class.getDeclaredMethod("noteEngineFailed", String.class);
+    fail.setAccessible(true);
+    fail.invoke(engine, "exit-before-ready");
+    awaitLogs(runtime);
+    String app = readApp();
+    assertTrue(app.contains("engine event=bootstrap"), app);
+    assertTrue(app.contains("engine event=started"), app);
+    assertTrue(app.contains("engine event=failed reason=exit-before-ready"), app);
+    assertTrue(identity != null && app.contains("engine=" + identity), app);
+    assertSameEngineIdentity(app, "event=bootstrap", "event=failed");
+    assertSameEngineIdentity(app, "event=started", "event=failed");
+  }
+
+  @Test
+  void bundledLaunchBootstrapRecordsSourceAndAvailableBackend() throws Exception {
+    LoggingRuntime runtime = startRuntime();
+    Leelaz engine = prepareEngine();
+    Path enginePath =
+        tempDir
+            .resolve("engines")
+            .resolve("katago")
+            .resolve("windows-x64-nvidia")
+            .resolve("katago.exe");
+    Files.createDirectories(enginePath.getParent());
+    Files.writeString(enginePath, "", StandardCharsets.UTF_8);
+    engine.setEngineCommand(
+        "\""
+            + enginePath.toAbsolutePath().normalize()
+            + "\" gtp -model kata1.bin.gz -config gtp.cfg");
+    Method started = Leelaz.class.getDeclaredMethod("noteEngineStarted");
+    started.setAccessible(true);
+    started.invoke(engine);
+    Method loaded = Leelaz.class.getDeclaredMethod("markEngineLoaded");
+    loaded.setAccessible(true);
+    engine.isLoaded = false;
+    loaded.invoke(engine);
+    awaitLogs(runtime);
+    String app = readApp();
+    String identity = EngineObservation.identityFor(engine);
+    assertTrue(app.contains("engine event=bootstrap"), app);
+    assertTrue(app.contains("source=bundled"), app);
+    assertTrue(app.contains("backend=nvidia"), app);
+    assertTrue(app.contains("engineType=katago"), app);
+    assertEquals(
+        KataGoRuntimeHelper.resolveNvidiaBackend(enginePath),
+        EngineStartupBootstrap.factsFor(engine.engineCommand, "MAIN_BOARD").backend());
+    assertEquals(
+        "unknown",
+        EngineStartupBootstrap.factsFor(engine.engineCommand, "MAIN_BOARD").onnxProvider());
+    assertTrue(app.contains("engine event=ready"), app);
+    assertTrue(identity != null && app.contains("engine=" + identity), app);
+    assertSameEngineIdentity(app, "event=bootstrap", "event=ready");
+    String bootstrapLine = eventLine(app, "event=bootstrap");
+    assertTrue(bootstrapLine != null && !bootstrapLine.contains(tempDir.toString()), app);
   }
 
   @Test
@@ -299,6 +396,33 @@ class EngineGtpLoggingTest {
   private String readApp() throws Exception {
     Path file = tempDir.resolve("logs/app.log");
     return Files.isRegularFile(file) ? Files.readString(file, StandardCharsets.UTF_8) : "";
+  }
+
+  private static void assertSameEngineIdentity(String app, String firstEvent, String secondEvent) {
+    String first = engineIdOnEventLine(app, firstEvent);
+    String second = engineIdOnEventLine(app, secondEvent);
+    assertTrue(
+        first != null && first.equals(second),
+        firstEvent + "=" + first + " " + secondEvent + "=" + second + "\n" + app);
+  }
+
+  private static String eventLine(String app, String eventToken) {
+    for (String line : app.split("\n")) {
+      if (line.contains(eventToken)) {
+        return line;
+      }
+    }
+    return null;
+  }
+
+  private static String engineIdOnEventLine(String app, String eventToken) {
+    String line = eventLine(app, eventToken);
+    if (line == null) {
+      return null;
+    }
+    java.util.regex.Matcher matcher =
+        java.util.regex.Pattern.compile("engine=(eng-[0-9a-f-]+)").matcher(line);
+    return matcher.find() ? matcher.group(1) : null;
   }
 
   private static void awaitLogs(LoggingRuntime runtime) throws Exception {

--- a/src/test/java/featurecat/lizzie/analysis/EngineStartupBootstrapTest.java
+++ b/src/test/java/featurecat/lizzie/analysis/EngineStartupBootstrapTest.java
@@ -1,0 +1,92 @@
+package featurecat.lizzie.analysis;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import featurecat.lizzie.Config;
+import featurecat.lizzie.logging.EngineBootstrapFacts;
+import featurecat.lizzie.util.KataGoRuntimeHelper;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class EngineStartupBootstrapTest {
+  @TempDir Path tempDir;
+
+  @Test
+  void bundledNvidiaBackendMatchesRuntimeHelper() throws Exception {
+    Path engine =
+        touch(
+            tempDir
+                .resolve("engines")
+                .resolve("katago")
+                .resolve("windows-x64-nvidia")
+                .resolve("katago.exe"));
+    String command = quote(engine) + " gtp -model kata1.bin.gz -config gtp.cfg";
+
+    EngineBootstrapFacts facts = EngineStartupBootstrap.factsFor(command, "MAIN_BOARD");
+
+    assertEquals("katago", facts.engineType());
+    assertEquals(EngineBootstrapFacts.SOURCE_BUNDLED, facts.source());
+    assertEquals("MAIN_BOARD", facts.purpose());
+    assertEquals(KataGoRuntimeHelper.resolveNvidiaBackend(engine), facts.backend());
+    assertEquals("nvidia", facts.backend());
+    assertEquals("unknown", facts.onnxProvider());
+    assertEquals("kata1.bin.gz", facts.model());
+    assertEquals("gtp.cfg", facts.config());
+    assertTrue(Config.isBundledKataGoCommand(command));
+  }
+
+  @Test
+  void userConfiguredMissingBackendAndProviderStayUnknown() {
+    String command =
+        "\"C:\\\\Users\\\\Player\\\\secret\\\\katago.exe\" gtp "
+            + "-model \"C:\\\\Users\\\\Player\\\\secret\\\\net.bin.gz\"";
+
+    EngineBootstrapFacts facts = EngineStartupBootstrap.factsFor(command, "MAIN_BOARD");
+
+    assertEquals("katago", facts.engineType());
+    assertEquals(EngineBootstrapFacts.SOURCE_USER_CONFIGURED, facts.source());
+    assertEquals("unknown", facts.backend());
+    assertEquals("unknown", facts.onnxProvider());
+    assertEquals("net.bin.gz", facts.model());
+    assertNotEquals("Player", facts.model());
+  }
+
+  @Test
+  void onnxMarkerFromRuntimeHelperSetsBackendAndProvider() throws Exception {
+    Path engine =
+        touch(
+            tempDir
+                .resolve("engines")
+                .resolve("katago")
+                .resolve("windows-x64")
+                .resolve("katago.exe"));
+    Files.writeString(
+        engine.getParent().resolve("lizzieyzy-next-engine-backend.txt"),
+        "directml\n",
+        StandardCharsets.UTF_8);
+
+    EngineBootstrapFacts facts =
+        EngineStartupBootstrap.factsFor(quote(engine) + " gtp -model m.bin.gz", "MAIN_BOARD");
+
+    assertEquals("onnx", facts.backend());
+    assertEquals("directml", facts.onnxProvider());
+    assertEquals(EngineBootstrapFacts.SOURCE_BUNDLED, facts.source());
+  }
+
+  private static Path touch(Path path) throws Exception {
+    Files.createDirectories(path.getParent());
+    if (!Files.exists(path)) {
+      Files.writeString(path, "", StandardCharsets.UTF_8);
+    }
+    return path;
+  }
+
+  private static String quote(Path path) {
+    return "\"" + path.toAbsolutePath().normalize() + "\"";
+  }
+}

--- a/src/test/java/featurecat/lizzie/logging/EngineBootstrapFactsTest.java
+++ b/src/test/java/featurecat/lizzie/logging/EngineBootstrapFactsTest.java
@@ -1,0 +1,155 @@
+package featurecat.lizzie.logging;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import featurecat.lizzie.Config;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class EngineBootstrapFactsTest {
+  @TempDir Path tempDir;
+
+  @Test
+  void userConfiguredCommandSanitizesPathsAndKeepsUnknownBackend() {
+    String command =
+        "\"C:\\\\Users\\\\Player\\\\secret\\\\katago.exe\" gtp "
+            + "-model \"C:\\\\Users\\\\Player\\\\secret\\\\weights\\\\b18c384nbt.bin.gz\" "
+            + "-config \"C:\\\\Users\\\\Player\\\\secret\\\\configs\\\\gtp.cfg\"";
+
+    EngineBootstrapFacts facts = EngineBootstrapFacts.fromCommand(command, "MAIN_BOARD");
+
+    assertEquals("katago", facts.engineType());
+    assertEquals("unknown", facts.version());
+    assertEquals("MAIN_BOARD", facts.purpose());
+    assertEquals(EngineBootstrapFacts.SOURCE_USER_CONFIGURED, facts.source());
+    assertEquals("unknown", facts.backend());
+    assertEquals("unknown", facts.onnxProvider());
+    assertEquals("b18c384nbt.bin.gz", facts.model());
+    assertEquals("gtp.cfg", facts.config());
+    String line = facts.formatLogLine("");
+    assertTrue(line.startsWith("engine event=bootstrap"), line);
+    assertFalse(line.contains("Player"), line);
+    assertFalse(line.contains("Users"), line);
+    assertFalse(line.contains("secret"), line);
+    assertFalse(line.contains("C:"), line);
+    assertFalse(line.contains("\\\\"), line);
+  }
+
+  @Test
+  void bundledCommandRecordsSourceAndNvidiaBackendFromPath() throws Exception {
+    Path engine =
+        touch(
+            tempDir
+                .resolve("engines")
+                .resolve("katago")
+                .resolve("windows-x64-nvidia")
+                .resolve("katago.exe"));
+    Path model = touch(tempDir.resolve("weights").resolve("kata1.bin.gz"));
+    Path config =
+        touch(tempDir.resolve("engines").resolve("katago").resolve("configs").resolve("gtp.cfg"));
+    String command = quote(engine) + " gtp -model " + quote(model) + " -config " + quote(config);
+
+    EngineBootstrapFacts facts = EngineBootstrapFacts.fromCommand(command, "MAIN_BOARD");
+
+    assertEquals("katago", facts.engineType());
+    assertEquals(EngineBootstrapFacts.SOURCE_BUNDLED, facts.source());
+    assertEquals("nvidia", facts.backend());
+    assertTrue(Config.isBundledKataGoCommand(command));
+    assertEquals("unknown", facts.onnxProvider());
+    assertEquals("kata1.bin.gz", facts.model());
+    assertEquals("gtp.cfg", facts.config());
+    assertFalse(facts.formatLogLine("").contains(tempDir.toString()), facts.formatLogLine(""));
+  }
+
+  @Test
+  void onnxProviderFromOverrideConfigSetsBackendWithoutInventingAValue() throws Exception {
+    Path engine =
+        touch(
+            tempDir
+                .resolve("engines")
+                .resolve("katago")
+                .resolve("windows-x64")
+                .resolve("katago.exe"));
+    Files.writeString(
+        engine.getParent().resolve("lizzieyzy-next-engine-backend.txt"),
+        "directml\n",
+        StandardCharsets.UTF_8);
+    String command =
+        quote(engine)
+            + " gtp -model model.bin.gz -config gtp.cfg "
+            + "-override-config \"onnxProvider=directml,onnxOpenVINOCacheDir=C:\\\\Users\\\\Player\\\\cache\"";
+
+    EngineBootstrapFacts facts = EngineBootstrapFacts.fromCommand(command, "MAIN_BOARD");
+
+    assertEquals("onnx", facts.backend());
+    assertEquals("directml", facts.onnxProvider());
+    assertEquals(EngineBootstrapFacts.SOURCE_BUNDLED, facts.source());
+    String line = facts.formatLogLine("");
+    assertFalse(line.contains("Player"), line);
+    assertFalse(line.contains("cache"), line);
+  }
+
+  @Test
+  void missingBackendAndProviderStayExplicitlyUnknown() {
+    EngineBootstrapFacts facts =
+        EngineBootstrapFacts.fromCommand("katago gtp -model model.bin.gz", "MAIN_BOARD");
+
+    assertEquals("katago", facts.engineType());
+    assertEquals(EngineBootstrapFacts.SOURCE_USER_CONFIGURED, facts.source());
+    assertEquals("unknown", facts.backend());
+    assertEquals("unknown", facts.onnxProvider());
+    assertEquals("model.bin.gz", facts.model());
+    assertEquals("unknown", facts.config());
+  }
+
+  @Test
+  void openClMarkerIsUsedWhenNvidiaBackendIsAbsent() throws Exception {
+    Path engine =
+        touch(
+            tempDir
+                .resolve("app")
+                .resolve("engines")
+                .resolve("katago")
+                .resolve("windows-x64")
+                .resolve("katago.exe"));
+    Files.writeString(
+        engine.getParent().resolve("lizzieyzy-next-engine-backend.txt"),
+        "opencl\n",
+        StandardCharsets.UTF_8);
+
+    EngineBootstrapFacts facts =
+        EngineBootstrapFacts.fromCommand(quote(engine) + " gtp -model net.bin.gz", "MAIN_BOARD");
+
+    assertEquals("opencl", facts.backend());
+    assertEquals("unknown", facts.onnxProvider());
+  }
+
+  @Test
+  void emptyOrNullCommandDoesNotInventTypeOrPaths() {
+    EngineBootstrapFacts empty = EngineBootstrapFacts.fromCommand("", "MAIN_BOARD");
+    assertEquals("unknown", empty.engineType());
+    assertEquals("unknown", empty.backend());
+    assertEquals("unknown", empty.model());
+    assertEquals(EngineBootstrapFacts.SOURCE_USER_CONFIGURED, empty.source());
+    EngineBootstrapFacts missing = EngineBootstrapFacts.fromCommand(null, "MAIN_BOARD");
+    assertEquals("unknown", missing.engineType());
+    assertEquals("unknown", missing.backend());
+  }
+
+  private static Path touch(Path path) throws Exception {
+    Files.createDirectories(path.getParent());
+    if (!Files.exists(path)) {
+      Files.writeString(path, "", StandardCharsets.UTF_8);
+    }
+    return path;
+  }
+
+  private static String quote(Path path) {
+    return "\"" + path.toAbsolutePath().normalize() + "\"";
+  }
+}

--- a/src/test/java/featurecat/lizzie/logging/EngineObservationTest.java
+++ b/src/test/java/featurecat/lizzie/logging/EngineObservationTest.java
@@ -43,6 +43,7 @@ class EngineObservationTest {
     assertFalse(EngineObservation.traceEnabled());
 
     EngineObservation.recordStarted("eng-1", "MAIN_BOARD");
+    EngineObservation.recordBootstrap("eng-1", EngineBootstrapFacts.unknown("MAIN_BOARD"));
     EngineObservation.recordQueue("eng-1", 1, 1);
     EngineObservation.recordCommandSent("eng-1", "cmd-1", "play", 0, 1);
     EngineObservation.traceRawCommand("eng-1", "cmd-1", "play B D4");
@@ -84,8 +85,7 @@ class EngineObservationTest {
     String message = traceEvents.list.get(0).getFormattedMessage();
     String payload = message.substring(message.indexOf('=') + 1);
     assertTrue(
-        payload.getBytes(StandardCharsets.UTF_8).length
-            <= ObservationText.RAW_EVENT_MAX_UTF8_BYTES,
+        payload.getBytes(StandardCharsets.UTF_8).length <= ObservationText.RAW_EVENT_MAX_UTF8_BYTES,
         Integer.toString(payload.getBytes(StandardCharsets.UTF_8).length));
     assertTrue(payload.endsWith(" [truncated]"), payload);
   }
@@ -108,6 +108,91 @@ class EngineObservationTest {
     assertTrue(message.contains("reason=io-error"), message);
     assertTrue(message.contains("errorType=IOException"), message);
     assertFalse(message.contains("secret raw payload"), message);
+  }
+
+  @Test
+  void bootstrapUsesStructuredFieldsAndOmitsUnknownStages() {
+    LoggingRuntime.initialize(
+        new WorkDirectoryResolution(tempDir, List.of()),
+        new LoggingLimits(64, 32, 32, 32, 7, 1_000_000, 256_000));
+    Logger engine = (Logger) LoggerFactory.getLogger(LogCategories.ENGINE);
+    ListAppender<ILoggingEvent> events = attach(engine);
+
+    EngineBootstrapFacts facts =
+        EngineBootstrapFacts.fromCommand(
+            "\"C:\\\\Users\\\\Player\\\\katago.exe\" gtp -model model.bin.gz", "MAIN_BOARD");
+    EngineObservation.recordBootstrap("eng-bootstrap", facts);
+
+    assertEquals(1, events.list.size(), events.list.toString());
+    String message = events.list.get(0).getFormattedMessage();
+    assertTrue(message.contains("event=bootstrap"), message);
+    assertTrue(message.contains("engineType=katago"), message);
+    assertTrue(message.contains("purpose=MAIN_BOARD"), message);
+    assertTrue(message.contains("source=user-configured"), message);
+    assertTrue(message.contains("backend=unknown"), message);
+    assertTrue(message.contains("onnxProvider=unknown"), message);
+    assertTrue(message.contains("model=model.bin.gz"), message);
+    assertFalse(message.contains("Player"), message);
+    assertFalse(message.contains("process-started="), message);
+  }
+
+  @Test
+  void readyAndFailedReuseTheSameIdentityAsBootstrap() {
+    LoggingRuntime.initialize(
+        new WorkDirectoryResolution(tempDir, List.of()),
+        new LoggingLimits(64, 32, 32, 32, 7, 1_000_000, 256_000));
+    Logger engine = (Logger) LoggerFactory.getLogger(LogCategories.ENGINE);
+    ListAppender<ILoggingEvent> events = attach(engine);
+
+    Object owner = new Object();
+    String id =
+        EngineObservation.ensureStarted(
+            owner, "MAIN_BOARD", EngineBootstrapFacts.fromCommand("katago gtp", "MAIN_BOARD"));
+    EngineObservation.markStartupStage(id, EngineObservation.STAGE_PROCESS_STARTED);
+    EngineObservation.recordReady(id);
+
+    assertEquals(id, EngineObservation.identityFor(owner));
+    String readyLogs = formatted(events);
+    assertTrue(readyLogs.contains("event=bootstrap"), readyLogs);
+    assertTrue(readyLogs.contains("event=started"), readyLogs);
+    assertTrue(readyLogs.contains("event=ready"), readyLogs);
+    assertTrue(readyLogs.contains("process-started="), readyLogs);
+
+    events.list.clear();
+    EngineObservation.discardIdentity(owner);
+    String failedId = EngineObservation.mintIdentity(owner);
+    EngineObservation.recordBootstrap(
+        failedId, EngineBootstrapFacts.fromCommand("katago gtp", "MAIN_BOARD"));
+    EngineObservation.recordFailed(failedId, "process start failed");
+    String failedLogs = formatted(events);
+    assertTrue(failedLogs.contains("event=bootstrap"), failedLogs);
+    assertTrue(failedLogs.contains("event=failed reason=process start failed"), failedLogs);
+    assertFalse(failedLogs.contains("event=started"), failedLogs);
+  }
+
+  @Test
+  void bootstrapIsRecordedOncePerIdentity() {
+    LoggingRuntime.initialize(
+        new WorkDirectoryResolution(tempDir, List.of()),
+        new LoggingLimits(64, 32, 32, 32, 7, 1_000_000, 256_000));
+    Logger engine = (Logger) LoggerFactory.getLogger(LogCategories.ENGINE);
+    ListAppender<ILoggingEvent> events = attach(engine);
+
+    String id = EngineObservation.mintIdentity(new Object());
+    EngineBootstrapFacts facts = EngineBootstrapFacts.fromCommand("katago gtp", "MAIN_BOARD");
+    EngineObservation.recordBootstrap(id, facts);
+    EngineObservation.recordBootstrap(id, facts);
+
+    assertEquals(1, events.list.size(), events.list.toString());
+    assertTrue(events.list.get(0).getFormattedMessage().contains("event=bootstrap"));
+  }
+
+  private static String formatted(ListAppender<ILoggingEvent> events) {
+    StringBuilder text = new StringBuilder();
+    for (ILoggingEvent event : events.list) {
+      text.append(event.getFormattedMessage()).append('\n');
+    }
+    return text.toString();
   }
 
   private static ListAppender<ILoggingEvent> attach(Logger logger) {


### PR DESCRIPTION
## Repro
Existing EngineObservation lifecycle logs have `event=started` / `ready` / `failed` only. There is no `event=bootstrap` and no engineType / backend / source / stage timing. A pre-ready failure can log `failed` without matching startup config (`EngineGtpLoggingTest.startupFailureAllocatesEngineIdentityWithoutStartedEvent`).

## Cause
`recordStarted` writes purpose only. `noteEngineFailed` allocates identity then records `failed` without a bootstrap snapshot. Bundled/backend helpers already exist at launch (`isBundledKataGoCommand`, `resolveNvidiaBackend`) but were not written into EngineObservation.

## Fix
- Add one structured `engine event=bootstrap` per main launch identity: type, purpose, source, backend, ONNX provider, sanitized model/config identity (filename only).
- Ready and failed reuse that identity, including pre-ready failures.
- Missing backend/provider is `unknown`. Stage timings only when they already happen; unknown stages omitted.
- No full command or absolute paths. Log failure cannot block start. Start success/fail, raw GTP, and engine selection unchanged.

## Verification
`mvn -B -Dfmt.skip=true -Dtest=EngineBootstrapFactsTest,EngineObservationTest,EngineGtpLoggingTest,AnalysisResourceCoordinatorTest,EngineStartupBootstrapTest test` — 38 tests, 0 failures. No desktop shots.

Fixes #376
