### PR TITLE
Release next-2026-08-30.1 pre-release

### DIFF
--- a/.github/release-notes/next-2026-08-30.1.md
+++ b/.github/release-notes/next-2026-08-30.1.md
@@ -1,0 +1,371 @@
+# LizzieYzy Next next-2026-08-30.1
+
+## 中文
+
+这是面向愿意提前体验新功能用户的预发布版，重点加强 AI 陪练在高段位与战斗局面中的选招质量，并完善引擎工作流、界面可用性和故障诊断。AI 陪练现在会先由 HumanSL 提供符合人类棋风的候选，再由强模型核验，并按照用户设置的思考时间自动加深。
+
+### 本版主要更新
+
+- AI 陪练新增战术质量保护：先读取 HumanSL 的人类选点分布，再用强模型逐个核验合理候选，明显有被吃、崩盘或过大损失风险的招法不会仅因“像人”就被选中。
+- 核验深度会随思考时间自动调整：先完成 64/128 visits 基线，再根据已测得的本机速度和剩余时间逐轮加深，最多 4 轮、4096 visits，并预留约 450 毫秒安全收尾。
+- 深度请求来不及完成时会主动终止，并使用最后一轮已经完整核验的安全结果；7段、8段、9段和职业棋风会尽量利用剩余时间，较低段位只在候选不稳定时加深。
+- 随机选招仍然没有跨局记忆，不保存布局、随机种子或历史选择；变化来自当前局面的 HumanSL 概率和强模型质量保护。
+- 引擎对局的开始、暂停、继续、批量续局、保存与恢复现在由统一状态管理；引擎切换失败回滚后，顶部名称会重新显示真正运行中的引擎。
+- 主窗口多个区域支持拖动调整并保存尺寸；个人评论与自动对局信息分开显示，问题手空状态、英文界面和 Linux 底部裁切也得到修复。
+- 诊断包新增引擎启动阶段、GTP 错误输出、线程与 EDT 卡顿快照、JVM 内存/磁盘状态，以及权重和 TensorRT 下载生命周期，便于定位偶发问题。
+- 感谢 @qiyi71w 持续完善引擎对局、评论显示、问题反馈模板与多项界面细节。
+
+### 下载前先看
+
+- 已安装 `next-2026-08-27.5` 完整包的 Windows 用户，可以使用 `windows64.core-update.zip` 获取本次程序修复；它不会替换现有权重、引擎、TensorRT 或 `user-data`。
+- 新安装用户下载对应完整包，仍会得到 KataGo v1.18.1 与默认 B11；更重视速度可在“一键设置 → 权重”明确切换 B10。
+- RTX 20/30/40/50 继续使用统一的 `windows64.nvidia` CUDA 包；TensorRT 仅作为 RTX 30 系及以下可选方案。
+- 这是预发布版，适合先体验 AI 陪练新策略；覆盖旧版本前建议备份现有 `user-data`、权重和棋谱。
+- DirectML、OpenVINO 和 ROCm 包仍为 experimental，未在缺少对应硬件的机器上冒充实测通过。
+
+### 下载建议
+
+| 你的电脑 | 直接下载这个 |
+| --- | --- |
+| Windows 64 位，RTX 20/30/40/50 NVIDIA CUDA 推荐版，免安装 | [`2026-08-30-windows64.nvidia.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-30.1/2026-08-30-windows64.nvidia.portable.zip) |
+| 已有 Windows 免安装版，只更新主程序 | [`2026-08-30-windows64.core-update.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-30.1/2026-08-30-windows64.core-update.zip) |
+| Windows 64 位，RTX 20/30/40/50 NVIDIA CUDA 推荐安装版 | [`2026-08-30-windows64.nvidia.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-30.1/2026-08-30-windows64.nvidia.installer.exe) |
+| Windows 64 位，AMD / Intel / 旧 NVIDIA OpenCL 兼容版，免安装 | [`2026-08-30-windows64.opencl.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-30.1/2026-08-30-windows64.opencl.portable.zip) |
+| Windows 64 位，AMD / Intel / 旧 NVIDIA OpenCL 兼容安装版 | [`2026-08-30-windows64.opencl.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-30.1/2026-08-30-windows64.opencl.installer.exe) |
+| Windows 64 位，CPU 兼容版，免安装 | [`2026-08-30-windows64.with-katago.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-30.1/2026-08-30-windows64.with-katago.portable.zip) |
+| Windows 64 位，CPU 兼容安装版 | [`2026-08-30-windows64.with-katago.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-30.1/2026-08-30-windows64.with-katago.installer.exe) |
+| Windows DirectML 实验版 | [`2026-08-30-windows64.experimental.directml.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-30.1/2026-08-30-windows64.experimental.directml.portable.zip) |
+| Windows Intel OpenVINO 实验版 | [`2026-08-30-windows64.experimental.openvino.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-30.1/2026-08-30-windows64.experimental.openvino.portable.zip) |
+| Windows AMD RX 6000 ROCm 实验版 | [`2026-08-30-windows64.experimental.rocm.gfx103x.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-30.1/2026-08-30-windows64.experimental.rocm.gfx103x.portable.zip) |
+| Windows AMD RX 7000 ROCm 实验版 | [`2026-08-30-windows64.experimental.rocm.gfx110x.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-30.1/2026-08-30-windows64.experimental.rocm.gfx110x.portable.zip) |
+| Windows AMD Ryzen AI Max ROCm 实验版 | [`2026-08-30-windows64.experimental.rocm.gfx1151.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-30.1/2026-08-30-windows64.experimental.rocm.gfx1151.portable.zip) |
+| Windows AMD RX 9000 ROCm 实验版 | [`2026-08-30-windows64.experimental.rocm.gfx120x.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-30.1/2026-08-30-windows64.experimental.rocm.gfx120x.portable.zip) |
+| RTX 30 系及以下可选 TensorRT，需下载两个分卷 | [`2026-08-30-windows64.nvidia.tensorrt.portable.7z.001`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-30.1/2026-08-30-windows64.nvidia.tensorrt.portable.7z.001)<br>[`2026-08-30-windows64.nvidia.tensorrt.portable.7z.002`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-30.1/2026-08-30-windows64.nvidia.tensorrt.portable.7z.002) |
+| Windows 64 位，自行配置引擎，免安装 | [`2026-08-30-windows64.without.engine.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-30.1/2026-08-30-windows64.without.engine.portable.zip) |
+| Windows 64 位，自行配置引擎，安装版 | [`2026-08-30-windows64.without.engine.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-30.1/2026-08-30-windows64.without.engine.installer.exe) |
+| macOS Apple Silicon，Metal | [`2026-08-30-mac-apple-silicon.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-30.1/2026-08-30-mac-apple-silicon.with-katago.dmg) |
+| macOS Intel | [`2026-08-30-mac-intel.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-30.1/2026-08-30-mac-intel.with-katago.dmg) |
+| Linux 64 位，CPU 兼容版 | [`2026-08-30-linux64.with-katago.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-30.1/2026-08-30-linux64.with-katago.zip) |
+| Linux 64 位，OpenCL 版 | [`2026-08-30-linux64.opencl.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-30.1/2026-08-30-linux64.opencl.zip) |
+| Linux 64 位，NVIDIA CUDA 版 | [`2026-08-30-linux64.nvidia.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-30.1/2026-08-30-linux64.nvidia.zip) |
+
+### 为什么值得升级
+
+- AI 陪练的高段位与职业棋风现在既保留 HumanSL 的人类感，也会把更多思考时间真正用于战术核验，而不是固定使用同一浅层深度。
+- 真实 KataGo 1.18.1 Metal 探针中，10 秒限制在 9.55 秒内返回最后一轮完整安全结果；30 秒限制完成 64 → 80 → 124 → 162 → 202 visits 多轮加深，总耗时 28.31 秒。
+- 专项自适应测试 35 项、HumanSL 测试 85 项、完整 Maven 测试 3586 项全部通过；主线 Linux 与 Windows 全量门禁及 shaded jar 打包均通过。
+- 已在 macOS Apple Silicon 使用隔离配置真实启动应用并验证内置 KataGo 与界面可用性；完整 Windows AI 陪练点击流程仍建议在本预发布版继续真机验收。
+
+### 交流
+
+- QQ 群：`299419120`
+
+---
+
+## 繁體中文
+
+這是提供給願意提前體驗新功能使用者的預發布版，重點加強 AI 陪練在高段位與戰鬥局面的選招品質，並改善引擎流程、介面可用性和故障診斷。AI 陪練現在先由 HumanSL 提供符合人類棋風的候選，再由強模型驗證，並依照使用者設定的思考時間自動加深。
+
+### 本版主要更新
+
+- AI 陪練新增戰術品質保護：先讀取 HumanSL 的人類選點分布，再以強模型逐一驗證合理候選；有明顯被吃、崩盤或過大損失風險的招法，不會只因為「像人」就被選中。
+- 驗證深度會隨思考時間自動調整：先完成 64/128 visits 基線，再依本機實測速度和剩餘時間逐輪加深，最多 4 輪、4096 visits，並保留約 450 毫秒安全收尾。
+- 深度要求若無法及時完成，會主動終止並使用上一輪已完整驗證的安全結果；7段、8段、9段與職業棋風會盡量利用剩餘時間，較低段位只在候選不穩定時加深。
+- 隨機選招仍沒有跨局記憶，不保存布局、隨機種子或歷史選擇；變化只來自目前局面的 HumanSL 機率和強模型品質保護。
+- 引擎對局的開始、暫停、繼續、批次續局、保存與恢復改由統一狀態管理；引擎切換失敗回滾後，頂部名稱會重新顯示真正運行中的引擎。
+- 主視窗多個區域支援拖曳調整並保存尺寸；個人評論與自動對局資訊分開顯示，問題手空狀態、英文介面和 Linux 底部裁切也已修正。
+- 診斷包新增引擎啟動階段、GTP 錯誤輸出、執行緒與 EDT 卡頓快照、JVM 記憶體/磁碟狀態，以及權重和 TensorRT 下載生命週期。
+- 感謝 @qiyi71w 持續改善引擎對局、評論顯示、問題回報模板與多項介面細節。
+
+### 下載前先看
+
+- 已安裝 `next-2026-08-27.5` 完整套件的 Windows 使用者，可用 `windows64.core-update.zip` 取得本次程式修復；它不會替換現有權重、引擎、TensorRT 或 `user-data`。
+- 新安裝請下載對應完整套件，仍包含 KataGo v1.18.1 與預設 B11；重視速度可在「一鍵設定 → 權重」明確切換 B10。
+- RTX 20/30/40/50 繼續使用統一 `windows64.nvidia` CUDA 套件；TensorRT 僅作為 RTX 30 系及以下可選方案。
+- 這是預發布版，適合先體驗 AI 陪練新策略；覆蓋舊版本前建議備份現有 `user-data`、權重與棋譜。
+- DirectML、OpenVINO 與 ROCm 仍為 experimental，未在缺少對應硬體的機器上宣稱實測通過。
+
+### 下載建議
+
+| 你的電腦 | 直接下載這個 |
+| --- | --- |
+| Windows 64 位，RTX 20/30/40/50 NVIDIA CUDA 建議版，免安裝 | [`2026-08-30-windows64.nvidia.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-30.1/2026-08-30-windows64.nvidia.portable.zip) |
+| 既有 Windows 免安裝版，只更新主程式 | [`2026-08-30-windows64.core-update.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-30.1/2026-08-30-windows64.core-update.zip) |
+| Windows 64 位，RTX 20/30/40/50 NVIDIA CUDA 建議安裝版 | [`2026-08-30-windows64.nvidia.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-30.1/2026-08-30-windows64.nvidia.installer.exe) |
+| Windows 64 位，AMD / Intel / 舊 NVIDIA OpenCL 相容版，免安裝 | [`2026-08-30-windows64.opencl.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-30.1/2026-08-30-windows64.opencl.portable.zip) |
+| Windows 64 位，AMD / Intel / 舊 NVIDIA OpenCL 相容安裝版 | [`2026-08-30-windows64.opencl.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-30.1/2026-08-30-windows64.opencl.installer.exe) |
+| Windows 64 位，CPU 相容版，免安裝 | [`2026-08-30-windows64.with-katago.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-30.1/2026-08-30-windows64.with-katago.portable.zip) |
+| Windows 64 位，CPU 相容安裝版 | [`2026-08-30-windows64.with-katago.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-30.1/2026-08-30-windows64.with-katago.installer.exe) |
+| Windows DirectML 實驗版 | [`2026-08-30-windows64.experimental.directml.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-30.1/2026-08-30-windows64.experimental.directml.portable.zip) |
+| Windows Intel OpenVINO 實驗版 | [`2026-08-30-windows64.experimental.openvino.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-30.1/2026-08-30-windows64.experimental.openvino.portable.zip) |
+| Windows AMD RX 6000 ROCm 實驗版 | [`2026-08-30-windows64.experimental.rocm.gfx103x.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-30.1/2026-08-30-windows64.experimental.rocm.gfx103x.portable.zip) |
+| Windows AMD RX 7000 ROCm 實驗版 | [`2026-08-30-windows64.experimental.rocm.gfx110x.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-30.1/2026-08-30-windows64.experimental.rocm.gfx110x.portable.zip) |
+| Windows AMD Ryzen AI Max ROCm 實驗版 | [`2026-08-30-windows64.experimental.rocm.gfx1151.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-30.1/2026-08-30-windows64.experimental.rocm.gfx1151.portable.zip) |
+| Windows AMD RX 9000 ROCm 實驗版 | [`2026-08-30-windows64.experimental.rocm.gfx120x.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-30.1/2026-08-30-windows64.experimental.rocm.gfx120x.portable.zip) |
+| RTX 30 系及以下可選 TensorRT，需下載兩個分卷 | [`2026-08-30-windows64.nvidia.tensorrt.portable.7z.001`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-30.1/2026-08-30-windows64.nvidia.tensorrt.portable.7z.001)<br>[`2026-08-30-windows64.nvidia.tensorrt.portable.7z.002`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-30.1/2026-08-30-windows64.nvidia.tensorrt.portable.7z.002) |
+| Windows 64 位，自行設定引擎，免安裝 | [`2026-08-30-windows64.without.engine.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-30.1/2026-08-30-windows64.without.engine.portable.zip) |
+| Windows 64 位，自行設定引擎，安裝版 | [`2026-08-30-windows64.without.engine.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-30.1/2026-08-30-windows64.without.engine.installer.exe) |
+| macOS Apple Silicon，Metal | [`2026-08-30-mac-apple-silicon.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-30.1/2026-08-30-mac-apple-silicon.with-katago.dmg) |
+| macOS Intel | [`2026-08-30-mac-intel.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-30.1/2026-08-30-mac-intel.with-katago.dmg) |
+| Linux 64 位，CPU 相容版 | [`2026-08-30-linux64.with-katago.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-30.1/2026-08-30-linux64.with-katago.zip) |
+| Linux 64 位，OpenCL 版 | [`2026-08-30-linux64.opencl.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-30.1/2026-08-30-linux64.opencl.zip) |
+| Linux 64 位，NVIDIA CUDA 版 | [`2026-08-30-linux64.nvidia.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-30.1/2026-08-30-linux64.nvidia.zip) |
+
+### 為什麼值得升級
+
+- AI 陪練的高段位與職業棋風現在保留 HumanSL 的人類感，同時把更多思考時間真正用於戰術驗證，而不是固定使用相同淺層深度。
+- 真實 KataGo 1.18.1 Metal 測試中，10 秒限制在 9.55 秒內回傳上一輪完整安全結果；30 秒限制完成 64 → 80 → 124 → 162 → 202 visits 多輪加深，總耗時 28.31 秒。
+- 自適應專項測試 35 項、HumanSL 測試 85 項、完整 Maven 測試 3586 項全部通過；主線 Linux 與 Windows 完整門檻及 shaded jar 打包均通過。
+- 已在 macOS Apple Silicon 使用隔離設定真實啟動並驗證內建 KataGo 與介面可用性；完整 Windows AI 陪練點擊流程仍建議透過本預發布版繼續真機驗收。
+
+### 交流
+
+- QQ 群：`299419120`
+
+---
+
+## English
+
+This pre-release is for users who want to validate the newest improvements early. It strengthens AI Coach move quality in high-rank and tactical positions, while improving engine workflows, UI usability, and diagnostics. AI Coach now starts from HumanSL human-style candidates, verifies them with the strong model, and automatically deepens verification to fit the selected think time.
+
+### Release highlights
+
+- AI Coach now protects tactical quality: it reads the HumanSL human-move distribution, verifies reasonable candidates with the strong model, and rejects moves with clear capture, collapse, or excessive-loss risk even when they look human.
+- Verification depth adapts to think time. It completes a 64/128-visit baseline, estimates local speed from completed requests, and deepens round by round up to four rounds and 4096 visits while reserving about 450 ms for a safe finish.
+- If a deeper request cannot finish in time, it is terminated and the last fully verified safe result is used. 7d, 8d, 9d, and pro-style profiles use spare time aggressively; lower ranks deepen only when candidates are incomplete or volatile.
+- Random move selection still has no cross-game memory. Openings, random seeds, and previous selections are not saved; variation comes only from the current HumanSL probabilities and strong-model quality guard.
+- Engine-game start, pause, resume, batch continuation, save, and recovery now share one authoritative state. After a failed engine switch rolls back, the top engine label returns to the engine that is actually running.
+- Main-window regions can be resized by dragging and retain their sizes. Personal comments are separated from automatic match data, while empty problem-move states, English UI text, and Linux bottom clipping are improved.
+- Diagnostic bundles now include engine startup stages, bounded GTP stderr, thread and EDT hang snapshots, JVM memory/disk state, and weight/TensorRT download lifecycle details.
+- Thanks to @qiyi71w for continued improvements to engine games, comment presentation, issue templates, and multiple UI details.
+
+### Read before downloading
+
+- Windows users who already installed a complete `next-2026-08-27.5` bundle can use `windows64.core-update.zip` for this app fix. It does not replace existing weights, engines, TensorRT, or `user-data`.
+- New users should choose a matching full bundle, which still includes KataGo v1.18.1 and default B11. Explicitly choose B10 in Auto Setup when throughput matters more.
+- RTX 20/30/40/50 continue to use the unified `windows64.nvidia` CUDA package. TensorRT remains optional for RTX 30 series and earlier.
+- This is a pre-release for early AI Coach validation. Back up `user-data`, weights, and game records before replacing an existing copy.
+- DirectML, OpenVINO, and ROCm remain experimental and are not claimed as tested on hardware that was unavailable locally.
+
+### Download guide
+
+| Your computer | Download this file |
+| --- | --- |
+| Windows x64, recommended RTX 20/30/40/50 NVIDIA CUDA portable | [`2026-08-30-windows64.nvidia.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-30.1/2026-08-30-windows64.nvidia.portable.zip) |
+| Existing Windows portable install, app-only update | [`2026-08-30-windows64.core-update.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-30.1/2026-08-30-windows64.core-update.zip) |
+| Windows x64, recommended RTX 20/30/40/50 NVIDIA CUDA installer | [`2026-08-30-windows64.nvidia.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-30.1/2026-08-30-windows64.nvidia.installer.exe) |
+| Windows x64, AMD / Intel / older NVIDIA OpenCL portable | [`2026-08-30-windows64.opencl.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-30.1/2026-08-30-windows64.opencl.portable.zip) |
+| Windows x64, AMD / Intel / older NVIDIA OpenCL installer | [`2026-08-30-windows64.opencl.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-30.1/2026-08-30-windows64.opencl.installer.exe) |
+| Windows x64, CPU fallback portable | [`2026-08-30-windows64.with-katago.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-30.1/2026-08-30-windows64.with-katago.portable.zip) |
+| Windows x64, CPU fallback installer | [`2026-08-30-windows64.with-katago.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-30.1/2026-08-30-windows64.with-katago.installer.exe) |
+| Windows DirectML experimental | [`2026-08-30-windows64.experimental.directml.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-30.1/2026-08-30-windows64.experimental.directml.portable.zip) |
+| Windows Intel OpenVINO experimental | [`2026-08-30-windows64.experimental.openvino.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-30.1/2026-08-30-windows64.experimental.openvino.portable.zip) |
+| Windows AMD RX 6000 ROCm experimental | [`2026-08-30-windows64.experimental.rocm.gfx103x.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-30.1/2026-08-30-windows64.experimental.rocm.gfx103x.portable.zip) |
+| Windows AMD RX 7000 ROCm experimental | [`2026-08-30-windows64.experimental.rocm.gfx110x.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-30.1/2026-08-30-windows64.experimental.rocm.gfx110x.portable.zip) |
+| Windows AMD Ryzen AI Max ROCm experimental | [`2026-08-30-windows64.experimental.rocm.gfx1151.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-30.1/2026-08-30-windows64.experimental.rocm.gfx1151.portable.zip) |
+| Windows AMD RX 9000 ROCm experimental | [`2026-08-30-windows64.experimental.rocm.gfx120x.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-30.1/2026-08-30-windows64.experimental.rocm.gfx120x.portable.zip) |
+| Optional TensorRT for RTX 30 and earlier, download both parts | [`2026-08-30-windows64.nvidia.tensorrt.portable.7z.001`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-30.1/2026-08-30-windows64.nvidia.tensorrt.portable.7z.001)<br>[`2026-08-30-windows64.nvidia.tensorrt.portable.7z.002`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-30.1/2026-08-30-windows64.nvidia.tensorrt.portable.7z.002) |
+| Windows x64, bring your own engine, portable | [`2026-08-30-windows64.without.engine.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-30.1/2026-08-30-windows64.without.engine.portable.zip) |
+| Windows x64, bring your own engine, installer | [`2026-08-30-windows64.without.engine.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-30.1/2026-08-30-windows64.without.engine.installer.exe) |
+| macOS Apple Silicon, Metal | [`2026-08-30-mac-apple-silicon.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-30.1/2026-08-30-mac-apple-silicon.with-katago.dmg) |
+| macOS Intel | [`2026-08-30-mac-intel.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-30.1/2026-08-30-mac-intel.with-katago.dmg) |
+| Linux x64, CPU fallback | [`2026-08-30-linux64.with-katago.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-30.1/2026-08-30-linux64.with-katago.zip) |
+| Linux x64, OpenCL | [`2026-08-30-linux64.opencl.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-30.1/2026-08-30-linux64.opencl.zip) |
+| Linux x64, NVIDIA CUDA | [`2026-08-30-linux64.nvidia.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-30.1/2026-08-30-linux64.nvidia.zip) |
+
+### Why upgrade
+
+- High-rank and pro-style AI Coach profiles now keep the HumanSL human feel while spending available think time on real tactical verification instead of using one fixed shallow depth.
+- With real KataGo 1.18.1 Metal probes, a 10-second limit returned the last complete safe result in 9.55 seconds; a 30-second limit completed 64 → 80 → 124 → 162 → 202 visits in 28.31 seconds.
+- All 35 adaptive-depth tests, 85 HumanSL tests, and 3586 full Maven tests passed. The main Linux and Windows verification gates and shaded-jar packaging also passed.
+- A real isolated macOS Apple Silicon launch verified the bundled KataGo and UI smoke path. The complete Windows AI Coach click-through remains an important target for this pre-release.
+
+### Contact
+
+- QQ group: `299419120`
+
+---
+
+## 日本語
+
+新機能を早めに試したいユーザー向けの pre-release です。高段位と戦闘局面での AI 陪練の着手品質を強化し、engine workflow、UI の使いやすさ、診断機能も改善しました。AI 陪練は HumanSL の人間らしい候補を強い model で検証し、設定した思考時間に合わせて自動的に深く読みます。
+
+### 主な更新
+
+- AI 陪練に戦術的な品質保護を追加しました。HumanSL の人間着手分布から候補を取り、強い model で検証し、取られる・崩れる・大きく損をする危険な手を「人間らしい」だけで選ばないようにします。
+- 検証深度は思考時間に適応します。64/128 visits の基準を完了し、実測した local speed と残り時間から最大 4 round、4096 visits まで深く読み、約 450 ms を安全な終了用に残します。
+- 深い request が時間内に終わらない場合は停止し、最後に完了した安全な結果を使用します。7d、8d、9d、pro style は残り時間を積極的に使い、低い rank は候補が不安定な場合だけ深く読みます。
+- ランダム着手に対局をまたぐ memory はありません。布石、random seed、過去の選択を保存せず、現在局面の HumanSL 確率と強い model の品質保護だけで変化を作ります。
+- engine game の開始、一時停止、再開、batch 継続、保存、復旧を一つの状態で管理します。engine switch 失敗から rollback した後は、上部に実際に動いている engine 名を表示します。
+- main window の複数領域を drag で調整し、サイズを保存できます。個人 comment と自動対局情報を分け、問題手の empty state、英語 UI、Linux 下部の裁切も改善しました。
+- 診断 bundle に engine 起動段階、GTP stderr、thread/EDT hang snapshot、JVM memory/disk、weight と TensorRT download lifecycle を追加しました。
+- @qiyi71w による engine game、comment 表示、Issue template、UI 細部への継続的な貢献に感謝します。
+
+### ダウンロード前に
+
+- `next-2026-08-27.5` の complete bundle を導入済みの Windows ユーザーは、`windows64.core-update.zip` で今回の app 修正を適用できます。既存の weight、engine、TensorRT、`user-data` は置換しません。
+- 新規ユーザーは対応する full bundle を選んでください。KataGo v1.18.1 と既定 B11 を引き続き収録し、速度重視なら Auto Setup で B10 を明示選択できます。
+- RTX 20/30/40/50 は統合 `windows64.nvidia` CUDA package を使用します。TensorRT は RTX 30 系以前の optional 選択です。
+- AI 陪練の新しい strategy を早めに試す pre-release です。既存の copy を置き換える前に `user-data`、weight、棋譜を backup してください。
+- DirectML、OpenVINO、ROCm は experimental のままで、利用できない hardware を実機確認済みとは表示していません。
+
+### ダウンロード案内
+
+| 環境 | ダウンロードするファイル |
+| --- | --- |
+| Windows x64、推奨 RTX 20/30/40/50 NVIDIA CUDA portable | [`2026-08-30-windows64.nvidia.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-30.1/2026-08-30-windows64.nvidia.portable.zip) |
+| 既存 Windows portable、app のみ更新 | [`2026-08-30-windows64.core-update.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-30.1/2026-08-30-windows64.core-update.zip) |
+| Windows x64、推奨 RTX 20/30/40/50 NVIDIA CUDA installer | [`2026-08-30-windows64.nvidia.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-30.1/2026-08-30-windows64.nvidia.installer.exe) |
+| Windows x64、AMD / Intel / 旧 NVIDIA 向け OpenCL portable | [`2026-08-30-windows64.opencl.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-30.1/2026-08-30-windows64.opencl.portable.zip) |
+| Windows x64、AMD / Intel / 旧 NVIDIA 向け OpenCL installer | [`2026-08-30-windows64.opencl.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-30.1/2026-08-30-windows64.opencl.installer.exe) |
+| Windows x64、CPU fallback portable | [`2026-08-30-windows64.with-katago.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-30.1/2026-08-30-windows64.with-katago.portable.zip) |
+| Windows x64、CPU fallback installer | [`2026-08-30-windows64.with-katago.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-30.1/2026-08-30-windows64.with-katago.installer.exe) |
+| Windows DirectML experimental | [`2026-08-30-windows64.experimental.directml.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-30.1/2026-08-30-windows64.experimental.directml.portable.zip) |
+| Windows Intel OpenVINO experimental | [`2026-08-30-windows64.experimental.openvino.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-30.1/2026-08-30-windows64.experimental.openvino.portable.zip) |
+| Windows AMD RX 6000 ROCm experimental | [`2026-08-30-windows64.experimental.rocm.gfx103x.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-30.1/2026-08-30-windows64.experimental.rocm.gfx103x.portable.zip) |
+| Windows AMD RX 7000 ROCm experimental | [`2026-08-30-windows64.experimental.rocm.gfx110x.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-30.1/2026-08-30-windows64.experimental.rocm.gfx110x.portable.zip) |
+| Windows AMD Ryzen AI Max ROCm experimental | [`2026-08-30-windows64.experimental.rocm.gfx1151.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-30.1/2026-08-30-windows64.experimental.rocm.gfx1151.portable.zip) |
+| Windows AMD RX 9000 ROCm experimental | [`2026-08-30-windows64.experimental.rocm.gfx120x.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-30.1/2026-08-30-windows64.experimental.rocm.gfx120x.portable.zip) |
+| RTX 30 系以前向け optional TensorRT、両分割を取得 | [`2026-08-30-windows64.nvidia.tensorrt.portable.7z.001`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-30.1/2026-08-30-windows64.nvidia.tensorrt.portable.7z.001)<br>[`2026-08-30-windows64.nvidia.tensorrt.portable.7z.002`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-30.1/2026-08-30-windows64.nvidia.tensorrt.portable.7z.002) |
+| Windows x64、独自 engine、portable | [`2026-08-30-windows64.without.engine.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-30.1/2026-08-30-windows64.without.engine.portable.zip) |
+| Windows x64、独自 engine、installer | [`2026-08-30-windows64.without.engine.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-30.1/2026-08-30-windows64.without.engine.installer.exe) |
+| macOS Apple Silicon、Metal | [`2026-08-30-mac-apple-silicon.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-30.1/2026-08-30-mac-apple-silicon.with-katago.dmg) |
+| macOS Intel | [`2026-08-30-mac-intel.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-30.1/2026-08-30-mac-intel.with-katago.dmg) |
+| Linux x64、CPU fallback | [`2026-08-30-linux64.with-katago.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-30.1/2026-08-30-linux64.with-katago.zip) |
+| Linux x64、OpenCL | [`2026-08-30-linux64.opencl.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-30.1/2026-08-30-linux64.opencl.zip) |
+| Linux x64、NVIDIA CUDA | [`2026-08-30-linux64.nvidia.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-30.1/2026-08-30-linux64.nvidia.zip) |
+
+### アップグレードする理由
+
+- 高段位と pro style の AI 陪練は HumanSL の人間らしさを保ちながら、利用可能な思考時間を固定の浅い深度ではなく戦術検証に使います。
+- 実際の KataGo 1.18.1 Metal probe では、10 秒制限で 9.55 秒以内に最後の完全な安全結果を返し、30 秒制限では 64 → 80 → 124 → 162 → 202 visits を 28.31 秒で完了しました。
+- adaptive-depth 35 test、HumanSL 85 test、Maven full test 3586 件がすべて成功しました。main の Linux/Windows verification gate と shaded jar package も成功しています。
+- macOS Apple Silicon の隔離環境で実際に起動し、同梱 KataGo と UI smoke path を確認しました。Windows の AI 陪練 click-through 全体は、この pre-release で引き続き実機確認する重要項目です。
+
+### 連絡先
+
+- QQ group: `299419120`
+
+---
+
+## 한국어
+
+새 기능을 먼저 검증하려는 사용자를 위한 pre-release입니다. 고단과 전투 국면에서 AI 코치의 수 품질을 강화하고 engine workflow, UI 사용성, 진단 기능도 개선했습니다. AI 코치는 HumanSL의 사람다운 후보를 강한 model로 검증하고 설정한 생각 시간에 맞춰 자동으로 더 깊게 읽습니다.
+
+### 주요 업데이트
+
+- AI 코치에 전술 품질 보호를 추가했습니다. HumanSL 사람 수 분포에서 합리적인 후보를 고르고 강한 model로 검증하여, 잡히거나 무너지거나 손실이 지나치게 큰 수는 사람답다는 이유만으로 선택하지 않습니다.
+- 검증 깊이는 생각 시간에 맞춰 조절됩니다. 64/128 visits 기준을 먼저 완료하고 실제 local speed와 남은 시간으로 최대 4 round, 4096 visits까지 깊게 읽으며 약 450 ms를 안전한 종료에 남깁니다.
+- 더 깊은 request가 제시간에 끝나지 않으면 중단하고 마지막으로 완전히 검증된 안전한 결과를 사용합니다. 7d, 8d, 9d와 pro style은 남은 시간을 적극 활용하고 낮은 rank는 후보가 불안정할 때만 깊게 읽습니다.
+- 랜덤 수 선택에는 대국 간 memory가 없습니다. 포석, random seed, 과거 선택을 저장하지 않으며 현재 국면의 HumanSL 확률과 강한 model 품질 보호만 사용합니다.
+- engine game 시작, 일시정지, 계속, batch 이어가기, 저장, 복구를 하나의 상태로 관리합니다. engine switch 실패 후 rollback되면 상단 이름이 실제 실행 중인 engine으로 돌아옵니다.
+- main window 여러 영역을 drag로 조절하고 크기를 저장할 수 있습니다. 개인 comment와 자동 대국 정보를 분리하고 문제수 empty state, 영어 UI, Linux 하단 잘림도 개선했습니다.
+- 진단 bundle에 engine 시작 단계, GTP stderr, thread/EDT 멈춤 snapshot, JVM memory/disk, weight 및 TensorRT download lifecycle이 추가되었습니다.
+- engine game, comment 표시, Issue template과 여러 UI 세부 사항을 계속 개선해 준 @qiyi71w 님께 감사드립니다.
+
+### 다운로드 전 확인
+
+- `next-2026-08-27.5` complete bundle을 이미 설치한 Windows 사용자는 `windows64.core-update.zip`으로 이번 app 수정만 적용할 수 있습니다. 기존 weight, engine, TensorRT, `user-data`는 교체하지 않습니다.
+- 새 설치에는 해당 full bundle을 사용하세요. KataGo v1.18.1과 기본 B11이 계속 포함되며 처리량을 우선하면 Auto Setup에서 B10을 명시적으로 선택할 수 있습니다.
+- RTX 20/30/40/50은 통합 `windows64.nvidia` CUDA package를 계속 사용합니다. TensorRT는 RTX 30 시리즈 이하에서만 optional 선택입니다.
+- AI 코치의 새 strategy를 먼저 검증하는 pre-release입니다. 기존 copy를 덮어쓰기 전에 `user-data`, weight, 기보를 backup하세요.
+- DirectML, OpenVINO, ROCm은 experimental이며 사용할 수 없는 hardware를 실기기 검증 완료로 표시하지 않았습니다.
+
+### 다운로드 안내
+
+| 환경 | 다운로드할 파일 |
+| --- | --- |
+| Windows x64, 권장 RTX 20/30/40/50 NVIDIA CUDA portable | [`2026-08-30-windows64.nvidia.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-30.1/2026-08-30-windows64.nvidia.portable.zip) |
+| 기존 Windows portable, app-only update | [`2026-08-30-windows64.core-update.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-30.1/2026-08-30-windows64.core-update.zip) |
+| Windows x64, 권장 RTX 20/30/40/50 NVIDIA CUDA installer | [`2026-08-30-windows64.nvidia.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-30.1/2026-08-30-windows64.nvidia.installer.exe) |
+| Windows x64, AMD / Intel / 구형 NVIDIA용 OpenCL portable | [`2026-08-30-windows64.opencl.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-30.1/2026-08-30-windows64.opencl.portable.zip) |
+| Windows x64, AMD / Intel / 구형 NVIDIA용 OpenCL installer | [`2026-08-30-windows64.opencl.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-30.1/2026-08-30-windows64.opencl.installer.exe) |
+| Windows x64, CPU fallback portable | [`2026-08-30-windows64.with-katago.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-30.1/2026-08-30-windows64.with-katago.portable.zip) |
+| Windows x64, CPU fallback installer | [`2026-08-30-windows64.with-katago.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-30.1/2026-08-30-windows64.with-katago.installer.exe) |
+| Windows DirectML experimental | [`2026-08-30-windows64.experimental.directml.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-30.1/2026-08-30-windows64.experimental.directml.portable.zip) |
+| Windows Intel OpenVINO experimental | [`2026-08-30-windows64.experimental.openvino.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-30.1/2026-08-30-windows64.experimental.openvino.portable.zip) |
+| Windows AMD RX 6000 ROCm experimental | [`2026-08-30-windows64.experimental.rocm.gfx103x.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-30.1/2026-08-30-windows64.experimental.rocm.gfx103x.portable.zip) |
+| Windows AMD RX 7000 ROCm experimental | [`2026-08-30-windows64.experimental.rocm.gfx110x.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-30.1/2026-08-30-windows64.experimental.rocm.gfx110x.portable.zip) |
+| Windows AMD Ryzen AI Max ROCm experimental | [`2026-08-30-windows64.experimental.rocm.gfx1151.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-30.1/2026-08-30-windows64.experimental.rocm.gfx1151.portable.zip) |
+| Windows AMD RX 9000 ROCm experimental | [`2026-08-30-windows64.experimental.rocm.gfx120x.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-30.1/2026-08-30-windows64.experimental.rocm.gfx120x.portable.zip) |
+| RTX 30 시리즈 이하 optional TensorRT, 두 part 모두 다운로드 | [`2026-08-30-windows64.nvidia.tensorrt.portable.7z.001`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-30.1/2026-08-30-windows64.nvidia.tensorrt.portable.7z.001)<br>[`2026-08-30-windows64.nvidia.tensorrt.portable.7z.002`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-30.1/2026-08-30-windows64.nvidia.tensorrt.portable.7z.002) |
+| Windows x64, 사용자 engine, portable | [`2026-08-30-windows64.without.engine.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-30.1/2026-08-30-windows64.without.engine.portable.zip) |
+| Windows x64, 사용자 engine, installer | [`2026-08-30-windows64.without.engine.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-30.1/2026-08-30-windows64.without.engine.installer.exe) |
+| macOS Apple Silicon, Metal | [`2026-08-30-mac-apple-silicon.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-30.1/2026-08-30-mac-apple-silicon.with-katago.dmg) |
+| macOS Intel | [`2026-08-30-mac-intel.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-30.1/2026-08-30-mac-intel.with-katago.dmg) |
+| Linux x64, CPU fallback | [`2026-08-30-linux64.with-katago.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-30.1/2026-08-30-linux64.with-katago.zip) |
+| Linux x64, OpenCL | [`2026-08-30-linux64.opencl.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-30.1/2026-08-30-linux64.opencl.zip) |
+| Linux x64, NVIDIA CUDA | [`2026-08-30-linux64.nvidia.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-30.1/2026-08-30-linux64.nvidia.zip) |
+
+### 업그레이드할 이유
+
+- 고단과 pro style AI 코치는 HumanSL의 사람다운 느낌을 유지하면서 사용 가능한 생각 시간을 고정된 얕은 깊이가 아니라 실제 전술 검증에 사용합니다.
+- 실제 KataGo 1.18.1 Metal probe에서 10초 제한은 9.55초 안에 마지막 완전한 안전 결과를 반환했고, 30초 제한은 64 → 80 → 124 → 162 → 202 visits를 28.31초에 완료했습니다.
+- adaptive-depth 35개, HumanSL 85개, 전체 Maven 3586개 테스트가 모두 통과했습니다. main Linux/Windows verification gate와 shaded jar package도 통과했습니다.
+- 격리된 macOS Apple Silicon 환경에서 실제 실행하여 번들 KataGo와 UI smoke path를 확인했습니다. Windows AI 코치 전체 click-through는 이 pre-release에서 계속 실기 검증할 중요 항목입니다.
+
+### 연락처
+
+- QQ 그룹: `299419120`
+
+---
+
+## ภาษาไทย
+
+นี่คือ pre-release สำหรับผู้ใช้ที่ต้องการทดลองฟังก์ชันใหม่ก่อน เน้นเพิ่มคุณภาพการเลือกเดินของ AI Coach ในระดับสูงและสถานการณ์ต่อสู้ พร้อมปรับปรุง engine workflow, การใช้งาน UI และระบบวินิจฉัย AI Coach จะเริ่มจากตัวเลือกแบบมนุษย์ของ HumanSL ตรวจสอบด้วย model ที่แข็งแรง และเพิ่มความลึกอัตโนมัติตามเวลาคิดที่ตั้งไว้
+
+### ไฮไลต์ของเวอร์ชันนี้
+
+- AI Coach เพิ่มการป้องกันคุณภาพเชิงกลยุทธ์: อ่านการกระจายหมากแบบมนุษย์จาก HumanSL แล้วใช้ model ที่แข็งแรงตรวจสอบตัวเลือกที่เหมาะสม หมากที่เสี่ยงถูกจับ พัง หรือเสียมากจะไม่ถูกเลือกเพียงเพราะดูเหมือนมนุษย์
+- ความลึกของการตรวจสอบปรับตามเวลาคิด เริ่มจาก baseline 64/128 visits แล้วประเมินความเร็วจริงของเครื่องและเวลาที่เหลือ เพิ่มได้สูงสุด 4 รอบและ 4096 visits พร้อมกันเวลาประมาณ 450 ms สำหรับจบงานอย่างปลอดภัย
+- หาก request ที่ลึกกว่าเสร็จไม่ทัน ระบบจะหยุดและใช้ผลปลอดภัยล่าสุดที่ตรวจสอบครบแล้ว โปรไฟล์ 7d, 8d, 9d และ pro style จะใช้เวลาที่เหลือให้คุ้ม ส่วนระดับต่ำจะเพิ่มความลึกเมื่อ candidate ยังไม่เสถียรเท่านั้น
+- การสุ่มเดินยังไม่มี memory ข้ามเกม ไม่บันทึก opening, random seed หรือการเลือกครั้งก่อน ความหลากหลายมาจาก HumanSL probability ของตำแหน่งปัจจุบันและ strong-model quality guard เท่านั้น
+- การเริ่ม หยุดชั่วคราว เล่นต่อ เล่น batch บันทึก และกู้คืน engine game ใช้สถานะกลางเดียวกัน หลัง engine switch ล้มเหลวและ rollback ชื่อด้านบนจะกลับไปแสดง engine ที่กำลังทำงานจริง
+- พื้นที่หลายส่วนใน main window ลากปรับขนาดและบันทึกได้ แยก comment ส่วนตัวออกจากข้อมูลเกมอัตโนมัติ และแก้ empty state, English UI และการตัดขอบล่างบน Linux
+- diagnostic bundle เพิ่มขั้นตอนเริ่ม engine, GTP stderr, thread/EDT hang snapshot, สถานะ JVM memory/disk และวงจรดาวน์โหลด weight/TensorRT
+- ขอบคุณ @qiyi71w ที่ช่วยปรับปรุง engine game, การแสดง comment, Issue template และรายละเอียด UI อย่างต่อเนื่อง
+
+### ก่อนดาวน์โหลด
+
+- ผู้ใช้ Windows ที่ติดตั้ง complete bundle `next-2026-08-27.5` แล้ว ใช้ `windows64.core-update.zip` เพื่อรับเฉพาะการแก้ไข app ครั้งนี้ได้ โดยไม่แทนที่ weight, engine, TensorRT หรือ `user-data`
+- ผู้ใช้ใหม่ควรดาวน์โหลด full bundle ที่ตรงกับเครื่อง ซึ่งยังมี KataGo v1.18.1 และ B11 เป็นค่าเริ่มต้น หากให้ความสำคัญกับ throughput มากกว่า ให้เลือก B10 ใน Auto Setup อย่างชัดเจน
+- RTX 20/30/40/50 ยังคงใช้ `windows64.nvidia` CUDA package เดียวกัน TensorRT เป็นตัวเลือกสำหรับ RTX 30 series และรุ่นก่อนหน้าเท่านั้น
+- นี่คือ pre-release สำหรับทดลอง AI Coach รุ่นใหม่ ควร backup `user-data`, weight และ game records ก่อนแทนที่เวอร์ชันเดิม
+- DirectML, OpenVINO และ ROCm ยังเป็น experimental และเราไม่อ้างว่าผ่าน hardware test บนอุปกรณ์ที่ไม่มีในเครื่องทดสอบ
+
+### คู่มือดาวน์โหลด
+
+| คอมพิวเตอร์ของคุณ | ดาวน์โหลดไฟล์นี้ |
+| --- | --- |
+| Windows x64, RTX 20/30/40/50 NVIDIA CUDA portable ที่แนะนำ | [`2026-08-30-windows64.nvidia.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-30.1/2026-08-30-windows64.nvidia.portable.zip) |
+| Windows portable เดิม, อัปเดตเฉพาะ app | [`2026-08-30-windows64.core-update.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-30.1/2026-08-30-windows64.core-update.zip) |
+| Windows x64, RTX 20/30/40/50 NVIDIA CUDA installer ที่แนะนำ | [`2026-08-30-windows64.nvidia.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-30.1/2026-08-30-windows64.nvidia.installer.exe) |
+| Windows x64, OpenCL portable สำหรับ AMD / Intel / NVIDIA รุ่นเก่า | [`2026-08-30-windows64.opencl.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-30.1/2026-08-30-windows64.opencl.portable.zip) |
+| Windows x64, OpenCL installer สำหรับ AMD / Intel / NVIDIA รุ่นเก่า | [`2026-08-30-windows64.opencl.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-30.1/2026-08-30-windows64.opencl.installer.exe) |
+| Windows x64, CPU fallback portable | [`2026-08-30-windows64.with-katago.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-30.1/2026-08-30-windows64.with-katago.portable.zip) |
+| Windows x64, CPU fallback installer | [`2026-08-30-windows64.with-katago.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-30.1/2026-08-30-windows64.with-katago.installer.exe) |
+| Windows DirectML experimental | [`2026-08-30-windows64.experimental.directml.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-30.1/2026-08-30-windows64.experimental.directml.portable.zip) |
+| Windows Intel OpenVINO experimental | [`2026-08-30-windows64.experimental.openvino.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-30.1/2026-08-30-windows64.experimental.openvino.portable.zip) |
+| Windows AMD RX 6000 ROCm experimental | [`2026-08-30-windows64.experimental.rocm.gfx103x.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-30.1/2026-08-30-windows64.experimental.rocm.gfx103x.portable.zip) |
+| Windows AMD RX 7000 ROCm experimental | [`2026-08-30-windows64.experimental.rocm.gfx110x.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-30.1/2026-08-30-windows64.experimental.rocm.gfx110x.portable.zip) |
+| Windows AMD Ryzen AI Max ROCm experimental | [`2026-08-30-windows64.experimental.rocm.gfx1151.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-30.1/2026-08-30-windows64.experimental.rocm.gfx1151.portable.zip) |
+| Windows AMD RX 9000 ROCm experimental | [`2026-08-30-windows64.experimental.rocm.gfx120x.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-30.1/2026-08-30-windows64.experimental.rocm.gfx120x.portable.zip) |
+| TensorRT สำหรับ RTX 30 และรุ่นก่อนหน้า, ดาวน์โหลดทั้งสอง part | [`2026-08-30-windows64.nvidia.tensorrt.portable.7z.001`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-30.1/2026-08-30-windows64.nvidia.tensorrt.portable.7z.001)<br>[`2026-08-30-windows64.nvidia.tensorrt.portable.7z.002`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-30.1/2026-08-30-windows64.nvidia.tensorrt.portable.7z.002) |
+| Windows x64, ใช้ engine ของคุณเอง, portable | [`2026-08-30-windows64.without.engine.portable.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-30.1/2026-08-30-windows64.without.engine.portable.zip) |
+| Windows x64, ใช้ engine ของคุณเอง, installer | [`2026-08-30-windows64.without.engine.installer.exe`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-30.1/2026-08-30-windows64.without.engine.installer.exe) |
+| macOS Apple Silicon, Metal | [`2026-08-30-mac-apple-silicon.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-30.1/2026-08-30-mac-apple-silicon.with-katago.dmg) |
+| macOS Intel | [`2026-08-30-mac-intel.with-katago.dmg`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-30.1/2026-08-30-mac-intel.with-katago.dmg) |
+| Linux x64, CPU fallback | [`2026-08-30-linux64.with-katago.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-30.1/2026-08-30-linux64.with-katago.zip) |
+| Linux x64, OpenCL | [`2026-08-30-linux64.opencl.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-30.1/2026-08-30-linux64.opencl.zip) |
+| Linux x64, NVIDIA CUDA | [`2026-08-30-linux64.nvidia.zip`](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-30.1/2026-08-30-linux64.nvidia.zip) |
+
+### เหตุผลที่ควรอัปเกรด
+
+- AI Coach ระดับสูงและ pro style ยังคงความเป็นมนุษย์ของ HumanSL แต่ใช้เวลาคิดที่มีเพื่อการตรวจสอบเชิงกลยุทธ์จริง แทน depth ตื้นแบบคงที่
+- การทดสอบด้วย KataGo 1.18.1 Metal จริง: จำกัด 10 วินาทีคืนผลปลอดภัยล่าสุดใน 9.55 วินาที และจำกัด 30 วินาทีทำ 64 → 80 → 124 → 162 → 202 visits เสร็จใน 28.31 วินาที
+- adaptive-depth 35 tests, HumanSL 85 tests และ Maven เต็ม 3586 tests ผ่านทั้งหมด รวมถึง main Linux/Windows verification gates และ shaded jar packaging
+- ทดสอบเปิดแอปจริงบน macOS Apple Silicon แบบแยก config และตรวจ bundled KataGo กับ UI smoke path แล้ว ส่วน Windows AI Coach click-through แบบครบขั้นยังเป็นจุดสำคัญที่ควรทดสอบต่อใน pre-release นี้
+
+### ติดต่อ
+
+- QQ group: `299419120`

--- a/.github/release-requests/next-2026-08-30.1.json
+++ b/.github/release-requests/next-2026-08-30.1.json
@@ -1,0 +1,7 @@
+{
+  "date_tag": "2026-08-30",
+  "release_tag": "next-2026-08-30.1",
+  "title": "LizzieYzy Next next-2026-08-30.1",
+  "prerelease": true,
+  "notes_file": ".github/release-notes/next-2026-08-30.1.md"
+}


### PR DESCRIPTION
## Summary

- Requests the fail-closed `next-2026-08-30.1` pre-release from current `main`.
- Highlights AI Coach tactical-quality protection and think-time adaptive deepening.
- Includes the engine-game, engine-switch, resizable-layout, comment, Linux UI, and diagnostic improvements merged since `next-2026-08-27.5`.
- Keeps the fixed six-language release-note structure and direct GitHub asset links.

## Validation

- Main Linux and Windows full verification gates passed.
- Release notes validator passed.
- 112 release-pipeline tests passed.
- Line-ending and local Markdown-link checks passed.
- `git diff --check` passed.

After merge, the release workflow will keep the release as a draft until Windows, Linux, macOS Intel, and macOS Apple Silicon assets all pass validation.