### PR TITLE
feat(diagnostics): structured maintenance lifecycle events (#377)

### DIFF
--- a/src/main/java/featurecat/lizzie/logging/MaintenanceObservation.java
+++ b/src/main/java/featurecat/lizzie/logging/MaintenanceObservation.java
@@ -1,0 +1,266 @@
+package featurecat.lizzie.logging;
+
+import java.io.IOException;
+import java.io.InterruptedIOException;
+import java.util.Locale;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Shared maintenance/lifecycle diagnostics. One sanitized key-value line per stage; recording
+ * failures never change the business-flow outcome.
+ */
+public final class MaintenanceObservation {
+  public static final String OPERATION_TENSORRT_SETUP = "tensorrt-setup";
+  public static final String OPERATION_WEIGHT_DOWNLOAD = "weight-download";
+
+  public static final String STAGE_LOCK = "lock";
+  public static final String STAGE_DOWNLOAD = "download";
+  public static final String STAGE_VERIFY = "verify";
+  public static final String STAGE_EXTRACT = "extract";
+  public static final String STAGE_INSTALL = "install";
+  public static final String STAGE_APPLY_CONFIG = "apply-config";
+  public static final String STAGE_CACHE_CLEANUP = "cache-cleanup";
+  public static final String STAGE_EXISTING_FILE = "existing-file";
+  public static final String STAGE_HTTP_DOWNLOAD = "http-download";
+  public static final String STAGE_MOVE = "move";
+
+  public static final String OUTCOME_SUCCESS = "success";
+  public static final String OUTCOME_FAILED = "failed";
+
+  public static final String REASON_FILE_LOCKED = "file-locked";
+  public static final String REASON_CANCELLED = "cancelled";
+  public static final String REASON_CHECKSUM_MISMATCH = "checksum-mismatch";
+  public static final String REASON_INCOMPLETE = "incomplete";
+  public static final String REASON_SIZE_MISMATCH = "size-mismatch";
+  public static final String REASON_INTEGRITY_CHECK_FAILED = "integrity-check-failed";
+  public static final String REASON_UNKNOWN = "unknown";
+
+  public static final int REASON_MAX_UTF8_BYTES = 256;
+  public static final int REASON_MAX_LINES = 1;
+
+  private static final Logger DIAG = LoggerFactory.getLogger(LogCategories.DIAGNOSTICS);
+  private static final PersistenceSanitizer SANITIZER = new PersistenceSanitizer();
+  private static final String UNKNOWN = "unknown";
+
+  private static final Set<String> OPERATIONS =
+      Set.of(OPERATION_TENSORRT_SETUP, OPERATION_WEIGHT_DOWNLOAD);
+  private static final Set<String> STAGES =
+      Set.of(
+          STAGE_LOCK,
+          STAGE_DOWNLOAD,
+          STAGE_VERIFY,
+          STAGE_EXTRACT,
+          STAGE_INSTALL,
+          STAGE_APPLY_CONFIG,
+          STAGE_CACHE_CLEANUP,
+          STAGE_EXISTING_FILE,
+          STAGE_HTTP_DOWNLOAD,
+          STAGE_MOVE);
+  private static final Set<String> OUTCOMES = Set.of(OUTCOME_SUCCESS, OUTCOME_FAILED);
+  private static final Set<String> CLOSED_REASONS =
+      Set.of(
+          REASON_FILE_LOCKED,
+          REASON_CANCELLED,
+          REASON_CHECKSUM_MISMATCH,
+          REASON_INCOMPLETE,
+          REASON_SIZE_MISMATCH,
+          REASON_INTEGRITY_CHECK_FAILED,
+          REASON_UNKNOWN);
+
+  private static final Pattern HTTP_REASON = Pattern.compile("http-\\d{3}");
+  private static final Pattern HTTP_STATUS = Pattern.compile("(?i)\\bHTTP\\s+(\\d{3})\\b");
+  private static final Pattern URL =
+      Pattern.compile("(?i)\\b[a-z][a-z0-9+.-]*://\\S+");
+  private static final Pattern WINDOWS_ABS_PATH =
+      Pattern.compile("(?:[A-Za-z]:[\\\\/]|\\\\\\\\)[^\\s\\]]+");
+  private static final Pattern UNIX_ABS_PATH =
+      Pattern.compile("(?<![A-Za-z0-9:])(/(?:[^\\s/]+/)+[^\\s/]*)");
+
+  private MaintenanceObservation() {}
+
+  @FunctionalInterface
+  public interface IoTask {
+    void run() throws IOException;
+  }
+
+  @FunctionalInterface
+  public interface IoCall<T> {
+    T get() throws IOException;
+  }
+
+  public static long elapsedMillis(long startedNanos) {
+    return TimeUnit.NANOSECONDS.toMillis(Math.max(0L, System.nanoTime() - startedNanos));
+  }
+
+  public static void runStage(String operation, String stage, IoTask task) throws IOException {
+    if (task == null) {
+      return;
+    }
+    long started = System.nanoTime();
+    try {
+      task.run();
+    } catch (IOException e) {
+      recordFailure(operation, stage, elapsedMillis(started), e);
+      throw e;
+    } catch (RuntimeException e) {
+      recordFailure(operation, stage, elapsedMillis(started), e);
+      throw e;
+    }
+    record(operation, stage, OUTCOME_SUCCESS, elapsedMillis(started), null);
+  }
+
+  public static <T> T callStage(String operation, String stage, IoCall<T> task) throws IOException {
+    if (task == null) {
+      return null;
+    }
+    long started = System.nanoTime();
+    try {
+      T result = task.get();
+      record(operation, stage, OUTCOME_SUCCESS, elapsedMillis(started), null);
+      return result;
+    } catch (IOException e) {
+      recordFailure(operation, stage, elapsedMillis(started), e);
+      throw e;
+    } catch (RuntimeException e) {
+      recordFailure(operation, stage, elapsedMillis(started), e);
+      throw e;
+    }
+  }
+
+  public static void recordFailure(
+      String operation, String stage, long durationMs, Throwable error) {
+    record(operation, stage, OUTCOME_FAILED, durationMs, reasonFrom(error));
+  }
+
+  public static void record(
+      String operation, String stage, String outcome, long durationMs, String reason) {
+    try {
+      if (!initialized()) {
+        return;
+      }
+      String safeOperation = tokenOrUnknown(operation, OPERATIONS);
+      String safeStage = tokenOrUnknown(stage, STAGES);
+      String safeOutcome = tokenOrUnknown(outcome, OUTCOMES);
+      long safeDuration = Math.max(0L, durationMs);
+      boolean failed = OUTCOME_FAILED.equals(safeOutcome);
+      if (failed) {
+        if (!DIAG.isWarnEnabled()) {
+          return;
+        }
+        String safeReason = sanitizeReason(reason);
+        DIAG.warn(
+            "maintenance operation={} stage={} outcome={} durationMs={} reason={}",
+            safeOperation,
+            safeStage,
+            safeOutcome,
+            safeDuration,
+            safeReason);
+        return;
+      }
+      if (!DIAG.isInfoEnabled()) {
+        return;
+      }
+      DIAG.info(
+          "maintenance operation={} stage={} outcome={} durationMs={}",
+          safeOperation,
+          safeStage,
+          safeOutcome,
+          safeDuration);
+    } catch (RuntimeException ignored) {
+    } catch (Error error) {
+      if (error instanceof VirtualMachineError) {
+        throw error;
+      }
+    }
+  }
+
+  static String reasonFrom(Throwable error) {
+    if (error == null) {
+      return REASON_UNKNOWN;
+    }
+    if (error instanceof InterruptedIOException) {
+      return REASON_CANCELLED;
+    }
+    String type = error.getClass().getSimpleName();
+    String message = error.getMessage() == null ? "" : error.getMessage();
+    Matcher http = HTTP_STATUS.matcher(message);
+    if (http.find()) {
+      return "http-" + http.group(1);
+    }
+    if (containsIgnoreCase(message, "already running")
+        || containsIgnoreCase(message, "file lock")
+        || "OverlappingFileLockException".equals(type)) {
+      return REASON_FILE_LOCKED;
+    }
+    if (containsIgnoreCase(message, "checksum")
+        || containsIgnoreCase(message, "sha-256")
+        || containsIgnoreCase(message, "sha256")) {
+      return REASON_CHECKSUM_MISMATCH;
+    }
+    if (containsIgnoreCase(message, "incomplete")) {
+      return REASON_INCOMPLETE;
+    }
+    if (containsIgnoreCase(message, "size mismatch")) {
+      return REASON_SIZE_MISMATCH;
+    }
+    if ("WeightIntegrityException".equals(type)
+        || "CorruptRuntimePackageDownloadException".equals(type)) {
+      return REASON_INTEGRITY_CHECK_FAILED;
+    }
+    String fallback = type.isEmpty() ? message : type + ": " + message;
+    return sanitizeReason(fallback);
+  }
+
+  static String sanitizeReason(String reason) {
+    if (reason == null || reason.isEmpty()) {
+      return REASON_UNKNOWN;
+    }
+    if (CLOSED_REASONS.contains(reason) || HTTP_REASON.matcher(reason).matches()) {
+      return reason;
+    }
+    try {
+      String safe = SANITIZER.sanitize(reason);
+      if (safe == null || safe.isEmpty()) {
+        return REASON_UNKNOWN;
+      }
+      if (PersistenceSanitizer.FAILURE_MARKER.equals(safe)) {
+        return PersistenceSanitizer.FAILURE_MARKER;
+      }
+      safe = URL.matcher(safe).replaceAll("<redacted-url>");
+      safe = WINDOWS_ABS_PATH.matcher(safe).replaceAll("<redacted-path>");
+      safe = UNIX_ABS_PATH.matcher(safe).replaceAll("<redacted-path>");
+      safe = safe.replace('\r', ' ').replace('\n', ' ').replace('\t', ' ');
+      safe = safe.replaceAll(" {2,}", " ").trim();
+      if (safe.isEmpty()) {
+        return REASON_UNKNOWN;
+      }
+      String bounded = ObservationText.boundedUtf8(safe, REASON_MAX_UTF8_BYTES, REASON_MAX_LINES);
+      return bounded == null || bounded.isEmpty() ? REASON_UNKNOWN : bounded;
+    } catch (RuntimeException ignored) {
+      return REASON_UNKNOWN;
+    }
+  }
+
+  private static String tokenOrUnknown(String value, Set<String> allowed) {
+    if (value != null && allowed.contains(value)) {
+      return value;
+    }
+    return UNKNOWN;
+  }
+
+  private static boolean containsIgnoreCase(String text, String needle) {
+    if (text == null || needle == null || needle.isEmpty()) {
+      return false;
+    }
+    return text.toLowerCase(Locale.ROOT).contains(needle.toLowerCase(Locale.ROOT));
+  }
+
+  private static boolean initialized() {
+    return LoggingRuntime.current().filter(runtime -> !runtime.isShutdown()).isPresent();
+  }
+}

--- a/src/main/java/featurecat/lizzie/logging/MaintenanceObservation.java
+++ b/src/main/java/featurecat/lizzie/logging/MaintenanceObservation.java
@@ -78,10 +78,10 @@ public final class MaintenanceObservation {
       Pattern.compile("(?i)\\b[a-z][a-z0-9+.-]*://\\S+");
   private static final Pattern WINDOWS_ABS_PATH =
       Pattern.compile(
-          "(?:[A-Za-z]:[\\\\/]|\\\\\\\\)(?:[^]<>:\"|?*\\r\\n\\\\/]+[\\\\/])*[^]<>:\"|?*\\r\\n\\\\/\\s]+");
+          "(?:[A-Za-z]:\\\\|\\\\\\\\)(?:[^]\\\\<>:\"|?*\\r\\n\\\\]+\\\\)*[^]\\\\<>:\"|?*\\r\\n\\\\\\s]+|[A-Za-z]:/[^\\s\\]]+");
   private static final Pattern UNIX_ABS_PATH =
       Pattern.compile(
-          "(?<![A-Za-z0-9:])(/(?:[^]/<>:\"|?*\\r\\n]+/)+[^]/<>:\"|?*\\r\\n\\s]+)");
+          "(?<![A-Za-z0-9:])(/(?:[^/<>:\"|?*\\r\\n]+/)+[^/<>:\"|?*\\r\\n\\s]+)");
 
   private MaintenanceObservation() {}
 

