### PR TITLE
feat(diagnostics): keep bounded GTP probe stderr (#375)

### DIFF
--- a/src/main/java/featurecat/lizzie/analysis/gtpconfig/GtpConfigurationProbe.java
+++ b/src/main/java/featurecat/lizzie/analysis/gtpconfig/GtpConfigurationProbe.java
@@ -461,6 +461,11 @@ public final class GtpConfigurationProbe {
         }
         payload.append(line);
       }
+      try {
+        process.waitFor(200, TimeUnit.MILLISECONDS);
+      } catch (InterruptedException error) {
+        Thread.currentThread().interrupt();
+      }
       if (!process.isAlive()) {
         throw new IOException("Engine exited before configuration completed");
       }

--- a/src/main/java/featurecat/lizzie/analysis/gtpconfig/GtpConfigurationProbe.java
+++ b/src/main/java/featurecat/lizzie/analysis/gtpconfig/GtpConfigurationProbe.java
@@ -1,6 +1,8 @@
 package featurecat.lizzie.analysis.gtpconfig;
 
 import featurecat.lizzie.analysis.AnalysisResourceCoordinator;
+import featurecat.lizzie.logging.EngineObservation;
+import featurecat.lizzie.logging.ObservationText;
 import featurecat.lizzie.util.CommandLaunchHelper;
 import featurecat.lizzie.util.KataGoRuntimeHelper;
 import featurecat.lizzie.util.Utils;
@@ -11,6 +13,7 @@ import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
+import java.util.ArrayDeque;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -19,6 +22,8 @@ import java.util.concurrent.Future;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
 import org.json.JSONObject;
 
 /** Detects and updates optional engine-owned configuration through an isolated GTP process. */
