### PR TITLE
docs(readme): streamline multilingual project guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Windows `portable.zip` 把配置、日志、棋谱、权重和软件内安装的
 
 已有 Windows 免安装版时，小版本升级可下载 `*windows64.core-update.zip`。关闭软件后，把 zip 内容解压到原目录并覆盖旧文件。该包只更新 `app/lizzie-yzy2.5.3-shaded.jar`、`app/LizzieYzy Next*.cfg` 和供旧版自动更新器识别的兼容文件，不会覆盖 `weights/`、`engines/`、`runtime/`、`jcef-bundle/`、`readboard/` 或 `user-data/`。如果 release 说明包含 KataGo、权重或运行环境升级，请改用完整包或对应资源包。
 
-完整包的 CPU、OpenCL、CUDA、TensorRT、Metal 和 Linux 后端均使用 KataGo `v1.18.1`。Linux NVIDIA 仍使用 CUDA 12.1，以兼顾系统运行环境。
+完整包的 CPU、OpenCL、CUDA、TensorRT、Metal 后端和 Linux 包均使用 KataGo `v1.18.1`。Linux NVIDIA 仍使用 CUDA 12.1，以兼顾系统运行环境。
 
 主推荐完整包默认内置官方旗舰 B11 `b11c768h12nbt3tflrs-fson-silu.bin.gz`（约 202 MiB）；本机 RTX 3070 实测搜索吞吐比 B10 慢约 40%，追求速度可在 `KataGo 一键设置 -> 权重` 中切换 B10。
 

--- a/README.md
+++ b/README.md
@@ -15,9 +15,8 @@
 </p>
 
 <p align="center">
-  <strong>LizzieYzy Next 是当前仍在维护的 lizzieyzy 维护版，也是一个面向普通棋友的 KataGo 围棋复盘 GUI。</strong><br/>
-  它把真正影响体验的几件事重新打磨了一遍：更好选的下载包、更省心的首次启动、继续可用的野狐抓谱，以及更容易看懂的整盘分析视角。<br/>
-  <strong>下载安装，输入野狐昵称，抓最近公开棋谱，跑快速全盘分析，再用新版胜率图和底部快速概览快速定位关键手。</strong>
+  <strong>LizzieYzy Next 是仍在维护的 lizzieyzy 分支，面向使用 KataGo 复盘的普通棋友。</strong><br/>
+  提供野狐昵称抓谱、快速全盘分析、新版胜率图和底部快速概览，并发布 Windows、macOS、Linux 版本。
 </p>
 
 <p align="center">
@@ -40,41 +39,9 @@
 > 提取码：`3i8w`
 
 > [!TIP]