--- a/src/main/java/featurecat/lizzie/logging/MaintenanceObservation.java
+++ b/src/main/java/featurecat/lizzie/logging/MaintenanceObservation.java
@@ -199,7 +199,8 @@ public final class MaintenanceObservation {
     }
     if (containsIgnoreCase(message, "checksum")
         || containsIgnoreCase(message, "sha-256")
-        || containsIgnoreCase(message, "sha256")) {
+        || containsIgnoreCase(message, "sha256")
+        || containsIgnoreCase(message, "verification failed")) {
       return REASON_CHECKSUM_MISMATCH;
     }
     if (containsIgnoreCase(message, "incomplete")) {

--- a/src/main/java/featurecat/lizzie/logging/MaintenanceObservation.java
+++ b/src/main/java/featurecat/lizzie/logging/MaintenanceObservation.java
@@ -77,9 +77,11 @@ public final class MaintenanceObservation {
   private static final Pattern URL =
       Pattern.compile("(?i)\\b[a-z][a-z0-9+.-]*://\\S+");
   private static final Pattern WINDOWS_ABS_PATH =
-      Pattern.compile("(?:[A-Za-z]:[\\\\/]|\\\\\\\\)[^\\s\\]]+");
+      Pattern.compile(
+          "(?:[A-Za-z]:[\\\\/]|\\\\\\\\)(?:[^]<>:\"|?*\\r\\n\\\\/]+[\\\\/])*[^]<>:\"|?*\\r\\n\\\\/\\s]+");
   private static final Pattern UNIX_ABS_PATH =
-      Pattern.compile("(?<![A-Za-z0-9:])(/(?:[^\\s/]+/)+[^\\s/]*)");
+      Pattern.compile(
+          "(?<![A-Za-z0-9:])(/(?:[^]/<>:\"|?*\\r\\n]+/)+[^]/<>:\"|?*\\r\\n\\s]+)");
 
   private MaintenanceObservation() {}
 

--- a/src/main/java/featurecat/lizzie/util/KataGoAutoSetupHelper.java
+++ b/src/main/java/featurecat/lizzie/util/KataGoAutoSetupHelper.java
@@ -1435,6 +1435,15 @@ public final class KataGoAutoSetupHelper {
               MaintenanceObservation.OUTCOME_FAILED,
               MaintenanceObservation.elapsedMillis(stageStarted),
               MaintenanceObservation.REASON_CANCELLED);
+        } else if (e instanceof WeightIntegrityException) {
+          WeightIntegrityException integrity = (WeightIntegrityException) e;
+          recordWeightDownload(
+              currentStage,
+              MaintenanceObservation.OUTCOME_FAILED,
+              MaintenanceObservation.elapsedMillis(stageStarted),
+              integrity.discardPartial
+                  ? MaintenanceObservation.REASON_CHECKSUM_MISMATCH
+                  : MaintenanceObservation.REASON_INCOMPLETE);
         } else {
           MaintenanceObservation.recordFailure(
               MaintenanceObservation.OPERATION_WEIGHT_DOWNLOAD,

--- a/src/main/java/featurecat/lizzie/util/KataGoAutoSetupHelper.java
+++ b/src/main/java/featurecat/lizzie/util/KataGoAutoSetupHelper.java
@@ -4,6 +4,7 @@ import featurecat.lizzie.Config;
 import featurecat.lizzie.Lizzie;
 import featurecat.lizzie.analysis.EngineManager;
 import featurecat.lizzie.gui.EngineData;
+import featurecat.lizzie.logging.MaintenanceObservation;
 import java.io.BufferedInputStream;
 import java.io.BufferedReader;
 import java.io.ByteArrayOutputStream;
@@ -1280,7 +1281,13 @@ public final class KataGoAutoSetupHelper {
     activeSession.throwIfCancelled();
 
     Path target = weightsDir.resolve(info.fileName());
+    long existingStarted = System.nanoTime();
     if (isDownloadedWeightValid(target, info)) {
+      recordWeightDownload(
+          MaintenanceObservation.STAGE_EXISTING_FILE,
+          MaintenanceObservation.OUTCOME_SUCCESS,
+          MaintenanceObservation.elapsedMillis(existingStarted),
+          null);
       if (listener != null) {
         listener.onProgress(info.modelName, Files.size(target), Files.size(target));
       }
@@ -1290,15 +1297,31 @@ public final class KataGoAutoSetupHelper {
 
     Path temp = weightsDir.resolve(info.fileName() + ".part");
     HttpURLConnection conn = null;
+    String currentStage = null;
+    long stageStarted = 0L;
     try {
       if (isDownloadedWeightValid(temp, info)) {
+        recordWeightDownload(
+            MaintenanceObservation.STAGE_EXISTING_FILE,
+            MaintenanceObservation.OUTCOME_SUCCESS,
+            0L,
+            null);
+        currentStage = MaintenanceObservation.STAGE_MOVE;
+        stageStarted = System.nanoTime();
         Files.move(temp, target, StandardCopyOption.REPLACE_EXISTING);
+        recordWeightDownload(
+            MaintenanceObservation.STAGE_MOVE,
+            MaintenanceObservation.OUTCOME_SUCCESS,
+            MaintenanceObservation.elapsedMillis(stageStarted),
+            null);
         return target;
       }
       if (Files.isRegularFile(temp) && info.sizeBytes > 0L && Files.size(temp) > info.sizeBytes) {
         Files.delete(temp);
       }
       long resumeFrom = Files.isRegularFile(temp) ? Files.size(temp) : 0L;
+      currentStage = MaintenanceObservation.STAGE_HTTP_DOWNLOAD;
+      stageStarted = System.nanoTime();
       while (true) {
         conn =
             (HttpURLConnection) NetworkProxy.openConnection(URI.create(info.downloadUrl).toURL());
@@ -1373,19 +1396,53 @@ public final class KataGoAutoSetupHelper {
         }
         break;
       }
+      recordWeightDownload(
+          MaintenanceObservation.STAGE_HTTP_DOWNLOAD,
+          MaintenanceObservation.OUTCOME_SUCCESS,
+          MaintenanceObservation.elapsedMillis(stageStarted),
+          null);
+      currentStage = MaintenanceObservation.STAGE_VERIFY;
+      stageStarted = System.nanoTime();
       activeSession.throwIfCancelled();
       verifyDownloadedWeight(temp, info);
+      recordWeightDownload(
+          MaintenanceObservation.STAGE_VERIFY,
+          MaintenanceObservation.OUTCOME_SUCCESS,
+          MaintenanceObservation.elapsedMillis(stageStarted),
+          null);
+      currentStage = MaintenanceObservation.STAGE_MOVE;
+      stageStarted = System.nanoTime();
       try {
         Files.move(
             temp, target, StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE);
       } catch (AtomicMoveNotSupportedException e) {
         Files.move(temp, target, StandardCopyOption.REPLACE_EXISTING);
       }
+      recordWeightDownload(
+          MaintenanceObservation.STAGE_MOVE,
+          MaintenanceObservation.OUTCOME_SUCCESS,
+          MaintenanceObservation.elapsedMillis(stageStarted),
+          null);
       if (listener != null) {
         listener.onProgress(info.modelName, Files.size(target), Files.size(target));
       }
       return target;
     } catch (IOException e) {
+      if (currentStage != null) {
+        if (activeSession.isCancelled()) {
+          recordWeightDownload(
+              currentStage,
+              MaintenanceObservation.OUTCOME_FAILED,
+              MaintenanceObservation.elapsedMillis(stageStarted),
+              MaintenanceObservation.REASON_CANCELLED);
+        } else {
+          MaintenanceObservation.recordFailure(
+              MaintenanceObservation.OPERATION_WEIGHT_DOWNLOAD,
+              currentStage,
+              MaintenanceObservation.elapsedMillis(stageStarted),
+              e);
+        }
+      }
       if (shouldDiscardWeightPartial(e)) {
         Files.deleteIfExists(temp);
       }
@@ -1400,6 +1457,12 @@ public final class KataGoAutoSetupHelper {
       }
       activeSession.clear();
     }
+  }
+
+  private static void recordWeightDownload(
+      String stage, String outcome, long durationMs, String reason) {
+    MaintenanceObservation.record(
+        MaintenanceObservation.OPERATION_WEIGHT_DOWNLOAD, stage, outcome, durationMs, reason);
   }
 
   private static boolean isDownloadedWeightValid(Path path, RemoteWeightInfo info) {

--- a/src/main/java/featurecat/lizzie/util/KataGoRuntimeHelper.java
+++ b/src/main/java/featurecat/lizzie/util/KataGoRuntimeHelper.java
@@ -5827,7 +5827,10 @@ public final class KataGoRuntimeHelper {
       URLConnection conn = null;
       HttpURLConnection httpConn = null;
       boolean downloadCompleted = false;
+      boolean verifyFailureRecorded = false;
+      String currentStage = MaintenanceObservation.STAGE_DOWNLOAD;
       long downloadStarted = System.nanoTime();
+      long stageStarted = downloadStarted;
       try {
         session.throwIfCancelled();
         long existingBytes = resumeBytes;
@@ -5925,22 +5928,26 @@ public final class KataGoRuntimeHelper {
             MaintenanceObservation.elapsedMillis(downloadStarted),
             null);
         downloadCompleted = true;
+        currentStage = MaintenanceObservation.STAGE_VERIFY;
+        stageStarted = System.nanoTime();
         session.throwIfCancelled();
-        long verifyStarted = System.nanoTime();
         try {
           validateRuntimePackageDownload(spec, tempPath);
           recordTensorRt(
               MaintenanceObservation.STAGE_VERIFY,
               MaintenanceObservation.OUTCOME_SUCCESS,
-              MaintenanceObservation.elapsedMillis(verifyStarted),
+              MaintenanceObservation.elapsedMillis(stageStarted),
               null);
         } catch (IOException e) {
+          verifyFailureRecorded = true;
           recordTensorRtFailure(
               MaintenanceObservation.STAGE_VERIFY,
-              MaintenanceObservation.elapsedMillis(verifyStarted),
+              MaintenanceObservation.elapsedMillis(stageStarted),
               e);
           throw e;
         }
+        currentStage = MaintenanceObservation.STAGE_MOVE;
+        stageStarted = System.nanoTime();
         moveRuntimePackageIntoCache(tempPath, archivePath);
         notifyRuntimePackageComplete(spec, listener);
         return;
@@ -5957,6 +5964,17 @@ public final class KataGoRuntimeHelper {
                 MaintenanceObservation.STAGE_DOWNLOAD,
                 MaintenanceObservation.elapsedMillis(downloadStarted),
                 e);
+          }
+        } else if (!verifyFailureRecorded) {
+          if (session.isCancelled()) {
+            recordTensorRt(
+                currentStage,
+                MaintenanceObservation.OUTCOME_FAILED,
+                MaintenanceObservation.elapsedMillis(stageStarted),
+                MaintenanceObservation.REASON_CANCELLED);
+          } else {
+            recordTensorRtFailure(
+                currentStage, MaintenanceObservation.elapsedMillis(stageStarted), e);
           }
         }
         if (e instanceof CorruptRuntimePackageDownloadException) {

--- a/src/main/java/featurecat/lizzie/util/KataGoRuntimeHelper.java
+++ b/src/main/java/featurecat/lizzie/util/KataGoRuntimeHelper.java
@@ -7,6 +7,7 @@ import featurecat.lizzie.analysis.AnalysisResourceCoordinator;
 import featurecat.lizzie.analysis.EngineManager;
 import featurecat.lizzie.analysis.Leelaz;
 import featurecat.lizzie.gui.EngineData;
+import featurecat.lizzie.logging.MaintenanceObservation;
 import featurecat.lizzie.rules.Board;
 import featurecat.lizzie.util.KataGoAutoSetupHelper.DownloadCancelledException;
 import featurecat.lizzie.util.KataGoAutoSetupHelper.DownloadSession;
@@ -1669,6 +1670,7 @@ public final class KataGoRuntimeHelper {
     DownloadSession activeSession = session != null ? session : new DownloadSession();
     Path runtimeDir = getNvidiaRuntimeDir();
     Files.createDirectories(runtimeDir);
+    long lockStarted = System.nanoTime();
     try (FileChannel lockChannel =
             FileChannel.open(
                 runtimeDir.resolve(TENSORRT_INSTALL_LOCK_NAME),
@@ -1676,11 +1678,31 @@ public final class KataGoRuntimeHelper {
                 StandardOpenOption.WRITE);
         FileLock installLock = lockChannel.tryLock()) {
       if (installLock == null) {
-        throw new IOException(tensorRtInstallAlreadyRunningMessage());
+        IOException error = new IOException(tensorRtInstallAlreadyRunningMessage());
+        MaintenanceObservation.record(
+            MaintenanceObservation.OPERATION_TENSORRT_SETUP,
+            MaintenanceObservation.STAGE_LOCK,
+            MaintenanceObservation.OUTCOME_FAILED,
+            MaintenanceObservation.elapsedMillis(lockStarted),
+            MaintenanceObservation.REASON_FILE_LOCKED);
+        throw error;
       }
+      MaintenanceObservation.record(
+          MaintenanceObservation.OPERATION_TENSORRT_SETUP,
+          MaintenanceObservation.STAGE_LOCK,
+          MaintenanceObservation.OUTCOME_SUCCESS,
+          MaintenanceObservation.elapsedMillis(lockStarted),
+          null);
       return downloadAndInstallTensorRtLocked(snapshot, listener, activeSession, spec, runtimeDir);
     } catch (OverlappingFileLockException e) {
-      throw new IOException(tensorRtInstallAlreadyRunningMessage(), e);
+      IOException error = new IOException(tensorRtInstallAlreadyRunningMessage(), e);
+      MaintenanceObservation.record(
+          MaintenanceObservation.OPERATION_TENSORRT_SETUP,
+          MaintenanceObservation.STAGE_LOCK,
+          MaintenanceObservation.OUTCOME_FAILED,
+          MaintenanceObservation.elapsedMillis(lockStarted),
+          MaintenanceObservation.REASON_FILE_LOCKED);
+      throw error;
     }
   }
 
@@ -1794,7 +1816,9 @@ public final class KataGoRuntimeHelper {
           resource("AutoSetup.tensorRtReady", "TensorRT acceleration is installed."),
           spec.totalDownloadBytes,
           spec.totalDownloadBytes);
-      return applyTensorRtEngineProfile(snapshot, spec);
+      return observeTensorRtStage(
+          MaintenanceObservation.STAGE_APPLY_CONFIG,
+          () -> applyTensorRtEngineProfile(snapshot, spec));
     }
     if (humanSlCompanionSource == null
         && resolveConfiguredHumanSlCudaFallback(spec.targetEnginePath) == null) {
@@ -1858,7 +1882,9 @@ public final class KataGoRuntimeHelper {
                 + runtimePackage.displayName,
             Math.min(completedBytes, effectiveTotalBytes),
             effectiveTotalBytes);
-        extractRuntimePackage(runtimePackage, archivePath, runtimeDir, licenseDir);
+        observeTensorRtStage(
+            MaintenanceObservation.STAGE_EXTRACT,
+            () -> extractRuntimePackage(runtimePackage, archivePath, runtimeDir, licenseDir));
       }
       writeRuntimeManifest(runtimeDir, runtimePackages);
     }
@@ -1877,13 +1903,18 @@ public final class KataGoRuntimeHelper {
       throw new IOException(tensorRtCompanionMissingMessage());
     }
 
-    SetupResult result = applyTensorRtEngineProfile(snapshot, spec);
+    SetupResult result =
+        observeTensorRtStage(
+            MaintenanceObservation.STAGE_APPLY_CONFIG,
+            () -> applyTensorRtEngineProfile(snapshot, spec));
     notifyProgress(
         listener,
         resource("AutoSetup.tensorRtCleaningCache", "Cleaning TensorRT download cache..."),
         effectiveTotalBytes,
         effectiveTotalBytes);
-    cleanupCompletedTensorRtDownloadArchives(cacheDir, completedArchives);
+    observeTensorRtStage(
+        MaintenanceObservation.STAGE_CACHE_CLEANUP,
+        () -> cleanupCompletedTensorRtDownloadArchives(cacheDir, completedArchives));
     notifyProgress(
         listener,
         resource("AutoSetup.tensorRtInstallDone", "TensorRT acceleration installed."),
@@ -1896,6 +1927,29 @@ public final class KataGoRuntimeHelper {
       SetupSnapshot snapshot, TensorRtInstallSpec spec) throws IOException {
     SetupSnapshot tensorRtSnapshot = snapshot.withEnginePath(spec.targetEnginePath);
     return KataGoAutoSetupHelper.applyEngineProfile(tensorRtSnapshot, TENSORRT_ENGINE_NAME, true);
+  }
+
+  private static void observeTensorRtStage(String stage, MaintenanceObservation.IoTask task)
+      throws IOException {
+    MaintenanceObservation.runStage(
+        MaintenanceObservation.OPERATION_TENSORRT_SETUP, stage, task);
+  }
+
+  private static <T> T observeTensorRtStage(String stage, MaintenanceObservation.IoCall<T> task)
+      throws IOException {
+    return MaintenanceObservation.callStage(
+        MaintenanceObservation.OPERATION_TENSORRT_SETUP, stage, task);
+  }
+
+  private static void recordTensorRt(
+      String stage, String outcome, long durationMs, String reason) {
+    MaintenanceObservation.record(
+        MaintenanceObservation.OPERATION_TENSORRT_SETUP, stage, outcome, durationMs, reason);
+  }
+
+  private static void recordTensorRtFailure(String stage, long durationMs, Throwable error) {
+    MaintenanceObservation.recordFailure(
+        MaintenanceObservation.OPERATION_TENSORRT_SETUP, stage, durationMs, error);
   }
 
   private static String tensorRtInstallAlreadyRunningMessage() {
@@ -5298,46 +5352,62 @@ public final class KataGoRuntimeHelper {
     Path backupDir = parent.resolve(targetEngineDir.getFileName().toString() + ".backup-" + suffix);
     try {
       Files.createDirectories(stagingDir);
-      extractKatagoEnginePackage(archivePath, stagingDir);
+      observeTensorRtStage(
+          MaintenanceObservation.STAGE_EXTRACT,
+          () -> extractKatagoEnginePackage(archivePath, stagingDir));
       session.throwIfCancelled();
-      Files.write(
-          stagingDir.resolve(ENGINE_BACKEND_MARKER_NAME),
-          (NVIDIA_TRT_BACKEND + "\n").getBytes(StandardCharsets.UTF_8));
-      String engineManifest = tensorRtEngineManifestText();
-      if (humanSlCompanionSource != null) {
-        requirePinnedTensorRtCompanionSource(humanSlCompanionSource);
-        Path companionTarget = stagingDir.resolve(HUMAN_SL_CUDA_COMPANION_NAME);
-        Files.copy(
-            humanSlCompanionSource, companionTarget, StandardCopyOption.REPLACE_EXISTING);
-        if (!isPinnedHumanSlCudaExecutable(companionTarget)) {
-          throw new IOException("HumanSL companion changed while it was being installed.");
-        }
-        engineManifest +=
-            "HumanSL companion: "
-                + HUMAN_SL_CUDA_COMPANION_NAME
-                + "\nHumanSL companion SHA-256: "
-                + expectedHumanSlCompanionSha256()
-                + "\n";
-      }
-      Files.writeString(
-          stagingDir.resolve(TENSORRT_ENGINE_MANIFEST_NAME),
-          engineManifest,
-          StandardCharsets.UTF_8);
-      if (!Files.isRegularFile(stagingDir.resolve("katago.exe"))) {
-        throw new IOException("KataGo TensorRT package did not contain katago.exe");
-      }
-      if (Files.exists(targetEngineDir)) {
-        Files.move(targetEngineDir, backupDir, StandardCopyOption.REPLACE_EXISTING);
-      }
+      long installStarted = System.nanoTime();
       try {
-        Files.move(stagingDir, targetEngineDir, StandardCopyOption.REPLACE_EXISTING);
-      } catch (IOException e) {
-        if (Files.exists(backupDir) && !Files.exists(targetEngineDir)) {
-          Files.move(backupDir, targetEngineDir, StandardCopyOption.REPLACE_EXISTING);
+        Files.write(
+            stagingDir.resolve(ENGINE_BACKEND_MARKER_NAME),
+            (NVIDIA_TRT_BACKEND + "\n").getBytes(StandardCharsets.UTF_8));
+        String engineManifest = tensorRtEngineManifestText();
+        if (humanSlCompanionSource != null) {
+          requirePinnedTensorRtCompanionSource(humanSlCompanionSource);
+          Path companionTarget = stagingDir.resolve(HUMAN_SL_CUDA_COMPANION_NAME);
+          Files.copy(
+              humanSlCompanionSource, companionTarget, StandardCopyOption.REPLACE_EXISTING);
+          if (!isPinnedHumanSlCudaExecutable(companionTarget)) {
+            throw new IOException("HumanSL companion changed while it was being installed.");
+          }
+          engineManifest +=
+              "HumanSL companion: "
+                  + HUMAN_SL_CUDA_COMPANION_NAME
+                  + "\nHumanSL companion SHA-256: "
+                  + expectedHumanSlCompanionSha256()
+                  + "\n";
         }
+        Files.writeString(
+            stagingDir.resolve(TENSORRT_ENGINE_MANIFEST_NAME),
+            engineManifest,
+            StandardCharsets.UTF_8);
+        if (!Files.isRegularFile(stagingDir.resolve("katago.exe"))) {
+          throw new IOException("KataGo TensorRT package did not contain katago.exe");
+        }
+        if (Files.exists(targetEngineDir)) {
+          Files.move(targetEngineDir, backupDir, StandardCopyOption.REPLACE_EXISTING);
+        }
+        try {
+          Files.move(stagingDir, targetEngineDir, StandardCopyOption.REPLACE_EXISTING);
+        } catch (IOException e) {
+          if (Files.exists(backupDir) && !Files.exists(targetEngineDir)) {
+            Files.move(backupDir, targetEngineDir, StandardCopyOption.REPLACE_EXISTING);
+          }
+          throw e;
+        }
+        deleteRecursively(backupDir);
+        recordTensorRt(
+            MaintenanceObservation.STAGE_INSTALL,
+            MaintenanceObservation.OUTCOME_SUCCESS,
+            MaintenanceObservation.elapsedMillis(installStarted),
+            null);
+      } catch (IOException e) {
+        recordTensorRtFailure(
+            MaintenanceObservation.STAGE_INSTALL,
+            MaintenanceObservation.elapsedMillis(installStarted),
+            e);
         throw e;
       }
-      deleteRecursively(backupDir);
     } catch (IOException e) {
       deleteRecursively(stagingDir);
       throw e;
@@ -5723,17 +5793,30 @@ public final class KataGoRuntimeHelper {
       RuntimePackageSpec spec, Path archivePath, DownloadSession session, ProgressListener listener)
       throws IOException {
     if (!isValidSha256(spec.sha256)) {
-      throw new CorruptRuntimePackageDownloadException(
-          "Missing or invalid trusted SHA-256 for " + spec.displayName);
+      CorruptRuntimePackageDownloadException error =
+          new CorruptRuntimePackageDownloadException(
+              "Missing or invalid trusted SHA-256 for " + spec.displayName);
+      recordTensorRtFailure(MaintenanceObservation.STAGE_VERIFY, 0L, error);
+      throw error;
     }
     if (isRuntimePackageFileValid(spec, archivePath)) {
       notifyRuntimePackageComplete(spec, listener);
+      recordTensorRt(
+          MaintenanceObservation.STAGE_VERIFY,
+          MaintenanceObservation.OUTCOME_SUCCESS,
+          0L,
+          null);
       return;
     }
 
     Files.createDirectories(archivePath.getParent());
     Path tempPath = archivePath.resolveSibling(archivePath.getFileName().toString() + ".part");
     if (promoteCompletedRuntimePackagePartial(spec, tempPath, archivePath, listener)) {
+      recordTensorRt(
+          MaintenanceObservation.STAGE_VERIFY,
+          MaintenanceObservation.OUTCOME_SUCCESS,
+          0L,
+          null);
       return;
     }
 
@@ -5743,6 +5826,8 @@ public final class KataGoRuntimeHelper {
     while (true) {
       URLConnection conn = null;
       HttpURLConnection httpConn = null;
+      boolean downloadCompleted = false;
+      long downloadStarted = System.nanoTime();
       try {
         session.throwIfCancelled();
         long existingBytes = resumeBytes;
@@ -5770,6 +5855,11 @@ public final class KataGoRuntimeHelper {
               appendToPartial = false;
             } else if (responseCode == HTTP_RANGE_NOT_SATISFIABLE) {
               if (promoteCompletedRuntimePackagePartial(spec, tempPath, archivePath, listener)) {
+                recordTensorRt(
+                    MaintenanceObservation.STAGE_VERIFY,
+                    MaintenanceObservation.OUTCOME_SUCCESS,
+                    0L,
+                    null);
                 return;
               }
               Files.deleteIfExists(tempPath);
@@ -5829,12 +5919,46 @@ public final class KataGoRuntimeHelper {
           }
         }
 
+        recordTensorRt(
+            MaintenanceObservation.STAGE_DOWNLOAD,
+            MaintenanceObservation.OUTCOME_SUCCESS,
+            MaintenanceObservation.elapsedMillis(downloadStarted),
+            null);
+        downloadCompleted = true;
         session.throwIfCancelled();
-        validateRuntimePackageDownload(spec, tempPath);
+        long verifyStarted = System.nanoTime();
+        try {
+          validateRuntimePackageDownload(spec, tempPath);
+          recordTensorRt(
+              MaintenanceObservation.STAGE_VERIFY,
+              MaintenanceObservation.OUTCOME_SUCCESS,
+              MaintenanceObservation.elapsedMillis(verifyStarted),
+              null);
+        } catch (IOException e) {
+          recordTensorRtFailure(
+              MaintenanceObservation.STAGE_VERIFY,
+              MaintenanceObservation.elapsedMillis(verifyStarted),
+              e);
+          throw e;
+        }
         moveRuntimePackageIntoCache(tempPath, archivePath);
         notifyRuntimePackageComplete(spec, listener);
         return;
       } catch (IOException e) {
+        if (!downloadCompleted) {
+          if (session.isCancelled()) {
+            recordTensorRt(
+                MaintenanceObservation.STAGE_DOWNLOAD,
+                MaintenanceObservation.OUTCOME_FAILED,
+                MaintenanceObservation.elapsedMillis(downloadStarted),
+                MaintenanceObservation.REASON_CANCELLED);
+          } else {
+            recordTensorRtFailure(
+                MaintenanceObservation.STAGE_DOWNLOAD,
+                MaintenanceObservation.elapsedMillis(downloadStarted),
+                e);
+          }
+        }
         if (e instanceof CorruptRuntimePackageDownloadException) {
           Files.deleteIfExists(tempPath);
         }

--- a/src/test/java/featurecat/lizzie/logging/MaintenanceObservationTest.java
+++ b/src/test/java/featurecat/lizzie/logging/MaintenanceObservationTest.java
@@ -1,0 +1,183 @@
+package featurecat.lizzie.logging;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.slf4j.LoggerFactory;
+
+class MaintenanceObservationTest {
+  @TempDir Path tempDir;
+
+  @AfterEach
+  void tearDown() {
+    LoggingRuntime.resetForTests();
+  }
+
+  @Test
+  void withoutRuntimeDoesNotThrowOrEmit() {
+    LoggingRuntime.resetForTests();
+    Logger diagnostics = (Logger) LoggerFactory.getLogger(LogCategories.DIAGNOSTICS);
+    ListAppender<ILoggingEvent> events = attach(diagnostics);
+
+    MaintenanceObservation.record(
+        MaintenanceObservation.OPERATION_WEIGHT_DOWNLOAD,
+        MaintenanceObservation.STAGE_VERIFY,
+        MaintenanceObservation.OUTCOME_FAILED,
+        12L,
+        "token=should-not-appear");
+
+    assertTrue(events.list.isEmpty(), events.list.toString());
+  }
+
+  @Test
+  void successPathEmitsExplicitOutcomeWithoutReason() {
+    initializeRuntime();
+    ListAppender<ILoggingEvent> events = attachDiagnostics();
+
+    MaintenanceObservation.record(
+        MaintenanceObservation.OPERATION_WEIGHT_DOWNLOAD,
+        MaintenanceObservation.STAGE_EXISTING_FILE,
+        MaintenanceObservation.OUTCOME_SUCCESS,
+        7L,
+        "token=should-not-be-logged");
+    MaintenanceObservation.record(
+        MaintenanceObservation.OPERATION_WEIGHT_DOWNLOAD,
+        MaintenanceObservation.STAGE_VERIFY,
+        MaintenanceObservation.OUTCOME_SUCCESS,
+        3L,
+        null);
+
+    String logs = formatted(events);
+    assertTrue(logs.contains("maintenance operation=weight-download"), logs);
+    assertTrue(logs.contains("stage=existing-file outcome=success durationMs=7"), logs);
+    assertTrue(logs.contains("stage=verify outcome=success durationMs=3"), logs);
+    assertFalse(logs.contains("reason="), logs);
+    assertFalse(logs.contains("token="), logs);
+  }
+
+  @Test
+  void runStageStopsAtFailedStageAndRethrowsOriginalException() {
+    initializeRuntime();
+    ListAppender<ILoggingEvent> events = attachDiagnostics();
+    IOException boom =
+        new IOException("HTTP 503 from https://alice:s3cret@cdn.example.com/weights.bin");
+
+    IOException thrown =
+        assertThrows(
+            IOException.class,
+            () ->
+                MaintenanceObservation.runStage(
+                    MaintenanceObservation.OPERATION_WEIGHT_DOWNLOAD,
+                    MaintenanceObservation.STAGE_HTTP_DOWNLOAD,
+                    () -> {
+                      throw boom;
+                    }));
+
+    assertSame(boom, thrown);
+    String logs = formatted(events);
+    assertTrue(logs.contains("operation=weight-download"), logs);
+    assertTrue(logs.contains("stage=http-download"), logs);
+    assertTrue(logs.contains("outcome=failed"), logs);
+    assertTrue(logs.contains("reason=http-503"), logs);
+    assertFalse(logs.contains("alice:s3cret"), logs);
+    assertFalse(logs.contains("cdn.example.com"), logs);
+  }
+
+  @Test
+  void failureReasonIsBoundedAndSanitized() {
+    initializeRuntime();
+    ListAppender<ILoggingEvent> events = attachDiagnostics();
+    String unixPath = "/tmp/lizzie-diag-canary/weights/model.bin.gz";
+    String windowsPath = "C:\\Users\\Jake\\AppData\\Local\\Lizzie\\model.bin.gz";
+    String credentialedUrl = "https://alice:s3cret@cdn.example.com/private/weights.bin";
+    String reason =
+        "token=super-secret-token password=hunter2 "
+            + credentialedUrl
+            + " "
+            + unixPath
+            + " "
+            + windowsPath
+            + " "
+            + "x".repeat(400);
+
+    MaintenanceObservation.record(
+        MaintenanceObservation.OPERATION_TENSORRT_SETUP,
+        MaintenanceObservation.STAGE_INSTALL,
+        MaintenanceObservation.OUTCOME_FAILED,
+        44L,
+        reason);
+
+    assertEquals(1, events.list.size(), events.list.toString());
+    String message = events.list.get(0).getFormattedMessage();
+    assertTrue(message.contains("operation=tensorrt-setup"), message);
+    assertTrue(message.contains("stage=install"), message);
+    assertTrue(message.contains("outcome=failed"), message);
+    assertTrue(message.contains("durationMs=44"), message);
+    assertTrue(message.contains("reason="), message);
+    String payload = message.substring(message.indexOf("reason=") + "reason=".length());
+    assertTrue(
+        payload.getBytes(StandardCharsets.UTF_8).length
+            <= MaintenanceObservation.REASON_MAX_UTF8_BYTES,
+        Integer.toString(payload.getBytes(StandardCharsets.UTF_8).length));
+    assertTrue(payload.endsWith(" [truncated]") || payload.length() < reason.length(), payload);
+    assertFalse(message.contains("super-secret-token"), message);
+    assertFalse(message.contains("hunter2"), message);
+    assertFalse(message.contains("alice:s3cret"), message);
+    assertFalse(message.contains(unixPath), message);
+    assertFalse(message.contains(windowsPath), message);
+    assertFalse(message.contains("C:\\Users\\Jake"), message);
+    assertTrue(message.contains("<redacted>"), message);
+    assertTrue(message.contains("<redacted-url>") || message.contains("<redacted-path>"), message);
+  }
+
+  @Test
+  void unknownTokensAreCoercedToUnknown() {
+    initializeRuntime();
+    ListAppender<ILoggingEvent> events = attachDiagnostics();
+
+    MaintenanceObservation.record("not-an-operation", "not-a-stage", "maybe", 1L, null);
+
+    String logs = formatted(events);
+    assertTrue(logs.contains("operation=unknown"), logs);
+    assertTrue(logs.contains("stage=unknown"), logs);
+    assertTrue(logs.contains("outcome=unknown"), logs);
+  }
+
+  private void initializeRuntime() {
+    LoggingRuntime.initialize(
+        new WorkDirectoryResolution(tempDir, List.of()),
+        new LoggingLimits(64, 32, 32, 32, 7, 1_000_000, 256_000));
+  }
+
+  private static ListAppender<ILoggingEvent> attachDiagnostics() {
+    return attach((Logger) LoggerFactory.getLogger(LogCategories.DIAGNOSTICS));
+  }
+
+  private static String formatted(ListAppender<ILoggingEvent> events) {
+    StringBuilder text = new StringBuilder();
+    for (ILoggingEvent event : events.list) {
+      text.append(event.getFormattedMessage()).append('\n');
+    }
+    return text.toString();
+  }
+
+  private static ListAppender<ILoggingEvent> attach(Logger logger) {
+    ListAppender<ILoggingEvent> appender = new ListAppender<>();
+    appender.start();
+    logger.addAppender(appender);
+    return appender;
+  }
+}

--- a/src/test/java/featurecat/lizzie/logging/MaintenanceObservationTest.java
+++ b/src/test/java/featurecat/lizzie/logging/MaintenanceObservationTest.java
@@ -144,6 +144,39 @@ class MaintenanceObservationTest {
   }
 
   @Test
+  void spacedAbsolutePathsAreFullyRedactedFromFailureReason() {
+    initializeRuntime();
+    ListAppender<ILoggingEvent> events = attachDiagnostics();
+    String windowsSpaced =
+        "C:\\Users\\Jake Smith\\AppData\\Local\\Lizzie\\engine\\nvidia-runtime\\downloads\\katago-trt.zip";
+    String unixSpaced = "/home/Jake Smith/.local/share/Lizzie/weights/model.bin.gz";
+    String reason =
+        "TensorRT install failed: "
+            + windowsSpaced
+            + " (sharing violation) also "
+            + unixSpaced;
+
+    MaintenanceObservation.record(
+        MaintenanceObservation.OPERATION_TENSORRT_SETUP,
+        MaintenanceObservation.STAGE_INSTALL,
+        MaintenanceObservation.OUTCOME_FAILED,
+        18L,
+        reason);
+
+    assertEquals(1, events.list.size(), events.list.toString());
+    String message = events.list.get(0).getFormattedMessage();
+    assertTrue(message.contains("reason="), message);
+    assertTrue(message.contains("<redacted-path>"), message);
+    assertTrue(message.contains("(sharing violation)"), message);
+    assertFalse(message.contains(windowsSpaced), message);
+    assertFalse(message.contains(unixSpaced), message);
+    assertFalse(message.contains("Jake Smith"), message);
+    assertFalse(message.contains("Smith\\AppData"), message);
+    assertFalse(message.contains("Smith/.local"), message);
+    assertFalse(message.contains("AppData\\Local\\Lizzie"), message);
+  }
+
+  @Test
   void unknownTokensAreCoercedToUnknown() {
     initializeRuntime();
     ListAppender<ILoggingEvent> events = attachDiagnostics();

--- a/src/test/java/featurecat/lizzie/util/KataGoAutoSetupHelperTest.java
+++ b/src/test/java/featurecat/lizzie/util/KataGoAutoSetupHelperTest.java
@@ -9,11 +9,18 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
 import com.sun.net.httpserver.HttpServer;
 import featurecat.lizzie.Config;
 import featurecat.lizzie.ConfigTestHelper;
 import featurecat.lizzie.Lizzie;
 import featurecat.lizzie.gui.EngineData;
+import featurecat.lizzie.logging.LogCategories;
+import featurecat.lizzie.logging.LoggingLimits;
+import featurecat.lizzie.logging.LoggingRuntime;
+import featurecat.lizzie.logging.WorkDirectoryResolution;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.net.InetSocketAddress;
@@ -26,6 +33,7 @@ import java.util.Locale;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
 
 public class KataGoAutoSetupHelperTest {
   @Test
@@ -901,6 +909,86 @@ public class KataGoAutoSetupHelperTest {
             assertFalse(Files.exists(tempRoot.resolve("weights").resolve("model.bin.gz")));
             assertFalse(Files.exists(tempRoot.resolve("weights").resolve("model.bin.gz.part")));
           });
+    }
+  }
+
+  @Test
+  void existingVerifiedWeightEmitsSuccessfulExistingFileStage() throws Exception {
+    Path tempRoot = Files.createTempDirectory("katago-weight-existing-diag");
+    Path logDir = Files.createTempDirectory("katago-weight-existing-logs");
+    byte[] modelBytes = repeatedBytes(16 * 1024, (byte) 19);
+    LoggingRuntime.initialize(
+        new WorkDirectoryResolution(logDir, List.of()),
+        new LoggingLimits(64, 32, 32, 32, 7, 1_000_000, 256_000));
+    try {
+      ListAppender<ILoggingEvent> events = attachDiagnostics();
+      withUserDirAndConfig(
+          tempRoot,
+          () -> {
+            Path weightsDir = Files.createDirectories(tempRoot.resolve("weights"));
+            Files.write(weightsDir.resolve("model.bin.gz"), modelBytes);
+            KataGoAutoSetupHelper.RemoteWeightInfo info =
+                transformerFixtureWeight("http://127.0.0.1:1/model.bin.gz", modelBytes);
+
+            Path downloaded = KataGoAutoSetupHelper.downloadWeight(info, null);
+
+            assertEquals(
+                weightsDir.resolve("model.bin.gz").toAbsolutePath().normalize(),
+                downloaded.toAbsolutePath().normalize());
+            assertArrayEquals(modelBytes, Files.readAllBytes(downloaded));
+          });
+      String logs = formattedDiagnostics(events);
+      assertTrue(logs.contains("operation=weight-download"), logs);
+      assertTrue(logs.contains("stage=existing-file"), logs);
+      assertTrue(logs.contains("outcome=success"), logs);
+      assertTrue(logs.contains("durationMs="), logs);
+      assertFalse(logs.contains("outcome=failed"), logs);
+      assertFalse(logs.contains("stage=http-download"), logs);
+      assertFalse(logs.contains("stage=move"), logs);
+    } finally {
+      LoggingRuntime.resetForTests();
+    }
+  }
+
+  @Test
+  void weightChecksumFailureStopsAtVerifyStage() throws Exception {
+    Path tempRoot = Files.createTempDirectory("katago-weight-verify-diag");
+    Path logDir = Files.createTempDirectory("katago-weight-verify-logs");
+    byte[] modelBytes = repeatedBytes(16 * 1024, (byte) 31);
+    LoggingRuntime.initialize(
+        new WorkDirectoryResolution(logDir, List.of()),
+        new LoggingLimits(64, 32, 32, 32, 7, 1_000_000, 256_000));
+    try (FixtureServer server = FixtureServer.start(modelBytes)) {
+      ListAppender<ILoggingEvent> events = attachDiagnostics();
+      withUserDirAndConfig(
+          tempRoot,
+          () -> {
+            KataGoAutoSetupHelper.RemoteWeightInfo info =
+                new KataGoAutoSetupHelper.RemoteWeightInfo(
+                    "Transformer",
+                    "fixture-transformer",
+                    server.url(),
+                    "2026-07-29",
+                    "",
+                    true,
+                    true,
+                    "0000000000000000000000000000000000000000000000000000000000000000",
+                    modelBytes.length,
+                    "1.17.0",
+                    KataGoAutoSetupHelper.TransformerTier.BALANCED);
+
+            assertThrows(IOException.class, () -> KataGoAutoSetupHelper.downloadWeight(info, null));
+          });
+      String logs = formattedDiagnostics(events);
+      assertTrue(logs.contains("operation=weight-download"), logs);
+      assertTrue(logs.contains("stage=http-download outcome=success"), logs);
+      assertTrue(logs.contains("stage=verify outcome=failed"), logs);
+      assertTrue(logs.contains("reason=checksum-mismatch"), logs);
+      assertFalse(logs.contains("stage=move"), logs);
+      assertFalse(logs.contains("0000000000000000"), logs);
+      assertFalse(logs.contains(server.url()), logs);
+    } finally {
+      LoggingRuntime.resetForTests();
     }
   }
 
@@ -1927,6 +2015,22 @@ public class KataGoAutoSetupHelperTest {
       restoreProperty("lizzie.quick-analysis.model.sha256", previousSha);
       restoreProperty("lizzie.quick-analysis.model.size", previousSize);
     }
+  }
+
+  private static ListAppender<ILoggingEvent> attachDiagnostics() {
+    ListAppender<ILoggingEvent> appender = new ListAppender<>();
+    appender.start();
+    Logger logger = (Logger) LoggerFactory.getLogger(LogCategories.DIAGNOSTICS);
+    logger.addAppender(appender);
+    return appender;
+  }
+
+  private static String formattedDiagnostics(ListAppender<ILoggingEvent> events) {
+    StringBuilder text = new StringBuilder();
+    for (ILoggingEvent event : events.list) {
+      text.append(event.getFormattedMessage()).append('\n');
+    }
+    return text.toString();
   }
 
   private static void restoreProperty(String key, String previousValue) {

--- a/src/test/java/featurecat/lizzie/util/KataGoRuntimeHelperTest.java
+++ b/src/test/java/featurecat/lizzie/util/KataGoRuntimeHelperTest.java
@@ -5,12 +5,19 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
 import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpServer;
 import featurecat.lizzie.Config;
 import featurecat.lizzie.ConfigTestHelper;
 import featurecat.lizzie.Lizzie;
 import featurecat.lizzie.gui.EngineData;
+import featurecat.lizzie.logging.LogCategories;
+import featurecat.lizzie.logging.LoggingLimits;
+import featurecat.lizzie.logging.LoggingRuntime;
+import featurecat.lizzie.logging.WorkDirectoryResolution;
 import featurecat.lizzie.rules.Board;
 import featurecat.lizzie.util.KataGoAutoSetupHelper.DownloadCancelledException;
 import featurecat.lizzie.util.KataGoAutoSetupHelper.DownloadSession;
@@ -40,6 +47,7 @@ import org.json.JSONObject;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
 
 public class KataGoRuntimeHelperTest {
   private static final String OS_NAME_PROPERTY = "os.name";
@@ -1064,6 +1072,105 @@ public class KataGoRuntimeHelperTest {
                             "Successful TensorRT installs should remove the completed installer archive.");
                       }));
         });
+  }
+
+  @Test
+  void tensorRtInstallEmitsSuccessfulStageDiagnostics() throws Exception {
+    Path logDir = Files.createTempDirectory("katago-tensorrt-success-logs");
+    LoggingRuntime.initialize(
+        new WorkDirectoryResolution(logDir, List.of()),
+        new LoggingLimits(64, 32, 32, 32, 7, 1_000_000, 256_000));
+    try {
+      ListAppender<ILoggingEvent> events = attachDiagnostics();
+      withOsName(
+          WINDOWS_OS_NAME,
+          () -> {
+            Path tempRoot = Files.createTempDirectory("katago-helper-tensorrt-diag-success");
+            Path runtimeWorkDirectory = Files.createDirectories(tempRoot.resolve("runtime-root"));
+            SetupSnapshot snapshot = createUnifiedNvidiaSnapshot(tempRoot);
+            Path fixtureZip =
+                createTensorRtFixtureZip(tempRoot.resolve("fixture").resolve("katago-trt.zip"));
+            withTensorRtFixtureProperties(
+                fixtureZip.toUri().toString(),
+                sha256(fixtureZip),
+                Files.size(fixtureZip),
+                () ->
+                    withConfig(
+                        runtimeWorkDirectory,
+                        () -> {
+                          SetupResult result =
+                              KataGoRuntimeHelper.downloadAndInstallTensorRt(
+                                  snapshot, null, new DownloadSession());
+                          assertEquals("KataGo TensorRT", result.engineName);
+                        }));
+          });
+      String logs = formattedDiagnostics(events);
+      assertTrue(logs.contains("operation=tensorrt-setup"), logs);
+      assertTrue(logs.contains("stage=lock outcome=success"), logs);
+      assertTrue(logs.contains("stage=download outcome=success"), logs);
+      assertTrue(logs.contains("stage=verify outcome=success"), logs);
+      assertTrue(logs.contains("stage=extract outcome=success"), logs);
+      assertTrue(logs.contains("stage=install outcome=success"), logs);
+      assertTrue(logs.contains("stage=apply-config outcome=success"), logs);
+      assertTrue(logs.contains("stage=cache-cleanup outcome=success"), logs);
+      assertFalse(logs.contains("outcome=failed"), logs);
+      assertFalse(logs.contains("reason="), logs);
+    } finally {
+      LoggingRuntime.resetForTests();
+    }
+  }
+
+  @Test
+  void tensorRtInstallLockConflictStopsAtLockStage() throws Exception {
+    Path logDir = Files.createTempDirectory("katago-tensorrt-lock-logs");
+    LoggingRuntime.initialize(
+        new WorkDirectoryResolution(logDir, List.of()),
+        new LoggingLimits(64, 32, 32, 32, 7, 1_000_000, 256_000));
+    try {
+      ListAppender<ILoggingEvent> events = attachDiagnostics();
+      withOsName(
+          WINDOWS_OS_NAME,
+          () -> {
+            Path tempRoot = Files.createTempDirectory("katago-helper-tensorrt-diag-lock");
+            Path runtimeWorkDirectory = Files.createDirectories(tempRoot.resolve("runtime-root"));
+            SetupSnapshot snapshot = createUnifiedNvidiaSnapshot(tempRoot);
+            Path fixtureZip =
+                createTensorRtFixtureZip(tempRoot.resolve("fixture").resolve("katago-trt.zip"));
+            withTensorRtFixtureProperties(
+                fixtureZip.toUri().toString(),
+                sha256(fixtureZip),
+                Files.size(fixtureZip),
+                () ->
+                    withConfig(
+                        runtimeWorkDirectory,
+                        () -> {
+                          Path runtimeDir =
+                              Files.createDirectories(
+                                  runtimeWorkDirectory.resolve("nvidia-runtime"));
+                          Path lockPath = runtimeDir.resolve("tensorrt-install.lock");
+                          try (FileChannel lockChannel =
+                                  FileChannel.open(
+                                      lockPath,
+                                      StandardOpenOption.CREATE,
+                                      StandardOpenOption.WRITE);
+                              FileLock ignored = lockChannel.lock()) {
+                            assertThrows(
+                                IOException.class,
+                                () ->
+                                    KataGoRuntimeHelper.downloadAndInstallTensorRt(
+                                        snapshot, null, new DownloadSession()));
+                          }
+                        }));
+          });
+      String logs = formattedDiagnostics(events);
+      assertTrue(logs.contains("operation=tensorrt-setup"), logs);
+      assertTrue(logs.contains("stage=lock outcome=failed"), logs);
+      assertTrue(logs.contains("reason=file-locked"), logs);
+      assertFalse(logs.contains("stage=download"), logs);
+      assertFalse(logs.contains("stage=install outcome=success"), logs);
+    } finally {
+      LoggingRuntime.resetForTests();
+    }
   }
 
   @Test
@@ -2659,6 +2766,22 @@ public class KataGoRuntimeHelperTest {
       restoreProperty("lizzie.tensorrt.katago.size", previousSize);
       restoreProperty("lizzie.tensorrt.skipRuntimePackagesForTests", previousSkip);
     }
+  }
+
+  private static ListAppender<ILoggingEvent> attachDiagnostics() {
+    ListAppender<ILoggingEvent> appender = new ListAppender<>();
+    appender.start();
+    Logger logger = (Logger) LoggerFactory.getLogger(LogCategories.DIAGNOSTICS);
+    logger.addAppender(appender);
+    return appender;
+  }
+
+  private static String formattedDiagnostics(ListAppender<ILoggingEvent> events) {
+    StringBuilder text = new StringBuilder();
+    for (ILoggingEvent event : events.list) {
+      text.append(event.getFormattedMessage()).append('\n');
+    }
+    return text.toString();
   }
 
   private static void restoreProperty(String key, String previousValue) {

--- a/src/test/java/featurecat/lizzie/util/KataGoRuntimeHelperTest.java
+++ b/src/test/java/featurecat/lizzie/util/KataGoRuntimeHelperTest.java
@@ -38,6 +38,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.zip.ZipEntry;
@@ -1167,6 +1168,110 @@ public class KataGoRuntimeHelperTest {
       assertTrue(logs.contains("stage=lock outcome=failed"), logs);
       assertTrue(logs.contains("reason=file-locked"), logs);
       assertFalse(logs.contains("stage=download"), logs);
+      assertFalse(logs.contains("stage=install outcome=success"), logs);
+    } finally {
+      LoggingRuntime.resetForTests();
+    }
+  }
+
+  @Test
+  void tensorRtInstallRecordsFailedStageWhenCancelledAfterDownload() throws Exception {
+    Path logDir = Files.createTempDirectory("katago-tensorrt-cancel-after-download-logs");
+    LoggingRuntime.initialize(
+        new WorkDirectoryResolution(logDir, List.of()),
+        new LoggingLimits(64, 32, 32, 32, 7, 1_000_000, 256_000));
+    try {
+      ListAppender<ILoggingEvent> events = attachDiagnostics();
+      withOsName(
+          WINDOWS_OS_NAME,
+          () -> {
+            Path tempRoot =
+                Files.createTempDirectory("katago-helper-tensorrt-diag-cancel-after-download");
+            Path runtimeWorkDirectory = Files.createDirectories(tempRoot.resolve("runtime-root"));
+            SetupSnapshot snapshot = createUnifiedNvidiaSnapshot(tempRoot);
+            Path fixtureZip =
+                createTensorRtFixtureZip(tempRoot.resolve("fixture").resolve("katago-trt.zip"));
+            long fixtureSize = Files.size(fixtureZip);
+            DownloadSession session = new DownloadSession();
+            AtomicBoolean cancelledAtDownloadEnd = new AtomicBoolean();
+            withTensorRtFixtureProperties(
+                fixtureZip.toUri().toString(),
+                sha256(fixtureZip),
+                fixtureSize,
+                () ->
+                    withConfig(
+                        runtimeWorkDirectory,
+                        () ->
+                            assertThrows(
+                                DownloadCancelledException.class,
+                                () ->
+                                    KataGoRuntimeHelper.downloadAndInstallTensorRt(
+                                        snapshot,
+                                        (status, downloaded, total) -> {
+                                          if (status != null
+                                              && status.contains("KataGo TensorRT")
+                                              && downloaded >= fixtureSize
+                                              && cancelledAtDownloadEnd.compareAndSet(
+                                                  false, true)) {
+                                            session.cancel();
+                                          }
+                                        },
+                                        session))));
+          });
+      String logs = formattedDiagnostics(events);
+      assertTrue(logs.contains("operation=tensorrt-setup"), logs);
+      assertTrue(logs.contains("stage=download outcome=success"), logs);
+      assertTrue(logs.contains("outcome=failed"), logs);
+      assertTrue(logs.contains("reason=cancelled"), logs);
+      assertFalse(logs.contains("stage=install outcome=success"), logs);
+    } finally {
+      LoggingRuntime.resetForTests();
+    }
+  }
+
+  @Test
+  void tensorRtInstallRecordsFailedMoveWhenCachePromotionFails() throws Exception {
+    Path logDir = Files.createTempDirectory("katago-tensorrt-move-fail-logs");
+    LoggingRuntime.initialize(
+        new WorkDirectoryResolution(logDir, List.of()),
+        new LoggingLimits(64, 32, 32, 32, 7, 1_000_000, 256_000));
+    try {
+      ListAppender<ILoggingEvent> events = attachDiagnostics();
+      withOsName(
+          WINDOWS_OS_NAME,
+          () -> {
+            Path tempRoot = Files.createTempDirectory("katago-helper-tensorrt-diag-move-fail");
+            Path runtimeWorkDirectory = Files.createDirectories(tempRoot.resolve("runtime-root"));
+            SetupSnapshot snapshot = createUnifiedNvidiaSnapshot(tempRoot);
+            Path fixtureZip =
+                createTensorRtFixtureZip(tempRoot.resolve("fixture").resolve("katago-trt.zip"));
+            withTensorRtFixtureProperties(
+                fixtureZip.toUri().toString(),
+                sha256(fixtureZip),
+                Files.size(fixtureZip),
+                () ->
+                    withConfig(
+                        runtimeWorkDirectory,
+                        () -> {
+                          Path archiveDir =
+                              Files.createDirectories(
+                                  runtimeWorkDirectory
+                                      .resolve("nvidia-runtime")
+                                      .resolve("downloads")
+                                      .resolve("katago-trt.zip"));
+                          Files.writeString(archiveDir.resolve("blocker.txt"), "not-an-archive");
+                          assertThrows(
+                              IOException.class,
+                              () ->
+                                  KataGoRuntimeHelper.downloadAndInstallTensorRt(
+                                      snapshot, null, new DownloadSession()));
+                        }));
+          });
+      String logs = formattedDiagnostics(events);
+      assertTrue(logs.contains("operation=tensorrt-setup"), logs);
+      assertTrue(logs.contains("stage=download outcome=success"), logs);
+      assertTrue(logs.contains("stage=verify outcome=success"), logs);
+      assertTrue(logs.contains("stage=move outcome=failed"), logs);
       assertFalse(logs.contains("stage=install outcome=success"), logs);
     } finally {
       LoggingRuntime.resetForTests();


### PR DESCRIPTION
## Repro
Run TensorRT setup or a weight download. Failures surface as a final `IOException` (or UI progress text) with no `operation=` / `stage=` / `outcome=` line, so the failing step is not in the logs.

## Cause
`DiagnosticModule` and `LogCategories` had no maintenance/lifecycle events. `KataGoRuntimeHelper.downloadAndInstallTensorRt` and `KataGoAutoSetupHelper.downloadWeightToDirectory` were already multi-stage, but they only threw or called `notifyProgress`.

## Fix
- Add shared `MaintenanceObservation` on existing `lizzie.diagnostics` (no new DiagnosticModule, no event framework).
- Closed tokens: `operation=tensorrt-setup|weight-download`, stages (`lock`, `download`, `verify`, `extract`, `install`, `apply-config`, `cache-cleanup`, `existing-file`, `http-download`, `move`), `outcome=success|failed`, plus `durationMs` and a bounded `reason`.
- Wire TensorRT setup and weight download only. Control flow, return values, and thrown types stay the same; diagnostics are additive.
- Reasons are length-bounded (256 UTF-8 bytes) and sanitized: no tokens, credentialed URLs, or unnecessary absolute paths. Recording failures cannot change the business-flow outcome.
- Follow-up: Windows/Unix path redaction now covers spaced profile paths (`C:\Users\Jake Smith\…`). TensorRT post-download cancel and `move` failures now emit `outcome=failed` (SPEC-1, SPEC-2).

## Verification
`MaintenanceObservationTest`, `KataGoRuntimeHelperTest`, and `KataGoAutoSetupHelperTest` cover a full success path, a mid-stage failure, reason length + sanitization, a spaced Windows path, cancel-after-download, and a move failure. Linux and Windows CI still pending on `90df61a7` at post time. No desktop shots.

Fixes #377
