### PR TITLE
feat(diagnostics): add JVM memory and disk snapshot to diagnostic pack (#374)

### DIFF
--- a/src/main/java/featurecat/lizzie/logging/DiagnosticBundleExporter.java
+++ b/src/main/java/featurecat/lizzie/logging/DiagnosticBundleExporter.java
@@ -94,12 +94,18 @@ public final class DiagnosticBundleExporter {
     String capture(ExportSanitizer sanitizer);
   }
 
+  @FunctionalInterface
+  interface RuntimeSnapshotSource {
+    String capture(Path workDirectory, ExportSanitizer sanitizer);
+  }
+
   private final Path outputDirectory;
   private final DiagnosticBundleLimits limits;
   private final PartialFileObserver partialFileObserver;
   private final BundleNameSupplier bundleNameSupplier;
   private final PartialFileCleanupStrategy partialFileCleanupStrategy;
   private ThreadSnapshotSource threadSnapshotSource = ThreadSnapshot::capture;
+  private RuntimeSnapshotSource runtimeSnapshotSource = RuntimeSnapshot::capture;
 
   public DiagnosticBundleExporter(Path outputDirectory) {
     this(outputDirectory, DiagnosticBundleLimits.production());
@@ -169,6 +175,10 @@ public final class DiagnosticBundleExporter {
 
   void setThreadSnapshotSourceForTests(ThreadSnapshotSource source) {
     this.threadSnapshotSource = source == null ? ThreadSnapshot::capture : source;
+  }
+
+  void setRuntimeSnapshotSourceForTests(RuntimeSnapshotSource source) {
+    this.runtimeSnapshotSource = source == null ? RuntimeSnapshot::capture : source;
   }
 
   public static Path defaultOutputDirectory(Path workDirectory) {
@@ -721,6 +731,7 @@ public final class DiagnosticBundleExporter {
     versions.put("host", sanitizer.sanitizeText(request.appVersion()));
     versions.put("readboard", sanitizer.sanitizeText(request.readBoardVersion()));
     writeTextEntry(out, NS_SNAPSHOTS + "versions.json", versions.toString(2));
+    writeRuntimeSnapshot(out, request, sanitizer);
     writeTextEntry(
         out,
         NS_SNAPSHOTS + "readboard-observed.json",
@@ -757,6 +768,37 @@ public final class DiagnosticBundleExporter {
             hostSession,
             "",
             false));
+  }
+
+  private void writeRuntimeSnapshot(
+      ZipOutputStream out, DiagnosticBundleRequest request, ExportSanitizer sanitizer)
+      throws IOException {
+    String text;
+    try {
+      text = runtimeSnapshotSource.capture(resolveWorkDirectory(request), sanitizer);
+      if (text == null || text.isBlank()) {
+        text = RuntimeSnapshot.unavailableJson();
+      }
+    } catch (RuntimeException | Error ignored) {
+      text = RuntimeSnapshot.unavailableJson();
+    }
+    writeTextEntry(out, NS_SNAPSHOTS + RuntimeSnapshot.ENTRY_NAME, text);
+  }
+
+  private static Path resolveWorkDirectory(DiagnosticBundleRequest request) {
+    try {
+      Path work = request.runtime().workDirectory();
+      if (work != null) {
+        return work;
+      }
+    } catch (RuntimeException ignored) {
+    }
+    try {
+      Path logs = request.runtime().logsDirectory();
+      return logs == null ? null : logs.getParent();
+    } catch (RuntimeException ignored) {
+      return null;
+    }
   }
 
   private void writeThreadSnapshot(

--- a/src/main/java/featurecat/lizzie/logging/LoggingRuntime.java
+++ b/src/main/java/featurecat/lizzie/logging/LoggingRuntime.java
@@ -160,6 +160,10 @@ public final class LoggingRuntime {
     return logsDirectory;
   }
 
+  public Path workDirectory() {
+    return workDirectory;
+  }
+
   public LoggingSettings settings() {
     return settings;
   }

--- a/src/main/java/featurecat/lizzie/logging/RuntimeSnapshot.java
+++ b/src/main/java/featurecat/lizzie/logging/RuntimeSnapshot.java
@@ -1,0 +1,332 @@
+package featurecat.lizzie.logging;
+
+import java.lang.management.GarbageCollectorMXBean;
+import java.lang.management.ManagementFactory;
+import java.lang.management.MemoryUsage;
+import java.lang.management.OperatingSystemMXBean;
+import java.lang.management.RuntimeMXBean;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+/**
+ * Formats a point-in-time JVM / work-dir resource snapshot for the diagnostic package {@code
+ * snapshots/runtime.json}.
+ *
+ * <p>Each metric is independent: a single probe failure becomes an explicit missing state and does
+ * not abort the rest of the snapshot. Absolute work-dir paths are never written.
+ */
+public final class RuntimeSnapshot {
+  static final String ENTRY_NAME = "runtime.json";
+  static final String MISSING_UNREADABLE = "unreadable";
+  static final String MISSING_UNDEFINED = "undefined";
+  static final String MISSING_UNAVAILABLE = "unavailable";
+  static final List<String> REQUIRED_FIELDS =
+      List.of(
+          "processors",
+          "heapUsedMiB",
+          "heapCommittedMiB",
+          "heapMaxMiB",
+          "nonHeapUsedMiB",
+          "workDirUsableGiB",
+          "uptimeSeconds");
+
+  private static final long MIB = 1024L * 1024L;
+  private static final long GIB = 1024L * 1024L * 1024L;
+  private static final int MAX_GC_NAMES = 8;
+  private static final int MAX_TOKEN_UTF8_BYTES = 96;
+
+  @FunctionalInterface
+  interface DiskSpaceProbe {
+    long usableBytes(Path workDirectory) throws Exception;
+  }
+
+  private RuntimeSnapshot() {}
+
+  public static String capture(Path workDirectory, ExportSanitizer sanitizer) {
+    return capture(workDirectory, sanitizer, RuntimeSnapshot::usableBytes);
+  }
+
+  static String capture(Path workDirectory, ExportSanitizer sanitizer, DiskSpaceProbe disk) {
+    try {
+      ExportSanitizer active = sanitizer == null ? new ExportSanitizer() : sanitizer;
+      DiskSpaceProbe probe = disk == null ? RuntimeSnapshot::usableBytes : disk;
+      return render(workDirectory, active, probe).toString(2);
+    } catch (RuntimeException | Error ignored) {
+      return unavailableJson();
+    }
+  }
+
+  static String unavailableJson() {
+    return missingDocument(MISSING_UNREADABLE).toString(2);
+  }
+
+  static JSONObject render(Path workDirectory, ExportSanitizer sanitizer, DiskSpaceProbe disk) {
+    JSONObject json = new JSONObject();
+    JSONObject missing = new JSONObject();
+    putProcessors(json, missing);
+    putHeap(json, missing);
+    putNonHeap(json, missing);
+    putWorkDirUsable(json, missing, workDirectory, disk);
+    putUptime(json, missing);
+    putGcNames(json, missing, sanitizer);
+    putToken(
+        json,
+        missing,
+        "jvmVendor",
+        sanitizer,
+        () -> ManagementFactory.getRuntimeMXBean().getVmVendor());
+    putToken(
+        json,
+        missing,
+        "jvmVersion",
+        sanitizer,
+        () -> {
+          RuntimeMXBean runtime = ManagementFactory.getRuntimeMXBean();
+          String version = runtime.getVmVersion();
+          if (version == null || version.isBlank()) {
+            version = runtime.getSpecVersion();
+          }
+          return version;
+        });
+    putSystemLoad(json, missing);
+    if (missing.length() > 0) {
+      json.put("missing", missing);
+    }
+    return json;
+  }
+
+  static JSONObject missingDocument(String reason) {
+    String why = reason == null || reason.isBlank() ? MISSING_UNREADABLE : reason;
+    JSONObject json = new JSONObject();
+    JSONObject missing = new JSONObject();
+    for (String field : REQUIRED_FIELDS) {
+      json.put(field, JSONObject.NULL);
+      missing.put(field, why);
+    }
+    json.put("missing", missing);
+    return json;
+  }
+
+  static void putByteQuantity(
+      JSONObject json, JSONObject missing, String field, long bytes, long unit) {
+    if (bytes < 0L) {
+      json.put(field, JSONObject.NULL);
+      missing.put(field, MISSING_UNDEFINED);
+      return;
+    }
+    json.put(field, bytes / unit);
+  }
+
+  private static void putProcessors(JSONObject json, JSONObject missing) {
+    putNonNegative(
+        json,
+        missing,
+        "processors",
+        () -> Runtime.getRuntime().availableProcessors(),
+        MISSING_UNDEFINED);
+  }
+
+  private static void putHeap(JSONObject json, JSONObject missing) {
+    MemoryUsage heap = readHeapUsage();
+    putMemoryMiB(json, missing, "heapUsedMiB", heap, MemoryUsage::getUsed);
+    putMemoryMiB(json, missing, "heapCommittedMiB", heap, MemoryUsage::getCommitted);
+    putMemoryMiB(json, missing, "heapMaxMiB", heap, MemoryUsage::getMax);
+  }
+
+  private static void putNonHeap(JSONObject json, JSONObject missing) {
+    MemoryUsage nonHeap = readNonHeapUsage();
+    putMemoryMiB(json, missing, "nonHeapUsedMiB", nonHeap, MemoryUsage::getUsed);
+  }
+
+  private static void putWorkDirUsable(
+      JSONObject json, JSONObject missing, Path workDirectory, DiskSpaceProbe disk) {
+    putNonNegative(
+        json,
+        missing,
+        "workDirUsableGiB",
+        () -> {
+          if (disk == null) {
+            throw new IllegalStateException("disk-probe-missing");
+          }
+          long bytes = disk.usableBytes(workDirectory);
+          if (bytes < 0L) {
+            return bytes;
+          }
+          return bytes / GIB;
+        },
+        MISSING_UNDEFINED);
+  }
+
+  private static void putUptime(JSONObject json, JSONObject missing) {
+    putNonNegative(
+        json,
+        missing,
+        "uptimeSeconds",
+        () -> TimeUnit.MILLISECONDS.toSeconds(ManagementFactory.getRuntimeMXBean().getUptime()),
+        MISSING_UNDEFINED);
+  }
+
+  private static void putGcNames(JSONObject json, JSONObject missing, ExportSanitizer sanitizer) {
+    try {
+      List<GarbageCollectorMXBean> collectors = ManagementFactory.getGarbageCollectorMXBeans();
+      JSONArray names = new JSONArray();
+      if (collectors != null) {
+        for (GarbageCollectorMXBean collector : collectors) {
+          if (names.length() >= MAX_GC_NAMES) {
+            break;
+          }
+          if (collector == null) {
+            continue;
+          }
+          try {
+            String name = boundedToken(collector.getName(), sanitizer);
+            if (name != null && !name.isEmpty()) {
+              names.put(name);
+            }
+          } catch (RuntimeException ignoredCollector) {
+            // One collector name must not drop the remaining names.
+          }
+        }
+      }
+      if (names.length() == 0) {
+        json.put("gcNames", JSONObject.NULL);
+        missing.put("gcNames", MISSING_UNREADABLE);
+        return;
+      }
+      json.put("gcNames", names);
+    } catch (RuntimeException ignored) {
+      json.put("gcNames", JSONObject.NULL);
+      missing.put("gcNames", MISSING_UNREADABLE);
+    }
+  }
+
+  private static void putSystemLoad(JSONObject json, JSONObject missing) {
+    try {
+      OperatingSystemMXBean os = ManagementFactory.getOperatingSystemMXBean();
+      double load = os.getSystemLoadAverage();
+      if (load < 0D) {
+        json.put("systemLoadAverage", JSONObject.NULL);
+        missing.put("systemLoadAverage", MISSING_UNAVAILABLE);
+        return;
+      }
+      json.put("systemLoadAverage", load);
+    } catch (RuntimeException ignored) {
+      json.put("systemLoadAverage", JSONObject.NULL);
+      missing.put("systemLoadAverage", MISSING_UNREADABLE);
+    }
+  }
+
+  private static void putToken(
+      JSONObject json,
+      JSONObject missing,
+      String field,
+      ExportSanitizer sanitizer,
+      TokenReader reader) {
+    try {
+      String value = boundedToken(reader.read(), sanitizer);
+      if (value == null || value.isEmpty()) {
+        json.put(field, JSONObject.NULL);
+        missing.put(field, MISSING_UNAVAILABLE);
+        return;
+      }
+      json.put(field, value);
+    } catch (Exception ignored) {
+      json.put(field, JSONObject.NULL);
+      missing.put(field, MISSING_UNREADABLE);
+    }
+  }
+
+  private static void putMemoryMiB(
+      JSONObject json,
+      JSONObject missing,
+      String field,
+      MemoryUsage usage,
+      MemoryQuantity quantity) {
+    if (usage == null) {
+      json.put(field, JSONObject.NULL);
+      missing.put(field, MISSING_UNREADABLE);
+      return;
+    }
+    try {
+      putByteQuantity(json, missing, field, quantity.read(usage), MIB);
+    } catch (RuntimeException ignored) {
+      json.put(field, JSONObject.NULL);
+      missing.put(field, MISSING_UNREADABLE);
+    }
+  }
+
+  private static void putNonNegative(
+      JSONObject json, JSONObject missing, String field, LongMetric metric, String negativeReason) {
+    try {
+      long value = metric.read();
+      if (value < 0L) {
+        json.put(field, JSONObject.NULL);
+        missing.put(field, negativeReason);
+        return;
+      }
+      json.put(field, value);
+    } catch (Exception ignored) {
+      json.put(field, JSONObject.NULL);
+      missing.put(field, MISSING_UNREADABLE);
+    }
+  }
+
+  private static MemoryUsage readHeapUsage() {
+    try {
+      return ManagementFactory.getMemoryMXBean().getHeapMemoryUsage();
+    } catch (RuntimeException ignored) {
+      return null;
+    }
+  }
+
+  private static MemoryUsage readNonHeapUsage() {
+    try {
+      return ManagementFactory.getMemoryMXBean().getNonHeapMemoryUsage();
+    } catch (RuntimeException ignored) {
+      return null;
+    }
+  }
+
+  private static long usableBytes(Path workDirectory) throws Exception {
+    if (workDirectory == null) {
+      throw new IllegalStateException("work-directory-missing");
+    }
+    return Files.getFileStore(workDirectory).getUsableSpace();
+  }
+
+  private static String boundedToken(String value, ExportSanitizer sanitizer) {
+    if (value == null) {
+      return null;
+    }
+    String trimmed = value.trim();
+    if (trimmed.isEmpty()) {
+      return null;
+    }
+    String bounded = ObservationText.boundedUtf8(trimmed, MAX_TOKEN_UTF8_BYTES, 1);
+    String sanitized = sanitizer.sanitizeText(bounded);
+    if (sanitized == null) {
+      return null;
+    }
+    String safe = sanitized.trim();
+    return safe.isEmpty() ? null : safe;
+  }
+
+  @FunctionalInterface
+  private interface LongMetric {
+    long read() throws Exception;
+  }
+
+  @FunctionalInterface
+  private interface TokenReader {
+    String read() throws Exception;
+  }
+
+  @FunctionalInterface
+  private interface MemoryQuantity {
+    long read(MemoryUsage usage);
+  }
+}

--- a/src/test/java/featurecat/lizzie/logging/DiagnosticBundleExporterTest.java
+++ b/src/test/java/featurecat/lizzie/logging/DiagnosticBundleExporterTest.java
@@ -131,6 +131,7 @@ class DiagnosticBundleExporterTest {
     assertTrue(names.contains("snapshots/summary.txt"));
     assertTrue(names.contains("snapshots/sync-context.json"));
     assertTrue(names.contains("snapshots/versions.json"));
+    assertTrue(names.contains("snapshots/runtime.json"));
     assertTrue(names.contains("snapshots/threads.txt"));
     assertFalse(names.contains("app.log"));
     assertFalse(names.contains("crash.log"));
@@ -173,6 +174,13 @@ class DiagnosticBundleExporterTest {
     assertFalse(engine.has("command"));
     JSONObject versions = new JSONObject(text(entries, "snapshots/versions.json"));
     assertEquals("next-dev", versions.getString("host"));
+    JSONObject runtimeSnapshot = new JSONObject(text(entries, "snapshots/runtime.json"));
+    assertRuntimeSnapshotShape(runtimeSnapshot);
+    assertRuntimeSnapshotMemoryNonNegative(runtimeSnapshot);
+    assertWorkDirUsablePresentOrMissing(runtimeSnapshot);
+    assertFalse(
+        text(entries, "snapshots/runtime.json").contains(tempDir.toAbsolutePath().toString()),
+        text(entries, "snapshots/runtime.json"));
     String threads = text(entries, "snapshots/threads.txt");
     assertTrue(threads.contains("name="), threads);
     assertTrue(threads.contains("state="), threads);
@@ -241,11 +249,86 @@ class DiagnosticBundleExporterTest {
     Map<String, byte[]> entries = unzipEntries(zip);
     assertTrue(entries.containsKey("snapshots/config.json"));
     assertTrue(entries.containsKey("snapshots/versions.json"));
+    assertTrue(entries.containsKey("snapshots/runtime.json"));
     assertTrue(entries.containsKey("snapshots/threads.txt"));
     assertTrue(text(entries, "snapshots/threads.txt").contains("thread snapshot failed"));
     JSONObject threads = source(manifest(entries), "threads");
     assertSource(threads, true, false, "failed", "snapshots/");
     assertEquals("unreadable", threads.getString("reason"));
+  }
+
+  @Test
+  void exportWritesParseableRuntimeSnapshot() throws Exception {
+    LoggingRuntime runtime = start();
+    Map<String, byte[]> entries = unzipEntries(exportDefault(runtime));
+    assertTrue(entries.containsKey("snapshots/config.json"));
+    assertTrue(entries.containsKey("snapshots/environment.txt"));
+    assertTrue(entries.containsKey("snapshots/summary.txt"));
+    assertTrue(entries.containsKey("snapshots/sync-context.json"));
+    assertTrue(entries.containsKey("snapshots/versions.json"));
+    assertTrue(entries.containsKey("snapshots/threads.txt"));
+    assertTrue(entries.containsKey("snapshots/runtime.json"));
+    JSONObject runtimeSnapshot = new JSONObject(text(entries, "snapshots/runtime.json"));
+    assertRuntimeSnapshotShape(runtimeSnapshot);
+    assertRuntimeSnapshotMemoryNonNegative(runtimeSnapshot);
+    assertWorkDirUsablePresentOrMissing(runtimeSnapshot);
+    assertFalse(
+        text(entries, "snapshots/runtime.json").contains(tempDir.toAbsolutePath().toString()));
+  }
+
+  @Test
+  void runtimeSnapshotDiskFailureDoesNotFailThePackage() throws Exception {
+    LoggingRuntime runtime = start();
+    DiagnosticBundleExporter exporter =
+        new DiagnosticBundleExporter(DiagnosticBundleExporter.defaultOutputDirectory(tempDir));
+    exporter.setRuntimeSnapshotSourceForTests(
+        (workDirectory, sanitizer) ->
+            RuntimeSnapshot.capture(
+                workDirectory,
+                sanitizer,
+                ignored -> {
+                  throw new IOException("store-unreadable");
+                }));
+    Path zip = exporter.export(request(runtime, EnumSet.noneOf(TraceScope.class)));
+    assertTrue(Files.isRegularFile(zip));
+    Map<String, byte[]> entries = unzipEntries(zip);
+    assertTrue(entries.containsKey("snapshots/config.json"));
+    assertTrue(entries.containsKey("snapshots/environment.txt"));
+    assertTrue(entries.containsKey("snapshots/summary.txt"));
+    assertTrue(entries.containsKey("snapshots/sync-context.json"));
+    assertTrue(entries.containsKey("snapshots/versions.json"));
+    assertTrue(entries.containsKey("snapshots/threads.txt"));
+    assertTrue(entries.containsKey("snapshots/runtime.json"));
+    JSONObject runtimeSnapshot = new JSONObject(text(entries, "snapshots/runtime.json"));
+    assertRuntimeSnapshotShape(runtimeSnapshot);
+    assertTrue(runtimeSnapshot.isNull("workDirUsableGiB"), runtimeSnapshot.toString());
+    assertEquals(
+        RuntimeSnapshot.MISSING_UNREADABLE,
+        runtimeSnapshot.getJSONObject("missing").getString("workDirUsableGiB"));
+    assertRuntimeSnapshotMemoryNonNegative(runtimeSnapshot);
+    assertTrue(runtimeSnapshot.getLong("heapUsedMiB") >= 0L, runtimeSnapshot.toString());
+  }
+
+  @Test
+  void runtimeSnapshotCaptureFailureDoesNotFailThePackage() throws Exception {
+    LoggingRuntime runtime = start();
+    DiagnosticBundleExporter exporter =
+        new DiagnosticBundleExporter(DiagnosticBundleExporter.defaultOutputDirectory(tempDir));
+    exporter.setRuntimeSnapshotSourceForTests(
+        (workDirectory, sanitizer) -> {
+          throw new IllegalStateException("runtime boom");
+        });
+    Path zip = exporter.export(request(runtime, EnumSet.noneOf(TraceScope.class)));
+    assertTrue(Files.isRegularFile(zip));
+    Map<String, byte[]> entries = unzipEntries(zip);
+    assertTrue(entries.containsKey("snapshots/config.json"));
+    assertTrue(entries.containsKey("snapshots/versions.json"));
+    assertTrue(entries.containsKey("snapshots/runtime.json"));
+    JSONObject runtimeSnapshot = new JSONObject(text(entries, "snapshots/runtime.json"));
+    assertRuntimeSnapshotShape(runtimeSnapshot);
+    for (String field : RuntimeSnapshot.REQUIRED_FIELDS) {
+      assertTrue(runtimeSnapshot.isNull(field), field);
+    }
   }
 
   @Test
@@ -2321,6 +2404,37 @@ class DiagnosticBundleExporterTest {
 
   private static JSONObject source(JSONObject manifest, String name) {
     return manifest.getJSONObject("sources").getJSONObject(name);
+  }
+
+  private static void assertRuntimeSnapshotShape(JSONObject runtime) {
+    for (String field : RuntimeSnapshot.REQUIRED_FIELDS) {
+      assertTrue(runtime.has(field), field + " missing from " + runtime);
+    }
+  }
+
+  private static void assertRuntimeSnapshotMemoryNonNegative(JSONObject runtime) {
+    assertNonNegativeIfPresent(runtime, "heapUsedMiB");
+    assertNonNegativeIfPresent(runtime, "heapCommittedMiB");
+    assertNonNegativeIfPresent(runtime, "heapMaxMiB");
+    assertNonNegativeIfPresent(runtime, "nonHeapUsedMiB");
+  }
+
+  private static void assertWorkDirUsablePresentOrMissing(JSONObject runtime) {
+    assertTrue(runtime.has("workDirUsableGiB"), runtime.toString());
+    if (runtime.isNull("workDirUsableGiB")) {
+      assertEquals(
+          RuntimeSnapshot.MISSING_UNREADABLE,
+          runtime.getJSONObject("missing").getString("workDirUsableGiB"));
+    } else {
+      assertTrue(runtime.getLong("workDirUsableGiB") >= 0L, runtime.toString());
+    }
+  }
+
+  private static void assertNonNegativeIfPresent(JSONObject json, String field) {
+    assertTrue(json.has(field), field);
+    if (!json.isNull(field)) {
+      assertTrue(json.getLong(field) >= 0L, field + "=" + json.get(field));
+    }
   }
 
   private static void assertSource(

--- a/src/test/java/featurecat/lizzie/logging/LoggingRuntimeTest.java
+++ b/src/test/java/featurecat/lizzie/logging/LoggingRuntimeTest.java
@@ -43,6 +43,8 @@ class LoggingRuntimeTest {
     LoggingRuntime runtime = start();
 
     runtime.awaitIdle();
+    assertEquals(tempDir, runtime.workDirectory());
+    assertEquals(tempDir.resolve("logs"), runtime.logsDirectory());
     String appLog = read("logs/app.log");
     assertTrue(appLog.contains("application log session started"));
     assertTrue(appLog.contains(runtime.applicationLogSessionId()));

--- a/src/test/java/featurecat/lizzie/logging/RuntimeSnapshotTest.java
+++ b/src/test/java/featurecat/lizzie/logging/RuntimeSnapshotTest.java
@@ -1,0 +1,105 @@
+package featurecat.lizzie.logging;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.UUID;
+import org.json.JSONObject;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class RuntimeSnapshotTest {
+  @TempDir Path tempDir;
+
+  @Test
+  void captureIncludesRequiredFieldsWithNonNegativeMemory() throws Exception {
+    Files.createDirectories(tempDir);
+    JSONObject json = new JSONObject(RuntimeSnapshot.capture(tempDir, new ExportSanitizer()));
+
+    for (String field : RuntimeSnapshot.REQUIRED_FIELDS) {
+      assertTrue(json.has(field), field + " missing from " + json);
+    }
+    assertNonNegativeIfPresent(json, "processors");
+    assertNonNegativeIfPresent(json, "heapUsedMiB");
+    assertNonNegativeIfPresent(json, "heapCommittedMiB");
+    assertNonNegativeIfPresent(json, "heapMaxMiB");
+    assertNonNegativeIfPresent(json, "nonHeapUsedMiB");
+    assertNonNegativeIfPresent(json, "uptimeSeconds");
+    if (json.isNull("workDirUsableGiB")) {
+      assertEquals(
+          RuntimeSnapshot.MISSING_UNREADABLE,
+          json.getJSONObject("missing").getString("workDirUsableGiB"));
+    } else {
+      assertTrue(json.getLong("workDirUsableGiB") >= 0L, json.toString());
+    }
+    assertFalse(json.toString().contains(tempDir.toAbsolutePath().toString()), json.toString());
+  }
+
+  @Test
+  void diskInfoFailureIsExplicitMissingAndKeepsMemoryFields() {
+    JSONObject json =
+        new JSONObject(
+            RuntimeSnapshot.capture(
+                tempDir,
+                new ExportSanitizer(),
+                ignored -> {
+                  throw new IOException("store-unreadable");
+                }));
+
+    assertTrue(json.has("workDirUsableGiB"), json.toString());
+    assertTrue(json.isNull("workDirUsableGiB"), json.toString());
+    assertEquals(
+        RuntimeSnapshot.MISSING_UNREADABLE,
+        json.getJSONObject("missing").getString("workDirUsableGiB"));
+    assertTrue(json.getLong("heapUsedMiB") >= 0L, json.toString());
+    assertTrue(json.getLong("heapCommittedMiB") >= 0L, json.toString());
+    assertTrue(json.getLong("nonHeapUsedMiB") >= 0L, json.toString());
+    assertTrue(json.getLong("processors") >= 1L, json.toString());
+    assertFalse(json.toString().contains(tempDir.toAbsolutePath().toString()), json.toString());
+  }
+
+  @Test
+  void missingWorkDirectoryDoesNotWriteThePath() {
+    Path missing = Path.of("/this/runtime-snapshot-path-must-not-exist/" + UUID.randomUUID());
+    JSONObject json = new JSONObject(RuntimeSnapshot.capture(missing, new ExportSanitizer()));
+
+    assertTrue(json.has("workDirUsableGiB"), json.toString());
+    assertTrue(json.isNull("workDirUsableGiB"), json.toString());
+    assertTrue(json.getJSONObject("missing").has("workDirUsableGiB"), json.toString());
+    assertFalse(json.toString().contains(missing.toString()), json.toString());
+    assertTrue(json.getLong("heapUsedMiB") >= 0L, json.toString());
+  }
+
+  @Test
+  void undefinedByteQuantityIsExplicitMissingNotNegative() {
+    JSONObject json = new JSONObject();
+    JSONObject missing = new JSONObject();
+    RuntimeSnapshot.putByteQuantity(json, missing, "heapMaxMiB", -1L, 1024L * 1024L);
+
+    assertTrue(json.has("heapMaxMiB"));
+    assertTrue(json.isNull("heapMaxMiB"));
+    assertEquals(RuntimeSnapshot.MISSING_UNDEFINED, missing.getString("heapMaxMiB"));
+  }
+
+  @Test
+  void wholeCaptureFailureStillYieldsParseableMissingDocument() {
+    JSONObject json = new JSONObject(RuntimeSnapshot.unavailableJson());
+    for (String field : RuntimeSnapshot.REQUIRED_FIELDS) {
+      assertTrue(json.has(field), field);
+      assertTrue(json.isNull(field), field);
+      assertEquals(
+          RuntimeSnapshot.MISSING_UNREADABLE, json.getJSONObject("missing").getString(field));
+    }
+  }
+
+  private static void assertNonNegativeIfPresent(JSONObject json, String field) {
+    assertTrue(json.has(field), field);
+    if (!json.isNull(field)) {
+      assertTrue(json.getLong(field) >= 0L, field + "=" + json.get(field));
+    }
+  }
+}


### PR DESCRIPTION
## Repro
Export a diagnostic ZIP. The pack has `snapshots/` (config, versions, readboard, sync, threads) but no `snapshots/runtime.json`, so JVM heap and work-dir disk space are not in the pack.

## Cause
`DiagnosticBundleExporter.writeSnapshots` did not collect a one-shot runtime resource snapshot. `LoggingRuntime` held `workDirectory` but only exposed `logsDirectory()`.

## Fix
- Write `snapshots/runtime.json` via existing `writeTextEntry` / `NS_SNAPSHOTS`.
- Fields: processors, heapUsedMiB, heapCommittedMiB, heapMaxMiB, nonHeapUsedMiB, workDirUsableGiB, uptimeSeconds. Optional extras (gcNames, jvmVendor, jvmVersion, systemLoadAverage) when cheap.
- Work dir from `LoggingRuntime.workDirectory()` (or logs parent). Absolute path is not written.
- One metric failure is explicit missing/`null`, not a pack abort. Snapshot only; no sampler.
- Standard JDK only. No ConfigDialog2 change. No new user-facing flags.

## Verification
`mvn -B -Dfmt.skip=true -Djava.awt.headless=true -Dtest=RuntimeSnapshotTest,DiagnosticBundleExporterTest,LoggingRuntimeTest surefire:test` — 81 tests, 0 failures. Linux CI pass; Windows still pending at post time. No desktop shots.

Fixes #374
