### PR TITLE
提升 AI 陪练高段位战术稳定性

### DIFF
--- a/src/main/java/featurecat/lizzie/analysis/HumanLikeMoveSelector.java
+++ b/src/main/java/featurecat/lizzie/analysis/HumanLikeMoveSelector.java
@@ -15,7 +15,7 @@ final class HumanLikeMoveSelector {
   static final double CANDIDATE_POLICY_MASS = 0.95;
 
   private static final double MIN_RELATIVE_POLICY = 0.01;
-  private static final double MAX_QUALITY_SCALE_LOSS = 4.0;
+  private static final double DEEP_VERIFICATION_THRESHOLD_RATIO = 0.55;
   private static final int OPENING_END_MOVE = 60;
   private static final int MIDDLEGAME_END_MOVE = 160;
   private static final double OPENING_TEMPERATURE = 1.25;
@@ -34,16 +34,20 @@ final class HumanLikeMoveSelector {
     if (pool.isEmpty()) {
       return null;
     }
-    if (pool.size() == 1) {
-      return pool.get(0).move;
-    }
 
     QualityTable quality = QualityTable.from(moveInfos);
-    double qualityScale = qualityScale(profile, quality.kind);
+    if (!quality.hasSearchResult()) {
+      return null;
+    }
+    if (quality.kind == QualityKind.NONE) {
+      return quality.bestMove;
+    }
+
+    double maxQualityLoss = maxQualityLoss(profile, quality.kind);
     double temperature = temperatureForMove(moveNumber);
     ArrayList<WeightedMove> weighted = new ArrayList<WeightedMove>(pool.size());
     for (Candidate candidate : pool) {
-      double qualityFactor = quality.factor(candidate.move, qualityScale);
+      double qualityFactor = quality.factor(candidate.move, maxQualityLoss);
       if (qualityFactor <= 0.0) {
         continue;
       }
@@ -55,9 +59,30 @@ final class HumanLikeMoveSelector {
     }
 
     if (weighted.isEmpty()) {
-      return pool.get(0).move;
+      return quality.bestMove;
     }
     return sampleWeighted(weighted, randomValue);
+  }
+
+  /** Returns true when shallow results are too incomplete or volatile for a safe final choice. */
+  static boolean needsDeepVerification(
+      List<Candidate> legalMoves, JSONArray moveInfos, String profile) {
+    List<Candidate> pool = candidatePool(legalMoves);
+    if (pool.isEmpty()) {
+      return false;
+    }
+    QualityTable quality = QualityTable.from(moveInfos);
+    if (quality.kind == QualityKind.NONE || !quality.hasSearchResult()) {
+      return true;
+    }
+    double threshold = maxQualityLoss(profile, quality.kind) * DEEP_VERIFICATION_THRESHOLD_RATIO;
+    for (Candidate candidate : pool) {
+      Double loss = quality.loss(candidate.move);
+      if (loss == null || loss.doubleValue() > threshold) {
+        return true;
+      }
+    }
+    return false;
   }
 
   static List<Candidate> candidatePool(List<Candidate> legalMoves) {
@@ -136,37 +161,88 @@ final class HumanLikeMoveSelector {
     return moves.get(moves.size() - 1).move;
   }
 
-  private static double qualityScale(String profile, QualityKind kind) {
-    double rankMultiplier = rankQualityMultiplier(profile);
+  private static double maxQualityLoss(String profile, QualityKind kind) {
+    StrengthBand band = strengthBand(profile);
     switch (kind) {
       case UTILITY:
-        return 0.50 * rankMultiplier;
+        switch (band) {
+          case ELITE:
+            return 0.32;
+          case HIGH_DAN:
+            return 0.45;
+          case DAN:
+            return 0.65;
+          case STRONG_KYU:
+            return 0.85;
+          case KYU:
+            return 1.15;
+          case DEVELOPING:
+          default:
+            return 1.80;
+        }
       case SCORE:
-        return 4.0 * rankMultiplier;
+        switch (band) {
+          case ELITE:
+            return 3.0;
+          case HIGH_DAN:
+            return 4.0;
+          case DAN:
+            return 5.5;
+          case STRONG_KYU:
+            return 7.0;
+          case KYU:
+            return 10.0;
+          case DEVELOPING:
+          default:
+            return 15.0;
+        }
       case WINRATE:
-        return 0.12 * rankMultiplier;
+        switch (band) {
+          case ELITE:
+            return 0.10;
+          case HIGH_DAN:
+            return 0.14;
+          case DAN:
+            return 0.20;
+          case STRONG_KYU:
+            return 0.25;
+          case KYU:
+            return 0.34;
+          case DEVELOPING:
+          default:
+            return 0.48;
+        }
       case NONE:
       default:
         return 1.0;
     }
   }
 
-  private static double rankQualityMultiplier(String profile) {
+  private static StrengthBand strengthBand(String profile) {
     if (profile == null) {
-      return 1.0;
+      return StrengthBand.KYU;
     }
     String normalized = profile.trim().toLowerCase(Locale.ROOT);
+    if (normalized.startsWith("proyear_")) {
+      return StrengthBand.ELITE;
+    }
     int rank = parseRankNumber(normalized);
-    if (normalized.endsWith("d") || normalized.startsWith("proyear_")) {
-      return 0.70;
+    if (normalized.endsWith("d")) {
+      if (rank >= 7) {
+        return StrengthBand.ELITE;
+      }
+      if (rank >= 4) {
+        return StrengthBand.HIGH_DAN;
+      }
+      return StrengthBand.DAN;
     }
     if (rank <= 5) {
-      return 0.90;
+      return StrengthBand.STRONG_KYU;
     }
     if (rank <= 10) {
-      return 1.15;
+      return StrengthBand.KYU;
     }
-    return 1.45;
+    return StrengthBand.DEVELOPING;
   }
 
   private static int parseRankNumber(String profile) {
@@ -209,30 +285,48 @@ final class HumanLikeMoveSelector {
     NONE
   }
 
+  private enum StrengthBand {
+    ELITE,
+    HIGH_DAN,
+    DAN,
+    STRONG_KYU,
+    KYU,
+    DEVELOPING
+  }
+
   private static final class QualityTable {
     private final QualityKind kind;
     private final Map<String, Double> values;
     private final double best;
+    private final String bestMove;
 
-    private QualityTable(QualityKind kind, Map<String, Double> values, double best) {
+    private QualityTable(
+        QualityKind kind, Map<String, Double> values, double best, String bestMove) {
       this.kind = kind;
       this.values = values;
       this.best = best;
+      this.bestMove = bestMove;
     }
 
-    private double factor(String move, double scale) {
-      if (kind == QualityKind.NONE || values.isEmpty()) {
-        return 1.0;
-      }
+    private double factor(String move, double maxLoss) {
       Double value = values.get(normalizeMove(move));
       if (value == null) {
-        return 1.0;
-      }
-      double loss = Math.max(0.0, best - value.doubleValue());
-      if (loss > scale * MAX_QUALITY_SCALE_LOSS) {
         return 0.0;
       }
-      return Math.exp(-loss / Math.max(1.0e-9, scale * MAX_QUALITY_SCALE_LOSS));
+      double loss = Math.max(0.0, best - value.doubleValue());
+      if (loss > maxLoss) {
+        return 0.0;
+      }
+      return Math.exp(-loss / Math.max(1.0e-9, maxLoss));
+    }
+
+    private Double loss(String move) {
+      Double value = values.get(normalizeMove(move));
+      return value == null ? null : Double.valueOf(Math.max(0.0, best - value.doubleValue()));
+    }
+
+    private boolean hasSearchResult() {
+      return bestMove != null && !bestMove.isEmpty();
     }
 
     private static QualityTable from(JSONArray moveInfos) {
@@ -248,12 +342,13 @@ final class HumanLikeMoveSelector {
       if (!winrate.values.isEmpty()) {
         return winrate;
       }
-      return new QualityTable(QualityKind.NONE, Map.of(), 0.0);
+      return new QualityTable(QualityKind.NONE, Map.of(), 0.0, firstSearchMove(moveInfos));
     }
 
     private static QualityTable collect(JSONArray moveInfos, QualityKind kind) {
       HashMap<String, Double> values = new HashMap<String, Double>();
       double best = Double.NEGATIVE_INFINITY;
+      String bestMove = null;
       if (moveInfos != null) {
         for (int i = 0; i < moveInfos.length(); i++) {
           JSONObject moveInfo = moveInfos.optJSONObject(i);
@@ -266,10 +361,37 @@ final class HumanLikeMoveSelector {
             continue;
           }
           values.put(move, value);
-          best = Math.max(best, value.doubleValue());
+          if (bestMove == null || value.doubleValue() > best) {
+            best = value.doubleValue();
+            bestMove = move;
+          }
         }
       }
-      return new QualityTable(kind, values, best);
+      return new QualityTable(kind, values, best, bestMove);
+    }
+
+    private static String firstSearchMove(JSONArray moveInfos) {
+      if (moveInfos == null) {
+        return null;
+      }
+      JSONObject fallback = null;
+      for (int i = 0; i < moveInfos.length(); i++) {
+        JSONObject moveInfo = moveInfos.optJSONObject(i);
+        if (moveInfo == null) {
+          continue;
+        }
+        String move = normalizeMove(moveInfo.optString("move", ""));
+        if (move.isEmpty()) {
+          continue;
+        }
+        if (fallback == null) {
+          fallback = moveInfo;
+        }
+        if (moveInfo.optInt("order", i) == 0) {
+          return move;
+        }
+      }
+      return fallback == null ? null : normalizeMove(fallback.optString("move", ""));
     }
 
     private static Double qualityValue(JSONObject moveInfo, QualityKind kind) {

--- a/src/main/java/featurecat/lizzie/analysis/HumanSlAnalysisRunner.java
+++ b/src/main/java/featurecat/lizzie/analysis/HumanSlAnalysisRunner.java
@@ -42,8 +42,12 @@ public class HumanSlAnalysisRunner implements AutoCloseable {
   private static final String GTP_COLUMNS = "ABCDEFGHJKLMNOPQRSTUVWXYZ";
   private static final int POLICY_PROBE_VISITS = 1;
   private static final int HUMAN_LIKE_PLAY_VISITS = 64;
-  private static final int MAX_TACTICAL_VERIFICATION_VISITS = 768;
-  private static final long MIN_DEEP_VERIFICATION_MILLIS = 5_000L;
+  private static final int MAX_ADAPTIVE_VERIFICATION_VISITS = 4_096;
+  private static final int MAX_ADAPTIVE_VERIFICATION_ROUNDS = 4;
+  private static final int MIN_ADAPTIVE_VISIT_GAIN = 16;
+  private static final long MIN_ADAPTIVE_REQUEST_MILLIS = 750L;
+  private static final long ADAPTIVE_RETURN_RESERVE_MILLIS = 450L;
+  private static final double ADAPTIVE_TIME_USE_RATIO = 0.85;
   private static final int MAX_STARTUP_DIAGNOSTICS = 10;
   private static final long PROCESS_TERMINATION_TIMEOUT_MILLIS = 10_000L;
 
@@ -284,32 +288,52 @@ public class HumanSlAnalysisRunner implements AutoCloseable {
               verificationVisits,
               rootSymmetries,
               new ArrayList<String>(verificationMoves));
+      long verificationStartedNanos = System.nanoTime();
       JSONObject verifiedResponse =
           request(verificationRequest, remainingRequestTime(deadlineNanos));
+      long verificationElapsedNanos = Math.max(1L, System.nanoTime() - verificationStartedNanos);
       if (allowPass && isSearchTopMovePass(verifiedResponse)) {
         return Optional.of("pass");
       }
 
       JSONObject finalResponse = verifiedResponse;
-      if (HumanLikeMoveSelector.needsDeepVerification(
-          selectableMoves, verifiedResponse.optJSONArray("moveInfos"), profile)) {
-        int deepVisits = tacticalVerificationVisits(verificationVisits);
-        if (deepVisits > verificationVisits
-            && remainingMillis(deadlineNanos) >= MIN_DEEP_VERIFICATION_MILLIS) {
-          String deepId = "humansl-tactical-" + nextRequestId.getAndIncrement();
-          JSONObject deepRequest =
-              buildHumanSlVerificationRequest(
-                  deepId,
-                  positionNode,
-                  profile,
-                  deepVisits,
-                  rootSymmetries,
-                  new ArrayList<String>(verificationMoves));
-          try {
-            finalResponse = request(deepRequest, remainingRequestTime(deadlineNanos));
-          } catch (TimeoutException timeoutFailure) {
-            terminateRequestBestEffort(generation, deepId);
-          }
+      boolean volatileCandidates =
+          HumanLikeMoveSelector.needsDeepVerification(
+              selectableMoves, verifiedResponse.optJSONArray("moveInfos"), profile);
+      int completedVisits = verificationVisits;
+      long completedElapsedNanos = verificationElapsedNanos;
+      for (int round = 0;
+          round < MAX_ADAPTIVE_VERIFICATION_ROUNDS
+              && shouldAdaptivelyDeepen(profile, volatileCandidates);
+          round++) {
+        int deepVisits =
+            adaptiveVerificationVisits(
+                completedVisits,
+                completedElapsedNanos,
+                Math.max(0L, deadlineNanos - System.nanoTime()));
+        if (deepVisits <= completedVisits) {
+          break;
+        }
+        String deepId = "humansl-tactical-" + nextRequestId.getAndIncrement();
+        JSONObject deepRequest =
+            buildHumanSlVerificationRequest(
+                deepId,
+                positionNode,
+                profile,
+                deepVisits,
+                rootSymmetries,
+                new ArrayList<String>(verificationMoves));
+        long deepStartedNanos = System.nanoTime();
+        try {
+          finalResponse = request(deepRequest, remainingAdaptiveRequestTime(deadlineNanos));
+          completedElapsedNanos = Math.max(1L, System.nanoTime() - deepStartedNanos);
+          completedVisits = deepVisits;
+          volatileCandidates =
+              HumanLikeMoveSelector.needsDeepVerification(
+                  selectableMoves, finalResponse.optJSONArray("moveInfos"), profile);
+        } catch (TimeoutException timeoutFailure) {
+          terminateRequestBestEffort(generation, deepId);
+          break;
         }
       }
       if (allowPass && isSearchTopMovePass(finalResponse)) {
@@ -781,9 +805,33 @@ public class HumanSlAnalysisRunner implements AutoCloseable {
     return request;
   }
 
-  private static int tacticalVerificationVisits(int baseVisits) {
-    long doubled = Math.max((long) baseVisits + 64L, (long) baseVisits * 2L);
-    return (int) Math.min(MAX_TACTICAL_VERIFICATION_VISITS, doubled);
+  static int adaptiveVerificationVisits(
+      int completedVisits, long completedElapsedNanos, long remainingNanos) {
+    int safeCompletedVisits = Math.max(1, completedVisits);
+    long reserveNanos = TimeUnit.MILLISECONDS.toNanos(ADAPTIVE_RETURN_RESERVE_MILLIS);
+    long usableNanos = Math.max(0L, remainingNanos - reserveNanos);
+    if (completedElapsedNanos <= 0L
+        || usableNanos < TimeUnit.MILLISECONDS.toNanos(MIN_ADAPTIVE_REQUEST_MILLIS)) {
+      return safeCompletedVisits;
+    }
+
+    double estimatedVisits =
+        safeCompletedVisits
+            * ((double) usableNanos / (double) completedElapsedNanos)
+            * ADAPTIVE_TIME_USE_RATIO;
+    int minimumGain = Math.max(MIN_ADAPTIVE_VISIT_GAIN, safeCompletedVisits / 4);
+    int minimumTarget =
+        Math.min(MAX_ADAPTIVE_VERIFICATION_VISITS, safeCompletedVisits + minimumGain);
+    int targetVisits =
+        (int)
+            Math.min(
+                MAX_ADAPTIVE_VERIFICATION_VISITS,
+                Math.max(minimumTarget, Math.floor(estimatedVisits)));
+    return targetVisits > safeCompletedVisits ? targetVisits : safeCompletedVisits;
+  }
+
+  static boolean shouldAdaptivelyDeepen(String profile, boolean volatileCandidates) {
+    return volatileCandidates || isEliteHumanProfile(profile);
   }
 
   private static boolean isEliteHumanProfile(String profile) {
@@ -805,8 +853,13 @@ public class HumanSlAnalysisRunner implements AutoCloseable {
     return Duration.ofNanos(remaining);
   }
 
-  private static long remainingMillis(long deadlineNanos) {
-    return Math.max(0L, TimeUnit.NANOSECONDS.toMillis(deadlineNanos - System.nanoTime()));
+  private static Duration remainingAdaptiveRequestTime(long deadlineNanos) throws TimeoutException {
+    long reserveNanos = TimeUnit.MILLISECONDS.toNanos(ADAPTIVE_RETURN_RESERVE_MILLIS);
+    long remaining = deadlineNanos - System.nanoTime() - reserveNanos;
+    if (remaining <= 0L) {
+      throw new TimeoutException("No safe time remains for deeper HumanSL verification.");
+    }
+    return Duration.ofNanos(remaining);
   }
 
   private void terminateRequestBestEffort(int expectedGeneration, String terminateId) {

--- a/src/main/java/featurecat/lizzie/analysis/HumanSlAnalysisRunner.java
+++ b/src/main/java/featurecat/lizzie/analysis/HumanSlAnalysisRunner.java
@@ -21,6 +21,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Deque;
 import java.util.IdentityHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -39,7 +40,10 @@ import org.json.JSONObject;
 /** Runs KataGo HumanSL analysis queries without changing the normal analysis engine. */
 public class HumanSlAnalysisRunner implements AutoCloseable {
   private static final String GTP_COLUMNS = "ABCDEFGHJKLMNOPQRSTUVWXYZ";
+  private static final int POLICY_PROBE_VISITS = 1;
   private static final int HUMAN_LIKE_PLAY_VISITS = 64;
+  private static final int MAX_TACTICAL_VERIFICATION_VISITS = 768;
+  private static final long MIN_DEEP_VERIFICATION_MILLIS = 5_000L;
   private static final int MAX_STARTUP_DIAGNOSTICS = 10;
   private static final long PROCESS_TERMINATION_TIMEOUT_MILLIS = 10_000L;
 
@@ -179,8 +183,7 @@ public class HumanSlAnalysisRunner implements AutoCloseable {
    * creation alone is insufficient because KataGo can fail later while loading models or GPU
    * libraries.
    */
-  public boolean verifyReady(
-      BoardHistoryNode positionNode, String profile, Duration timeout) {
+  public boolean verifyReady(BoardHistoryNode positionNode, String profile, Duration timeout) {
     if (positionNode == null || profile == null || profile.trim().isEmpty()) {
       unavailableReason = "HumanSL readiness position or profile is missing.";
       return false;
@@ -190,8 +193,7 @@ public class HumanSlAnalysisRunner implements AutoCloseable {
     }
     int generation = activeProcessGeneration;
     String requestId = "humansl-ready-" + nextRequestId.getAndIncrement();
-    JSONObject readinessRequest =
-        buildHumanSlRequest(requestId, positionNode, profile, 1, 1);
+    JSONObject readinessRequest = buildHumanSlRequest(requestId, positionNode, profile, 1, 1);
     try {
       JSONObject response =
           request(readinessRequest, timeout == null ? Duration.ofSeconds(180) : timeout);
@@ -234,29 +236,96 @@ public class HumanSlAnalysisRunner implements AutoCloseable {
       return Optional.empty();
     }
     int generation = activeProcessGeneration;
-    String requestId = "humansl-genmove-" + nextRequestId.getAndIncrement();
     boolean allowPass = shouldAllowPass(positionNode);
-    JSONObject request =
-        buildHumanSlRequest(requestId, positionNode, profile, maxVisits, rootSymmetries);
+    Duration effectiveTimeout = timeout == null ? Duration.ofSeconds(30) : timeout;
+    long deadlineNanos = System.nanoTime() + Math.max(1L, effectiveTimeout.toNanos());
     try {
-      JSONObject response = request(request, timeout == null ? Duration.ofSeconds(30) : timeout);
-      if (allowPass && isSearchTopMovePass(response)) {
-        return Optional.of("pass");
-      }
-      Object policy = extractHumanPolicy(response);
+      String probeId = "humansl-policy-" + nextRequestId.getAndIncrement();
+      JSONObject probe =
+          buildHumanSlRequest(probeId, positionNode, profile, POLICY_PROBE_VISITS, rootSymmetries);
+      JSONObject probeResponse = request(probe, remainingRequestTime(deadlineNanos));
+      Object policy = extractHumanPolicy(probeResponse);
       if (policy == null) {
         return Optional.empty();
       }
-      List<HumanLikeMoveSelector.Candidate> legalMoves =
+      List<HumanLikeMoveSelector.Candidate> selectableMoves =
           policyMoves(
               policy, Board.boardWidth, Board.boardHeight, positionNode.getData().stones, false);
-      return Optional.ofNullable(
+      List<HumanLikeMoveSelector.Candidate> policyMovesIncludingPass =
+          policyMoves(
+              policy,
+              Board.boardWidth,
+              Board.boardHeight,
+              positionNode.getData().stones,
+              allowPass);
+      LinkedHashSet<String> verificationMoves = new LinkedHashSet<String>();
+      addVerificationMoves(
+          verificationMoves,
+          HumanLikeMoveSelector.candidatePool(policyMovesIncludingPass),
+          allowPass);
+      addVerificationMoves(
+          verificationMoves, HumanLikeMoveSelector.candidatePool(selectableMoves), allowPass);
+      addVerificationMove(verificationMoves, searchTopMove(probeResponse), allowPass);
+      addVerificationMove(
+          verificationMoves,
+          argmaxPolicyMove(probeResponse.opt("policy"), Board.boardWidth, Board.boardHeight),
+          allowPass);
+      if (verificationMoves.isEmpty()) {
+        return Optional.empty();
+      }
+
+      int verificationVisits = Math.max(1, maxVisits);
+      String verificationId = "humansl-verify-" + nextRequestId.getAndIncrement();
+      JSONObject verificationRequest =
+          buildHumanSlVerificationRequest(
+              verificationId,
+              positionNode,
+              profile,
+              verificationVisits,
+              rootSymmetries,
+              new ArrayList<String>(verificationMoves));
+      JSONObject verifiedResponse =
+          request(verificationRequest, remainingRequestTime(deadlineNanos));
+      if (allowPass && isSearchTopMovePass(verifiedResponse)) {
+        return Optional.of("pass");
+      }
+
+      JSONObject finalResponse = verifiedResponse;
+      if (HumanLikeMoveSelector.needsDeepVerification(
+          selectableMoves, verifiedResponse.optJSONArray("moveInfos"), profile)) {
+        int deepVisits = tacticalVerificationVisits(verificationVisits);
+        if (deepVisits > verificationVisits
+            && remainingMillis(deadlineNanos) >= MIN_DEEP_VERIFICATION_MILLIS) {
+          String deepId = "humansl-tactical-" + nextRequestId.getAndIncrement();
+          JSONObject deepRequest =
+              buildHumanSlVerificationRequest(
+                  deepId,
+                  positionNode,
+                  profile,
+                  deepVisits,
+                  rootSymmetries,
+                  new ArrayList<String>(verificationMoves));
+          try {
+            finalResponse = request(deepRequest, remainingRequestTime(deadlineNanos));
+          } catch (TimeoutException timeoutFailure) {
+            terminateRequestBestEffort(generation, deepId);
+          }
+        }
+      }
+      if (allowPass && isSearchTopMovePass(finalResponse)) {
+        return Optional.of("pass");
+      }
+      String selected =
           HumanLikeMoveSelector.select(
-              legalMoves,
-              response.optJSONArray("moveInfos"),
+              selectableMoves,
+              finalResponse.optJSONArray("moveInfos"),
               positionNode.getData().moveNumber,
               profile,
-              ThreadLocalRandom.current().nextDouble()));
+              ThreadLocalRandom.current().nextDouble());
+      if (!allowPass && "pass".equalsIgnoreCase(selected)) {
+        return Optional.empty();
+      }
+      return Optional.ofNullable(selected);
     } catch (TimeoutException | IOException e) {
       stopActiveProcess(
           generation,
@@ -471,9 +540,9 @@ public class HumanSlAnalysisRunner implements AutoCloseable {
   }
 
   /**
-   * Cancels the current request and process without permanently closing the runner. A later
-   * request starts a clean process, so user actions such as "finish" never queue behind a stuck
-   * engine request.
+   * Cancels the current request and process without permanently closing the runner. A later request
+   * starts a clean process, so user actions such as "finish" never queue behind a stuck engine
+   * request.
    */
   public void cancelActiveRequests() {
     stopActiveProcess(false, "HumanSL request cancelled.");
@@ -665,11 +734,7 @@ public class HumanSlAnalysisRunner implements AutoCloseable {
   }
 
   static JSONObject buildHumanSlRequest(
-      String id,
-      BoardHistoryNode positionNode,
-      String profile,
-      int maxVisits,
-      int rootSymmetries) {
+      String id, BoardHistoryNode positionNode, String profile, int maxVisits, int rootSymmetries) {
     JSONObject request =
         AnalysisRequestBuilder.buildRequest(
             id, positionNode, Math.max(1, maxVisits), false, false, false);
@@ -681,10 +746,111 @@ public class HumanSlAnalysisRunner implements AutoCloseable {
     }
     overrideSettings.put("humanSLProfile", profile);
     overrideSettings.put("ignorePreRootHistory", false);
-    overrideSettings.put("humanSLRootExploreProbWeightless", 0.5);
+    overrideSettings.put(
+        "humanSLRootExploreProbWeightless", isEliteHumanProfile(profile) ? 0.8 : 0.5);
     overrideSettings.put("rootNumSymmetriesToSample", Math.max(1, Math.min(8, rootSymmetries)));
     request.put("overrideSettings", overrideSettings);
     return request;
+  }
+
+  static JSONObject buildHumanSlVerificationRequest(
+      String id,
+      BoardHistoryNode positionNode,
+      String profile,
+      int maxVisits,
+      int rootSymmetries,
+      List<String> allowedMoves) {
+    JSONObject request = buildHumanSlRequest(id, positionNode, profile, maxVisits, rootSymmetries);
+    JSONObject overrideSettings = request.getJSONObject("overrideSettings");
+    overrideSettings.put("humanSLCpuctPermanent", 2.0);
+    JSONArray moves = new JSONArray();
+    if (allowedMoves != null) {
+      for (String move : allowedMoves) {
+        String normalized = normalizeMove(move);
+        if (!normalized.isEmpty()) {
+          moves.put(normalized);
+        }
+      }
+    }
+    JSONObject allowance =
+        new JSONObject()
+            .put("player", positionNode.getData().blackToPlay ? "B" : "W")
+            .put("moves", moves)
+            .put("untilDepth", 1);
+    request.put("allowMoves", new JSONArray().put(allowance));
+    return request;
+  }
+
+  private static int tacticalVerificationVisits(int baseVisits) {
+    long doubled = Math.max((long) baseVisits + 64L, (long) baseVisits * 2L);
+    return (int) Math.min(MAX_TACTICAL_VERIFICATION_VISITS, doubled);
+  }
+
+  private static boolean isEliteHumanProfile(String profile) {
+    if (profile == null) {
+      return false;
+    }
+    String normalized = profile.trim().toLowerCase(java.util.Locale.ROOT);
+    if (normalized.startsWith("proyear_")) {
+      return true;
+    }
+    return normalized.matches("rank_[789]d");
+  }
+
+  private static Duration remainingRequestTime(long deadlineNanos) throws TimeoutException {
+    long remaining = deadlineNanos - System.nanoTime();
+    if (remaining <= 0L) {
+      throw new TimeoutException("HumanSL move verification exceeded its time budget.");
+    }
+    return Duration.ofNanos(remaining);
+  }
+
+  private static long remainingMillis(long deadlineNanos) {
+    return Math.max(0L, TimeUnit.NANOSECONDS.toMillis(deadlineNanos - System.nanoTime()));
+  }
+
+  private void terminateRequestBestEffort(int expectedGeneration, String terminateId) {
+    BufferedOutputStream activeOutput;
+    synchronized (this) {
+      if (!started
+          || expectedGeneration != activeProcessGeneration
+          || outputStream == null
+          || terminateId == null
+          || terminateId.isEmpty()) {
+        return;
+      }
+      activeOutput = outputStream;
+    }
+    JSONObject terminate =
+        new JSONObject()
+            .put("id", "humansl-terminate-" + nextRequestId.getAndIncrement())
+            .put("action", "terminate")
+            .put("terminateId", terminateId);
+    try {
+      synchronized (activeOutput) {
+        if (!started || expectedGeneration != activeProcessGeneration) {
+          return;
+        }
+        activeOutput.write((terminate.toString() + "\n").getBytes(StandardCharsets.UTF_8));
+        activeOutput.flush();
+      }
+    } catch (IOException ignored) {
+      // The next normal request will perform the authoritative process-health check.
+    }
+  }
+
+  private static void addVerificationMoves(
+      Set<String> moves, List<HumanLikeMoveSelector.Candidate> candidates, boolean allowPass) {
+    for (HumanLikeMoveSelector.Candidate candidate : candidates) {
+      addVerificationMove(moves, candidate.move, allowPass);
+    }
+  }
+
+  private static void addVerificationMove(Set<String> moves, String move, boolean allowPass) {
+    String normalized = normalizeMove(move);
+    if (!normalized.isEmpty() && (allowPass || !"pass".equals(normalized))) {
+      moves.add(normalized);
+    }
   }
 
   private static JSONObject orderedMoveInfo(JSONArray moveInfos, int order) {
@@ -798,9 +964,13 @@ public class HumanSlAnalysisRunner implements AutoCloseable {
   }
 
   private static boolean isSearchTopMovePass(JSONObject response) {
+    return "pass".equalsIgnoreCase(searchTopMove(response));
+  }
+
+  private static String searchTopMove(JSONObject response) {
     JSONArray moveInfos = response == null ? null : response.optJSONArray("moveInfos");
     if (moveInfos == null || moveInfos.length() == 0) {
-      return false;
+      return null;
     }
     JSONObject topMove = null;
     for (int i = 0; i < moveInfos.length(); i++) {
@@ -816,7 +986,7 @@ public class HumanSlAnalysisRunner implements AutoCloseable {
     if (topMove == null) {
       topMove = moveInfos.optJSONObject(0);
     }
-    return topMove != null && "pass".equalsIgnoreCase(topMove.optString("move", ""));
+    return topMove == null ? null : topMove.optString("move", null);
   }
 
   static Object extractHumanPolicy(JSONObject response) {
@@ -938,13 +1108,9 @@ public class HumanSlAnalysisRunner implements AutoCloseable {
       boolean activeGeneration = generation == activeProcessGeneration;
       if (activeGeneration && !closed) {
         IOException ioException =
-            failure == null
-                ? new IOException(
-                    stoppedProcessMessage(generation))
-                : failure;
+            failure == null ? new IOException(stoppedProcessMessage(generation)) : failure;
         String reason =
-            withStartupDiagnostics(
-                usefulMessage(ioException, "HumanSL analysis engine stopped."));
+            withStartupDiagnostics(usefulMessage(ioException, "HumanSL analysis engine stopped."));
         stopActiveProcess(generation, false, reason);
       }
     }
@@ -1004,7 +1170,8 @@ public class HumanSlAnalysisRunner implements AutoCloseable {
     synchronized (startupDiagnostics) {
       diagnostics = new ArrayList<String>(startupDiagnostics);
     }
-    String base = reason == null || reason.trim().isEmpty() ? "HumanSL engine failed." : reason.trim();
+    String base =
+        reason == null || reason.trim().isEmpty() ? "HumanSL engine failed." : reason.trim();
     return diagnostics.isEmpty() ? base : base + " | " + String.join(" | ", diagnostics);
   }
 
@@ -1014,9 +1181,7 @@ public class HumanSlAnalysisRunner implements AutoCloseable {
       return "HumanSL analysis engine stopped unexpectedly.";
     }
     try {
-      return "HumanSL analysis engine stopped unexpectedly (exit code "
-          + active.exitValue()
-          + ").";
+      return "HumanSL analysis engine stopped unexpectedly (exit code " + active.exitValue() + ").";
     } catch (IllegalThreadStateException e) {
       return "HumanSL analysis engine stopped unexpectedly.";
     }

--- a/src/test/java/featurecat/lizzie/analysis/HumanLikeMoveSelectorTest.java
+++ b/src/test/java/featurecat/lizzie/analysis/HumanLikeMoveSelectorTest.java
@@ -1,6 +1,8 @@
 package featurecat.lizzie.analysis;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.lang.reflect.Field;
@@ -58,6 +60,72 @@ class HumanLikeMoveSelectorTest {
   }
 
   @Test
+  void unverifiedHumanCandidateCanNeverBeSelected() {
+    List<HumanLikeMoveSelector.Candidate> candidates =
+        List.of(candidate("D4", 0.20), candidate("Q4", 0.80));
+    JSONArray moveInfos = new JSONArray().put(moveInfo("D4", 0.40));
+
+    for (int i = 0; i < 1000; i++) {
+      assertEquals(
+          "D4",
+          HumanLikeMoveSelector.select(candidates, moveInfos, 20, "rank_7d", (i + 0.5) / 1000.0));
+    }
+  }
+
+  @Test
+  void selectorRefusesToGuessWithoutAnySearchResult() {
+    List<HumanLikeMoveSelector.Candidate> candidates = List.of(candidate("D4", 1.0));
+
+    assertNull(HumanLikeMoveSelector.select(candidates, null, 20, "rank_7d", 0.5));
+  }
+
+  @Test
+  void sevenDanGuardRejectsTheObservedTacticalUtilityLoss() {
+    List<HumanLikeMoveSelector.Candidate> candidates =
+        List.of(candidate("S8", 0.45), candidate("D8", 0.55));
+    JSONArray moveInfos = new JSONArray().put(moveInfo("S8", 0.80)).put(moveInfo("D8", -0.12));
+
+    for (int i = 0; i < 1000; i++) {
+      assertEquals(
+          "S8",
+          HumanLikeMoveSelector.select(candidates, moveInfos, 40, "rank_7d", (i + 0.5) / 1000.0));
+    }
+  }
+
+  @Test
+  void allUnsafeHumanCandidatesFallBackToTheStrongModelMove() {
+    List<HumanLikeMoveSelector.Candidate> candidates =
+        List.of(candidate("D4", 0.55), candidate("Q4", 0.45));
+    JSONArray moveInfos =
+        new JSONArray()
+            .put(moveInfo("A3", 0.80))
+            .put(moveInfo("D4", 0.20))
+            .put(moveInfo("Q4", 0.05));
+
+    assertEquals("A3", HumanLikeMoveSelector.select(candidates, moveInfos, 40, "rank_7d", 0.5));
+  }
+
+  @Test
+  void volatileOrIncompleteCandidateSearchRequestsDeeperVerification() {
+    List<HumanLikeMoveSelector.Candidate> candidates =
+        List.of(candidate("D4", 0.55), candidate("Q4", 0.45));
+
+    assertTrue(
+        HumanLikeMoveSelector.needsDeepVerification(
+            candidates, new JSONArray().put(moveInfo("D4", 0.8)), "rank_7d"));
+    assertTrue(
+        HumanLikeMoveSelector.needsDeepVerification(
+            candidates,
+            new JSONArray().put(moveInfo("D4", 0.8)).put(moveInfo("Q4", 0.5)),
+            "rank_7d"));
+    assertFalse(
+        HumanLikeMoveSelector.needsDeepVerification(
+            candidates,
+            new JSONArray().put(moveInfo("D4", 0.8)).put(moveInfo("Q4", 0.7)),
+            "rank_7d"));
+  }
+
+  @Test
   void weakerProfileRetainsMoreNaturalMistakesThanStrongProfile() {
     List<HumanLikeMoveSelector.Candidate> candidates =
         List.of(candidate("D4", 0.50), candidate("Q4", 0.50));
@@ -95,10 +163,17 @@ class HumanLikeMoveSelectorTest {
       String profile,
       int samples) {
     HashMap<String, Integer> counts = new HashMap<>();
+    JSONArray effectiveMoveInfos = moveInfos;
+    if (effectiveMoveInfos == null) {
+      effectiveMoveInfos = new JSONArray();
+      for (HumanLikeMoveSelector.Candidate candidate : candidates) {
+        effectiveMoveInfos.put(moveInfo(candidate.move, 0.5));
+      }
+    }
     for (int i = 0; i < samples; i++) {
       String selected =
           HumanLikeMoveSelector.select(
-              candidates, moveInfos, moveNumber, profile, (i + 0.5) / samples);
+              candidates, effectiveMoveInfos, moveNumber, profile, (i + 0.5) / samples);
       counts.merge(selected, 1, Integer::sum);
     }
     return counts;

--- a/src/test/java/featurecat/lizzie/analysis/HumanSlAnalysisRunnerTest.java
+++ b/src/test/java/featurecat/lizzie/analysis/HumanSlAnalysisRunnerTest.java
@@ -45,8 +45,7 @@ class HumanSlAnalysisRunnerTest {
   void closeWaitsUntilTheCompanionProcessHasActuallyExited() throws Exception {
     try (TestEnvironment env = TestEnvironment.open()) {
       DelayedExitProcess process =
-          new DelayedExitProcess(
-              request -> new JSONObject().put("id", request.optString("id")));
+          new DelayedExitProcess(request -> new JSONObject().put("id", request.optString("id")));
       HumanSlAnalysisRunner runner =
           new HumanSlAnalysisRunner(List.of("katago", "analysis"), ignored -> process);
       assertTrue(runner.start());
@@ -78,8 +77,7 @@ class HumanSlAnalysisRunnerTest {
   void restartWaitsForTheCancelledCompanionToActuallyExit() throws Exception {
     try (TestEnvironment env = TestEnvironment.open()) {
       DelayedExitProcess first =
-          new DelayedExitProcess(
-              request -> new JSONObject().put("id", request.optString("id")));
+          new DelayedExitProcess(request -> new JSONObject().put("id", request.optString("id")));
       FakeProcess replacement =
           new FakeProcess(request -> new JSONObject().put("id", request.optString("id")));
       AtomicInteger launches = new AtomicInteger();
@@ -165,10 +163,38 @@ class HumanSlAnalysisRunnerTest {
 
       assertEquals(128, request.getInt("maxVisits"));
       assertEquals(
-          2,
-          request
-              .getJSONObject("overrideSettings")
-              .getInt("rootNumSymmetriesToSample"));
+          2, request.getJSONObject("overrideSettings").getInt("rootNumSymmetriesToSample"));
+    }
+  }
+
+  @Test
+  void buildHumanSlVerificationRequest_limitsRootToHumanCandidates() throws Exception {
+    try (TestEnvironment env = TestEnvironment.open()) {
+      BoardHistoryList history = new BoardHistoryList(BoardData.empty(BOARD_SIZE, BOARD_SIZE));
+      boardWithHistory(history);
+
+      JSONObject request =
+          HumanSlAnalysisRunner.buildHumanSlVerificationRequest(
+              "humansl-verify",
+              history.getCurrentHistoryNode(),
+              "rank_7d",
+              256,
+              2,
+              List.of("A3", "B2"));
+
+      assertEquals(256, request.getInt("maxVisits"));
+      assertEquals(
+          2.0,
+          request.getJSONObject("overrideSettings").getDouble("humanSLCpuctPermanent"),
+          0.0001);
+      assertEquals(
+          0.8,
+          request.getJSONObject("overrideSettings").getDouble("humanSLRootExploreProbWeightless"),
+          0.0001);
+      JSONObject allowance = request.getJSONArray("allowMoves").getJSONObject(0);
+      assertEquals("B", allowance.getString("player"));
+      assertEquals(1, allowance.getInt("untilDepth"));
+      assertEquals(List.of("A3", "B2"), allowance.getJSONArray("moves").toList());
     }
   }
 
@@ -252,6 +278,24 @@ class HumanSlAnalysisRunnerTest {
           new FakeProcess(
               request -> {
                 JSONObject policy = new JSONObject().put("A3", 0.1).put("B2", 0.8);
+                if (request.has("allowMoves")) {
+                  return new JSONObject()
+                      .put("id", request.getString("id"))
+                      .put("humanPolicy", policy)
+                      .put(
+                          "moveInfos",
+                          new JSONArray()
+                              .put(
+                                  new JSONObject()
+                                      .put("move", "B2")
+                                      .put("order", 0)
+                                      .put("utility", 0.50))
+                              .put(
+                                  new JSONObject()
+                                      .put("move", "A3")
+                                      .put("order", 1)
+                                      .put("utility", 0.45)));
+                }
                 return new JSONObject()
                     .put("id", request.getString("id"))
                     .put("rootInfo", new JSONObject().put("humanPolicy", policy))
@@ -267,7 +311,10 @@ class HumanSlAnalysisRunnerTest {
 
       assertTrue(best.isPresent());
       assertFalse("pass".equals(best.get()));
-      assertEquals(64, process.sentRequests.get(0).getInt("maxVisits"));
+      assertEquals(2, process.sentRequests.size());
+      assertEquals(1, process.sentRequests.get(0).getInt("maxVisits"));
+      assertEquals(64, process.sentRequests.get(1).getInt("maxVisits"));
+      assertTrue(process.sentRequests.get(1).has("allowMoves"));
       assertFalse(process.sentRequests.get(0).has("maxTime"));
       assertFalse(
           process
@@ -332,7 +379,9 @@ class HumanSlAnalysisRunnerTest {
           runner.bestHumanMove(history.getCurrentHistoryNode(), "rank_3k", Duration.ofSeconds(1));
 
       assertEquals(java.util.Optional.of("pass"), best);
-      assertEquals(64, process.sentRequests.get(0).getInt("maxVisits"));
+      assertEquals(2, process.sentRequests.size());
+      assertEquals(1, process.sentRequests.get(0).getInt("maxVisits"));
+      assertEquals(64, process.sentRequests.get(1).getInt("maxVisits"));
       runner.close();
     }
   }
@@ -368,6 +417,68 @@ class HumanSlAnalysisRunnerTest {
   }
 
   @Test
+  void bestHumanMove_deepensVolatileCandidatesAndRejectsTheTacticalBlunder() throws Exception {
+    try (TestEnvironment env = TestEnvironment.open()) {
+      BoardHistoryList history = new BoardHistoryList(BoardData.empty(BOARD_SIZE, BOARD_SIZE));
+      boardWithHistory(history);
+      FakeProcess process =
+          new FakeProcess(
+              request -> {
+                JSONObject response =
+                    new JSONObject()
+                        .put("id", request.getString("id"))
+                        .put("humanPolicy", new JSONObject().put("A3", 0.45).put("B2", 0.55));
+                int visits = request.getInt("maxVisits");
+                if (visits == 1) {
+                  return response.put(
+                      "moveInfos",
+                      new JSONArray()
+                          .put(
+                              new JSONObject()
+                                  .put("move", "A3")
+                                  .put("order", 0)
+                                  .put("utility", 0.8)));
+                }
+                double badUtility = visits >= 512 ? -0.12 : 0.20;
+                return response.put(
+                    "moveInfos",
+                    new JSONArray()
+                        .put(
+                            new JSONObject().put("move", "A3").put("order", 0).put("utility", 0.80))
+                        .put(
+                            new JSONObject()
+                                .put("move", "B2")
+                                .put("order", 1)
+                                .put("utility", badUtility)));
+              });
+      HumanSlAnalysisRunner runner =
+          new HumanSlAnalysisRunner(List.of("katago", "analysis"), ignored -> process);
+
+      assertEquals(
+          java.util.Optional.of("A3"),
+          runner.bestHumanMove(
+              history.getCurrentHistoryNode(), "rank_7d", 256, 2, Duration.ofSeconds(10)));
+
+      assertEquals(3, process.sentRequests.size());
+      assertEquals(1, process.sentRequests.get(0).getInt("maxVisits"));
+      assertEquals(256, process.sentRequests.get(1).getInt("maxVisits"));
+      assertEquals(512, process.sentRequests.get(2).getInt("maxVisits"));
+      for (int index = 1; index < process.sentRequests.size(); index++) {
+        JSONObject request = process.sentRequests.get(index);
+        assertTrue(request.has("allowMoves"));
+        assertEquals(
+            2.0,
+            request.getJSONObject("overrideSettings").getDouble("humanSLCpuctPermanent"),
+            0.0001);
+        assertEquals(
+            List.of("B2", "A3"),
+            request.getJSONArray("allowMoves").getJSONObject(0).getJSONArray("moves").toList());
+      }
+      runner.close();
+    }
+  }
+
+  @Test
   void verifyReady_requiresARealHumanSlResponse() throws Exception {
     try (TestEnvironment env = TestEnvironment.open()) {
       BoardHistoryList history = new BoardHistoryList(BoardData.empty(BOARD_SIZE, BOARD_SIZE));
@@ -386,8 +497,7 @@ class HumanSlAnalysisRunnerTest {
       runner.setStartupListener((stage, detail) -> stages.add(stage));
 
       assertTrue(
-          runner.verifyReady(
-              history.getCurrentHistoryNode(), "rank_3k", Duration.ofSeconds(1)));
+          runner.verifyReady(history.getCurrentHistoryNode(), "rank_3k", Duration.ofSeconds(1)));
       assertEquals(1, process.sentRequests.size());
       assertEquals(1, process.sentRequests.get(0).getInt("maxVisits"));
       assertTrue(stages.contains(HumanSlAnalysisRunner.StartupStage.READY));
@@ -405,8 +515,7 @@ class HumanSlAnalysisRunnerTest {
           new HumanSlAnalysisRunner(List.of("katago", "analysis"), ignored -> process);
 
       assertFalse(
-          runner.verifyReady(
-              history.getCurrentHistoryNode(), "rank_3k", Duration.ofMillis(40)));
+          runner.verifyReady(history.getCurrentHistoryNode(), "rank_3k", Duration.ofMillis(40)));
       assertFalse(runner.isStarted());
       assertTrue(runner.getUnavailableReason().contains("Timed out"));
       runner.close();
@@ -444,8 +553,7 @@ class HumanSlAnalysisRunnerTest {
     Files.createDirectories(engine.getParent());
     Files.write(engine, new byte[0]);
     Files.writeString(
-        engine.getParent().resolve("lizzieyzy-next-engine-backend.txt"),
-        "nvidia50-cuda\n");
+        engine.getParent().resolve("lizzieyzy-next-engine-backend.txt"), "nvidia50-cuda\n");
     Config previousConfig = Lizzie.config;
     String previousOsName = System.getProperty("os.name");
     AtomicInteger launches = new AtomicInteger();
@@ -501,8 +609,7 @@ class HumanSlAnalysisRunnerTest {
       }
 
       assertFalse(
-          runner.verifyReady(
-              history.getCurrentHistoryNode(), "rank_3k", Duration.ofMillis(40)));
+          runner.verifyReady(history.getCurrentHistoryNode(), "rank_3k", Duration.ofMillis(40)));
       assertTrue(stages.contains(HumanSlAnalysisRunner.StartupStage.STARTING));
       assertTrue(stages.contains(HumanSlAnalysisRunner.StartupStage.OPTIMIZING_GPU));
       assertTrue(runner.getUnavailableReason().contains("Timed out"));
@@ -525,8 +632,7 @@ class HumanSlAnalysisRunnerTest {
                       .put("humanPolicy", new JSONObject().put("B2", 1.0))
                       .put(
                           "moveInfos",
-                          new JSONArray()
-                              .put(new JSONObject().put("move", "B2").put("order", 0))));
+                          new JSONArray().put(new JSONObject().put("move", "B2").put("order", 0))));
       AtomicInteger launches = new AtomicInteger();
       HumanSlAnalysisRunner runner =
           new HumanSlAnalysisRunner(
@@ -538,9 +644,7 @@ class HumanSlAnalysisRunnerTest {
             worker.submit(
                 () ->
                     runner.bestHumanMove(
-                        history.getCurrentHistoryNode(),
-                        "rank_3k",
-                        Duration.ofSeconds(30)));
+                        history.getCurrentHistoryNode(), "rank_3k", Duration.ofSeconds(30)));
         waitForRequest(stalled, 1, 1, TimeUnit.SECONDS);
 
         runner.cancelActiveRequests();
@@ -585,8 +689,7 @@ class HumanSlAnalysisRunnerTest {
                       .put("humanPolicy", new JSONObject().put("B2", 1.0))
                       .put(
                           "moveInfos",
-                          new JSONArray()
-                              .put(new JSONObject().put("move", "B2").put("order", 0))));
+                          new JSONArray().put(new JSONObject().put("move", "B2").put("order", 0))));
       AtomicInteger launches = new AtomicInteger();
       HumanSlAnalysisRunner runner =
           new HumanSlAnalysisRunner(
@@ -598,9 +701,7 @@ class HumanSlAnalysisRunnerTest {
             worker.submit(
                 () ->
                     runner.bestHumanMove(
-                        history.getCurrentHistoryNode(),
-                        "rank_3k",
-                        Duration.ofSeconds(30)));
+                        history.getCurrentHistoryNode(), "rank_3k", Duration.ofSeconds(30)));
         assertTrue(oldRequestEntered.await(1, TimeUnit.SECONDS));
 
         runner.cancelActiveRequests();
@@ -643,8 +744,8 @@ class HumanSlAnalysisRunnerTest {
     assertEquals(1, launches.get());
   }
 
-  private static void waitForRequest(
-      FakeProcess process, int expected, long timeout, TimeUnit unit) throws Exception {
+  private static void waitForRequest(FakeProcess process, int expected, long timeout, TimeUnit unit)
+      throws Exception {
     long deadline = System.nanoTime() + unit.toNanos(timeout);
     while (System.nanoTime() < deadline) {
       synchronized (process.sentRequests) {

--- a/src/test/java/featurecat/lizzie/analysis/HumanSlAnalysisRunnerTest.java
+++ b/src/test/java/featurecat/lizzie/analysis/HumanSlAnalysisRunnerTest.java
@@ -199,6 +199,35 @@ class HumanSlAnalysisRunnerTest {
   }
 
   @Test
+  void adaptiveVerificationVisits_scalesWithMeasuredSpeedAndRemainingTime() {
+    assertEquals(
+        88,
+        HumanSlAnalysisRunner.adaptiveVerificationVisits(
+            64, Duration.ofMillis(3_500).toNanos(), Duration.ofMillis(6_150).toNanos()));
+    assertEquals(
+        4_096,
+        HumanSlAnalysisRunner.adaptiveVerificationVisits(
+            64, Duration.ofMillis(100).toNanos(), Duration.ofSeconds(9).toNanos()));
+    assertEquals(
+        80,
+        HumanSlAnalysisRunner.adaptiveVerificationVisits(
+            64, Duration.ofSeconds(7).toNanos(), Duration.ofSeconds(3).toNanos()));
+    assertEquals(
+        64,
+        HumanSlAnalysisRunner.adaptiveVerificationVisits(
+            64, Duration.ofSeconds(4).toNanos(), Duration.ofMillis(900).toNanos()));
+  }
+
+  @Test
+  void eliteProfilesUseSpareTimeEvenWhenShallowCandidatesLookStable() {
+    assertTrue(HumanSlAnalysisRunner.shouldAdaptivelyDeepen("rank_7d", false));
+    assertTrue(HumanSlAnalysisRunner.shouldAdaptivelyDeepen("rank_9d", false));
+    assertTrue(HumanSlAnalysisRunner.shouldAdaptivelyDeepen("proyear_2023", false));
+    assertTrue(HumanSlAnalysisRunner.shouldAdaptivelyDeepen("rank_3k", true));
+    assertFalse(HumanSlAnalysisRunner.shouldAdaptivelyDeepen("rank_3k", false));
+  }
+
+  @Test
   void samplePolicyMove_samplesByProbabilityAndCanExcludePass() throws Exception {
     try (TestEnvironment env = TestEnvironment.open()) {
       JSONArray pairPolicy =
@@ -462,7 +491,7 @@ class HumanSlAnalysisRunnerTest {
       assertEquals(3, process.sentRequests.size());
       assertEquals(1, process.sentRequests.get(0).getInt("maxVisits"));
       assertEquals(256, process.sentRequests.get(1).getInt("maxVisits"));
-      assertEquals(512, process.sentRequests.get(2).getInt("maxVisits"));
+      assertEquals(4_096, process.sentRequests.get(2).getInt("maxVisits"));
       for (int index = 1; index < process.sentRequests.size(); index++) {
         JSONObject request = process.sentRequests.get(index);
         assertTrue(request.has("allowMoves"));


### PR DESCRIPTION
## 背景

用户反馈 7-8 段 AI 陪练在战斗中会选择 HumanSL 概率较高、但未经主模型充分验算的招法，导致局部棋筋被吃。此前缺少搜索结果的 HumanSL 候选会被当作安全候选，这是本次修复的核心缺口。

## 改进

- 先用 HumanSL 概率生成少量“像人”的合理候选，再用主模型在这些候选中做受限搜索验证。
- 采用 KataGo Analysis API 的 `allowMoves` 只验算候选根节点，并使用官方推荐的 `humanSLCpuctPermanent`。
- 未出现在主模型搜索结果中的候选不再允许落子。
- 为职业、7-9 段、4-6 段、低段和级位设置分层质量保护；高段位更严格过滤明显战术损失。
- 所有 HumanSL 候选均不安全时，回退到已验证的主模型最佳手，而不是继续随机选择坏棋。
- 主模型先完成 64/128 visits 的可用验证，再根据本机实测速率与本手剩余时间逐轮加深；快机器会利用更多预算，慢机器不会被固定访问数拖死。
- 每轮完成后重新估算下一轮访问数，最多 4 轮、4096 visits，并预留 450 ms 用于终止请求和按时返回。
- 深层请求超时会发送 KataGo 官方 `terminate`，安全使用上一轮已完成结果，不丢弃整手、不重启 HumanSL 引擎。
- 7-9 段和职业棋风始终利用可用剩余时间继续验算；其他段位只在候选不完整或局面质量波动明显时加深。
- 保持现有段位、10/30/60 秒选项、随机性、无记忆设计和 UI 不变。

官方依据：[KataGo Human SL analysis guide](https://github.com/lightvector/KataGo/blob/master/docs/Analysis_Engine.md#human-sl-analysis-guide)

## 验证

- 完整回归：3586 tests，0 failures，0 errors，2 skipped。
- HumanSL 专项：85 tests，0 failures，0 errors。
- 自适应加深定向测试：35 tests，0 failures，0 errors。
- `git diff --check` 通过。
- shaded jar 打包成功。
- 使用 macOS 本机 KataGo 1.18.1 Metal、默认 Transformer 11B 主模型和 HumanSL 模型完成真实协议探针。
- 10 秒档实测：先完成 64 visits；剩余时间不足时尝试 80 visits 并按时终止，9.55 秒返回上一轮安全结果。
- 30 秒档实测：依次完成 64 → 80 → 124 → 162 → 202 visits，总耗时 28.31 秒，保留安全候选且没有未识别配置警告。
- 使用隔离用户目录和当前 shaded jar 启动真实 Swing 应用，确认本地 KataGo 正常加载、AI 陪练状态可进入、主界面保持响应；Windows 真机仍由发布候选资产做最终交互验收。