@@ -46,26 +51,34 @@ public final class GtpConfigurationProbe {
 
   Inspection inspect(String engineCommand, Duration timeout) throws IOException {
     try (Session session = sessionFactory.open(engineCommand, timeout)) {
-      Response capability = session.request("known_command " + ZENGTP_SCHEMA_COMMAND);
-      if (!capability.success() || !"true".equalsIgnoreCase(capability.payload().trim())) {
-        return Inspection.unsupported();
+      try {
+        Response capability = session.request("known_command " + ZENGTP_SCHEMA_COMMAND);
+        boolean supported =
+            capability.success() && "true".equalsIgnoreCase(capability.payload().trim());
+        noteCapabilityCheck(session, supported);
+        if (!supported) {
+          return Inspection.unsupported();
+        }
+        Response schemaResponse = session.request(ZENGTP_SCHEMA_COMMAND);
+        if (!schemaResponse.success()) {
+          noteProbeFailed(session, "schema");
+          throw protocolError(schemaResponse);
+        }
+        GtpConfigurationSchema schema =
+            GtpConfigurationSchema.parse(new JSONObject(schemaResponse.payload()));
+        if (!ZENGTP_PROTOCOL.equals(schema.protocol()) || schema.version() != 1) {
+          noteProbeFailed(session, "schema");
+          throw new IOException(
+              "Unsupported GTP configuration protocol: "
+                  + schema.protocol()
+                  + " v"
+                  + schema.version());
+        }
+        return Inspection.supported(schema);
+      } catch (IllegalArgumentException error) {
+        noteProbeFailed(session, "schema");
+        throw new IOException("Invalid GTP configuration schema: " + error.getMessage(), error);
       }
-      Response schemaResponse = session.request(ZENGTP_SCHEMA_COMMAND);
-      if (!schemaResponse.success()) {
-        throw protocolError(schemaResponse);
-      }
-      GtpConfigurationSchema schema =
-          GtpConfigurationSchema.parse(new JSONObject(schemaResponse.payload()));
-      if (!ZENGTP_PROTOCOL.equals(schema.protocol()) || schema.version() != 1) {
-        throw new IOException(
-            "Unsupported GTP configuration protocol: "
-                + schema.protocol()
-                + " v"
-                + schema.version());
-      }
-      return Inspection.supported(schema);
-    } catch (IllegalArgumentException error) {
-      throw new IOException("Invalid GTP configuration schema: " + error.getMessage(), error);
     }
   }
 
@@ -79,48 +92,61 @@ public final class GtpConfigurationProbe {
       throw new IllegalArgumentException("profile must not be null");
     }
     try (Session session = sessionFactory.open(engineCommand, timeout)) {
-      Response capability = session.request("known_command " + ZENGTP_SCHEMA_COMMAND);
-      if (!capability.success() || !"true".equalsIgnoreCase(capability.payload().trim())) {
-        throw new IOException("The selected engine does not support visual configuration");
-      }
-      Response schemaResponse = session.request(ZENGTP_SCHEMA_COMMAND);
-      if (!schemaResponse.success()) {
-        throw protocolError(schemaResponse);
-      }
-      GtpConfigurationSchema schema =
-          GtpConfigurationSchema.parse(new JSONObject(schemaResponse.payload()));
-      if (!ZENGTP_PROTOCOL.equals(schema.protocol()) || schema.version() != 1) {
-        throw new IOException(
-            "Unsupported GTP configuration protocol: "
-                + schema.protocol()
-                + " v"
-                + schema.version());
-      }
-      for (String key : profile.keySet()) {
-        GtpConfigurationSchema.Field field = schema.field(key);
-        if (field == null || !field.accepts(profile.opt(key))) {
-          throw new IOException("Invalid engine configuration value: " + key);
+      try {
+        Response capability = session.request("known_command " + ZENGTP_SCHEMA_COMMAND);
+        boolean supported =
+            capability.success() && "true".equalsIgnoreCase(capability.payload().trim());
+        noteCapabilityCheck(session, supported);
+        if (!supported) {
+          noteProbeFailed(session, "capability");
+          throw new IOException("The selected engine does not support visual configuration");
         }
+        Response schemaResponse = session.request(ZENGTP_SCHEMA_COMMAND);
+        if (!schemaResponse.success()) {
+          noteProbeFailed(session, "schema");
+          throw protocolError(schemaResponse);
+        }
+        GtpConfigurationSchema schema =
+            GtpConfigurationSchema.parse(new JSONObject(schemaResponse.payload()));
+        if (!ZENGTP_PROTOCOL.equals(schema.protocol()) || schema.version() != 1) {
+          noteProbeFailed(session, "schema");
+          throw new IOException(
+              "Unsupported GTP configuration protocol: "
+                  + schema.protocol()
+                  + " v"
+                  + schema.version());
+        }
+        for (String key : profile.keySet()) {
+          GtpConfigurationSchema.Field field = schema.field(key);
+          if (field == null || !field.accepts(profile.opt(key))) {
+            noteProbeFailed(session, "schema");
+            throw new IOException("Invalid engine configuration value: " + key);
+          }
+        }
+        Response setResponse = session.request(ZENGTP_SET_COMMAND + " " + profile.toString());
+        if (!setResponse.success()) {
+          noteProbeFailed(session, "apply");
+          throw protocolError(setResponse);
+        }
+        Response saveResponse = session.request(ZENGTP_SAVE_COMMAND);
+        if (!saveResponse.success()) {
+          noteProbeFailed(session, "apply");
+          throw protocolError(saveResponse);
+        }
+        JSONObject payload = new JSONObject(saveResponse.payload());
+        JSONObject savedProfile = payload.optJSONObject("profile");
+        JSONObject state = payload.optJSONObject("state");
+        if (savedProfile == null) {
+          noteProbeFailed(session, "apply");
+          throw new IOException("Engine did not return a saved configuration profile");
+        }
+        return new ApplyResult(
+            new JSONObject(savedProfile.toString()),
+            state == null ? new JSONObject() : new JSONObject(state.toString()));
+      } catch (IllegalArgumentException error) {
+        noteProbeFailed(session, "schema");
+        throw new IOException("Invalid engine configuration response: " + error.getMessage(), error);
       }
-      Response setResponse = session.request(ZENGTP_SET_COMMAND + " " + profile.toString());
-      if (!setResponse.success()) {
-        throw protocolError(setResponse);
-      }
-      Response saveResponse = session.request(ZENGTP_SAVE_COMMAND);
-      if (!saveResponse.success()) {
-        throw protocolError(saveResponse);
-      }
-      JSONObject payload = new JSONObject(saveResponse.payload());
-      JSONObject savedProfile = payload.optJSONObject("profile");
-      JSONObject state = payload.optJSONObject("state");
-      if (savedProfile == null) {
-        throw new IOException("Engine did not return a saved configuration profile");
-      }
-      return new ApplyResult(
-          new JSONObject(savedProfile.toString()),
-          state == null ? new JSONObject() : new JSONObject(state.toString()));
-    } catch (IllegalArgumentException error) {
-      throw new IOException("Invalid engine configuration response: " + error.getMessage(), error);
     }
   }
 
@@ -139,6 +165,98 @@ public final class GtpConfigurationProbe {
       // Fall through to the raw GTP payload when the engine did not return structured JSON.
     }
     return new IOException("Engine rejected the configuration: " + response.payload());
+  }
+
+  private static void noteCapabilityCheck(Session session, boolean success) {
+    try {
+      if (session instanceof ProcessSession processSession) {
+        processSession.recordCapabilityCheck(success);
+      }
+    } catch (RuntimeException ignored) {
+    }
+  }
+
+  private static void noteProbeFailed(Session session, String stage) {
+    try {
+      if (session instanceof ProcessSession processSession) {
+        processSession.noteProbeFailed(stage);
+      }
+    } catch (RuntimeException ignored) {
+    }
+  }
+
+  static void drainProbeStderr(
+      BufferedReader stderr, ProbeStderrTail tail, Supplier<String> engineId) {
+    if (stderr == null) {
+      return;
+    }
+    try {
+      String line;
+      while ((line = stderr.readLine()) != null) {
+        try {
+          if (tail != null) {
+            tail.add(line);
+          }
+        } catch (RuntimeException ignored) {
+        }
+      }
+    } catch (IOException ignored) {
+    } catch (RuntimeException error) {
+      try {
+        String id = engineId == null ? null : engineId.get();
+        EngineObservation.recordTransportFailure(id, "stderr", "reader-error", error);
+      } catch (RuntimeException ignored) {
+      }
+    }
+  }
+
+  static final class ProbeStderrTail {
+    static final int MAX_LINES = 40;
+    private final ArrayDeque<String> lines = new ArrayDeque<>();
+    private int utf8Bytes;
+
+    synchronized void add(String line) {
+      if (line == null || line.isEmpty()) {
+        return;
+      }
+      String bounded =
+          ObservationText.boundedUtf8(line, ObservationText.RAW_EVENT_MAX_UTF8_BYTES, 1);
+      int bytes = utf8ByteLength(bounded);
+      while (!lines.isEmpty()
+          && (lines.size() >= MAX_LINES
+              || utf8Bytes + bytes > ObservationText.RAW_EVENT_MAX_UTF8_BYTES)) {
+        String removed = lines.removeFirst();
+        utf8Bytes = Math.max(0, utf8Bytes - utf8ByteLength(removed));
+      }
+      lines.addLast(bounded);
+      utf8Bytes += bytes;
+    }
+
+    synchronized String snapshot() {
+      StringBuilder builder = new StringBuilder();
+      for (String line : lines) {
+        if (line == null || line.isEmpty()) {
+          continue;
+        }
+        if (builder.length() > 0) {
+          builder.append('\n');
+        }
+        builder.append(line);
+      }
+      return builder.toString();
+    }
+
+    synchronized int lineCount() {
+      return lines.size();
+    }
+
+    synchronized int utf8ByteCount() {
+      return utf8Bytes;
+    }
+
+    private static int utf8ByteLength(String value) {
+      return value.getBytes(StandardCharsets.UTF_8).length;
+    }
   }
 
   interface SessionFactory {
@@ -220,6 +338,9 @@ public final class GtpConfigurationProbe {
     private final BufferedWriter writer;
     private final Duration timeout;
     private final ExecutorService readerExecutor;
+    private final ProbeStderrTail stderrTail = new ProbeStderrTail();
+    private final AtomicReference<String> pendingFailureStage = new AtomicReference<>();
+    private final Thread stderrDrainer;
     private int nextCommandId = 1;
 
     private ProcessSession(Process process, Duration timeout) {
@@ -233,17 +354,15 @@ public final class GtpConfigurationProbe {
               new OutputStreamWriter(process.getOutputStream(), StandardCharsets.UTF_8));
       this.readerExecutor =
           Executors.newSingleThreadExecutor(daemonThreadFactory("gtp-configuration-probe-reader"));
-      Thread stderrDrainer =
+      this.stderrDrainer =
           new Thread(
               () -> {
                 try (BufferedReader stderr =
                     new BufferedReader(
                         new InputStreamReader(process.getErrorStream(), StandardCharsets.UTF_8))) {
-                  while (stderr.readLine() != null) {
-                    // Keep stderr drained so an engine cannot block on a full error pipe.
-                  }
-                } catch (IOException ignored) {
-                  // Closing the process normally closes this stream.
+                  drainProbeStderr(
+                      stderr, stderrTail, () -> EngineObservation.identityFor(this));
+                } catch (IOException | RuntimeException ignored) {
                 }
               },
               "gtp-configuration-probe-stderr");
@@ -271,31 +390,44 @@ public final class GtpConfigurationProbe {
       ProcessSession session = new ProcessSession(builder.start(), timeout);
       AnalysisResourceCoordinator.processStarted(
           session, AnalysisResourceCoordinator.Purpose.OTHER, engineCommand, session.process);
+      session.recordStartedQuietly();
       return session;
     }
 
     @Override
     public synchronized Response request(String command) throws IOException {
       if (!process.isAlive()) {
+        noteProbeFailed("exited");
         throw new IOException("Engine exited before configuration completed");
       }
       int commandId = nextCommandId++;
-      writer.write(commandId + " " + command);
-      writer.newLine();
-      writer.flush();
+      try {
+        writer.write(commandId + " " + command);
+        writer.newLine();
+        writer.flush();
+      } catch (IOException error) {
+        noteProbeFailed(process.isAlive() ? "handshake" : "exited");
+        if (!process.isAlive()) {
+          throw new IOException("Engine exited before configuration completed", error);
+        }
+        throw error;
+      }
       Future<Response> future =
           readerExecutor.submit((Callable<Response>) () -> readResponse(commandId));
       try {
         return future.get(Math.max(1, timeout.toMillis()), TimeUnit.MILLISECONDS);
       } catch (TimeoutException error) {
         future.cancel(true);
+        noteProbeFailed("timeout");
         throw new IOException("Timed out waiting for the engine configuration response", error);
       } catch (InterruptedException error) {
         Thread.currentThread().interrupt();
+        noteProbeFailed("interrupted");
         throw new IOException(
             "Interrupted while waiting for the engine configuration response", error);
       } catch (ExecutionException error) {
         Throwable cause = error.getCause();
+        noteProbeFailed(process.isAlive() ? "handshake" : "exited");
         if (cause instanceof IOException) {
           throw (IOException) cause;
         }
@@ -329,7 +461,45 @@ public final class GtpConfigurationProbe {
         }
         payload.append(line);
       }
+      if (!process.isAlive()) {
+        throw new IOException("Engine exited before configuration completed");
+      }
       throw new IOException("Engine closed its output before completing the GTP response");
+    }
+
+    private void recordStartedQuietly() {
+      try {
+        EngineObservation.recordProbeStarted(EngineObservation.identityFor(this));
+      } catch (RuntimeException ignored) {
+      }
+    }
+
+    private void recordCapabilityCheck(boolean success) {
+      try {
+        EngineObservation.recordProbeCapabilityCheck(
+            EngineObservation.identityFor(this), success);
+      } catch (RuntimeException ignored) {
+      }
+    }
+
+    private void noteProbeFailed(String stage) {
+      pendingFailureStage.compareAndSet(null, stage);
+    }
+
+    private void emitPendingFailureDiagnostics() {
+      try {
+        String stage = pendingFailureStage.get();
+        if (stage == null) {
+          return;
+        }
+        String id = EngineObservation.identityFor(this);
+        EngineObservation.recordProbeFailed(id, stage);
+        String facts = stderrTail.snapshot();
+        if (!facts.isEmpty()) {
+          EngineObservation.recordProbeStderr(id, facts);
+        }
+      } catch (RuntimeException ignored) {
+      }
     }
 
     @Override
@@ -354,8 +524,17 @@ public final class GtpConfigurationProbe {
         process.destroyForcibly();
       }
       readerExecutor.shutdownNow();
-      AnalysisResourceCoordinator.processStopped(
-          this, AnalysisResourceCoordinator.Purpose.OTHER, process);
+      try {
+        stderrDrainer.join(200);
+      } catch (InterruptedException error) {
+        Thread.currentThread().interrupt();
+      }
+      try {
+        emitPendingFailureDiagnostics();
+      } finally {
+        AnalysisResourceCoordinator.processStopped(
+            this, AnalysisResourceCoordinator.Purpose.OTHER, process);
+      }
     }
   }
 

--- a/src/main/java/featurecat/lizzie/logging/EngineObservation.java
+++ b/src/main/java/featurecat/lizzie/logging/EngineObservation.java
@@ -245,6 +245,69 @@ public final class EngineObservation {
     inContext(engineId, null, () -> ENGINE.debug("engine event=stderr facts={}", facts));
   }
 
+  public static void recordProbeStarted(String engineId) {
+    try {
+      if (!runtimeActive() || !ENGINE.isInfoEnabled()) {
+        return;
+      }
+      inContext(engineId, null, () -> ENGINE.info("probe event=started"));
+    } catch (RuntimeException ignored) {
+    }
+  }
+
+  public static void recordProbeCapabilityCheck(String engineId, boolean success) {
+    try {
+      if (!runtimeActive() || !ENGINE.isInfoEnabled()) {
+        return;
+      }
+      inContext(
+          engineId,
+          null,
+          () ->
+              ENGINE.info(
+                  "probe event=capability-check outcome={}", success ? "success" : "failure"));
+    } catch (RuntimeException ignored) {
+    }
+  }
+
+  public static void recordProbeFailed(String engineId, String stage) {
+    try {
+      if (!runtimeActive() || !ENGINE.isWarnEnabled()) {
+        return;
+      }
+      String safeStage = safeProbeStage(stage);
+      inContext(engineId, null, () -> ENGINE.warn("probe event=failed stage={}", safeStage));
+    } catch (RuntimeException ignored) {
+    }
+  }
+
+  public static void recordProbeStderr(String engineId, String facts) {
+    try {
+      if (!runtimeActive() || !ENGINE.isWarnEnabled() || facts == null || facts.isEmpty()) {
+        return;
+      }
+      String bounded = ObservationText.boundedRawEvent(facts);
+      inContext(engineId, null, () -> ENGINE.warn("probe event=stderr facts={}", bounded));
+    } catch (RuntimeException ignored) {
+    }
+  }
+
+  private static String safeProbeStage(String stage) {
+    return switch (stage == null ? "" : stage) {
+      case "start",
+          "capability",
+          "schema",
+          "handshake",
+          "timeout",
+          "exited",
+          "apply",
+          "interrupted",
+          "reader" ->
+          stage;
+      default -> "unknown";
+    };
+  }
+
   public static void recordThroughput(String engineId, int playouts, double playoutsPerSecond) {
     if (!engineDiagnosticsEnabled()) {
       return;

--- a/src/test/java/featurecat/lizzie/analysis/gtpconfig/GtpConfigurationProbeTest.java
+++ b/src/test/java/featurecat/lizzie/analysis/gtpconfig/GtpConfigurationProbeTest.java
@@ -5,12 +5,23 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
 import featurecat.lizzie.analysis.AnalysisResourceCoordinator;
 import featurecat.lizzie.analysis.AnalysisResourceCoordinatorTestAccess;
+import featurecat.lizzie.logging.LogCategories;
+import featurecat.lizzie.logging.LoggingLimits;
+import featurecat.lizzie.logging.LoggingRuntime;
+import featurecat.lizzie.logging.LoggingSettings;
+import featurecat.lizzie.logging.ObservationText;
+import featurecat.lizzie.logging.WorkDirectoryResolution;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.PrintWriter;
+import java.io.Reader;
+import java.lang.reflect.Method;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
@@ -37,13 +48,20 @@ import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import org.json.JSONObject;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.slf4j.LoggerFactory;
 
 class GtpConfigurationProbeTest {
   private static final long REAL_PROCESS_HANDSHAKE_TIMEOUT_SECONDS = 10L;
 
   @TempDir Path tempDir;
+
+  @AfterEach
+  void tearDownLogging() {
+    LoggingRuntime.resetForTests();
+  }
 
   @Test
   void reportsUnsupportedEngineWithoutRequestingSchema() throws Exception {
@@ -160,6 +178,149 @@ class GtpConfigurationProbeTest {
             IOException.class,
             () -> probe.inspect(fakeEngineCommand(true), Duration.ofMillis(200)));
     assertTrue(timeout.getMessage().contains("Timed out"));
+  }
+
+  @Test
+  void successfulRealProbeLeavesStructuredEventsWithoutChangingResult() throws Exception {
+    LoggingRuntime runtime = startProbeDiagnostics();
+    ListAppender<ILoggingEvent> events = attachEngine();
+    String command = fakeEngineCommand();
+    GtpConfigurationProbe probe = new GtpConfigurationProbe();
+
+    GtpConfigurationProbe.Inspection inspection = probe.inspect(command, Duration.ofSeconds(2));
+
+    assertTrue(inspection.supported());
+    assertEquals("zengtp-config", inspection.schema().protocol());
+    String logs = formatted(events);
+    assertTrue(logs.contains("probe event=started"), logs);
+    assertTrue(logs.contains("probe event=capability-check outcome=success"), logs);
+    assertFalse(logs.contains("probe event=failed"), logs);
+    assertFalse(logs.contains("probe event=stderr"), logs);
+    awaitLogs(runtime);
+  }
+
+  @Test
+  void stderrOnSuccessfulProbeDoesNotChangeInspectResult() throws Exception {
+    LoggingRuntime runtime = startProbeDiagnostics();
+    ListAppender<ILoggingEvent> events = attachEngine();
+    GtpConfigurationProbe.Inspection inspection =
+        new GtpConfigurationProbe().inspect(fakeEngineCommand("stderr"), Duration.ofSeconds(2));
+
+    assertTrue(inspection.supported());
+    String logs = formatted(events);
+    assertTrue(logs.contains("probe event=started"), logs);
+    assertTrue(logs.contains("probe event=capability-check outcome=success"), logs);
+    assertFalse(logs.contains("probe event=failed"), logs);
+    awaitLogs(runtime);
+  }
+
+  @Test
+  void hugeStderrStaysBoundedAndDoesNotBlockSuccessfulProbe() throws Exception {
+    GtpConfigurationProbe.ProbeStderrTail tail = new GtpConfigurationProbe.ProbeStderrTail();
+    for (int i = 0; i < 50_000; i++) {
+      tail.add("line-" + i + "-" + "x".repeat(80));
+    }
+    tail.add("y".repeat(1_000_000));
+    assertTrue(tail.lineCount() <= GtpConfigurationProbe.ProbeStderrTail.MAX_LINES);
+    assertTrue(tail.utf8ByteCount() <= ObservationText.RAW_EVENT_MAX_UTF8_BYTES);
+    assertTrue(
+        tail.snapshot().getBytes(StandardCharsets.UTF_8).length
+            <= ObservationText.RAW_EVENT_MAX_UTF8_BYTES + 64);
+
+    LoggingRuntime runtime = startProbeDiagnostics();
+    ListAppender<ILoggingEvent> events = attachEngine();
+    GtpConfigurationProbe.Inspection inspection =
+        new GtpConfigurationProbe()
+            .inspect(fakeEngineCommand("stderr-huge"), Duration.ofSeconds(5));
+
+    assertTrue(inspection.supported());
+    String logs = formatted(events);
+    assertTrue(logs.contains("probe event=capability-check outcome=success"), logs);
+    assertFalse(logs.contains("probe event=failed"), logs);
+    awaitLogs(runtime);
+  }
+
+  @Test
+  void earlyExitStillThrowsAndRecordsBoundedStderrSummary() throws Exception {
+    LoggingRuntime runtime = startProbeDiagnostics();
+    ListAppender<ILoggingEvent> events = attachEngine();
+
+    IOException exited =
+        assertThrows(
+            IOException.class,
+            () ->
+                new GtpConfigurationProbe()
+                    .inspect(fakeEngineCommand("stderr", "exit"), Duration.ofSeconds(2)));
+
+    assertTrue(
+        exited.getMessage().contains("Engine exited before configuration completed"),
+        exited.getMessage());
+    assertFalse(exited.getMessage().contains("probe-stderr"), exited.getMessage());
+    assertFalse(exited.getMessage().contains("probe-secret-token"), exited.getMessage());
+    String logs = formatted(events);
+    assertTrue(logs.contains("probe event=started"), logs);
+    assertTrue(logs.contains("probe event=failed stage=exited"), logs);
+    assertTrue(logs.contains("probe event=stderr facts="), logs);
+    assertTrue(logs.contains("probe-stderr"), logs);
+    awaitLogs(runtime);
+    String app = Files.readString(tempDir.resolve("logs/app.log"), StandardCharsets.UTF_8);
+    assertFalse(app.contains("probe-secret-token"), app);
+    assertTrue(app.contains("probe event=stderr"), app);
+  }
+
+  @Test
+  void probeTimeoutStillThrowsAndRecordsStderrSummary() throws Exception {
+    LoggingRuntime runtime = startProbeDiagnostics();
+    ListAppender<ILoggingEvent> events = attachEngine();
+
+    IOException timeout =
+        assertThrows(
+            IOException.class,
+            () ->
+                new GtpConfigurationProbe()
+                    .inspect(fakeEngineCommand("stderr", "hang"), Duration.ofMillis(200)));
+
+    assertTrue(
+        timeout.getMessage().contains("Timed out waiting for the engine configuration response"),
+        timeout.getMessage());
+    assertFalse(timeout.getMessage().contains("probe-stderr"), timeout.getMessage());
+    String logs = formatted(events);
+    assertTrue(logs.contains("probe event=started"), logs);
+    assertTrue(logs.contains("probe event=failed stage=timeout"), logs);
+    assertTrue(logs.contains("probe event=stderr facts="), logs);
+    assertTrue(logs.contains("probe-stderr"), logs);
+    awaitLogs(runtime);
+  }
+
+  @Test
+  void stderrReaderFailureDoesNotPropagateToCaller() throws Exception {
+    LoggingRuntime runtime = startProbeDiagnostics();
+    ListAppender<ILoggingEvent> events = attachEngine();
+    BufferedReader throwing =
+        new BufferedReader(
+            new Reader() {
+              @Override
+              public int read(char[] cbuf, int off, int len) {
+                throw new IllegalStateException("stderr exploded");
+              }
+
+              @Override
+              public void close() {}
+            });
+
+    GtpConfigurationProbe.drainProbeStderr(
+        throwing, new GtpConfigurationProbe.ProbeStderrTail(), () -> "eng-test");
+
+    GtpConfigurationProbe.Inspection inspection =
+        new GtpConfigurationProbe(new ScriptedFactory(response(true, "false")))
+            .inspect("fake-engine", Duration.ofSeconds(1));
+    assertFalse(inspection.supported());
+    String logs = formatted(events);
+    assertTrue(logs.contains("engine event=transport-failure"), logs);
+    assertTrue(logs.contains("stream=stderr"), logs);
+    assertTrue(logs.contains("reason=reader-error"), logs);
+    assertFalse(logs.contains("stderr exploded"), logs);
+    awaitLogs(runtime);
   }
 
   @Test
@@ -458,6 +619,10 @@ class GtpConfigurationProbeTest {
   }
 
   private static String fakeEngineCommand(boolean hangOnSchema) {
+    return hangOnSchema ? fakeEngineCommand("hang") : fakeEngineCommand();
+  }
+
+  private static String fakeEngineCommand(String... extras) {
     String executable =
         Path.of(
                 System.getProperty("java.home"),
@@ -466,12 +631,19 @@ class GtpConfigurationProbeTest {
             .toAbsolutePath()
             .toString();
     String classes = Path.of("target", "test-classes").toAbsolutePath().toString();
-    return quote(executable)
-        + " -cp "
-        + quote(classes)
-        + " "
-        + FakeGtpEngine.class.getName()
-        + (hangOnSchema ? " hang" : "");
+    StringBuilder command =
+        new StringBuilder()
+            .append(quote(executable))
+            .append(" -cp ")
+            .append(quote(classes))
+            .append(' ')
+            .append(FakeGtpEngine.class.getName());
+    for (String extra : extras) {
+      if (extra != null && !extra.isEmpty()) {
+        command.append(' ').append(extra);
+      }
+    }
+    return command.toString();
   }
 
   private static String fakeEngineCommand(Path schemaGate) {
@@ -484,6 +656,37 @@ class GtpConfigurationProbeTest {
 
   private static GtpConfigurationProbe.Response response(boolean success, String payload) {
     return new GtpConfigurationProbe.Response(success, payload);
+  }
+
+  private LoggingRuntime startProbeDiagnostics() {
+    LoggingRuntime runtime =
+        LoggingRuntime.initialize(
+            new WorkDirectoryResolution(tempDir, List.of()),
+            new LoggingLimits(64, 32, 32, 32, 7, 1_000_000, 256_000));
+    runtime.applySettings(LoggingSettings.defaults().withDiagnosticsEnabled(false));
+    return runtime;
+  }
+
+  private static ListAppender<ILoggingEvent> attachEngine() {
+    Logger engine = (Logger) LoggerFactory.getLogger(LogCategories.ENGINE);
+    ListAppender<ILoggingEvent> appender = new ListAppender<>();
+    appender.start();
+    engine.addAppender(appender);
+    return appender;
+  }
+
+  private static String formatted(ListAppender<ILoggingEvent> events) {
+    StringBuilder text = new StringBuilder();
+    for (ILoggingEvent event : events.list) {
+      text.append(event.getFormattedMessage()).append('\n');
+    }
+    return text.toString();
+  }
+
+  private static void awaitLogs(LoggingRuntime runtime) throws Exception {
+    Method awaitIdle = LoggingRuntime.class.getDeclaredMethod("awaitIdle");
+    awaitIdle.setAccessible(true);
+    awaitIdle.invoke(runtime);
   }
 
   private static final class ScriptedFactory implements GtpConfigurationProbe.SessionFactory {
@@ -539,8 +742,35 @@ class GtpConfigurationProbeTest {
     private FakeGtpEngine() {}
 
     public static void main(String[] args) throws Exception {
-      boolean hangOnSchema = args.length > 0 && "hang".equals(args[0]);
-      Path schemaGate = args.length > 1 && "gate".equals(args[0]) ? Path.of(args[1]) : null;
+      boolean hangOnSchema = false;
+      boolean exitBeforeHandshake = false;
+      Path schemaGate = null;
+      int stderrLines = 0;
+      for (int i = 0; i < args.length; i++) {
+        String arg = args[i];
+        if ("hang".equals(arg)) {
+          hangOnSchema = true;
+        } else if ("exit".equals(arg)) {
+          exitBeforeHandshake = true;
+        } else if ("stderr".equals(arg)) {
+          stderrLines = Math.max(stderrLines, 4);
+        } else if ("stderr-huge".equals(arg)) {
+          stderrLines = Math.max(stderrLines, 20_000);
+        } else if ("gate".equals(arg) && i + 1 < args.length) {
+          schemaGate = Path.of(args[++i]);
+        }
+      }
+      if (stderrLines > 0) {
+        PrintWriter err = new PrintWriter(System.err, true, StandardCharsets.UTF_8);
+        err.println("CUDA error: fake backend failed token=probe-secret-token");
+        for (int n = 0; n < stderrLines; n++) {
+          err.println("probe-stderr " + n);
+        }
+        err.flush();
+      }
+      if (exitBeforeHandshake) {
+        return;
+      }
       String profile = "{}";
       try (BufferedReader input =
               new BufferedReader(new InputStreamReader(System.in, StandardCharsets.UTF_8));

--- a/src/test/java/featurecat/lizzie/analysis/gtpconfig/GtpConfigurationProbeTest.java
+++ b/src/test/java/featurecat/lizzie/analysis/gtpconfig/GtpConfigurationProbeTest.java
@@ -48,7 +48,6 @@ import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import org.json.JSONObject;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.slf4j.LoggerFactory;
@@ -57,11 +56,6 @@ class GtpConfigurationProbeTest {
   private static final long REAL_PROCESS_HANDSHAKE_TIMEOUT_SECONDS = 10L;
 
   @TempDir Path tempDir;
-
-  @AfterEach
-  void tearDownLogging() {
-    LoggingRuntime.resetForTests();
-  }
 
   @Test
   void reportsUnsupportedEngineWithoutRequestingSchema() throws Exception {
@@ -183,35 +177,43 @@ class GtpConfigurationProbeTest {
   @Test
   void successfulRealProbeLeavesStructuredEventsWithoutChangingResult() throws Exception {
     LoggingRuntime runtime = startProbeDiagnostics();
-    ListAppender<ILoggingEvent> events = attachEngine();
-    String command = fakeEngineCommand();
-    GtpConfigurationProbe probe = new GtpConfigurationProbe();
+    try {
+      ListAppender<ILoggingEvent> events = attachEngine();
+      String command = fakeEngineCommand();
+      GtpConfigurationProbe probe = new GtpConfigurationProbe();
 
-    GtpConfigurationProbe.Inspection inspection = probe.inspect(command, Duration.ofSeconds(2));
+      GtpConfigurationProbe.Inspection inspection = probe.inspect(command, Duration.ofSeconds(2));
 
-    assertTrue(inspection.supported());
-    assertEquals("zengtp-config", inspection.schema().protocol());
-    String logs = formatted(events);
-    assertTrue(logs.contains("probe event=started"), logs);
-    assertTrue(logs.contains("probe event=capability-check outcome=success"), logs);
-    assertFalse(logs.contains("probe event=failed"), logs);
-    assertFalse(logs.contains("probe event=stderr"), logs);
-    awaitLogs(runtime);
+      assertTrue(inspection.supported());
+      assertEquals("zengtp-config", inspection.schema().protocol());
+      String logs = formatted(events);
+      assertTrue(logs.contains("probe event=started"), logs);
+      assertTrue(logs.contains("probe event=capability-check outcome=success"), logs);
+      assertFalse(logs.contains("probe event=failed"), logs);
+      assertFalse(logs.contains("probe event=stderr"), logs);
+      awaitLogs(runtime);
+    } finally {
+      runtime.shutdown();
+    }
   }
 
   @Test
   void stderrOnSuccessfulProbeDoesNotChangeInspectResult() throws Exception {
     LoggingRuntime runtime = startProbeDiagnostics();
-    ListAppender<ILoggingEvent> events = attachEngine();
-    GtpConfigurationProbe.Inspection inspection =
-        new GtpConfigurationProbe().inspect(fakeEngineCommand("stderr"), Duration.ofSeconds(2));
+    try {
+      ListAppender<ILoggingEvent> events = attachEngine();
+      GtpConfigurationProbe.Inspection inspection =
+          new GtpConfigurationProbe().inspect(fakeEngineCommand("stderr"), Duration.ofSeconds(2));
 
-    assertTrue(inspection.supported());
-    String logs = formatted(events);
-    assertTrue(logs.contains("probe event=started"), logs);
-    assertTrue(logs.contains("probe event=capability-check outcome=success"), logs);
-    assertFalse(logs.contains("probe event=failed"), logs);
-    awaitLogs(runtime);
+      assertTrue(inspection.supported());
+      String logs = formatted(events);
+      assertTrue(logs.contains("probe event=started"), logs);
+      assertTrue(logs.contains("probe event=capability-check outcome=success"), logs);
+      assertFalse(logs.contains("probe event=failed"), logs);
+      awaitLogs(runtime);
+    } finally {
+      runtime.shutdown();
+    }
   }
 
   @Test
@@ -228,99 +230,115 @@ class GtpConfigurationProbeTest {
             <= ObservationText.RAW_EVENT_MAX_UTF8_BYTES + 64);
 
     LoggingRuntime runtime = startProbeDiagnostics();
-    ListAppender<ILoggingEvent> events = attachEngine();
-    GtpConfigurationProbe.Inspection inspection =
-        new GtpConfigurationProbe()
-            .inspect(fakeEngineCommand("stderr-huge"), Duration.ofSeconds(5));
+    try {
+      ListAppender<ILoggingEvent> events = attachEngine();
+      GtpConfigurationProbe.Inspection inspection =
+          new GtpConfigurationProbe()
+              .inspect(fakeEngineCommand("stderr-huge"), Duration.ofSeconds(5));
 
-    assertTrue(inspection.supported());
-    String logs = formatted(events);
-    assertTrue(logs.contains("probe event=capability-check outcome=success"), logs);
-    assertFalse(logs.contains("probe event=failed"), logs);
-    awaitLogs(runtime);
+      assertTrue(inspection.supported());
+      String logs = formatted(events);
+      assertTrue(logs.contains("probe event=capability-check outcome=success"), logs);
+      assertFalse(logs.contains("probe event=failed"), logs);
+      awaitLogs(runtime);
+    } finally {
+      runtime.shutdown();
+    }
   }
 
   @Test
   void earlyExitStillThrowsAndRecordsBoundedStderrSummary() throws Exception {
     LoggingRuntime runtime = startProbeDiagnostics();
-    ListAppender<ILoggingEvent> events = attachEngine();
+    try {
+      ListAppender<ILoggingEvent> events = attachEngine();
 
-    IOException exited =
-        assertThrows(
-            IOException.class,
-            () ->
-                new GtpConfigurationProbe()
-                    .inspect(fakeEngineCommand("stderr", "exit"), Duration.ofSeconds(2)));
+      IOException exited =
+          assertThrows(
+              IOException.class,
+              () ->
+                  new GtpConfigurationProbe()
+                      .inspect(fakeEngineCommand("stderr", "exit"), Duration.ofSeconds(2)));
 
-    assertTrue(
-        exited.getMessage().contains("Engine exited before configuration completed"),
-        exited.getMessage());
-    assertFalse(exited.getMessage().contains("probe-stderr"), exited.getMessage());
-    assertFalse(exited.getMessage().contains("probe-secret-token"), exited.getMessage());
-    String logs = formatted(events);
-    assertTrue(logs.contains("probe event=started"), logs);
-    assertTrue(logs.contains("probe event=failed stage=exited"), logs);
-    assertTrue(logs.contains("probe event=stderr facts="), logs);
-    assertTrue(logs.contains("probe-stderr"), logs);
-    awaitLogs(runtime);
-    String app = Files.readString(tempDir.resolve("logs/app.log"), StandardCharsets.UTF_8);
-    assertFalse(app.contains("probe-secret-token"), app);
-    assertTrue(app.contains("probe event=stderr"), app);
+      assertTrue(
+          exited.getMessage().contains("Engine exited before configuration completed"),
+          exited.getMessage());
+      assertFalse(exited.getMessage().contains("probe-stderr"), exited.getMessage());
+      assertFalse(exited.getMessage().contains("probe-secret-token"), exited.getMessage());
+      String logs = formatted(events);
+      assertTrue(logs.contains("probe event=started"), logs);
+      assertTrue(logs.contains("probe event=failed stage=exited"), logs);
+      assertTrue(logs.contains("probe event=stderr facts="), logs);
+      assertTrue(logs.contains("probe-stderr"), logs);
+      awaitLogs(runtime);
+      String app = Files.readString(tempDir.resolve("logs/app.log"), StandardCharsets.UTF_8);
+      assertFalse(app.contains("probe-secret-token"), app);
+      assertTrue(app.contains("probe event=stderr"), app);
+    } finally {
+      runtime.shutdown();
+    }
   }
 
   @Test
   void probeTimeoutStillThrowsAndRecordsStderrSummary() throws Exception {
     LoggingRuntime runtime = startProbeDiagnostics();
-    ListAppender<ILoggingEvent> events = attachEngine();
+    try {
+      ListAppender<ILoggingEvent> events = attachEngine();
 
-    IOException timeout =
-        assertThrows(
-            IOException.class,
-            () ->
-                new GtpConfigurationProbe()
-                    .inspect(fakeEngineCommand("stderr", "hang"), Duration.ofMillis(200)));
+      IOException timeout =
+          assertThrows(
+              IOException.class,
+              () ->
+                  new GtpConfigurationProbe()
+                      .inspect(fakeEngineCommand("stderr", "hang"), Duration.ofMillis(200)));
 
-    assertTrue(
-        timeout.getMessage().contains("Timed out waiting for the engine configuration response"),
-        timeout.getMessage());
-    assertFalse(timeout.getMessage().contains("probe-stderr"), timeout.getMessage());
-    String logs = formatted(events);
-    assertTrue(logs.contains("probe event=started"), logs);
-    assertTrue(logs.contains("probe event=failed stage=timeout"), logs);
-    assertTrue(logs.contains("probe event=stderr facts="), logs);
-    assertTrue(logs.contains("probe-stderr"), logs);
-    awaitLogs(runtime);
+      assertTrue(
+          timeout.getMessage().contains("Timed out waiting for the engine configuration response"),
+          timeout.getMessage());
+      assertFalse(timeout.getMessage().contains("probe-stderr"), timeout.getMessage());
+      String logs = formatted(events);
+      assertTrue(logs.contains("probe event=started"), logs);
+      assertTrue(logs.contains("probe event=failed stage=timeout"), logs);
+      assertTrue(logs.contains("probe event=stderr facts="), logs);
+      assertTrue(logs.contains("probe-stderr"), logs);
+      awaitLogs(runtime);
+    } finally {
+      runtime.shutdown();
+    }
   }
 
   @Test
   void stderrReaderFailureDoesNotPropagateToCaller() throws Exception {
     LoggingRuntime runtime = startProbeDiagnostics();
-    ListAppender<ILoggingEvent> events = attachEngine();
-    BufferedReader throwing =
-        new BufferedReader(
-            new Reader() {
-              @Override
-              public int read(char[] cbuf, int off, int len) {
-                throw new IllegalStateException("stderr exploded");
-              }
+    try {
+      ListAppender<ILoggingEvent> events = attachEngine();
+      BufferedReader throwing =
+          new BufferedReader(
+              new Reader() {
+                @Override
+                public int read(char[] cbuf, int off, int len) {
+                  throw new IllegalStateException("stderr exploded");
+                }
 
-              @Override
-              public void close() {}
-            });
+                @Override
+                public void close() {}
+              });
 
-    GtpConfigurationProbe.drainProbeStderr(
-        throwing, new GtpConfigurationProbe.ProbeStderrTail(), () -> "eng-test");
+      GtpConfigurationProbe.drainProbeStderr(
+          throwing, new GtpConfigurationProbe.ProbeStderrTail(), () -> "eng-test");
 
-    GtpConfigurationProbe.Inspection inspection =
-        new GtpConfigurationProbe(new ScriptedFactory(response(true, "false")))
-            .inspect("fake-engine", Duration.ofSeconds(1));
-    assertFalse(inspection.supported());
-    String logs = formatted(events);
-    assertTrue(logs.contains("engine event=transport-failure"), logs);
-    assertTrue(logs.contains("stream=stderr"), logs);
-    assertTrue(logs.contains("reason=reader-error"), logs);
-    assertFalse(logs.contains("stderr exploded"), logs);
-    awaitLogs(runtime);
+      GtpConfigurationProbe.Inspection inspection =
+          new GtpConfigurationProbe(new ScriptedFactory(response(true, "false")))
+              .inspect("fake-engine", Duration.ofSeconds(1));
+      assertFalse(inspection.supported());
+      String logs = formatted(events);
+      assertTrue(logs.contains("engine event=transport-failure"), logs);
+      assertTrue(logs.contains("stream=stderr"), logs);
+      assertTrue(logs.contains("reason=reader-error"), logs);
+      assertFalse(logs.contains("stderr exploded"), logs);
+      awaitLogs(runtime);
+    } finally {
+      runtime.shutdown();
+    }
   }
 
   @Test

--- a/src/test/java/featurecat/lizzie/logging/EngineObservationTest.java
+++ b/src/test/java/featurecat/lizzie/logging/EngineObservationTest.java
@@ -46,6 +46,10 @@ class EngineObservationTest {
     EngineObservation.recordBootstrap("eng-1", EngineBootstrapFacts.unknown("MAIN_BOARD"));
     EngineObservation.recordQueue("eng-1", 1, 1);
     EngineObservation.recordCommandSent("eng-1", "cmd-1", "play", 0, 1);
+    EngineObservation.recordProbeStarted("eng-1");
+    EngineObservation.recordProbeCapabilityCheck("eng-1", true);
+    EngineObservation.recordProbeFailed("eng-1", "exited");
+    EngineObservation.recordProbeStderr("eng-1", "cuda failed");
     EngineObservation.traceRawCommand("eng-1", "cmd-1", "play B D4");
 
     assertTrue(engineEvents.list.isEmpty(), engineEvents.list.toString());
@@ -168,6 +172,50 @@ class EngineObservationTest {
     assertTrue(failedLogs.contains("event=bootstrap"), failedLogs);
     assertTrue(failedLogs.contains("event=failed reason=process start failed"), failedLogs);
     assertFalse(failedLogs.contains("event=started"), failedLogs);
+  }
+
+  @Test
+  void probeEventsStayVisibleWithoutEngineDiagnosticsDebugAndBoundStderr() {
+    LoggingRuntime runtime =
+        LoggingRuntime.initialize(
+            new WorkDirectoryResolution(tempDir, List.of()),
+            new LoggingLimits(64, 32, 32, 32, 7, 1_000_000, 256_000));
+    runtime.applySettings(LoggingSettings.defaults().withDiagnosticsEnabled(false));
+    Logger engine = (Logger) LoggerFactory.getLogger(LogCategories.ENGINE);
+    ListAppender<ILoggingEvent> events = attach(engine);
+
+    EngineObservation.recordRecentStderr("eng-1", "debug-only-stderr");
+    EngineObservation.recordProbeStarted("eng-1");
+    EngineObservation.recordProbeCapabilityCheck("eng-1", false);
+    EngineObservation.recordProbeFailed("eng-1", "exited");
+    EngineObservation.recordProbeFailed("eng-1", "free-form exception text");
+    EngineObservation.recordProbeStderr("eng-1", "x".repeat(100_000));
+
+    String logs = formatted(events);
+    assertFalse(logs.contains("debug-only-stderr"), logs);
+    assertFalse(logs.contains("engine event=stderr"), logs);
+    assertTrue(logs.contains("probe event=started"), logs);
+    assertTrue(logs.contains("probe event=capability-check outcome=failure"), logs);
+    assertTrue(logs.contains("probe event=failed stage=exited"), logs);
+    assertTrue(logs.contains("probe event=failed stage=unknown"), logs);
+    assertFalse(logs.contains("free-form exception text"), logs);
+    ILoggingEvent stderrEvent = null;
+    for (ILoggingEvent event : events.list) {
+      if (event.getFormattedMessage().contains("probe event=failed stage=exited")) {
+        assertEquals(Level.WARN, event.getLevel(), event.getFormattedMessage());
+      }
+      if (event.getFormattedMessage().contains("probe event=stderr facts=")) {
+        stderrEvent = event;
+      }
+    }
+    assertTrue(stderrEvent != null, logs);
+    assertEquals(Level.WARN, stderrEvent.getLevel());
+    String stderrMessage = stderrEvent.getFormattedMessage();
+    String facts = stderrMessage.substring(stderrMessage.indexOf("facts=") + "facts=".length());
+    assertTrue(
+        facts.getBytes(StandardCharsets.UTF_8).length <= ObservationText.RAW_EVENT_MAX_UTF8_BYTES,
+        Integer.toString(facts.getBytes(StandardCharsets.UTF_8).length));
+    assertTrue(facts.endsWith(" [truncated]"), facts);
   }
 
   @Test


### PR DESCRIPTION
## Repro
Start a GTP configuration probe (`inspect` / `applyProfile`). The child stderr is drained so the process cannot block, but the lines are discarded. When the engine exits early or times out, the thrown text is only `Engine exited before configuration completed` or `Timed out waiting for the engine configuration response`, with no recent stderr for CUDA / TensorRT / DirectML / DLL / model-load failures.

## Cause
`GtpConfigurationProbe.ProcessSession` read stderr only to keep the error pipe empty. `EngineObservation.recordRecentStderr` exists but is debug-gated, and the probe never recorded a recent-line ring or structured probe-stage events. Coordinator already writes `engine event=started|stopped` for `Purpose.OTHER`.

## Fix
- Keep draining stderr on the existing daemon thread; add a 40-line / 16 KiB ring.
- On the existing `lizzie.engine` channel (same sanitizer, no second logger): `probe event=started`, `probe event=capability-check outcome=success|failure`, `probe event=failed stage=…` (closed tokens such as `exited`, `timeout`, `schema`).
- Failure stderr summary is `probe event=stderr facts=…` at WARN, so it is visible without engine-diagnostics debug.
- Thrown `IOException` text stays generic; summary is not concatenated into it.
- Do not re-emit coordinator `engine event=started|stopped`. Diagnostic recording failures cannot change inspect / applyProfile results.

## Verification
`mvn -B -Dfmt.skip=true -Djava.awt.headless=true -Dtest=GtpConfigurationProbeTest,EngineObservationTest test` passed locally. Covers success, stderr-on-success, huge stderr, early exit, timeout, and reader-thread exception. Linux and Windows CI still pending at post time. No desktop shots.

Fixes #375