-> 项目讨论 QQ 群：`299419120`
+> [项目讨论 QQ 群：299419120](https://qm.qq.com/q/JZoeojjteg)
 >
 > 欢迎交流使用问题、反馈 bug、分享使用体验，或者讨论接下来最想加的功能。
-
-> [!IMPORTANT]
-> 如果你只想先下对版本，先记住这几句：
-> - RTX 20/30/40/50 NVIDIA 显卡：到 [正式版下载页](https://goagent.top/download/) 下载 `*windows64.nvidia.portable.zip`，内置 CUDA 12.8 + cuDNN 9.8
-> - AMD、Intel 或较老的 NVIDIA 显卡：下载 `*windows64.opencl.portable.zip`
-> - 没有合适独立显卡，或 GPU 版本无法正常启动：下载 `*windows64.with-katago.portable.zip` CPU 兼容版
-> - 已经有 Windows 免安装版：日常升级优先下载 `*windows64.core-update.zip`，关闭软件后解压到旧目录覆盖，只更新主程序和启动器配置
-> - RTX 40/50 默认使用 CUDA；TensorRT 是 RTX 30 系及以下 NVIDIA 显卡的可选方案，不再作为“高级版”推荐
-> - 完整包的 CPU、OpenCL、CUDA、TensorRT、Metal 和 Linux 后端已统一升级到 KataGo `v1.18.1`；Linux NVIDIA 仍使用 CUDA 12.1 以兼顾系统运行环境
-> - `KataGo 一键设置` 会检测 NVIDIA GPU 和 Compute Capability，自动提示是否推荐 TensorRT；检测失败也可以手动继续
-> - TensorRT 一键安装成功后会自动清理下载包缓存；运行缓存尽量写入软件自己的 `user-data/runtime`，减少 C 盘额外占用
-> - Release 里的 `*windows64.nvidia.tensorrt.portable.7z.001` 是 RTX 30 系及以下可选离线包，必须下载全部 `.7z.00N` 并用 7-Zip 解压
-> - 如果 OpenCL 在你的电脑上不稳定：下载 `*windows64.with-katago.portable.zip`
-> - 现在支持直接输入野狐昵称抓最近公开棋谱，不需要先查账号数字
-> - 主推荐完整包默认内置官方旗舰 B11 `b11c768h12nbt3tflrs-fson-silu.bin.gz`（约 202 MiB）：单次判断更强、复杂局面效果更好；本机 RTX 3070 实测搜索吞吐比 B10 慢约 40%，追求速度可在“一键设置 -> 权重”切换 B10
-> - Windows 主发布包已内置原生 `readboard.exe`，同步入口只保留这套更强的棋盘同步工具
-
-## 为什么很多用户会直接选它
-
-`LizzieYzy Next` 可以直接理解成：
-
-- 一套还在持续维护的 `KataGo 围棋复盘桌面工具`
-- 一条把 `野狐抓谱 + 快速全盘分析 + 多平台发布包` 串起来的实用工作流
-- 一个让老 `lizzieyzy` 用户更容易继续用下去的维护分支
-
-如果你正在找这些东西，这个项目应该优先看：
-
-- `KataGo 围棋复盘软件`
-- `KataGo GUI`
-- `lizzieyzy 维护版`
-- `野狐棋谱抓取 + KataGo 复盘`
-- `Windows 免安装围棋 AI 复盘工具`
 
 ## 你打开后马上能做什么
 
@@ -89,9 +56,11 @@
 | 做棋盘同步 | Windows 主发布包已内置原生 `readboard.exe`，同步入口更清晰 |
 | 本机算力不够 | `设置 -> 远程算力中心` 可登录智子云算力，创建远程 KataGo 引擎后像本机引擎一样使用 |
 
-## 先下载哪个
+远程算力中心默认使用“VIP 包月”（`--gpu-type vip-share`）；非 VIP 用户可在高级设置中切换到“按量 1x / 3x / 6x”等档位。默认预设使用智子28B模型。TensorRT/CUDA 指云端引擎后端，不是充值套餐名。
 
-国内用户建议从 [官网下载页面](https://goagent.top/download/) 选择常用正式版；安装器、Linux 包和历史版本可在 [GitHub Releases](https://github.com/wimi321/lizzieyzy-next/releases) 下载。
+勾选“记住登录/密码”后，凭据由 Windows DPAPI、macOS Keychain 或 Linux Secret Service 保护，不写入普通配置。系统安全存储不可用时，凭据只保留到程序退出。断线后会自动重连，也可一键切回本机引擎。
+
+## 先下载哪个
 
 <p align="center">
   <img src="assets/package-guide-zh.svg" alt="LizzieYzy Next 下载选择图" width="100%" />
@@ -117,41 +86,21 @@
 | macOS Intel，打开后拖到“应用程序” | `*mac-intel.with-katago.dmg` |
 | Linux | `*linux64.with-katago.zip` |
 
-Windows `portable.zip` 是真正的免安装模式：配置、日志、保存棋谱、下载权重和软件内安装的 TensorRT 加速文件都会保存在解压出来的同一个文件夹里，主要位置是 `user-data/`。如果想彻底清理这个免安装版，删除整个解压文件夹即可；如果想保留设置，升级前把旧文件夹里的 `user-data/` 复制到新文件夹。
+Windows `portable.zip` 把配置、日志、棋谱、权重和软件内安装的 TensorRT 文件保存在解压目录，主要位于 `user-data/`。删除整个目录即可卸载；换目录升级时，复制 `user-data/` 可保留设置。
 
-已有 Windows 免安装版时，日常小版本升级不用重新下载完整大包。下载 `*windows64.core-update.zip`，关闭软件，把 zip 里的内容解压到旧的免安装目录覆盖即可。这个小包更新 `app/lizzie-yzy2.5.3-shaded.jar` 和 `app/LizzieYzy Next*.cfg`，并保留一个供旧版自动更新器识别的兼容文件；不会重复下载或覆盖 `weights/`、`engines/`、`runtime/`、`jcef-bundle/`、`readboard/`、`user-data/`。如果某次 release 明确写了 KataGo、权重或运行环境升级，再按说明下载完整包或对应资源包。
+已有 Windows 免安装版时，小版本升级可下载 `*windows64.core-update.zip`。关闭软件后，把 zip 内容解压到原目录并覆盖旧文件。该包只更新 `app/lizzie-yzy2.5.3-shaded.jar`、`app/LizzieYzy Next*.cfg` 和供旧版自动更新器识别的兼容文件，不会覆盖 `weights/`、`engines/`、`runtime/`、`jcef-bundle/`、`readboard/` 或 `user-data/`。如果 release 说明包含 KataGo、权重或运行环境升级，请改用完整包或对应资源包。
 
-如果你懒得分辨：
+完整包的 CPU、OpenCL、CUDA、TensorRT、Metal 和 Linux 后端均使用 KataGo `v1.18.1`。Linux NVIDIA 仍使用 CUDA 12.1，以兼顾系统运行环境。
 
-- 已经有 Windows 免安装版：先下 `*windows64.core-update.zip` 覆盖旧目录，除非更新说明要求下载完整包
-- Windows + RTX 20/30/40/50 NVIDIA 显卡：统一下载 `*windows64.nvidia.portable.zip`
-- Windows + AMD、Intel 或较老 NVIDIA 显卡：下载 `*windows64.opencl.portable.zip`
-- Windows 没有合适 GPU，或 CUDA/OpenCL 无法正常启动：下载 `*windows64.with-katago.portable.zip`
-- Windows + RTX 30 系及以下想试 TensorRT：先打开统一 NVIDIA/CUDA 包，再在软件内“一键设置”按需安装；RTX 40/50 保留 CUDA
-- TensorRT 一键安装完成后会自动删除完整下载包，之前留下的下载缓存也可以在一键设置里点“清理 TensorRT 缓存”
-- Windows + RTX 30 系及以下需要离线 TensorRT：下载 `*windows64.nvidia.tensorrt.portable.7z.001/.002/...` 全部分卷后从 `.001` 解压
-- NVIDIA 驱动 `570.65` 及以上直接加载；`528.33–570.64` 首次运行会做一次轻量真实推理探测；更旧驱动会显示明确修复状态
-- GTX 10 系以前的 NVIDIA 显卡：优先使用 OpenCL 包
-- OpenCL 不稳定：改下 `*windows64.with-katago.portable.zip`
-- Mac：先分清 Apple Silicon 还是 Intel
-- Linux：直接下 `*linux64.with-katago.zip`
+主推荐完整包默认内置官方旗舰 B11 `b11c768h12nbt3tflrs-fson-silu.bin.gz`（约 202 MiB）；本机 RTX 3070 实测搜索吞吐比 B10 慢约 40%，追求速度可在 `KataGo 一键设置 -> 权重` 中切换 B10。
 
-## 为什么这一版更适合普通用户
+NVIDIA 和 TensorRT 说明：
 
-- `野狐抓谱能继续用`
-  现在支持直接输入野狐昵称，普通用户不用先查数字账号。
-- `快速全盘分析已经是主流程`
-  打开棋谱后，可以更快得到整盘走势，而不是完全依赖一步一步手动分析。
-- `新版主胜率图 + 底部快速概览`
-  更容易看出哪里是大恶手，哪里值得先回头看。
-- `Windows 免安装优先`
-  普通用户下载更直接，OpenCL / NVIDIA / CPU 三条线也更清楚。
-- `只保留原生 readboard 同步工具`
-  Windows 主发布包内置原生 `readboard.exe`，不再让普通用户在多个同步入口之间纠结。
-- `远程算力中心`
-  本机显卡不够时，可以在软件内登录智子云算力，默认使用“VIP 包月”（`--gpu-type vip-share`）远程 KataGo；非 VIP 用户可在高级设置切换到“按量 1x / 3x / 6x”等档位。默认预设使用智子28B模型，TensorRT/CUDA 表示云端引擎后端，不是充值套餐名。勾选“记住登录/密码”后，凭据由 Windows DPAPI、macOS Keychain 或 Linux Secret Service 保护，不写入普通配置；系统安全存储不可用时只在本次运行中保留。断线会自动重连，也可以一键切回本机引擎。
-- `真实发布 + 真实烟测`
-  不是只改源码，Windows / macOS / Linux 的发布包和烟测链路也都持续在做。
+- `KataGo 一键设置` 会检测 NVIDIA GPU 和 Compute Capability，并提示是否推荐 TensorRT；检测失败时仍可手动继续。
+- RTX 40/50 默认使用 CUDA。TensorRT 是 RTX 30 系及以下的可选方案；安装完成后会自动删除下载包，旧缓存可在一键设置中清理。
+- NVIDIA 驱动 `570.65` 及以上可直接加载；`528.33–570.64` 首次运行会做一次轻量推理探测；更旧驱动会显示修复状态。
+- 离线安装 TensorRT 时，下载 `*windows64.nvidia.tensorrt.portable.7z.001/.002/...` 全部分卷，并使用 7-Zip 从 `.001` 解压。先阅读同名 `README.txt`。
+- GTX 10 系以前的显卡优先使用 OpenCL 包。OpenCL 不稳定时，改用 `*windows64.with-katago.portable.zip`。
 
 ## 三步开始
 
@@ -169,15 +118,13 @@ Windows `portable.zip` 是真正的免安装模式：配置、日志、保存棋
   如果 GitHub 里的动图加载慢，直接点上面的图就能看完整演示。
 </p>
 
-## 当前真实界面
-
-下面这张就是当前 release 的真实界面截图，不是旧版本历史图。
+## 界面预览
 
 <p align="center">
-  <img src="assets/interface-overview-2026-04.png" alt="LizzieYzy Next 当前新版真实界面" width="100%" />
+  <img src="assets/interface-overview-2026-04.png" alt="LizzieYzy Next 界面预览" width="100%" />
 </p>
 
-主胜率图和底部快速概览现在可以这样理解：
+主胜率图和底部快速概览包含：
 
 <p align="center">
   <img src="assets/winrate-quick-overview-2026-04.png" alt="LizzieYzy Next 主胜率图与快速概览" width="46%" />
@@ -199,25 +146,11 @@ Windows `portable.zip` 是真正的免安装模式：配置、日志、保存棋
 | Windows 下载体验 | 需要用户自己判断更多 | 明确优先推荐 `portable.zip` 免安装包 |
 | 同步工具 | 用户自己拼环境的情况更多 | Windows 主发布包内置原生 `readboard.exe` |
 
-## 常见问题
-
-### 棋盘同步工具还需要单独找 readboard 仓库吗？
-
-多数 Windows 用户不需要。`LizzieYzy Next` 的 Windows 主发布包内置原生 `readboard.exe`，软件里只保留这一个棋盘同步入口，避免在多个同步工具之间选错。
-
-### 现在还需要先知道野狐账号数字吗？
-
-不需要。现在直接输入野狐昵称就行，程序会自动匹配账号。
-
-### 现在还要一步一步分析，才能看到整盘走势吗？
-
-大多数情况下不需要。现在可以直接走快速全盘分析，主胜率图和底部快速概览会更快形成整盘视角。
-
-### Mac 第一次打不开怎么办？
+## macOS 首次启动
 
 先确认下载的芯片版本正确，再打开 DMG，按画面箭头把 `LizzieYzy Next` 拖到“应用程序”，弹出安装磁盘后从 Finder 的“应用程序”启动。当前官方 release 流程会完成签名和公证；如果系统仍拦截，请按 [安装说明](docs/INSTALL.md) 排查。
 
-## 用户文档
+## 文档与参与
 
 - [获取帮助](SUPPORT.md)
 - [安装说明](docs/INSTALL.md)
@@ -225,32 +158,33 @@ Windows `portable.zip` 是真正的免安装模式：配置、日志、保存棋
 - [常见问题与排错](docs/TROUBLESHOOTING.md)
 - [已验证平台](docs/TESTED_PLATFORMS.md)
 - [GitHub Releases](https://github.com/wimi321/lizzieyzy-next/releases)
-- GitHub Discussions: <https://github.com/wimi321/lizzieyzy-next/discussions>
-- QQ 群：`299419120`
-
-## 项目链接
+- [GitHub Discussions](https://github.com/wimi321/lizzieyzy-next/discussions)
+- [QQ 群：299419120](https://qm.qq.com/q/JZoeojjteg)
 - [项目路线图](ROADMAP.md)
 - [参与贡献](CONTRIBUTING.md)
 - [更新日志](CHANGELOG.md)
-- [Support](SUPPORT.md)
 
 ## 致谢
-
-`LizzieYzy Next` 能继续向前走，离不开这些项目和贡献者：
 
 - 原项目：[yzyray/lizzieyzy](https://github.com/yzyray/lizzieyzy)
 - KataGo：[lightvector/KataGo](https://github.com/lightvector/KataGo)
 - 棋盘同步工具：[qiyi71w/readboard](https://github.com/qiyi71w/readboard)
 
-特别感谢 [qiyi71w](https://github.com/qiyi71w) 持续优化 readboard，对 `LizzieYzy Next` 的棋盘同步体验帮助很大。也欢迎更多开发者、棋友和工具作者参与到这个项目中来，一起把它打磨得更稳定、更好用。
+感谢 [qiyi71w](https://github.com/qiyi71w) 持续维护和优化 readboard。
 
-野狐抓谱历史参考：
+感谢所有参与提交的贡献者：
+
+<p align="left">
+  <a href="https://github.com/wimi321/lizzieyzy-next/graphs/contributors">
+    <img src="https://contrib.rocks/image?repo=wimi321/lizzieyzy-next" alt="LizzieYzy Next 贡献者" />
+  </a>
+</p>
+
+野狐抓谱参考：
 
 - [yzyray/FoxRequest](https://github.com/yzyray/FoxRequest)
 - [FuckUbuntu/Lizzieyzy-Helper](https://github.com/FuckUbuntu/Lizzieyzy-Helper)
 
 ## 参与翻译
 
-欢迎提供翻译！如果您愿意将本说明翻译成您的母语，请随时提交 PR。
-
-We welcome translations! If you want to translate this README into your native language, please feel free to submit a Pull Request.
+欢迎提交 README 翻译 PR。Translations are welcome; please submit a Pull Request.

--- a/README_EN.md
+++ b/README_EN.md
@@ -15,9 +15,8 @@
 </p>
 
 <p align="center">
-  <strong>LizzieYzy Next is the actively maintained LizzieYzy fork and a practical KataGo review GUI for everyday players.</strong><br/>
-  It focuses on the parts that actually affect the user experience: easier package selection, less painful first launch, Fox fetching that works again, and a whole-game view that is easier to read at a glance.<br/>
-  <strong>Download it, enter a Fox nickname, fetch recent public games, run fast full-game analysis, and use the redesigned winrate graph plus quick overview strip to jump to the key moves faster.</strong>
+  <strong>LizzieYzy Next is the maintained lizzieyzy branch for players who use KataGo to review games.</strong><br/>
+  It provides Fox nickname fetching, fast full-game analysis, a redesigned winrate graph and bottom quick overview, with releases for Windows, macOS, and Linux.
 </p>
 
 <p align="center">
@@ -40,39 +39,11 @@
 > Extraction code: `3i8w`
 
 > [!TIP]
-> Chinese QQ group: `299419120`
+> [Chinese QQ group: 299419120](https://qm.qq.com/q/JZoeojjteg)
 >
 > It is the fastest place for day-to-day user feedback, bug reports, and feature discussion.
 
-> [!IMPORTANT]
-> If you only want the shortest possible answer, remember these 10 points:
-> - Most Windows users should open [Stable Downloads](https://goagent.top/download/) and download `*windows64.opencl.portable.zip`
-> - RTX 20/30/40/50 NVIDIA users should download the single `*windows64.nvidia.portable.zip`, which bundles CUDA 12.8 + cuDNN 9.8
-> - RTX 40/50 should use CUDA by default. TensorRT is an optional alternative for RTX 30 series and earlier, not a premium edition
-> - CPU, OpenCL, CUDA, TensorRT, Metal, and Linux bundles are upgraded to KataGo `v1.18.1`; Linux NVIDIA stays on CUDA 12.1 for runtime compatibility
-> - `KataGo Auto Setup` detects the NVIDIA GPU and Compute Capability, then recommends whether TensorRT is a good fit; manual install remains available if detection fails
-> - If OpenCL behaves badly on your PC, switch to `*windows64.with-katago.portable.zip`
-> - The app now supports Fox nickname input directly, so most users no longer need the account number first
-> - Full recommended bundles include the official flagship B11 model `b11c768h12nbt3tflrs-fson-silu.bin.gz` (about 202 MiB). It is stronger per evaluation and in complex positions; an RTX 3070 comparison measured about 40% lower search throughput than B10, which remains available on demand
-> - Main release packages now ship the `readboard_java` helper, so most users do not need a separate readboard repository
-
-## Why Many Users Start Here
-
-`LizzieYzy Next` is:
-
-- an actively maintained `KataGo review desktop app`
-- a practical workflow that combines `Fox fetching + fast whole-game analysis + multi-platform release packages`
-- the maintained branch that makes it easier for long-time `lizzieyzy` users to keep going without rebuilding their setup
-
-If you are searching for these things, this is the project to check first:
-
-- `KataGo review software`
-- `KataGo GUI`
-- `LizzieYzy maintained fork`
-- `Fox game fetch + KataGo review`
-- `portable Windows Go AI review tool`
-
-## What You Can Do Right Away
+## What you can do right away
 
 | What you want | How the project handles it now |
 | --- | --- |
@@ -81,9 +52,9 @@ If you are searching for these things, this is the project to check first:
 | Find problem moves faster | Use the redesigned main winrate graph and the bottom heat overview strip |
 | Avoid setup work | Use bundled KataGo, bundled weight, and first-launch auto setup |
 | Avoid installation | Use the portable Windows packages |
-| Use board sync | Use the built-in `readboard_java` helper in the main release packages |
+| Use board sync | Windows release packages include the native `readboard.exe` |
 
-## What To Download First
+## What to download first
 
 Users in mainland China are encouraged to choose common stable builds from the [official download page](https://goagent.top/download/). Installers, Linux packages, and older versions are available from [GitHub Releases](https://github.com/wimi321/lizzieyzy-next/releases).
 
@@ -109,33 +80,18 @@ Users in mainland China are encouraged to choose common stable builds from the [
 | macOS Intel, then drag the app to Applications | `*mac-intel.with-katago.dmg` |
 | Linux | `*linux64.with-katago.zip` |
 
-Quick rule:
+Full packages use KataGo `v1.18.1` for CPU, OpenCL, CUDA, TensorRT, Metal, and Linux backends. Linux NVIDIA remains on CUDA 12.1 for runtime compatibility.
 
-- Windows: start with `*windows64.opencl.portable.zip`
-- Windows + RTX 20/30/40/50 NVIDIA GPU: use the unified `*windows64.nvidia.portable.zip`
-- Windows + RTX 30 series and earlier TensorRT testing: install it on demand from KataGo Auto Setup; RTX 40/50 should remain on CUDA
-- NVIDIA driver `570.65` or newer loads directly; `528.33–570.64` gets one lightweight real-inference probe; older drivers show a clear repair state
-- GTX 10 series and older NVIDIA cards: prefer CUDA/OpenCL instead of TensorRT
-- OpenCL unstable: switch to `*windows64.with-katago.portable.zip`
-- Mac: choose Apple Silicon or Intel first
-- Linux: choose `*linux64.with-katago.zip`
+The recommended full package includes the official flagship B11 model `b11c768h12nbt3tflrs-fson-silu.bin.gz` (about 202 MiB). An RTX 3070 comparison measured about 40% lower search throughput than B10, which remains available from `KataGo Auto Setup -> Weights`.
 
-## Why This Build Fits Real Users Better
+NVIDIA and TensorRT notes:
 
-- `Fox fetching works again`
-  Users can enter the Fox nickname they already know instead of hunting for the numeric ID first.
-- `Fast full-game analysis is now a main workflow`
-  You can get a whole-game picture much sooner instead of building it move by move.
-- `Redesigned winrate graph + bottom quick overview`
-  It is easier to scan where the large losses happened.
-- `Portable-first Windows releases`
-  OpenCL, NVIDIA, and CPU fallback options are easier to understand at a glance.
-- `Built-in readboard_java helper`
-  Most users no longer need to assemble a second repo just to get board sync working.
-- `Real releases + real smoke tests`
-  The project is backed by actual multi-platform release builds and smoke testing, not just source changes.
+- `KataGo Auto Setup` detects the NVIDIA GPU and Compute Capability, then recommends whether TensorRT is a good fit. Manual installation remains available if detection fails.
+- RTX 40/50 use CUDA by default. TensorRT is optional for RTX 30 series and earlier.
+- NVIDIA driver `570.65` or newer loads directly. Versions `528.33–570.64` run one lightweight inference probe on first launch; older drivers show a repair state.
+- GTX 10 series and older cards should use OpenCL. If OpenCL is unstable, switch to `*windows64.with-katago.portable.zip`.
 
-## Start In 3 Steps
+## Start in 3 steps
 
 1. Download the right stable package from [Stable Downloads](https://goagent.top/download/); use GitHub Releases for installers, Linux, or older versions.
 2. Open `Fox Kifu` and enter a Fox nickname.
@@ -151,15 +107,13 @@ Quick rule:
   If GitHub delays GIF playback, click the image above to open the full animation.
 </p>
 
-## Actual Interface
-
-This is the current maintained build, not an old historical screenshot.
+## Interface preview
 
 <p align="center">
-  <img src="assets/interface-overview-2026-04.png" alt="LizzieYzy Next actual interface" width="100%" />
+  <img src="assets/interface-overview-2026-04.png" alt="LizzieYzy Next interface preview" width="100%" />
 </p>
 
-You can read the main graph area like this:
+The main graph and quick overview show:
 
 <p align="center">
   <img src="assets/winrate-quick-overview-2026-04.png" alt="LizzieYzy Next winrate graph and quick overview" width="46%" />
@@ -170,7 +124,7 @@ You can read the main graph area like this:
 - bottom heat strip: where the whole game has the biggest mistakes
 - vertical guide line: the current move or hovered move position
 
-## How It Differs From The Original LizzieYzy
+## How it differs from the original LizzieYzy
 
 | Comparison | Original `lizzieyzy` | `LizzieYzy Next` |
 | --- | --- | --- |
@@ -179,27 +133,13 @@ You can read the main graph area like this:
 | Input model | More dependent on knowing the account number first | Enter the Fox nickname and let the app resolve the account |
 | KataGo setup barrier | Often means fixing your own environment | Recommended bundles already include KataGo and a default weight |
 | Windows download experience | More guesswork for users | Clear portable-first recommendation |
-| Board sync path | More manual assembly for users | Main release packages already include `readboard_java` |
+| Board sync path | More manual assembly for users | Windows release packages include the native `readboard.exe` |
 
-## Common Questions
+## First launch on macOS
 
-### Do I still need a separate readboard repository?
+Choose the package for your Mac, open the DMG, drag `LizzieYzy Next` to Applications, eject the installer disk, and launch it from Finder's Applications folder. Official releases are signed and notarized; if macOS still blocks the app, follow the [Installation Guide](docs/INSTALL_EN.md).
 
-Most users do not. `LizzieYzy Next` now ships the `readboard_java` helper as part of the main release packages.
-
-### Do I still need the Fox account number first?
-
-No. In most cases you can enter the Fox nickname directly and let the app resolve the account.
-
-### Do I still need to step move by move just to get a whole-game picture?
-
-Usually no. The app now supports fast full-game analysis, so the main graph and quick overview can form much earlier.
-
-### What if macOS blocks the app on first launch?
-
-Choose the package for your Mac, open the DMG, drag `LizzieYzy Next` to Applications, eject the installer disk, and launch it from Finder's Applications folder. Official releases go through signing and notarization; if macOS still blocks the app, follow the [Installation Guide](docs/INSTALL_EN.md).
-
-## User Docs
+## Documentation and contribution
 
 - [Support Guide](SUPPORT.md)
 - [Installation Guide](docs/INSTALL_EN.md)
@@ -207,23 +147,33 @@ Choose the package for your Mac, open the DMG, drag `LizzieYzy Next` to Applicat
 - [Troubleshooting](docs/TROUBLESHOOTING_EN.md)
 - [Tested Platforms](docs/TESTED_PLATFORMS.md)
 - [GitHub Releases](https://github.com/wimi321/lizzieyzy-next/releases)
-- GitHub Discussions: <https://github.com/wimi321/lizzieyzy-next/discussions>
-- Chinese QQ group: `299419120`
-
-## Project Links
+- [GitHub Discussions](https://github.com/wimi321/lizzieyzy-next/discussions)
+- [Chinese QQ group: 299419120](https://qm.qq.com/q/JZoeojjteg)
 - [Roadmap](ROADMAP.md)
 - [Contributing](CONTRIBUTING.md)
 - [Changelog](CHANGELOG.md)
-- [Support](SUPPORT.md)
 
 ## Credits
 
 - Original project: [yzyray/lizzieyzy](https://github.com/yzyray/lizzieyzy)
 - KataGo: [lightvector/KataGo](https://github.com/lightvector/KataGo)
-Historical Fox sync references:
+- Board sync: [qiyi71w/readboard](https://github.com/qiyi71w/readboard)
+
+Thanks to [qiyi71w](https://github.com/qiyi71w) for maintaining and improving readboard.
+
+Thanks to everyone who has contributed:
+
+<p align="left">
+  <a href="https://github.com/wimi321/lizzieyzy-next/graphs/contributors">
+    <img src="https://contrib.rocks/image?repo=wimi321/lizzieyzy-next" alt="LizzieYzy Next contributors" />
+  </a>
+</p>
+
+Historical Fox fetching references:
+
 - [yzyray/FoxRequest](https://github.com/yzyray/FoxRequest)
 - [FuckUbuntu/Lizzieyzy-Helper](https://github.com/FuckUbuntu/Lizzieyzy-Helper)
 
 ## Translations
 
-We welcome translations! If you want to translate this README into your native language, please feel free to submit a Pull Request.
+Translations are welcome; please submit a Pull Request.

--- a/README_EN.md
+++ b/README_EN.md
@@ -53,6 +53,12 @@
 | Avoid setup work | Use bundled KataGo, bundled weight, and first-launch auto setup |
 | Avoid installation | Use the portable Windows packages |
 | Use board sync | Windows release packages include the native `readboard.exe` |
+| Keep quick-curve work off the main engine | Download the optional 38 MB official lightweight model from `KataGo Auto Setup -> Weight management`; it runs only while filling missing game-curve positions and releases the GPU before main analysis |
+| Use more compute than this PC provides | Open `Settings -> Remote Compute`, sign in to Zhizi Cloud Compute, and create a remote KataGo engine |
+
+Remote Compute defaults to “VIP monthly” (`--gpu-type vip-share`). Non-VIP users can choose metered 1x / 3x / 6x tiers in Advanced Settings. The default preset uses the Zhizi 28B model; TensorRT and CUDA identify the cloud engine backend, not the billing plan.
+
+Saved login details are protected by Windows DPAPI, macOS Keychain, or Linux Secret Service and are not written to ordinary configuration. If secure storage is unavailable, credentials remain only until the app exits. The connection retries after interruption, and you can switch back to a local engine at any time.
 
 ## What to download first
 
@@ -64,12 +70,12 @@ Users in mainland China are encouraged to choose common stable builds from the [
 
 | Your situation | Find the file that contains this keyword on Releases |
 | --- | --- |
-| Most Windows users, recommended, no installer | `*windows64.opencl.portable.zip` |
-| Windows, OpenCL build, installer option | `*windows64.opencl.installer.exe` |
-| Windows, OpenCL is unstable, CPU fallback, no installer | `*windows64.with-katago.portable.zip` |
-| Windows, CPU fallback, installer option | `*windows64.with-katago.installer.exe` |
-| Windows, RTX 20/30/40/50 NVIDIA GPU, no installer | `*windows64.nvidia.portable.zip` |
+| Windows, RTX 20/30/40/50 NVIDIA GPU, recommended, no installer | `*windows64.nvidia.portable.zip` |
 | Windows, RTX 20/30/40/50 NVIDIA GPU, installer option | `*windows64.nvidia.installer.exe` |
+| Windows, AMD / Intel / older NVIDIA GPU, no installer | `*windows64.opencl.portable.zip` |
+| Windows, AMD / Intel / older NVIDIA GPU, installer option | `*windows64.opencl.installer.exe` |
+| Windows, no suitable GPU or the GPU build cannot start, CPU fallback | `*windows64.with-katago.portable.zip` |
+| Windows, CPU fallback, installer option | `*windows64.with-katago.installer.exe` |
 | Windows, RTX 30 series and earlier, optional TensorRT | Start with the unified NVIDIA package, then install TensorRT from `KataGo Auto Setup` |
 | Windows, DirectX 12 GPU, DirectML testing | `*windows64.experimental.directml.portable.zip` |
 | Windows, Intel GPU/NPU, OpenVINO testing | `*windows64.experimental.openvino.portable.zip` |
@@ -80,7 +86,7 @@ Users in mainland China are encouraged to choose common stable builds from the [
 | macOS Intel, then drag the app to Applications | `*mac-intel.with-katago.dmg` |
 | Linux | `*linux64.with-katago.zip` |
 
-Full packages use KataGo `v1.18.1` for CPU, OpenCL, CUDA, TensorRT, Metal, and Linux backends. Linux NVIDIA remains on CUDA 12.1 for runtime compatibility.
+Full packages for CPU, OpenCL, CUDA, TensorRT, and Metal backends, along with the Linux packages, use KataGo `v1.18.1`. Linux NVIDIA remains on CUDA 12.1 for runtime compatibility.
 
 The recommended full package includes the official flagship B11 model `b11c768h12nbt3tflrs-fson-silu.bin.gz` (about 202 MiB). An RTX 3070 comparison measured about 40% lower search throughput than B10, which remains available from `KataGo Auto Setup -> Weights`.
 

--- a/README_JA.md
+++ b/README_JA.md
@@ -15,9 +15,8 @@
 </p>
 
 <p align="center">
-  <strong>LizzieYzy Next は、現在も保守されている lizzieyzy 系の実用版であり、普通の利用者向けの KataGo 復盤 GUI です。</strong><br/>
-  配布物の選びやすさ、初回起動の負担、野狐棋譜取得の使いやすさ、そして全局を見渡しやすい解析体験の4点を、いまの利用者目線で整え直しています。<br/>
-  <strong>ダウンロードして、野狐のニックネームを入力し、公開棋譜を取得して、全局を素早く解析し、新しい勝率グラフと下部のクイック概要で重要な手へすぐ移動できます。</strong>
+  <strong>LizzieYzy Next は、KataGo で対局を振り返る利用者向けに保守されている lizzieyzy ブランチです。</strong><br/>
+  野狐のニックネームによる棋譜取得、全局の高速解析、新しい勝率グラフと下部概要を備え、Windows、macOS、Linux 向けに配布しています。
 </p>
 
 <p align="center">
@@ -40,34 +39,9 @@
 > 取り出しコード: `3i8w`
 
 > [!TIP]
-> 中国語 QQ グループ: `299419120`
+> [中国語 QQ グループ: 299419120](https://qm.qq.com/q/JZoeojjteg)
 >
 > 日常の利用相談、バグ報告、機能要望のやり取りが一番速い場所です。
-
-> [!IMPORTANT]
-> まずはこの 6 点だけ押さえれば大丈夫です:
-> - Windows 利用者の多くは [安定版ダウンロード](https://goagent.top/download/) で `*windows64.opencl.portable.zip` を選べば始めやすいです
-> - NVIDIA GPU があり、より速く解析したい場合は `*windows64.nvidia.portable.zip` を選べます
-> - OpenCL の相性が悪い場合は `*windows64.with-katago.portable.zip` に切り替えられます
-> - 野狐棋譜取得はニックネーム入力に対応しており、多くの利用者はアカウント番号を先に知らなくても大丈夫です
-> - 推奨フルパッケージには KataGo `v1.18.1` と公式フラッグシップ B11 Transformer が含まれ、画面では「Transformer 11B 棋力優先」（約 202 MiB）と表示されます。1 回ごとの判断は強くなりますが探索速度は遅くなる場合があり、速度優先なら自動設定で B10 に切り替えられます。コア更新パッケージにはエンジンとウェイトは含まれません
-> - 主な release パッケージには `readboard_java` も同梱されており、多くの利用者は別の readboard リポジトリを用意する必要がありません
-
-## なぜ多くの利用者がここから始めるのか
-
-`LizzieYzy Next` は次のように考えればわかりやすいです。
-
-- 普通の利用者向けに使いやすく整えた `KataGo 復盤ソフト`
-- `野狐棋譜取得 + 全局を素早く見る解析 + 複数 OS 向け配布` を一つにした実用ワークフロー
-- 古い `lizzieyzy` 環境から移りやすい現行の保守ブランチ
-
-次のようなものを探しているなら、まずこのプロジェクトを見る価値があります。
-
-- `KataGo 復盤ソフト`
-- `KataGo GUI`
-- `lizzieyzy 保守版`
-- `野狐棋譜取得 + KataGo 復盤`
-- `Windows 非インストール 囲碁 AI ツール`
 
 ## 起動したあとすぐできること
 
@@ -78,7 +52,7 @@
 | 問題手を早く見たい | 新しい主勝率グラフと下部のヒート概要で大きな損失を見つけやすくなっています |
 | 設定をあまり触りたくない | 推奨パッケージに KataGo、既定の重み、初回自動設定が入っています |
 | インストールしたくない | Windows では `portable.zip` を優先して選べます |
-| 棋盤同期も使いたい | 主な配布物に `readboard_java` が同梱されています |
+| 棋盤同期も使いたい | Windows 向けの主な配布物にネイティブ版 `readboard.exe` が同梱されています |
 
 ## まずどれをダウンロードするか
 
@@ -102,28 +76,16 @@
 | macOS Intel | `*mac-intel.with-katago.dmg` |
 | Linux | `*linux64.with-katago.zip` |
 
-迷ったときの目安:
+フルパッケージの CPU、OpenCL、CUDA、TensorRT、Metal、Linux バックエンドは KataGo `v1.18.1` を使用します。Linux NVIDIA 版は実行環境との互換性のため CUDA 12.1 を維持しています。
 
-- Windows: まず `*windows64.opencl.portable.zip`
-- Windows + NVIDIA GPU: まず `*windows64.nvidia.portable.zip`
-- OpenCL が合わない: `*windows64.with-katago.portable.zip`
-- Mac: Apple Silicon か Intel かを先に確認
-- Linux: `*linux64.with-katago.zip`
+推奨フルパッケージには、公式フラッグシップ B11 モデル `b11c768h12nbt3tflrs-fson-silu.bin.gz`（約 202 MiB）が含まれます。RTX 3070 での比較では、探索スループットが B10 より約 40% 低く、速度を優先する場合は `KataGo 自動設定 -> ウェイト` で B10 に切り替えられます。
 
-## なぜ今この版が使いやすいのか
+NVIDIA と TensorRT:
 
-- `野狐棋譜取得が再び使える`
-  利用者が覚えているニックネームから始められます。
-- `全局を素早く見る解析が主導線になった`
-  一手ずつ積み上げなくても、全体像を早く作れます。
-- `主勝率グラフ + 下部クイック概要`
-  大きな損失が出た場所を先に探しやすくなりました。
-- `Windows は非インストール版を先に案内`
-  OpenCL / NVIDIA / CPU フォールバックの違いがわかりやすくなっています。
-- `readboard_java を主 release に同梱`
-  多くの利用者は別リポジトリを組み合わせなくて済みます。
-- `実際の release とスモークテスト`
-  単にソースを更新するだけでなく、複数 OS の配布と確認も続けています。
+- `KataGo 自動設定` は NVIDIA GPU と Compute Capability を検出し、TensorRT が適しているかを案内します。検出に失敗しても手動で続行できます。
+- RTX 40/50 は既定で CUDA を使用します。TensorRT は RTX 30 シリーズ以前で選べます。
+- NVIDIA ドライバ `570.65` 以降はそのまま読み込みます。`528.33–570.64` は初回起動時に軽量推論テストを 1 回実行し、それより古いドライバでは修復状態を表示します。
+- GTX 10 シリーズ以前は OpenCL を使用してください。OpenCL が不安定な場合は `*windows64.with-katago.portable.zip` に切り替えます。
 
 ## 3 ステップで開始
 
@@ -141,15 +103,13 @@
   GitHub 上で GIF の再生が遅い場合は、上の画像をクリックすると全体を開けます。
 </p>
 
-## 実際の画面
-
-以下は現在のメンテ版そのものの実画面です。
+## 画面プレビュー
 
 <p align="center">
-  <img src="assets/interface-overview-2026-04.png" alt="LizzieYzy Next actual interface" width="100%" />
+  <img src="assets/interface-overview-2026-04.png" alt="LizzieYzy Next 画面プレビュー" width="100%" />
 </p>
 
-グラフ部分は次のように読むとわかりやすいです。
+主勝率グラフと下部のクイック概要には、次の情報が表示されます。
 
 <p align="center">
   <img src="assets/winrate-quick-overview-2026-04.png" alt="LizzieYzy Next winrate graph and quick overview" width="46%" />
@@ -169,27 +129,13 @@
 | 入力方法 | 数字のアカウント番号を先に知っている前提が強い | 野狐のニックネームを入れるとアプリが自動で対応付け |
 | KataGo 利用の敷居 | 自分で環境や不足リソースを補う場面が多い | 推奨パッケージに KataGo と既定の重みを同梱 |
 | Windows での選びやすさ | 利用者が自分で判断する余地が大きい | `portable.zip` を先に勧める構成でわかりやすい |
-| 同期ツール | 利用者が自分で組み合わせる場面が多い | 主な release に `readboard_java` を同梱 |
+| 同期ツール | 利用者が自分で組み合わせる場面が多い | Windows 向けの主な配布物にネイティブ版 `readboard.exe` を同梱 |
 
-## よくある質問
+## macOS の初回起動
 
-### readboard 用に別リポジトリは必要ですか？
+Mac に合うパッケージを選び、DMG を開いて `LizzieYzy Next` を「アプリケーション」へドラッグします。インストールディスクを取り出したあと、Finder の「アプリケーション」から起動してください。公式 release は署名と公証を行っています。macOS にブロックされる場合は [インストールガイド](docs/INSTALL_JA.md) を参照してください。
 
-多くの利用者には不要です。`LizzieYzy Next` は `readboard_java` を主な release パッケージに含めています。
-
-### 野狐のアカウント番号を先に知っておく必要はありますか？
-
-多くの場合は不要です。野狐のニックネームを入力すれば、アプリが対応するアカウントを探します。
-
-### 全局の流れを見るのに、まだ一手ずつ進める必要がありますか？
-
-通常はそこまで必要ありません。全局を素早く見る解析があるため、主勝率グラフと概要をかなり早く作れます。
-
-### macOS で初回起動時にブロックされたらどうすればよいですか？
-
-現在の macOS 配布物は未署名・未公証です。初回にブロックされた場合は [インストールガイド](docs/INSTALL_JA.md) の手順を見てください。
-
-## 利用者向けドキュメント
+## ドキュメントと参加
 
 - [サポートガイド](SUPPORT.md)
 - [インストールガイド](docs/INSTALL_JA.md)
@@ -197,25 +143,33 @@
 - [トラブル対応 (English)](docs/TROUBLESHOOTING_EN.md)
 - [検証済みプラットフォーム (English)](docs/TESTED_PLATFORMS.md)
 - [GitHub Releases](https://github.com/wimi321/lizzieyzy-next/releases)
-- GitHub Discussions: <https://github.com/wimi321/lizzieyzy-next/discussions>
-- 中国語 QQ グループ: `299419120`
-
-## プロジェクトリンク
+- [GitHub Discussions](https://github.com/wimi321/lizzieyzy-next/discussions)
+- [中国語 QQ グループ: 299419120](https://qm.qq.com/q/JZoeojjteg)
 - [Roadmap](ROADMAP.md)
 - [Contributing](CONTRIBUTING.md)
 - [Changelog](CHANGELOG.md)
-- [Support](SUPPORT.md)
 
 ## Credits
 
 - Original project: [yzyray/lizzieyzy](https://github.com/yzyray/lizzieyzy)
 - KataGo: [lightvector/KataGo](https://github.com/lightvector/KataGo)
-Historical Fox sync references:
+- 棋盤同期ツール: [qiyi71w/readboard](https://github.com/qiyi71w/readboard)
+
+readboard の継続的な保守と改善に取り組む [qiyi71w](https://github.com/qiyi71w) に感謝します。
+
+すべてのコントリビューターに感謝します:
+
+<p align="left">
+  <a href="https://github.com/wimi321/lizzieyzy-next/graphs/contributors">
+    <img src="https://contrib.rocks/image?repo=wimi321/lizzieyzy-next" alt="LizzieYzy Next のコントリビューター" />
+  </a>
+</p>
+
+野狐棋譜取得の参考:
+
 - [yzyray/FoxRequest](https://github.com/yzyray/FoxRequest)
 - [FuckUbuntu/Lizzieyzy-Helper](https://github.com/FuckUbuntu/Lizzieyzy-Helper)
 
 ## 翻訳について
 
-翻訳を歓迎します！この README をあなたの母語に翻訳したい方は、ぜひ Pull Request をお送りください。
-
-We welcome translations! If you want to translate this README into your native language, please feel free to submit a Pull Request.
+README の翻訳 PR を歓迎します。Translations are welcome; please submit a Pull Request.

--- a/README_JA.md
+++ b/README_JA.md
@@ -53,6 +53,12 @@
 | 設定をあまり触りたくない | 推奨パッケージに KataGo、既定の重み、初回自動設定が入っています |
 | インストールしたくない | Windows では `portable.zip` を優先して選べます |
 | 棋盤同期も使いたい | Windows 向けの主な配布物にネイティブ版 `readboard.exe` が同梱されています |
+| 高速曲線の補完で主エンジンを占有したくない | `KataGo 自動セットアップ -> ウェイト管理` から 38 MB の公式軽量モデルを必要に応じてダウンロードできます。棋譜曲線の欠落を補う間だけ起動し、通常分析の前に GPU を解放します |
+| 本機の計算能力が足りない | `設定 -> リモートコンピューティング` で Zhizi クラウドコンピューティングにログインし、リモート KataGo エンジンを作成できます |
+
+リモートコンピューティングの既定は「VIP 月額」(`--gpu-type vip-share`) です。非 VIP ユーザーは詳細設定で従量制の 1x / 3x / 6x を選べます。既定のプリセットは Zhizi 28B モデルを使用します。TensorRT と CUDA はクラウドエンジンのバックエンド名であり、料金プラン名ではありません。
+
+保存したログイン情報は Windows DPAPI、macOS Keychain、Linux Secret Service で保護され、通常の設定には書き込まれません。安全なストレージを利用できない場合、認証情報はアプリ終了時までだけ保持されます。切断後は自動で再接続し、いつでもローカルエンジンへ戻せます。
 
 ## まずどれをダウンロードするか
 
@@ -64,19 +70,23 @@
 
 | あなたの環境 | Releases でこのキーワードを含むファイルを探す |
 | --- | --- |
-| Windows 利用者の多く、推奨、非インストール | `*windows64.opencl.portable.zip` |
-| Windows、OpenCL 版、インストーラあり | `*windows64.opencl.installer.exe` |
-| Windows、OpenCL が不安定、CPU フォールバック、非インストール | `*windows64.with-katago.portable.zip` |
+| Windows、RTX 20/30/40/50 NVIDIA GPU、推奨、非インストール | `*windows64.nvidia.portable.zip` |
+| Windows、RTX 20/30/40/50 NVIDIA GPU、インストーラあり | `*windows64.nvidia.installer.exe` |
+| Windows、AMD / Intel / 旧世代 NVIDIA GPU、非インストール | `*windows64.opencl.portable.zip` |
+| Windows、AMD / Intel / 旧世代 NVIDIA GPU、インストーラあり | `*windows64.opencl.installer.exe` |
+| Windows、適切な GPU がない、または GPU 版を起動できない、CPU フォールバック | `*windows64.with-katago.portable.zip` |
 | Windows、CPU フォールバック、インストーラあり | `*windows64.with-katago.installer.exe` |
-| Windows、NVIDIA GPU、より速い解析、非インストール | `*windows64.nvidia.portable.zip` |
-| Windows、NVIDIA GPU、インストーラあり | `*windows64.nvidia.installer.exe` |
+| Windows、RTX 30 シリーズ以前、TensorRT を任意導入 | NVIDIA パッケージから開始し、`KataGo 自動セットアップ` で TensorRT をインストール |
+| Windows、DirectX 12 GPU、DirectML テスト | `*windows64.experimental.directml.portable.zip` |
+| Windows、Intel GPU/NPU、OpenVINO テスト | `*windows64.experimental.openvino.portable.zip` |
+| Windows、対応 AMD GPU、ROCm テスト | 対応する `*windows64.experimental.rocm.*.portable.zip` を選択 |
 | Windows、自分のエンジンを使う、非インストール | `*windows64.without.engine.portable.zip` |
 | Windows、自分のエンジンを使う、インストーラあり | `*windows64.without.engine.installer.exe` |
 | macOS Apple Silicon | `*mac-apple-silicon.with-katago.dmg` |
 | macOS Intel | `*mac-intel.with-katago.dmg` |
 | Linux | `*linux64.with-katago.zip` |
 
-フルパッケージの CPU、OpenCL、CUDA、TensorRT、Metal、Linux バックエンドは KataGo `v1.18.1` を使用します。Linux NVIDIA 版は実行環境との互換性のため CUDA 12.1 を維持しています。
+CPU、OpenCL、CUDA、TensorRT、Metal の各バックエンド向けフルパッケージと Linux パッケージは KataGo `v1.18.1` を使用します。Linux NVIDIA 版は実行環境との互換性のため CUDA 12.1 を維持しています。
 
 推奨フルパッケージには、公式フラッグシップ B11 モデル `b11c768h12nbt3tflrs-fson-silu.bin.gz`（約 202 MiB）が含まれます。RTX 3070 での比較では、探索スループットが B10 より約 40% 低く、速度を優先する場合は `KataGo 自動設定 -> ウェイト` で B10 に切り替えられます。
 

--- a/README_KO.md
+++ b/README_KO.md
@@ -53,6 +53,12 @@
 | 설정을 덜 건드리기 | 추천 패키지에 KataGo, 기본 가중치, 첫 실행 자동 설정이 들어 있습니다 |
 | 설치 없이 쓰기 | Windows 에서는 `portable.zip` 을 우선 고를 수 있습니다 |
 | 바둑판 동기화도 쓰기 | Windows 주요 배포판에 네이티브 `readboard.exe` 가 포함됩니다 |
+| 빠른 곡선 작업이 주 엔진을 차지하지 않게 하기 | `KataGo 자동 설정 -> 가중치 관리` 에서 38 MB 공식 경량 모델을 필요할 때 다운로드할 수 있습니다. 기보 곡선의 빈 구간을 채울 때만 실행하고 주 분석 전에 GPU 를 해제합니다 |
+| 이 PC보다 더 많은 연산 성능 사용하기 | `설정 -> 원격 컴퓨팅` 에서 Zhizi 클라우드 컴퓨팅에 로그인하고 원격 KataGo 엔진을 만들 수 있습니다 |
+
+원격 컴퓨팅의 기본값은 “VIP 월정액”(`--gpu-type vip-share`)입니다. 비 VIP 사용자는 고급 설정에서 종량제 1x / 3x / 6x 단계를 선택할 수 있습니다. 기본 프리셋은 Zhizi 28B 모델을 사용합니다. TensorRT 와 CUDA 는 클라우드 엔진 백엔드 이름이며 요금제 이름이 아닙니다.
+
+저장한 로그인 정보는 Windows DPAPI, macOS Keychain 또는 Linux Secret Service 로 보호되며 일반 설정에 기록되지 않습니다. 보안 저장소를 사용할 수 없으면 인증 정보는 앱을 종료할 때까지만 유지됩니다. 연결이 끊기면 자동으로 다시 연결하며 언제든 로컬 엔진으로 돌아갈 수 있습니다.
 
 ## 먼저 무엇을 다운로드할까
 
@@ -64,19 +70,23 @@
 
 | 내 환경 | Releases 에서 이 키워드를 포함하는 파일 찾기 |
 | --- | --- |
-| 대부분의 Windows 사용자, 추천, 무설치 | `*windows64.opencl.portable.zip` |
-| Windows, OpenCL 버전, 설치형 | `*windows64.opencl.installer.exe` |
-| Windows, OpenCL 이 불안정, CPU 대안, 무설치 | `*windows64.with-katago.portable.zip` |
+| Windows, RTX 20/30/40/50 NVIDIA GPU, 추천, 무설치 | `*windows64.nvidia.portable.zip` |
+| Windows, RTX 20/30/40/50 NVIDIA GPU, 설치형 | `*windows64.nvidia.installer.exe` |
+| Windows, AMD / Intel / 구형 NVIDIA GPU, 무설치 | `*windows64.opencl.portable.zip` |
+| Windows, AMD / Intel / 구형 NVIDIA GPU, 설치형 | `*windows64.opencl.installer.exe` |
+| Windows, 적합한 GPU 가 없거나 GPU 버전을 시작할 수 없음, CPU 대안 | `*windows64.with-katago.portable.zip` |
 | Windows, CPU 대안, 설치형 | `*windows64.with-katago.installer.exe` |
-| Windows, NVIDIA GPU, 더 빠른 분석, 무설치 | `*windows64.nvidia.portable.zip` |
-| Windows, NVIDIA GPU, 설치형 | `*windows64.nvidia.installer.exe` |
+| Windows, RTX 30 시리즈 이하, TensorRT 선택 설치 | NVIDIA 패키지로 시작한 뒤 `KataGo 자동 설정` 에서 TensorRT 설치 |
+| Windows, DirectX 12 GPU, DirectML 테스트 | `*windows64.experimental.directml.portable.zip` |
+| Windows, Intel GPU/NPU, OpenVINO 테스트 | `*windows64.experimental.openvino.portable.zip` |
+| Windows, 지원되는 AMD GPU, ROCm 테스트 | 해당 `*windows64.experimental.rocm.*.portable.zip` 선택 |
 | Windows, 내 엔진 사용, 무설치 | `*windows64.without.engine.portable.zip` |
 | Windows, 내 엔진 사용, 설치형 | `*windows64.without.engine.installer.exe` |
 | macOS Apple Silicon | `*mac-apple-silicon.with-katago.dmg` |
 | macOS Intel | `*mac-intel.with-katago.dmg` |
 | Linux | `*linux64.with-katago.zip` |
 
-전체 패키지의 CPU, OpenCL, CUDA, TensorRT, Metal, Linux 백엔드는 KataGo `v1.18.1` 을 사용합니다. Linux NVIDIA 버전은 실행 환경 호환성을 위해 CUDA 12.1 을 유지합니다.
+CPU, OpenCL, CUDA, TensorRT, Metal 백엔드용 전체 패키지와 Linux 패키지는 KataGo `v1.18.1` 을 사용합니다. Linux NVIDIA 버전은 실행 환경 호환성을 위해 CUDA 12.1 을 유지합니다.
 
 권장 전체 패키지에는 공식 플래그십 B11 모델 `b11c768h12nbt3tflrs-fson-silu.bin.gz`(약 202 MiB)이 포함됩니다. RTX 3070 비교에서는 탐색 처리량이 B10 보다 약 40% 낮았으며, 속도를 우선하면 `KataGo 자동 설정 -> 가중치` 에서 B10 으로 바꿀 수 있습니다.
 

--- a/README_KO.md
+++ b/README_KO.md
@@ -15,9 +15,8 @@
 </p>
 
 <p align="center">
-  <strong>LizzieYzy Next 는 지금도 유지보수 중인 lizzieyzy 계열 실사용판이며, 일반 사용자를 위한 KataGo 복기 GUI 입니다.</strong><br/>
-  사용자가 실제로 체감하는 부분인 배포판 선택, 첫 실행 준비, Fox 기보 가져오기, 전판을 한눈에 읽는 분석 경험을 지금 시점에 맞게 다시 다듬고 있습니다.<br/>
-  <strong>다운로드하고, Fox 닉네임을 입력하고, 공개 기보를 가져오고, 빠른 전판 분석을 돌린 뒤, 새 승률 그래프와 하단 빠른 개요로 중요한 수로 바로 이동할 수 있습니다.</strong>
+  <strong>LizzieYzy Next 는 KataGo 로 대국을 복기하는 사용자를 위해 유지보수되는 lizzieyzy 브랜치입니다.</strong><br/>
+  Fox 닉네임 기보 가져오기, 빠른 전판 분석, 새 승률 그래프와 하단 빠른 개요를 제공하며 Windows, macOS, Linux 버전을 배포합니다.
 </p>
 
 <p align="center">
@@ -40,34 +39,9 @@
 > 추출 코드: `3i8w`
 
 > [!TIP]
-> 중국어 QQ 그룹: `299419120`
+> [중국어 QQ 그룹: 299419120](https://qm.qq.com/q/JZoeojjteg)
 >
 > 일상적인 사용 질문, 버그 제보, 기능 요청을 가장 빠르게 주고받는 곳입니다.
-
-> [!IMPORTANT]
-> 먼저 이 6가지만 기억하면 됩니다:
-> - 대부분의 Windows 사용자는 [안정판 다운로드](https://goagent.top/download/)에서 `*windows64.opencl.portable.zip` 을 받으면 가장 쉽습니다
-> - NVIDIA GPU 가 있고 더 빠른 분석을 원하면 `*windows64.nvidia.portable.zip` 을 선택하면 됩니다
-> - OpenCL 이 잘 맞지 않으면 `*windows64.with-katago.portable.zip` 으로 바꿔 쓸 수 있습니다
-> - Fox 기보 가져오기는 닉네임 입력을 지원하므로, 많은 사용자는 계정 번호를 먼저 알 필요가 없습니다
-> - 권장 전체 패키지에는 KataGo `v1.18.1`과 공식 플래그십 B11 Transformer가 포함되며 화면에는 “Transformer 11B 기력 우선”(약 202 MiB)으로 표시됩니다. 한 번의 판단은 더 강하지만 탐색 속도는 느릴 수 있으며, 속도를 우선하면 자동 설정에서 B10으로 바꿀 수 있습니다. 코어 업데이트 패키지에는 엔진과 가중치가 포함되지 않습니다
-> - 주요 release 패키지에는 `readboard_java` 도 들어 있으므로, 대부분의 사용자는 별도 readboard 저장소가 필요하지 않습니다
-
-## 왜 많은 사용자가 여기서 시작하는가
-
-`LizzieYzy Next` 는 이렇게 이해하면 됩니다.
-
-- 일반 사용자가 바로 쓰기 쉬운 `KataGo 복기 소프트웨어`
-- `Fox 기보 가져오기 + 빠른 전판 분석 + 여러 OS 배포판` 을 한데 묶은 실사용 워크플로
-- 오래된 `lizzieyzy` 환경에서 이어서 쓰기 쉬운 현재 유지보수 브랜치
-
-다음 같은 것을 찾고 있다면 이 프로젝트를 먼저 보면 됩니다.
-
-- `KataGo 복기 소프트웨어`
-- `KataGo GUI`
-- `lizzieyzy 유지보수판`
-- `Fox 기보 가져오기 + KataGo 복기`
-- `Windows 무설치 바둑 AI 도구`
 
 ## 실행하자마자 할 수 있는 것
 
@@ -78,7 +52,7 @@
 | 문제수를 빨리 찾기 | 새 메인 승률 그래프와 하단 열지도 개요로 큰 손해 구간을 더 쉽게 찾습니다 |
 | 설정을 덜 건드리기 | 추천 패키지에 KataGo, 기본 가중치, 첫 실행 자동 설정이 들어 있습니다 |
 | 설치 없이 쓰기 | Windows 에서는 `portable.zip` 을 우선 고를 수 있습니다 |
-| 바둑판 동기화도 쓰기 | 주요 배포판에 `readboard_java` 가 포함됩니다 |
+| 바둑판 동기화도 쓰기 | Windows 주요 배포판에 네이티브 `readboard.exe` 가 포함됩니다 |
 
 ## 먼저 무엇을 다운로드할까
 
@@ -102,28 +76,16 @@
 | macOS Intel | `*mac-intel.with-katago.dmg` |
 | Linux | `*linux64.with-katago.zip` |
 
-헷갈릴 때는 이렇게 보면 됩니다:
+전체 패키지의 CPU, OpenCL, CUDA, TensorRT, Metal, Linux 백엔드는 KataGo `v1.18.1` 을 사용합니다. Linux NVIDIA 버전은 실행 환경 호환성을 위해 CUDA 12.1 을 유지합니다.
 
-- Windows: 먼저 `*windows64.opencl.portable.zip`
-- Windows + NVIDIA GPU: 먼저 `*windows64.nvidia.portable.zip`
-- OpenCL 이 잘 맞지 않음: `*windows64.with-katago.portable.zip`
-- Mac: Apple Silicon 인지 Intel 인지 먼저 확인
-- Linux: `*linux64.with-katago.zip`
+권장 전체 패키지에는 공식 플래그십 B11 모델 `b11c768h12nbt3tflrs-fson-silu.bin.gz`(약 202 MiB)이 포함됩니다. RTX 3070 비교에서는 탐색 처리량이 B10 보다 약 40% 낮았으며, 속도를 우선하면 `KataGo 자동 설정 -> 가중치` 에서 B10 으로 바꿀 수 있습니다.
 
-## 왜 지금 이 버전이 더 쓰기 쉬운가
+NVIDIA 및 TensorRT:
 
-- `Fox 기보 가져오기가 다시 작동`
-  사용자가 기억하는 닉네임에서 바로 시작할 수 있습니다.
-- `빠른 전판 분석이 주 흐름이 됨`
-  한 수씩 쌓지 않아도 전체 그림을 빨리 만들 수 있습니다.
-- `메인 승률 그래프 + 하단 빠른 개요`
-  큰 손해가 나온 구간을 먼저 보기 쉬워졌습니다.
-- `Windows 는 무설치판 우선`
-  OpenCL / NVIDIA / CPU 대안의 차이를 더 쉽게 이해할 수 있습니다.
-- `readboard_java 를 메인 release 에 포함`
-  대부분의 사용자는 별도 저장소를 조합할 필요가 없습니다.
-- `실제 release + 실제 스모크 테스트`
-  소스만 바꾸는 것이 아니라, 여러 OS 배포판과 실제 흐름 검증도 계속 하고 있습니다.
+- `KataGo 자동 설정` 은 NVIDIA GPU 와 Compute Capability 를 감지해 TensorRT 사용 여부를 안내합니다. 감지에 실패해도 수동으로 계속할 수 있습니다.
+- RTX 40/50 은 기본적으로 CUDA 를 사용합니다. TensorRT 는 RTX 30 시리즈 이하에서 선택할 수 있습니다.
+- NVIDIA 드라이버 `570.65` 이상은 바로 로드합니다. `528.33–570.64` 는 첫 실행 때 가벼운 추론 테스트를 한 번 수행하고, 그보다 오래된 드라이버는 복구 상태를 표시합니다.
+- GTX 10 시리즈 이전 카드는 OpenCL 을 사용하세요. OpenCL 이 불안정하면 `*windows64.with-katago.portable.zip` 으로 전환합니다.
 
 ## 3단계로 시작
 
@@ -141,15 +103,13 @@
   GitHub 에서 GIF 재생이 느리면 위 이미지를 눌러 전체 애니메이션을 열 수 있습니다.
 </p>
 
-## 실제 화면
-
-아래 이미지는 현재 유지보수판의 실제 화면입니다.
+## 화면 미리보기
 
 <p align="center">
-  <img src="assets/interface-overview-2026-04.png" alt="LizzieYzy Next actual interface" width="100%" />
+  <img src="assets/interface-overview-2026-04.png" alt="LizzieYzy Next 화면 미리보기" width="100%" />
 </p>
 
-그래프 영역은 이렇게 읽으면 됩니다.
+메인 승률 그래프와 하단 빠른 개요에는 다음 정보가 표시됩니다.
 
 <p align="center">
   <img src="assets/winrate-quick-overview-2026-04.png" alt="LizzieYzy Next winrate graph and quick overview" width="46%" />
@@ -169,27 +129,13 @@
 | 입력 방식 | 숫자 계정 번호를 먼저 알아야 하는 경우가 많음 | Fox 닉네임을 넣으면 앱이 계정을 자동으로 찾음 |
 | KataGo 사용 장벽 | 직접 환경이나 누락 리소스를 채워야 하는 경우가 많음 | 추천 패키지에 KataGo 와 기본 가중치가 이미 포함됨 |
 | Windows 다운로드 경험 | 사용자가 직접 판단해야 할 부분이 더 많음 | `portable.zip` 우선 추천으로 더 명확함 |
-| 동기화 도구 | 사용자가 직접 조합해야 하는 경우가 많음 | 주요 release 에 `readboard_java` 포함 |
+| 동기화 도구 | 사용자가 직접 조합해야 하는 경우가 많음 | Windows 주요 배포판에 네이티브 `readboard.exe` 포함 |
 
-## 자주 묻는 질문
+## macOS 첫 실행
 
-### readboard 용으로 별도 저장소가 아직도 필요한가?
+Mac 에 맞는 패키지를 선택하고 DMG 를 연 다음 `LizzieYzy Next` 를 응용 프로그램으로 드래그합니다. 설치 디스크를 꺼낸 뒤 Finder 의 응용 프로그램 폴더에서 실행하세요. 공식 release 는 서명과 공증을 거칩니다. macOS 가 계속 차단하면 [설치 가이드](docs/INSTALL_KO.md) 를 확인하세요.
 
-대부분의 사용자는 필요 없습니다. `LizzieYzy Next` 는 `readboard_java` 를 주요 release 패키지에 포함합니다.
-
-### Fox 계정 번호를 먼저 알아야 하나?
-
-대부분의 경우 그럴 필요 없습니다. Fox 닉네임을 입력하면 앱이 맞는 계정을 찾아 줍니다.
-
-### 전판 흐름을 보려면 아직도 한 수씩 넘겨야 하나?
-
-보통은 그럴 필요가 없습니다. 빠른 전판 분석이 있어서 메인 승률 그래프와 개요가 훨씬 빨리 만들어집니다.
-
-### macOS 에서 첫 실행 때 막히면 어떻게 하나?
-
-현재 macOS 배포판은 아직 서명과 공증이 없습니다. 첫 실행에서 막히면 [설치 가이드](docs/INSTALL_KO.md) 를 따라 진행하면 됩니다.
-
-## 사용자 문서
+## 문서와 참여
 
 - [지원 가이드](SUPPORT.md)
 - [설치 가이드](docs/INSTALL_KO.md)
@@ -197,25 +143,33 @@
 - [문제 해결 (English)](docs/TROUBLESHOOTING_EN.md)
 - [검증된 플랫폼 (English)](docs/TESTED_PLATFORMS.md)
 - [GitHub Releases](https://github.com/wimi321/lizzieyzy-next/releases)
-- GitHub Discussions: <https://github.com/wimi321/lizzieyzy-next/discussions>
-- 중국어 QQ 그룹: `299419120`
-
-## 프로젝트 링크
+- [GitHub Discussions](https://github.com/wimi321/lizzieyzy-next/discussions)
+- [중국어 QQ 그룹: 299419120](https://qm.qq.com/q/JZoeojjteg)
 - [Roadmap](ROADMAP.md)
 - [Contributing](CONTRIBUTING.md)
 - [Changelog](CHANGELOG.md)
-- [Support](SUPPORT.md)
 
 ## Credits
 
 - Original project: [yzyray/lizzieyzy](https://github.com/yzyray/lizzieyzy)
 - KataGo: [lightvector/KataGo](https://github.com/lightvector/KataGo)
-Historical Fox sync references:
+- 바둑판 동기화 도구: [qiyi71w/readboard](https://github.com/qiyi71w/readboard)
+
+readboard 를 계속 유지보수하고 개선하는 [qiyi71w](https://github.com/qiyi71w) 님께 감사드립니다.
+
+모든 기여자에게 감사드립니다:
+
+<p align="left">
+  <a href="https://github.com/wimi321/lizzieyzy-next/graphs/contributors">
+    <img src="https://contrib.rocks/image?repo=wimi321/lizzieyzy-next" alt="LizzieYzy Next 기여자" />
+  </a>
+</p>
+
+Fox 기보 가져오기 참고 자료:
+
 - [yzyray/FoxRequest](https://github.com/yzyray/FoxRequest)
 - [FuckUbuntu/Lizzieyzy-Helper](https://github.com/FuckUbuntu/Lizzieyzy-Helper)
 
 ## 번역 참여
 
-번역을 환영합니다! 이 README를 모국어로 번역해 주실 분은 Pull Request를 보내 주세요.
-
-We welcome translations! If you want to translate this README into your native language, please feel free to submit a Pull Request.
+README 번역 Pull Request 를 환영합니다. Translations are welcome; please submit a Pull Request.

--- a/README_TH.md
+++ b/README_TH.md
@@ -15,9 +15,8 @@
 </p>
 
 <p align="center">
-  <strong>LizzieYzy Next คือเวอร์ชันที่ดูแลต่อของ lizzieyzy ซึ่งเป็นเครื่องมือ GUI สำหรับทบทวนเกมโกะด้วย KataGo สำหรับผู้เล่นทั่วไป</strong><br/>
-  โปรเจกต์นี้ปรับปรุงประสบการณ์หลักใหม่ทั้งหมด: แพ็กเกจดาวน์โหลดที่เลือกง่ายขึ้น, การเริ่มต้นครั้งแรกที่ลื่นไหล, การดึงเกมจาก Fox (野狐) ที่ใช้งานได้ และมุมมองวิเคราะห์เกมทั้งกระดานที่เข้าใจง่ายกว่าเดิม<br/>
-  <strong>ดาวน์โหลดและติดตั้ง ใส่ชื่อเล่น Fox ดึงเกมสาธารณะล่าสุด รันการวิเคราะห์ทั้งกระดานอย่างรวดเร็ว จากนั้นใช้กราฟอัตราชนะและภาพรวมด้านล่างเพื่อหาจังหวะสำคัญทันที</strong>
+  <strong>LizzieYzy Next คือสาขา lizzieyzy ที่ยังได้รับการดูแล สำหรับผู้เล่นที่ใช้ KataGo ทบทวนเกมโกะ</strong><br/>
+  รองรับการดึงเกมด้วยชื่อเล่น Fox การวิเคราะห์ทั้งกระดานอย่างรวดเร็ว กราฟอัตราชนะใหม่ และภาพรวมด้านล่าง พร้อมเวอร์ชันสำหรับ Windows, macOS และ Linux
 </p>
 
 <p align="center">
@@ -33,22 +32,10 @@
 > [!NOTE]
 > แนะนำให้ผู้ใช้ในจีนแผ่นดินใหญ่ดาวน์โหลดเวอร์ชันเสถียรจาก [หน้าดาวน์โหลดอย่างเป็นทางการ](https://goagent.top/download/) ส่วน installer, แพ็กเกจ Linux และเวอร์ชันเก่าสามารถดาวน์โหลดได้จาก [GitHub Releases](https://github.com/wimi321/lizzieyzy-next/releases)
 
-> [!IMPORTANT]
-> ถ้าคุณแค่อยากดาวน์โหลดเวอร์ชันที่ใช่ ให้จำ 6 ข้อนี้:
-> - ผู้ใช้ Windows ส่วนใหญ่: ไปที่ [ดาวน์โหลดเวอร์ชันเสถียร](https://goagent.top/download/) แล้วดาวน์โหลด `*windows64.opencl.portable.zip`
-> - ถ้าคุณมีการ์ดจอ NVIDIA และต้องการความเร็วสูงกว่า: ดาวน์โหลด `*windows64.nvidia.portable.zip`
-> - ถ้า OpenCL ไม่เสถียรบนเครื่องของคุณ: ดาวน์โหลด `*windows64.with-katago.portable.zip`
-> - ตอนนี้รองรับการใส่ชื่อเล่น Fox โดยตรงเพื่อดึงเกมสาธารณะล่าสุด ไม่ต้องรู้เลขบัญชีก่อน
-> - แพ็กเกจฉบับเต็มที่แนะนำมาพร้อม KataGo `v1.18.1` และ B11 Transformer รุ่นเรือธงอย่างเป็นทางการ ซึ่งแสดงเป็น “Transformer 11B เน้นความแข็งแกร่ง” (ประมาณ 202 MiB) การประเมินแต่ละครั้งแข็งแกร่งกว่าแต่อาจค้นหาช้าลง หากเน้นความเร็วสามารถเปลี่ยนเป็น B10 ในการตั้งค่าอัตโนมัติได้ ส่วนแพ็กเกจอัปเดตเฉพาะตัวโปรแกรมไม่มีเอนจินและโมเดล
-> - แพ็กเกจหลักมาพร้อม `readboard_java` ผู้ใช้ส่วนใหญ่ไม่ต้องไปหา readboard แยกอีก
-
-## ทำไมหลายคนเลือกโปรเจกต์นี้
-
-`LizzieYzy Next` สามารถเข้าใจได้ว่า:
-
-- เครื่องมือ `KataGo ทบทวนเกมโกะบนเดสก์ท็อป` ที่ยังดูแลอย่างต่อเนื่อง
-- เวิร์กโฟลว์ที่รวม `ดึงเกมจาก Fox + การวิเคราะห์ทั้งกระดานรวดเร็ว + แพ็กเกจหลายแพลตฟอร์ม` เข้าด้วยกัน
-- สาขาที่ดูแลต่อเพื่อให้ผู้ใช้ `lizzieyzy` เก่าใช้งานได้อย่างต่อเนื่อง
+> [!TIP]
+> [กลุ่ม QQ ภาษาจีน: 299419120](https://qm.qq.com/q/JZoeojjteg)
+>
+> ใช้สำหรับถามวิธีใช้งาน รายงานบั๊ก และเสนอฟีเจอร์
 
 ## เปิดแล้วทำอะไรได้ทันที
 
@@ -59,7 +46,7 @@
 | ค้นหาจังหวะสำคัญอย่างรวดเร็ว | กราฟอัตราชนะใหม่และภาพรวม heatmap ด้านล่าง เห็นปัญหาใหญ่ได้ทันที |
 | การตั้งค่าน้อย | แพ็กเกจแนะนำมาพร้อม KataGo, น้ำหนักเริ่มต้น และ auto setup ครั้งแรก |
 | ไม่อยากติดตั้ง | Windows แนะนำแพ็กเกจ `portable.zip` ก่อน |
-| ซิงก์กระดาน | แพ็กเกจหลักมาพร้อม `readboard_java` |
+| ซิงก์กระดาน | แพ็กเกจหลักสำหรับ Windows มี `readboard.exe` แบบเนทีฟมาให้ |
 
 ## เลือกดาวน์โหลดตัวไหน
 
@@ -82,16 +69,41 @@
 2. เปิดโปรแกรมแล้วคลิก `Fox` เพื่อใส่ชื่อเล่น Fox
 3. หลังจากดึงเกมแล้ว ให้รันการวิเคราะห์ทั้งกระดานรวดเร็ว ใช้กราฟอัตราชนะและภาพรวมด้านล่างเพื่อหาจังหวะสำคัญ
 
+## เอกสารและการมีส่วนร่วม
+
+- [ขอความช่วยเหลือ](SUPPORT.md)
+- [คู่มือติดตั้ง](docs/INSTALL.md)
+- [รายละเอียดแพ็กเกจ](docs/PACKAGES.md)
+- [คำถามที่พบบ่อยและการแก้ปัญหา](docs/TROUBLESHOOTING.md)
+- [แพลตฟอร์มที่ทดสอบแล้ว](docs/TESTED_PLATFORMS.md)
+- [GitHub Releases](https://github.com/wimi321/lizzieyzy-next/releases)
+- [GitHub Discussions](https://github.com/wimi321/lizzieyzy-next/discussions)
+- [กลุ่ม QQ ภาษาจีน: 299419120](https://qm.qq.com/q/JZoeojjteg)
+- [แผนงานโครงการ](ROADMAP.md)
+- [ร่วมพัฒนา](CONTRIBUTING.md)
+- [บันทึกการเปลี่ยนแปลง](CHANGELOG.md)
+
 ## เครดิต
 
 - โปรเจกต์ดั้งเดิม: [yzyray/lizzieyzy](https://github.com/yzyray/lizzieyzy)
 - KataGo: [lightvector/KataGo](https://github.com/lightvector/KataGo)
-อ้างอิงประวัติการดึงเกม Fox:
+- เครื่องมือซิงก์กระดาน: [qiyi71w/readboard](https://github.com/qiyi71w/readboard)
+
+ขอบคุณ [qiyi71w](https://github.com/qiyi71w) ที่ดูแลและปรับปรุง readboard อย่างต่อเนื่อง
+
+ขอบคุณผู้ร่วมพัฒนาทุกคน:
+
+<p align="left">
+  <a href="https://github.com/wimi321/lizzieyzy-next/graphs/contributors">
+    <img src="https://contrib.rocks/image?repo=wimi321/lizzieyzy-next" alt="ผู้ร่วมพัฒนา LizzieYzy Next" />
+  </a>
+</p>
+
+ข้อมูลอ้างอิงการดึงเกม Fox:
+
 - [yzyray/FoxRequest](https://github.com/yzyray/FoxRequest)
 - [FuckUbuntu/Lizzieyzy-Helper](https://github.com/FuckUbuntu/Lizzieyzy-Helper)
 
 ## การแปล
 
-ยินดีรับการแปล! ถ้าคุณต้องการแปล README นี้เป็นภาษาแม่ของคุณ โปรดส่ง Pull Request ได้เลย
-
-We welcome translations! If you want to translate this README into your native language, please feel free to submit a Pull Request.
+ยินดีรับ Pull Request สำหรับการแปล README นี้ Translations are welcome; please submit a Pull Request.

--- a/README_TH.md
+++ b/README_TH.md
@@ -24,6 +24,8 @@
   ·
   <a href="https://goagent.top/download/"><strong>ดาวน์โหลดเวอร์ชันเสถียร</strong></a>
   ·
+  <a href="https://pan.baidu.com/s/1wthaL8YwGMxy_u0U7Mabpw?pwd=3i8w"><strong>ดาวน์โหลดจาก Baidu</strong></a>
+  ·
   <a href="docs/INSTALL.md"><strong>คู่มือติดตั้ง</strong></a>
   ·
   <a href="docs/TROUBLESHOOTING.md"><strong>คำถามที่พบบ่อย</strong></a>
@@ -31,6 +33,10 @@
 
 > [!NOTE]
 > แนะนำให้ผู้ใช้ในจีนแผ่นดินใหญ่ดาวน์โหลดเวอร์ชันเสถียรจาก [หน้าดาวน์โหลดอย่างเป็นทางการ](https://goagent.top/download/) ส่วน installer, แพ็กเกจ Linux และเวอร์ชันเก่าสามารถดาวน์โหลดได้จาก [GitHub Releases](https://github.com/wimi321/lizzieyzy-next/releases)
+>
+> ผู้ใช้ในจีนแผ่นดินใหญ่สามารถดาวน์โหลดจาก Baidu Netdisk สาธารณะได้เช่นกัน:
+> [https://pan.baidu.com/s/1wthaL8YwGMxy_u0U7Mabpw?pwd=3i8w](https://pan.baidu.com/s/1wthaL8YwGMxy_u0U7Mabpw?pwd=3i8w)
+> รหัสแตกไฟล์: `3i8w`
 
 > [!TIP]
 > [กลุ่ม QQ ภาษาจีน: 299419120](https://qm.qq.com/q/JZoeojjteg)
@@ -44,30 +50,100 @@
 | ดึงเกม Fox สาธารณะล่าสุด | ใส่ชื่อเล่น Fox โดยตรง โปรแกรมจะจับคู่บัญชีและดึงเกมให้ |
 | ดูแนวโน้มทั้งกระดานอย่างรวดเร็ว | การวิเคราะห์ทั้งกระดานรวดเร็ว ไม่ต้องคลิกทีละหมาก |
 | ค้นหาจังหวะสำคัญอย่างรวดเร็ว | กราฟอัตราชนะใหม่และภาพรวม heatmap ด้านล่าง เห็นปัญหาใหญ่ได้ทันที |
+| ลดผลกระทบของกราฟด่วนต่อเอนจินหลัก | ดาวน์โหลดโมเดลขนาดเล็กอย่างเป็นทางการ 38 MB ได้ตามต้องการจาก `KataGo การตั้งค่าอัตโนมัติ -> จัดการโมเดล` โมเดลจะทำงานเฉพาะตอนเติมช่วงที่ขาดในกราฟเกมและคืน GPU ก่อนการวิเคราะห์หลัก |
 | การตั้งค่าน้อย | แพ็กเกจแนะนำมาพร้อม KataGo, น้ำหนักเริ่มต้น และ auto setup ครั้งแรก |
 | ไม่อยากติดตั้ง | Windows แนะนำแพ็กเกจ `portable.zip` ก่อน |
 | ซิงก์กระดาน | แพ็กเกจหลักสำหรับ Windows มี `readboard.exe` แบบเนทีฟมาให้ |
+| ต้องการพลังประมวลผลมากกว่าเครื่องนี้ | เปิด `การตั้งค่า -> คอมพิวเตอร์ระยะไกล` เข้าสู่ระบบ Zhizi Cloud Compute แล้วสร้างเอนจิน KataGo ระยะไกล |
+
+คอมพิวเตอร์ระยะไกลใช้ “VIP รายเดือน” (`--gpu-type vip-share`) เป็นค่าเริ่มต้น ผู้ใช้ที่ไม่ใช่ VIP เลือกแบบคิดตามการใช้งาน 1x / 3x / 6x ได้ในการตั้งค่าขั้นสูง พรีเซ็ตเริ่มต้นใช้โมเดล Zhizi 28B ส่วน TensorRT และ CUDA คือแบ็กเอนด์ของเอนจินบนคลาวด์ ไม่ใช่ชื่อแพ็กเกจค่าบริการ
+
+ข้อมูลเข้าสู่ระบบที่บันทึกไว้ได้รับการป้องกันด้วย Windows DPAPI, macOS Keychain หรือ Linux Secret Service และไม่เขียนลงการตั้งค่าทั่วไป หากใช้ที่เก็บข้อมูลปลอดภัยไม่ได้ ข้อมูลจะอยู่จนกว่าโปรแกรมจะปิดเท่านั้น ระบบจะเชื่อมต่อใหม่หลังการตัดการเชื่อมต่อ และสลับกลับไปใช้เอนจินในเครื่องได้ทุกเมื่อ
 
 ## เลือกดาวน์โหลดตัวไหน
 
 แนะนำให้ผู้ใช้ในจีนแผ่นดินใหญ่เลือกเวอร์ชันเสถียรที่ใช้บ่อยจาก [หน้าดาวน์โหลดอย่างเป็นทางการ](https://goagent.top/download/) ส่วน installer, แพ็กเกจ Linux และเวอร์ชันเก่าสามารถดาวน์โหลดได้จาก [GitHub Releases](https://github.com/wimi321/lizzieyzy-next/releases)
 
+<p align="center">
+  <img src="assets/package-guide.svg" alt="คู่มือเลือกแพ็กเกจ LizzieYzy Next" width="100%" />
+</p>
+
 | สถานการณ์ของคุณ | คีย์เวิร์ดไฟล์ที่ควรหา |
 | --- | --- |
-| ผู้ใช้ Windows ส่วนใหญ่ (แนะนำ, portable) | `*windows64.opencl.portable.zip` |
-| Windows, OpenCL, ต้องการตัวติดตั้ง | `*windows64.opencl.installer.exe` |
-| Windows, OpenCL ไม่เสถียร, ใช้ CPU, portable | `*windows64.with-katago.portable.zip` |
-| Windows, การ์ดจอ NVIDIA, ต้องการความเร็ว, portable | `*windows64.nvidia.portable.zip` |
+| Windows, การ์ดจอ NVIDIA RTX 20/30/40/50, แนะนำ, portable | `*windows64.nvidia.portable.zip` |
+| Windows, การ์ดจอ NVIDIA RTX 20/30/40/50, ต้องการตัวติดตั้ง | `*windows64.nvidia.installer.exe` |
+| Windows, การ์ดจอ AMD / Intel / NVIDIA รุ่นเก่า, portable | `*windows64.opencl.portable.zip` |
+| Windows, การ์ดจอ AMD / Intel / NVIDIA รุ่นเก่า, ต้องการตัวติดตั้ง | `*windows64.opencl.installer.exe` |
+| Windows, ไม่มี GPU ที่เหมาะสมหรือเวอร์ชัน GPU เริ่มไม่ได้, ใช้ CPU | `*windows64.with-katago.portable.zip` |
+| Windows, ใช้ CPU, ต้องการตัวติดตั้ง | `*windows64.with-katago.installer.exe` |
+| Windows, RTX 30 หรือต่ำกว่า, เลือกติดตั้ง TensorRT | เริ่มจากแพ็กเกจ NVIDIA แล้วติดตั้ง TensorRT ใน `KataGo การตั้งค่าอัตโนมัติ` |
+| Windows, GPU ที่รองรับ DirectX 12, ทดสอบ DirectML | `*windows64.experimental.directml.portable.zip` |
+| Windows, Intel GPU/NPU, ทดสอบ OpenVINO | `*windows64.experimental.openvino.portable.zip` |
+| Windows, AMD GPU ที่รองรับ, ทดสอบ ROCm | เลือก `*windows64.experimental.rocm.*.portable.zip` ที่ตรงกัน |
 | Windows, ตั้งค่าเอนจินเอง, portable | `*windows64.without.engine.portable.zip` |
+| Windows, ตั้งค่าเอนจินเอง, ต้องการตัวติดตั้ง | `*windows64.without.engine.installer.exe` |
 | macOS Apple Silicon | `*mac-apple-silicon.with-katago.dmg` |
 | macOS Intel | `*mac-intel.with-katago.dmg` |
 | Linux | `*linux64.with-katago.zip` |
 
+แพ็กเกจฉบับเต็มสำหรับแบ็กเอนด์ CPU, OpenCL, CUDA, TensorRT และ Metal รวมถึงแพ็กเกจ Linux ใช้ KataGo `v1.18.1` ส่วน Linux NVIDIA ยังคงใช้ CUDA 12.1 เพื่อความเข้ากันได้ของสภาพแวดล้อม
+
+แพ็กเกจฉบับเต็มที่แนะนำมีโมเดลเรือธง B11 อย่างเป็นทางการ `b11c768h12nbt3tflrs-fson-silu.bin.gz` (ประมาณ 202 MiB) การเปรียบเทียบบน RTX 3070 วัด throughput การค้นหาต่ำกว่า B10 ประมาณ 40% หากต้องการความเร็วสามารถเปลี่ยนเป็น B10 ใน `KataGo การตั้งค่าอัตโนมัติ -> จัดการโมเดล`
+
+หมายเหตุ NVIDIA และ TensorRT:
+
+- `KataGo การตั้งค่าอัตโนมัติ` ตรวจหา NVIDIA GPU และ Compute Capability แล้วแนะนำว่า TensorRT เหมาะหรือไม่ หากตรวจหาไม่สำเร็จยังติดตั้งด้วยตนเองได้
+- RTX 40/50 ใช้ CUDA เป็นค่าเริ่มต้น ส่วน TensorRT เป็นตัวเลือกสำหรับ RTX 30 หรือต่ำกว่า
+- ไดรเวอร์ NVIDIA `570.65` ขึ้นไปโหลดได้โดยตรง รุ่น `528.33–570.64` จะทดสอบ inference ขนาดเล็กหนึ่งครั้งเมื่อเปิดครั้งแรก ส่วนรุ่นเก่ากว่าจะแสดงสถานะการแก้ไข
+- การ์ด GTX 10 หรือต่ำกว่าควรใช้ OpenCL หาก OpenCL ไม่เสถียรให้เปลี่ยนเป็น `*windows64.with-katago.portable.zip`
+
 ## เริ่มต้นใน 3 ขั้นตอน
 
 1. ไปที่ [ดาวน์โหลดเวอร์ชันเสถียร](https://goagent.top/download/) และเลือกแพ็กเกจที่เหมาะกับระบบของคุณ ส่วน installer, Linux และเวอร์ชันเก่าให้ใช้ GitHub Releases
-2. เปิดโปรแกรมแล้วคลิก `Fox` เพื่อใส่ชื่อเล่น Fox
+2. เปิด `Fox Kifu` แล้วใส่ชื่อเล่น Fox
 3. หลังจากดึงเกมแล้ว ให้รันการวิเคราะห์ทั้งกระดานรวดเร็ว ใช้กราฟอัตราชนะและภาพรวมด้านล่างเพื่อหาจังหวะสำคัญ
+
+<p align="center">
+  <a href="assets/fox-id-demo.gif">
+    <img src="assets/fox-id-demo-cover.png" alt="ตัวอย่างการดึงเกมด้วยชื่อเล่น Fox ใน LizzieYzy Next" width="100%" />
+  </a>
+</p>
+
+<p align="center">
+  หาก GIF บน GitHub เล่นช้า ให้คลิกรูปด้านบนเพื่อเปิดภาพเคลื่อนไหวทั้งหมด
+</p>
+
+## ตัวอย่างหน้าจอ
+
+<p align="center">
+  <img src="assets/interface-overview-2026-04.png" alt="หน้าจอ LizzieYzy Next" width="100%" />
+</p>
+
+กราฟหลักและภาพรวมด่วนแสดงข้อมูลต่อไปนี้:
+
+<p align="center">
+  <img src="assets/winrate-quick-overview-2026-04.png" alt="กราฟอัตราชนะและภาพรวมด่วนของ LizzieYzy Next" width="46%" />
+</p>
+
+- เส้นสีน้ำเงิน / สีม่วง: แนวโน้มอัตราชนะของทั้งสองฝ่าย
+- เส้นสีเขียว: การเปลี่ยนแปลงของคะแนนนำ
+- แถบ heatmap ด้านล่าง: ตำแหน่งที่มีความผิดพลาดใหญ่ตลอดทั้งเกม
+- เส้นแนวตั้ง: ตำแหน่งหมากปัจจุบันหรือหมากที่ชี้อยู่
+
+## แตกต่างจาก lizzieyzy เดิมอย่างไร
+
+| หัวข้อเปรียบเทียบ | `lizzieyzy` เดิม | `LizzieYzy Next` |
+| --- | --- | --- |
+| สถานะปัจจุบัน | โปรเจกต์เดิมที่ผู้ใช้จำนวนมากยังจำได้ แต่ไม่มีการดูแลต่อเนื่องในทางปฏิบัติ | สาขาที่ดูแลอยู่ในปัจจุบัน เน้นการใช้งานและการเผยแพร่ |
+| การดึงเกม Fox | ขั้นตอนเดิมใช้งานไม่ได้ในหลายกรณี | กู้คืนขั้นตอนที่ใช้บ่อยและรองรับการใส่ชื่อเล่น |
+| วิธีกรอกข้อมูล | มักต้องรู้หมายเลขบัญชีก่อน | ใส่ชื่อเล่น Fox แล้วโปรแกรมจับคู่บัญชีให้ |
+| การตั้งค่า KataGo | มักต้องเตรียมสภาพแวดล้อมและทรัพยากรเอง | แพ็กเกจแนะนำมาพร้อม KataGo และโมเดลเริ่มต้น |
+| การเลือกดาวน์โหลดบน Windows | ผู้ใช้ต้องตัดสินใจเองหลายอย่าง | แยกแพ็กเกจ portable ตามฮาร์ดแวร์อย่างชัดเจน |
+| การซิงก์กระดาน | มักต้องประกอบสภาพแวดล้อมเอง | แพ็กเกจหลักของ Windows มี `readboard.exe` แบบเนทีฟ |
+
+## การเปิดครั้งแรกบน macOS
+
+เลือกแพ็กเกจที่ตรงกับ Mac ของคุณ เปิด DMG แล้วลาก `LizzieYzy Next` ไปยัง Applications จากนั้นนำดิสก์ติดตั้งออกและเปิดโปรแกรมจากโฟลเดอร์ Applications ใน Finder เวอร์ชันทางการผ่านการลงนามและ notarization แล้ว หาก macOS ยังปิดกั้นโปรแกรม ให้ทำตาม [คู่มือติดตั้ง](docs/INSTALL.md)
 
 ## เอกสารและการมีส่วนร่วม
 

--- a/README_ZH_TW.md
+++ b/README_ZH_TW.md
@@ -24,6 +24,8 @@
   ·
   <a href="https://goagent.top/download/"><strong>正式版下載</strong></a>
   ·
+  <a href="https://pan.baidu.com/s/1wthaL8YwGMxy_u0U7Mabpw?pwd=3i8w"><strong>百度網盤下載</strong></a>
+  ·
   <a href="docs/INSTALL.md"><strong>安裝說明</strong></a>
   ·
   <a href="docs/TROUBLESHOOTING.md"><strong>常見問題</strong></a>
@@ -36,6 +38,10 @@
 
 > [!NOTE]
 > 中國大陸使用者建議從 [官方下載頁面](https://goagent.top/download/) 下載正式版；需要安裝程式、Linux 套件或歷史版本時，可使用 [GitHub Releases](https://github.com/wimi321/lizzieyzy-next/releases)。
+>
+> 中國大陸使用者也可使用公開的百度網盤下載：
+> [https://pan.baidu.com/s/1wthaL8YwGMxy_u0U7Mabpw?pwd=3i8w](https://pan.baidu.com/s/1wthaL8YwGMxy_u0U7Mabpw?pwd=3i8w)
+> 提取碼：`3i8w`
 
 ## 你打開後馬上能做什麼
 
@@ -44,30 +50,100 @@
 | 抓最近公開野狐棋譜 | 直接輸入野狐暱稱，程式自動匹配帳號並抓譜 |
 | 快速看整盤走勢 | 提供快速全盤分析，不用完全靠一步一步手點 |
 | 快速找問題手 | 提供新版主勝率圖和底部熱力概覽，更容易一眼看出大問題手 |
+| 減少快速曲線對主引擎的影響 | 可在 `KataGo 自動設定 -> 權重管理` 按需下載 38 MB 官方輕量模型；僅補齊棋譜曲線時啟動，主分析開始前即釋放顯示卡 |
 | 少折騰設定 | 推薦整合包已內建 KataGo、預設權重和首次自動設定 |
 | 不想安裝 | Windows 預設優先推薦 `portable.zip` 免安裝包 |
 | 做棋盤同步 | Windows 主發佈包已內建原生 `readboard.exe`，同步入口更清楚 |
+| 本機算力不足 | 從 `設定 -> 遠端計算` 登入智子雲端算力，建立遠端 KataGo 引擎後可像本機引擎一樣使用 |
+
+遠端計算預設使用「VIP 包月」(`--gpu-type vip-share`)；非 VIP 使用者可在進階設定切換到按量 1x / 3x / 6x。預設方案使用智子 28B 模型；TensorRT 和 CUDA 是雲端引擎後端，不是付費方案名稱。
+
+儲存的登入資料由 Windows DPAPI、macOS Keychain 或 Linux Secret Service 保護，不會寫入一般設定。系統安全儲存無法使用時，認證資料只保留到程式結束。斷線後會自動重連，也可隨時切回本機引擎。
 
 ## 先下載哪個
 
 中國大陸使用者建議從 [官方下載頁面](https://goagent.top/download/) 選擇常用正式版；安裝程式、Linux 套件和歷史版本可在 [GitHub Releases](https://github.com/wimi321/lizzieyzy-next/releases) 下載。
 
+<p align="center">
+  <img src="assets/package-guide-zh.svg" alt="LizzieYzy Next 下載選擇圖" width="100%" />
+</p>
+
 | 你的情況 | 到 Releases 裡找包含這個關鍵字的檔案 |
 | --- | --- |
-| Windows 大多數使用者，推薦，免安裝 | `*windows64.opencl.portable.zip` |
-| Windows，OpenCL 版，想安裝 | `*windows64.opencl.installer.exe` |
-| Windows，OpenCL 不穩定，CPU 相容兜底，免安裝 | `*windows64.with-katago.portable.zip` |
-| Windows，NVIDIA 顯示卡，想更快，免安裝 | `*windows64.nvidia.portable.zip` |
+| Windows，RTX 20/30/40/50 NVIDIA 顯示卡，推薦，免安裝 | `*windows64.nvidia.portable.zip` |
+| Windows，RTX 20/30/40/50 NVIDIA 顯示卡，想安裝 | `*windows64.nvidia.installer.exe` |
+| Windows，AMD / Intel / 較舊 NVIDIA 顯示卡，免安裝 | `*windows64.opencl.portable.zip` |
+| Windows，AMD / Intel / 較舊 NVIDIA 顯示卡，想安裝 | `*windows64.opencl.installer.exe` |
+| Windows，沒有合適 GPU 或 GPU 版本無法啟動，CPU 相容版 | `*windows64.with-katago.portable.zip` |
+| Windows，CPU 相容版，想安裝 | `*windows64.with-katago.installer.exe` |
+| Windows，RTX 30 系及以下，選裝 TensorRT | 先使用 NVIDIA 套件，再從 `KataGo 自動設定` 安裝 TensorRT |
+| Windows，DirectX 12 GPU，測試 DirectML | `*windows64.experimental.directml.portable.zip` |
+| Windows，Intel GPU/NPU，測試 OpenVINO | `*windows64.experimental.openvino.portable.zip` |
+| Windows，支援的 AMD GPU，測試 ROCm | 選擇對應的 `*windows64.experimental.rocm.*.portable.zip` |
 | Windows，自己設定引擎，免安裝 | `*windows64.without.engine.portable.zip` |
+| Windows，自己設定引擎，想安裝 | `*windows64.without.engine.installer.exe` |
 | macOS Apple Silicon | `*mac-apple-silicon.with-katago.dmg` |
 | macOS Intel | `*mac-intel.with-katago.dmg` |
 | Linux | `*linux64.with-katago.zip` |
 
+完整套件的 CPU、OpenCL、CUDA、TensorRT、Metal 後端及 Linux 套件均使用 KataGo `v1.18.1`。Linux NVIDIA 仍使用 CUDA 12.1，以兼顧執行環境相容性。
+
+推薦完整套件預設內建官方旗艦 B11 `b11c768h12nbt3tflrs-fson-silu.bin.gz`（約 202 MiB）；RTX 3070 實測搜尋吞吐比 B10 低約 40%，偏重速度時可在 `KataGo 自動設定 -> 權重管理` 切換 B10。
+
+NVIDIA 和 TensorRT 說明：
+
+- `KataGo 自動設定` 會偵測 NVIDIA GPU 和 Compute Capability，並提示是否適合 TensorRT；偵測失敗時仍可手動繼續。
+- RTX 40/50 預設使用 CUDA。TensorRT 是 RTX 30 系及以下的選用方案。
+- NVIDIA 驅動 `570.65` 及以上可直接載入；`528.33–570.64` 首次啟動時會執行一次輕量推論測試；更舊的驅動會顯示修復狀態。
+- GTX 10 系及更舊的顯示卡應使用 OpenCL。OpenCL 不穩定時，改用 `*windows64.with-katago.portable.zip`。
+
 ## 三步開始
 
-1. 到 [正式版下載頁](https://goagent.top/download/) 下載適合自己系統的包；需要安裝程式、Linux 或歷史版本時使用 GitHub Releases。
-2. 打開程式後，點擊 `野狐棋譜`，輸入野狐暱稱。
-3. 抓到棋譜後繼續做快速全盤分析，用主勝率圖和底部快速概覽直接定位關鍵手。
+1. 到 [正式版下載頁](https://goagent.top/download/) 下載適合自己系統的套件；需要安裝程式、Linux 或歷史版本時使用 GitHub Releases。
+2. 打開 `野狐棋譜`，輸入野狐暱稱。
+3. 抓到棋譜後執行快速全盤分析，用主勝率圖和底部快速概覽直接定位關鍵手。
+
+<p align="center">
+  <a href="assets/fox-id-demo-cn.gif">
+    <img src="assets/fox-id-demo-cn-cover.png" alt="LizzieYzy Next 野狐暱稱抓譜示範" width="100%" />
+  </a>
+</p>
+
+<p align="center">
+  如果 GitHub 裡的 GIF 載入較慢，點擊上方圖片即可查看完整動畫。
+</p>
+
+## 介面預覽
+
+<p align="center">
+  <img src="assets/interface-overview-2026-04.png" alt="LizzieYzy Next 介面預覽" width="100%" />
+</p>
+
+主勝率圖和底部快速概覽包含：
+
+<p align="center">
+  <img src="assets/winrate-quick-overview-2026-04.png" alt="LizzieYzy Next 主勝率圖與快速概覽" width="46%" />
+</p>
+
+- 藍線 / 紫線：雙方勝率走勢
+- 綠線：目差變化
+- 底部熱力概覽：整盤問題手分布，紅橙黃越多越值得先看
+- 垂直定位線：目前手或游標停留手的位置
+
+## 它和原來的 lizzieyzy 有什麼不同
+
+| 比較項目 | 原 `lizzieyzy` | `LizzieYzy Next` |
+| --- | --- | --- |
+| 目前狀態 | 許多人仍記得的歷史專案，但長期缺少持續維護 | 持續維護使用體驗和發佈流程的目前分支 |
+| 野狐抓譜 | 舊流程在許多情況下已失效 | 已恢復常用抓譜流程，並支援暱稱輸入 |
+| 輸入方式 | 更依賴事先知道數字帳號 | 輸入野狐暱稱後由程式自動匹配帳號 |
+| KataGo 使用門檻 | 經常需要自行補齊環境或資源 | 推薦整合包已內建 KataGo 和預設權重 |
+| Windows 下載體驗 | 使用者需要自行判斷更多項目 | 按硬體清楚區分免安裝套件 |
+| 同步工具 | 經常需要使用者自行組合環境 | Windows 主發佈包已內建原生 `readboard.exe` |
+
+## macOS 首次啟動
+
+選擇符合 Mac 晶片的套件，打開 DMG 後將 `LizzieYzy Next` 拖到「應用程式」。退出安裝磁碟，再從 Finder 的「應用程式」資料夾啟動。官方 release 已完成簽章和公證；如果 macOS 仍阻擋程式，請依照 [安裝說明](docs/INSTALL.md) 排查。
 
 ## 文件與參與
 

--- a/README_ZH_TW.md
+++ b/README_ZH_TW.md
@@ -15,9 +15,8 @@
 </p>
 
 <p align="center">
-  <strong>LizzieYzy Next 是目前仍持續維護的 lizzieyzy 維護版，也是一個面向一般棋友的 KataGo 圍棋覆盤 GUI。</strong><br/>
-  它把真正影響體驗的幾件事重新打磨了一遍：更好挑的下載包、更省心的首次啟動、持續可用的野狐抓譜，以及更容易看懂的整盤分析視角。<br/>
-  <strong>下載安裝，輸入野狐暱稱，抓最近公開棋譜,跑快速全盤分析，再用新版勝率圖和底部快速概覽快速定位關鍵手。</strong>
+  <strong>LizzieYzy Next 是仍在維護的 lizzieyzy 分支，面向使用 KataGo 覆盤的一般棋友。</strong><br/>
+  提供野狐暱稱抓譜、快速全盤分析、新版勝率圖和底部快速概覽，並發佈 Windows、macOS、Linux 版本。
 </p>
 
 <p align="center">
@@ -31,29 +30,12 @@
 </p>
 
 > [!TIP]
-> 專案討論 QQ 群：`299419120`
+> [專案討論 QQ 群：299419120](https://qm.qq.com/q/JZoeojjteg)
 >
 > 歡迎交流使用問題、回報 bug、分享使用體驗，或者討論接下來最想加的功能。
 
 > [!NOTE]
 > 中國大陸使用者建議從 [官方下載頁面](https://goagent.top/download/) 下載正式版；需要安裝程式、Linux 套件或歷史版本時，可使用 [GitHub Releases](https://github.com/wimi321/lizzieyzy-next/releases)。
-
-> [!IMPORTANT]
-> 如果你只想先下對版本，先記住這 6 句：
-> - Windows 大多數使用者：到 [正式版下載頁](https://goagent.top/download/) 下載 `*windows64.opencl.portable.zip`
-> - 如果你的電腦有 NVIDIA 顯示卡並且想更快：下載 `*windows64.nvidia.portable.zip`
-> - 如果 OpenCL 在你的電腦上不穩定：下載 `*windows64.with-katago.portable.zip`
-> - 現在支援直接輸入野狐暱稱抓最近公開棋譜，不需要先查帳號數字
-> - 主推薦完整包已內建 KataGo `v1.18.1` 與官方旗艦 B11 Transformer，介面顯示為「Transformer 11B 棋力優先」（約 202 MiB）；單次判斷更強但搜尋速度可能較慢，追求速度可在一鍵設定中切換 B10。主程式小更新包不包含引擎與權重
-> - 主發佈包已內建 `readboard_java`，多數使用者不需要再單獨找 readboard 倉庫
-
-## 為什麼很多使用者會直接選它
-
-`LizzieYzy Next` 可以直接理解成：
-
-- 一套還在持續維護的 `KataGo 圍棋覆盤桌面工具`
-- 一條把 `野狐抓譜 + 快速全盤分析 + 多平台發佈包` 串起來的實用工作流
-- 一個讓老 `lizzieyzy` 使用者更容易繼續用下去的維護分支
 
 ## 你打開後馬上能做什麼
 
@@ -64,7 +46,7 @@
 | 快速找問題手 | 提供新版主勝率圖和底部熱力概覽，更容易一眼看出大問題手 |
 | 少折騰設定 | 推薦整合包已內建 KataGo、預設權重和首次自動設定 |
 | 不想安裝 | Windows 預設優先推薦 `portable.zip` 免安裝包 |
-| 做棋盤同步 | 主發佈包已內建 `readboard_java` 簡易同步工具 |
+| 做棋盤同步 | Windows 主發佈包已內建原生 `readboard.exe`，同步入口更清楚 |
 
 ## 先下載哪個
 
@@ -87,16 +69,41 @@
 2. 打開程式後，點擊 `野狐棋譜`，輸入野狐暱稱。
 3. 抓到棋譜後繼續做快速全盤分析，用主勝率圖和底部快速概覽直接定位關鍵手。
 
+## 文件與參與
+
+- [取得協助](SUPPORT.md)
+- [安裝說明](docs/INSTALL.md)
+- [發佈包說明](docs/PACKAGES.md)
+- [常見問題與排錯](docs/TROUBLESHOOTING.md)
+- [已驗證平台](docs/TESTED_PLATFORMS.md)
+- [GitHub Releases](https://github.com/wimi321/lizzieyzy-next/releases)
+- [GitHub Discussions](https://github.com/wimi321/lizzieyzy-next/discussions)
+- [QQ 群：299419120](https://qm.qq.com/q/JZoeojjteg)
+- [專案路線圖](ROADMAP.md)
+- [參與貢獻](CONTRIBUTING.md)
+- [更新日誌](CHANGELOG.md)
+
 ## 致謝
 
 - 原專案：[yzyray/lizzieyzy](https://github.com/yzyray/lizzieyzy)
 - KataGo：[lightvector/KataGo](https://github.com/lightvector/KataGo)
-野狐抓譜歷史參考：
+- 棋盤同步工具：[qiyi71w/readboard](https://github.com/qiyi71w/readboard)
+
+感謝 [qiyi71w](https://github.com/qiyi71w) 持續維護和改進 readboard。
+
+感謝所有參與提交的貢獻者：
+
+<p align="left">
+  <a href="https://github.com/wimi321/lizzieyzy-next/graphs/contributors">
+    <img src="https://contrib.rocks/image?repo=wimi321/lizzieyzy-next" alt="LizzieYzy Next 貢獻者" />
+  </a>
+</p>
+
+野狐抓譜參考：
+
 - [yzyray/FoxRequest](https://github.com/yzyray/FoxRequest)
 - [FuckUbuntu/Lizzieyzy-Helper](https://github.com/FuckUbuntu/Lizzieyzy-Helper)
 
 ## 參與翻譯
 
-歡迎提供翻譯！如果您願意將本說明翻譯成您的母語，請隨時提交 PR。
-
-We welcome translations! If you want to translate this README into your native language, please feel free to submit a Pull Request.
+歡迎提交 README 翻譯 PR。Translations are welcome; please submit a Pull Request.

--- a/scripts/check_markdown_links.py
+++ b/scripts/check_markdown_links.py
@@ -9,6 +9,8 @@ FILES = [
     ROOT / "README_EN.md",
     ROOT / "README_JA.md",
     ROOT / "README_KO.md",
+    ROOT / "README_TH.md",
+    ROOT / "README_ZH_TW.md",
     ROOT / "CONTRIBUTING.md",
     ROOT / "CODE_OF_CONDUCT.md",
     ROOT / "SECURITY.md",


### PR DESCRIPTION
## Why

Project and download guidance is a primary user surface. The six README variants should present current workflows, support routes, and contributor information consistently.

## What

- Present the product workflow and package choices more directly in Simplified Chinese, Traditional Chinese, English, Japanese, Korean, and Thai.
- Keep Windows NVIDIA, OpenCL, and CPU package guidance together with the current KataGo and TensorRT notes.
- Align support, GitHub Discussions, QQ, native `readboard.exe`, and contributor routes across translations.

## Preview

- [Rendered README on the source branch](https://github.com/qiyi71w/lizzieyzy-next/tree/docs/readme-refresh#readme)

## Validation

- [x] `python3 scripts/check_line_endings.py`
- [x] `git diff --cached --check` before commit
- [x] Rendered all six README files through the GitHub Markdown API
- [x] Loaded the rendered output in Chromium and confirmed every image loaded successfully