### PR TITLE
ci: share local and hosted preflight gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,27 +27,6 @@ jobs:
         with:
           python-version: '3.x'
 
-      - name: Verify clean Windows checkout
-        shell: pwsh
-        run: |
-          $changes = git status --porcelain
-          if ($changes) {
-            $changes | Write-Error
-            throw 'Checkout is dirty; verify .gitattributes normalization.'
-          }
-
-      - name: Verify repository line endings
-        shell: pwsh
-        run: python scripts/check_line_endings.py
-
-      - name: Verify bundled JCEF logic on Windows
-        shell: pwsh
-        run: python scripts/test_prepare_bundled_jcef.py
-
-      - name: Verify bundled NVIDIA runtime packaging
-        shell: pwsh
-        run: python scripts/test_prepare_bundled_nvidia_runtime.py
-
       - name: Set up Java 21
         uses: actions/setup-java@v5
         with:
@@ -55,40 +34,17 @@ jobs:
           java-version: '21'
           cache: maven
 
-      - name: Parse RTX 50 benchmark script
+      - name: Run Windows CI preflight
         shell: pwsh
-        run: |
-          $tokens = $null
-          $errors = $null
-          [System.Management.Automation.Language.Parser]::ParseFile(
-            (Resolve-Path 'scripts/windows_rtx50_analysis_benchmark.ps1'),
-            [ref]$tokens,
-            [ref]$errors
-          ) | Out-Null
-          if ($errors.Count -gt 0) {
-            $errors | Format-List | Out-String | Write-Error
-            exit 1
-          }
+        run: python scripts/run_local_ci.py --profile windows --require-clean --summary-dir target/local-ci/windows
 
-      - name: Verify Windows credential persistence
-        shell: pwsh
-        run: >-
-          mvn -B "-Dfmt.skip=true"
-          "-Dlizzie.work.dir=$env:RUNNER_TEMP\lizzieyzy-next-credential-tests"
-          "-Dtest=PlatformCredentialStoreTest,RemoteComputeConfigTest,MigratingCredentialStoreTest"
-          test
-
-      - name: Run full Windows verification gate
-        shell: pwsh
-        run: >-
-          mvn -B "-Dfmt.skip=true"
-          "-Djava.awt.headless=true"
-          "-Dlizzie.work.dir=$env:RUNNER_TEMP\lizzieyzy-next-full-tests"
-          "-DskipTests=false"
-          "-DskipITs=false"
-          "-Dit.test=LoggingProviderSmokeIT"
-          "-Dfailsafe.failIfNoSpecifiedTests=true"
-          verify
+      - name: Upload local CI summary
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: local-ci-summary-windows
+          path: target/local-ci/windows
+          if-no-files-found: warn
 
       - name: Upload JaCoCo coverage report
         uses: actions/upload-artifact@v6
@@ -105,11 +61,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
 
-      - name: Verify repository line endings
-        run: |
-          python3 scripts/test_check_line_endings.py
-          python3 scripts/check_line_endings.py
-
       - name: Set up Java 21
         uses: actions/setup-java@v5
         with:
@@ -117,84 +68,16 @@ jobs:
           java-version: '21'
           cache: maven
 
-      - name: Verify local markdown links
-        run: python3 scripts/check_markdown_links.py
+      - name: Run portable CI preflight
+        run: python3 scripts/run_local_ci.py --profile portable --require-clean --summary-dir target/local-ci/portable
 
-      - name: Verify release packaging helpers
-        run: |
-          python3 -m py_compile \
-            scripts/audit_katago_binary_version.py \
-            scripts/audit_katago_package_metadata.py \
-            scripts/generate_release_notes.py \
-            scripts/macos_bundle_version.py \
-            scripts/macos_katago_bundle.py \
-            scripts/package_runtime_tools.py \
-            scripts/prepare_bundled_jcef.py \
-            scripts/prepare_bundled_nvidia_runtime.py \
-            scripts/publish_release_request.py \
-            scripts/r2_release.py \
-            scripts/summarize_jfr.py \
-            scripts/test_generate_release_notes.py \
-            scripts/test_audit_katago_binary_version.py \
-            scripts/test_audit_katago_package_metadata.py \
-            scripts/test_macos_drag_dmg_script.py \
-            scripts/test_macos_bundle_version.py \
-            scripts/test_macos_katago_bundle.py \
-            scripts/test_prepare_bundled_nvidia_runtime.py \
-            scripts/test_publish_release_request.py \
-            scripts/release_asset_provenance.py \
-            scripts/release_asset_topology.py \
-            scripts/test_release_asset_topology.py \
-            scripts/test_release_asset_provenance.py \
-            scripts/validate_release_notes.py \
-            scripts/test_validate_release_notes.py \
-            scripts/test_macos_signing_security.py \
-            scripts/test_r2_release.py \
-            scripts/test_windows_launcher_packaging.py \
-            scripts/test_validate_windows_release_assets.py \
-            scripts/validate_windows_release_assets.py \
-            scripts/test_validate_release_workflow_identity.py \
-            scripts/validate_release_workflow_identity.py
-          python3 scripts/test_generate_release_notes.py
-          python3 scripts/test_audit_katago_binary_version.py
-          python3 scripts/test_audit_katago_package_metadata.py
-          python3 scripts/test_macos_drag_dmg_script.py
-          python3 scripts/test_macos_bundle_version.py
-          python3 scripts/test_macos_katago_bundle.py
-          bash scripts/test_prepare_bundled_katago.sh
-          python3 scripts/test_prepare_bundled_jcef.py
-          python3 scripts/test_prepare_bundled_nvidia_runtime.py
-          python3 -m unittest scripts.test_publish_release_request
-          python3 -m unittest scripts.test_release_asset_provenance
-          python3 -m unittest scripts.test_release_asset_topology
-          python3 -m unittest scripts.test_validate_release_notes
-          python3 -m unittest scripts.test_macos_signing_security
-          python3 -m unittest scripts.test_r2_release
-          python3 scripts/test_windows_launcher_packaging.py
-          python3 -m unittest scripts.test_validate_windows_release_assets
-          python3 -m unittest scripts.test_validate_release_workflow_identity
-          bash -n \
-            scripts/create_macos_drag_dmg.sh \
-            scripts/prepare_bundled_katago.sh \
-            scripts/test_prepare_bundled_katago.sh \
-            scripts/package_macos_dmg.sh \
-            scripts/validate_macos_dmg_layout.sh \
-            scripts/package_release.sh \
-            scripts/package_windows_exe.sh \
-            scripts/run_jfr_benchmark.sh \
-            scripts/sign_macos_release.sh \
-            scripts/sign_macos_release_with_retry.sh \
-            scripts/validate_release_assets.sh
-
-      - name: Run full Linux verification gate
-        run: >-
-          mvn -B -Dfmt.skip=true
-          -Djava.awt.headless=true
-          -DskipTests=false
-          -DskipITs=false
-          -Dit.test=LoggingProviderSmokeIT
-          -Dfailsafe.failIfNoSpecifiedTests=true
-          verify
+      - name: Upload local CI summary
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: local-ci-summary-linux
+          path: target/local-ci/portable
+          if-no-files-found: warn
 
       - name: Upload JaCoCo coverage report
         uses: actions/upload-artifact@v6

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .DS_Store
+__pycache__/
 dependency-reduced-pom.xml
 
 .tools/

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -8,7 +8,7 @@
 
 - 这是一个持续维护中的 LizzieYzy 分支，不是一次性补丁仓库。
 - 当前最重要的用户链路是：能装、能开、能通过 **野狐昵称** 获取最新公开棋谱、能正常分析。
-- 这个项目现在没有完整自动化测试体系，当前维护基线主要是：本地构建、文档检查、定向手工验证。
+- 项目已有 Java 回归、发布脚本和多平台 CI 门禁；真实 GUI、显卡后端和签名安装包仍需对应平台手工验收。
 
 ## 本地构建
 
@@ -40,21 +40,36 @@ mvn -B -DskipTests package
 - `target/lizzie-yzy2.5.3.jar`
 - `target/lizzie-yzy2.5.3-shaded.jar`
 
-## 当前建议的本地校验
+## 本地一键 CI 预检
 
-提交前，至少建议做这些检查：
+提交前建议运行与 GitHub Actions 同源的本地预检。它会校验 JDK 21、执行完整
+Maven `verify`、打包辅助脚本、换行和链接检查，并把准确的 JUnit 数量写入
+`target/local-ci/`。
 
-```bash
-python3 scripts/check_line_endings.py
-python3 scripts/check_markdown_links.py
-git diff --check
+Windows：
+
+```powershell
+powershell -ExecutionPolicy Bypass -File scripts/run_local_ci.ps1 -Profile All
 ```
 
-如果你改了 Java 代码，再跑一次：
+macOS / Linux：
 
 ```bash
-mvn -B -DskipTests package
+bash scripts/run_local_ci.sh --profile portable
 ```
+
+推送前的干净工作树复核：
+
+```powershell
+powershell -ExecutionPolicy Bypass -File scripts/run_local_ci.ps1 -Profile All -RequireClean
+```
+
+可用 profile 为 `Windows`、`Portable` 和 `All`；加 `-DryRun` / `--dry-run`
+可只查看计划执行的步骤。`LIZZIE_PYTHON`、`LIZZIE_MAVEN`、`LIZZIE_BASH`
+和 `LIZZIE_POWERSHELL` 可用于指定工具路径。
+
+本地预检用于在推送前尽早发现问题，不能代替受保护分支上的干净 Windows 和
+Ubuntu runner，也不能代替 macOS 签名、公证与多平台发布资产审计。
 
 如果你改了打包、引擎路径、首次启动流程、野狐抓谱流程，建议再做对应平台的手工验证。
 

--- a/scripts/run_local_ci.ps1
+++ b/scripts/run_local_ci.ps1
@@ -1,0 +1,89 @@
+param(
+  [ValidateSet('Windows', 'Portable', 'All')]
+  [string]$Profile = 'All',
+  [switch]$DryRun,
+  [switch]$RequireClean,
+  [string]$SummaryDir = 'target/local-ci'
+)
+
+$ErrorActionPreference = 'Stop'
+$repoRoot = Split-Path -Parent $PSScriptRoot
+
+function Test-Java21([string]$JavaHome) {
+  if (-not $JavaHome) { return $false }
+  $java = Join-Path $JavaHome 'bin\java.exe'
+  if (-not (Test-Path -LiteralPath $java -PathType Leaf)) { return $false }
+  $previousPreference = $ErrorActionPreference
+  try {
+    # java -version intentionally writes to stderr. Windows PowerShell wraps
+    # that successful output in NativeCommandError when the global mode is Stop.
+    $ErrorActionPreference = 'Continue'
+    $version = & $java -version 2>&1 | Out-String
+  } finally {
+    $ErrorActionPreference = $previousPreference
+  }
+  return $version -match 'version "21(?:\.|\")'
+}
+
+if (-not (Test-Java21 $env:JAVA_HOME)) {
+  $jdkCandidates = @(
+    Get-ChildItem -Path (Join-Path $repoRoot '.tools\jdk-21*') -Directory -ErrorAction SilentlyContinue
+    Get-ChildItem -Path (Join-Path $env:SystemDrive 'jdk21\jdk-21*') -Directory -ErrorAction SilentlyContinue
+    Get-ChildItem -Path "$env:ProgramFiles\Eclipse Adoptium\jdk-21*" -Directory -ErrorAction SilentlyContinue
+    Get-ChildItem -Path "$env:ProgramFiles\Java\jdk-21*" -Directory -ErrorAction SilentlyContinue
+    Get-ChildItem -Path "$env:ProgramFiles\Microsoft\jdk-21*" -Directory -ErrorAction SilentlyContinue
+    Get-ChildItem -Path "$env:ProgramFiles\Amazon Corretto\jdk21*" -Directory -ErrorAction SilentlyContinue
+  )
+  $jdk = $jdkCandidates | Where-Object { Test-Java21 $_.FullName } | Sort-Object Name | Select-Object -Last 1
+  if ($jdk) {
+    $env:JAVA_HOME = $jdk.FullName
+    $env:Path = "$(Join-Path $jdk.FullName 'bin');$env:Path"
+  }
+}
+
+$python = $env:LIZZIE_PYTHON
+if (-not $python) {
+  $pythonCommand = Get-Command python3, python -ErrorAction SilentlyContinue | Select-Object -First 1
+  if ($pythonCommand) { $python = $pythonCommand.Source }
+}
+if (-not $python) {
+  throw 'Python 3 was not found. Set LIZZIE_PYTHON or add python to PATH.'
+}
+
+if (-not $env:LIZZIE_MAVEN) {
+  $maven = Get-Command mvn.cmd, mvn -ErrorAction SilentlyContinue | Select-Object -First 1
+  if (-not $maven) {
+    $maven = Get-ChildItem -Path (Join-Path $repoRoot '.tools\apache-maven-*\bin\mvn.cmd'), 'C:\tools\apache-maven-*\bin\mvn.cmd' -File -ErrorAction SilentlyContinue | Sort-Object FullName | Select-Object -Last 1
+  }
+  if ($maven) { $env:LIZZIE_MAVEN = $maven.FullName }
+}
+
+if (-not $env:LIZZIE_BASH) {
+  $gitBash = Join-Path $env:ProgramFiles 'Git\bin\bash.exe'
+  if (Test-Path -LiteralPath $gitBash -PathType Leaf) {
+    $env:LIZZIE_BASH = $gitBash
+  } else {
+    $bash = Get-Command bash.exe, bash -ErrorAction SilentlyContinue |
+      Where-Object { $_.Source -notmatch '\\Windows\\(?:System32|Sysnative)\\bash\.exe$' } |
+      Select-Object -First 1
+  }
+  if (-not $env:LIZZIE_BASH -and $bash) {
+    $env:LIZZIE_BASH = $bash.Source
+  }
+}
+
+$arguments = @(
+  (Join-Path $PSScriptRoot 'run_local_ci.py'),
+  '--profile', $Profile.ToLowerInvariant(),
+  '--summary-dir', $SummaryDir
+)
+if ($DryRun) { $arguments += '--dry-run' }
+if ($RequireClean) { $arguments += '--require-clean' }
+
+Push-Location $repoRoot
+try {
+  & $python @arguments
+  exit $LASTEXITCODE
+} finally {
+  Pop-Location
+}

--- a/scripts/run_local_ci.py
+++ b/scripts/run_local_ci.py
@@ -1,0 +1,602 @@
+#!/usr/bin/env python3
+"""Run the same preflight gates locally and in GitHub Actions."""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+import json
+import os
+from pathlib import Path
+import platform
+import re
+import shlex
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+from typing import Iterable, Sequence
+import xml.etree.ElementTree as ET
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+PY_COMPILE_FILES = (
+    "scripts/audit_katago_binary_version.py",
+    "scripts/audit_katago_package_metadata.py",
+    "scripts/generate_release_notes.py",
+    "scripts/macos_bundle_version.py",
+    "scripts/macos_katago_bundle.py",
+    "scripts/package_runtime_tools.py",
+    "scripts/prepare_bundled_jcef.py",
+    "scripts/prepare_bundled_nvidia_runtime.py",
+    "scripts/publish_release_request.py",
+    "scripts/r2_release.py",
+    "scripts/release_asset_provenance.py",
+    "scripts/release_asset_topology.py",
+    "scripts/run_local_ci.py",
+    "scripts/summarize_jfr.py",
+    "scripts/test_audit_katago_binary_version.py",
+    "scripts/test_audit_katago_package_metadata.py",
+    "scripts/test_generate_release_notes.py",
+    "scripts/test_macos_drag_dmg_script.py",
+    "scripts/test_macos_bundle_version.py",
+    "scripts/test_macos_katago_bundle.py",
+    "scripts/test_prepare_bundled_nvidia_runtime.py",
+    "scripts/test_publish_release_request.py",
+    "scripts/test_release_asset_provenance.py",
+    "scripts/test_release_asset_topology.py",
+    "scripts/test_r2_release.py",
+    "scripts/test_run_local_ci.py",
+    "scripts/test_validate_release_notes.py",
+    "scripts/test_validate_windows_release_assets.py",
+    "scripts/test_validate_release_workflow_identity.py",
+    "scripts/test_windows_launcher_packaging.py",
+    "scripts/validate_release_notes.py",
+    "scripts/validate_windows_release_assets.py",
+    "scripts/validate_release_workflow_identity.py",
+)
+
+DIRECT_PYTHON_TESTS = (
+    "scripts/test_generate_release_notes.py",
+    "scripts/test_audit_katago_binary_version.py",
+    "scripts/test_audit_katago_package_metadata.py",
+    "scripts/test_macos_drag_dmg_script.py",
+    "scripts/test_macos_bundle_version.py",
+    "scripts/test_macos_katago_bundle.py",
+    "scripts/test_prepare_bundled_jcef.py",
+    "scripts/test_prepare_bundled_nvidia_runtime.py",
+    "scripts/test_windows_launcher_packaging.py",
+)
+
+UNITTEST_MODULES = (
+    "scripts.test_publish_release_request",
+    "scripts.test_release_asset_provenance",
+    "scripts.test_release_asset_topology",
+    "scripts.test_run_local_ci",
+    "scripts.test_validate_release_notes",
+    "scripts.test_macos_signing_security",
+    "scripts.test_r2_release",
+    "scripts.test_validate_windows_release_assets",
+    "scripts.test_validate_release_workflow_identity",
+)
+
+BASH_SYNTAX_FILES = (
+    "scripts/create_macos_drag_dmg.sh",
+    "scripts/prepare_bundled_katago.sh",
+    "scripts/test_prepare_bundled_katago.sh",
+    "scripts/package_macos_dmg.sh",
+    "scripts/validate_macos_dmg_layout.sh",
+    "scripts/package_release.sh",
+    "scripts/package_windows_exe.sh",
+    "scripts/run_jfr_benchmark.sh",
+    "scripts/run_local_ci.sh",
+    "scripts/sign_macos_release.sh",
+    "scripts/sign_macos_release_with_retry.sh",
+    "scripts/validate_release_assets.sh",
+)
+
+
+@dataclass(frozen=True)
+class Step:
+    name: str
+    command: tuple[str, ...]
+    env: dict[str, str] | None = None
+
+
+@dataclass
+class StepResult:
+    name: str
+    command: list[str]
+    status: str
+    exit_code: int | None
+    duration_seconds: float
+
+
+@dataclass(frozen=True)
+class JunitSummary:
+    suites: int = 0
+    tests: int = 0
+    failures: int = 0
+    errors: int = 0
+    skipped: int = 0
+
+    def plus(self, other: "JunitSummary") -> "JunitSummary":
+        return JunitSummary(
+            suites=self.suites + other.suites,
+            tests=self.tests + other.tests,
+            failures=self.failures + other.failures,
+            errors=self.errors + other.errors,
+            skipped=self.skipped + other.skipped,
+        )
+
+
+def command_display(command: Sequence[str]) -> str:
+    return subprocess.list2cmdline(list(command)) if os.name == "nt" else " ".join(
+        subprocess.list2cmdline([part]) for part in command
+    )
+
+
+def executable_from_env_or_path(env_name: str, names: Iterable[str]) -> str | None:
+    configured = os.environ.get(env_name, "").strip()
+    if configured:
+        return configured
+    for name in names:
+        resolved = shutil.which(name)
+        if resolved:
+            return resolved
+    return None
+
+
+def resolve_maven() -> str:
+    resolved = executable_from_env_or_path(
+        "LIZZIE_MAVEN", ("mvn.cmd", "mvn.exe", "mvn")
+    )
+    if resolved:
+        return resolved
+    patterns = (
+        REPO_ROOT / ".tools" / "apache-maven-*" / "bin" / "mvn.cmd",
+        REPO_ROOT / ".tools" / "apache-maven-*" / "bin" / "mvn",
+    )
+    if os.name == "nt":
+        patterns += (Path("C:/tools/apache-maven-*/bin/mvn.cmd"),)
+    for pattern in patterns:
+        matches = sorted(pattern.parent.parent.parent.glob(pattern.parent.parent.name + "/bin/" + pattern.name))
+        if matches:
+            return str(matches[-1])
+    raise RuntimeError(
+        "Maven was not found. Set LIZZIE_MAVEN or add mvn to PATH."
+    )
+
+
+def resolve_bash() -> str:
+    configured = os.environ.get("LIZZIE_BASH", "").strip()
+    if configured:
+        return configured
+    if os.name == "nt":
+        program_files_roots = (
+            os.environ.get("ProgramFiles", "C:/Program Files"),
+            os.environ.get("ProgramFiles(x86)", "C:/Program Files (x86)"),
+        )
+        for root in program_files_roots:
+            candidate = Path(root) / "Git/bin/bash.exe"
+            if candidate.is_file():
+                return str(candidate)
+    resolved = shutil.which("bash")
+    if resolved and not is_windows_wsl_bash_launcher(resolved):
+        return resolved
+    raise RuntimeError("bash was not found. Set LIZZIE_BASH or add Git Bash to PATH.")
+
+
+def is_windows_wsl_bash_launcher(path: str, *, windows: bool | None = None) -> bool:
+    if windows is None:
+        windows = os.name == "nt"
+    if not windows:
+        return False
+    normalized = path.replace("\\", "/").casefold()
+    return normalized.endswith("/windows/system32/bash.exe") or normalized.endswith(
+        "/windows/sysnative/bash.exe"
+    )
+
+
+def resolve_powershell() -> str:
+    resolved = executable_from_env_or_path(
+        "LIZZIE_POWERSHELL", ("pwsh", "powershell.exe", "powershell")
+    )
+    if not resolved:
+        raise RuntimeError("PowerShell was not found.")
+    return resolved
+
+
+def java_major_version(maven: str) -> tuple[int, str]:
+    completed = subprocess.run(
+        [maven, "-version"],
+        cwd=REPO_ROOT,
+        check=False,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        encoding="utf-8",
+        errors="replace",
+    )
+    output = completed.stdout.strip()
+    if completed.returncode != 0:
+        raise RuntimeError(f"Unable to run Maven:\n{output}")
+    match = re.search(r"Java version:\s*([0-9]+)", output)
+    if not match:
+        raise RuntimeError(f"Unable to determine Maven Java version:\n{output}")
+    return int(match.group(1)), output
+
+
+def windows_steps(maven: str, powershell: str) -> list[Step]:
+    python = sys.executable
+    temp = Path(tempfile.gettempdir()) / f"lizzieyzy-next-local-ci-{os.getpid()}"
+    parser_script = (
+        "$tokens=$null; $errors=$null; "
+        "[System.Management.Automation.Language.Parser]::ParseFile("
+        "(Resolve-Path 'scripts/windows_rtx50_analysis_benchmark.ps1'),"
+        "[ref]$tokens,[ref]$errors)|Out-Null; "
+        "if($errors.Count -gt 0){$errors|Format-List|Out-String|Write-Error; exit 1}"
+    )
+    return [
+        Step("Verify repository line endings", (python, "scripts/check_line_endings.py")),
+        Step("Verify bundled JCEF logic", (python, "scripts/test_prepare_bundled_jcef.py")),
+        Step(
+            "Verify bundled NVIDIA runtime packaging",
+            (python, "scripts/test_prepare_bundled_nvidia_runtime.py"),
+        ),
+        Step(
+            "Parse RTX 50 benchmark PowerShell",
+            (powershell, "-NoProfile", "-Command", parser_script),
+        ),
+        Step(
+            "Verify Windows credential persistence",
+            (
+                maven,
+                "-B",
+                "-Dfmt.skip=true",
+                f"-Dlizzie.work.dir={temp / 'credential-tests'}",
+                "-Dtest=PlatformCredentialStoreTest,RemoteComputeConfigTest,MigratingCredentialStoreTest",
+                "test",
+            ),
+        ),
+        Step(
+            "Run full Windows verification gate",
+            (
+                maven,
+                "-B",
+                "-Dfmt.skip=true",
+                "-Djava.awt.headless=true",
+                f"-Dlizzie.work.dir={temp / 'full-tests'}",
+                "-DskipTests=false",
+                "-DskipITs=false",
+                "-Dit.test=LoggingProviderSmokeIT",
+                "-Dfailsafe.failIfNoSpecifiedTests=true",
+                "verify",
+            ),
+        ),
+    ]
+
+
+def portable_steps(maven: str, bash: str) -> list[Step]:
+    python = sys.executable
+    steps = [
+        Step("Test line-ending checker", (python, "scripts/test_check_line_endings.py")),
+        Step("Verify repository line endings", (python, "scripts/check_line_endings.py")),
+        Step("Verify local Markdown links", (python, "scripts/check_markdown_links.py")),
+        Step("Compile release helper Python", (python, "-m", "py_compile", *PY_COMPILE_FILES)),
+    ]
+    steps.extend(
+        Step(f"Run {Path(script).name}", (python, script)) for script in DIRECT_PYTHON_TESTS
+    )
+    steps.append(
+        Step(
+            "Verify bundled KataGo shell logic",
+            bash_login_command(bash, "scripts/test_prepare_bundled_katago.sh"),
+            env={"PYTHON_BIN": python},
+        )
+    )
+    steps.extend(
+        Step(
+            f"Run {module}",
+            (python, "-m", "unittest", module),
+            env={"LIZZIE_BASH": bash, "LIZZIE_PYTHON": python},
+        )
+        for module in UNITTEST_MODULES
+    )
+    steps.append(
+        Step(
+            "Parse release shell scripts",
+            bash_login_command(bash, "bash", "-n", *BASH_SYNTAX_FILES),
+        )
+    )
+    steps.append(
+        Step(
+            "Run full portable verification gate",
+            (
+                maven,
+                "-B",
+                "-Dfmt.skip=true",
+                "-Djava.awt.headless=true",
+                "-DskipTests=false",
+                "-DskipITs=false",
+                "-Dit.test=LoggingProviderSmokeIT",
+                "-Dfailsafe.failIfNoSpecifiedTests=true",
+                "verify",
+            ),
+        )
+    )
+    return steps
+
+
+def bash_login_command(bash: str, *command: str) -> tuple[str, ...]:
+    # Git Bash only adds its usr/bin tools for a login shell when launched
+    # programmatically from a regular Windows process.
+    return (bash, "-lc", shlex.join(command))
+
+
+def deduplicate_steps(steps: Iterable[Step]) -> list[Step]:
+    result: list[Step] = []
+    seen: set[tuple[str, ...]] = set()
+    for step in steps:
+        if step.command in seen:
+            continue
+        seen.add(step.command)
+        result.append(step)
+    return result
+
+
+def build_steps(profile: str, maven: str, bash: str | None, powershell: str | None) -> list[Step]:
+    if profile == "windows":
+        if powershell is None:
+            raise RuntimeError("The Windows profile requires PowerShell.")
+        return windows_steps(maven, powershell)
+    if profile == "portable":
+        if bash is None:
+            raise RuntimeError("The portable profile requires bash.")
+        return portable_steps(maven, bash)
+    if bash is None or powershell is None:
+        raise RuntimeError("The all profile requires both PowerShell and bash.")
+    combined = windows_steps(maven, powershell) + portable_steps(maven, bash)
+    # A local Windows run cannot become an Ubuntu run by invoking Maven twice.
+    # Keep the Windows verification gate and run every portable helper around it.
+    combined = [
+        step
+        for step in combined
+        if step.name != "Run full portable verification gate"
+    ]
+    return deduplicate_steps(combined)
+
+
+def git_output(*args: str) -> str:
+    completed = subprocess.run(
+        ["git", *args],
+        cwd=REPO_ROOT,
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        encoding="utf-8",
+        errors="replace",
+    )
+    return completed.stdout.strip()
+
+
+def require_clean_checkout() -> None:
+    status = git_output("status", "--porcelain", "--untracked-files=all")
+    if status:
+        raise RuntimeError(f"Checkout is dirty:\n{status}")
+
+
+def parse_suite(element: ET.Element) -> JunitSummary:
+    if element.tag.endswith("testsuites"):
+        total = JunitSummary()
+        for child in element:
+            if child.tag.endswith("testsuite"):
+                total = total.plus(parse_suite(child))
+        return total
+    return JunitSummary(
+        suites=1,
+        tests=int(element.attrib.get("tests", "0")),
+        failures=int(element.attrib.get("failures", "0")),
+        errors=int(element.attrib.get("errors", "0")),
+        skipped=int(element.attrib.get("skipped", "0")),
+    )
+
+
+def collect_junit_summary(root: Path = REPO_ROOT / "target") -> JunitSummary:
+    summary = JunitSummary()
+    files: list[Path] = []
+    for directory in (root / "surefire-reports", root / "failsafe-reports"):
+        if directory.is_dir():
+            files.extend(sorted(directory.glob("TEST-*.xml")))
+    for path in files:
+        try:
+            summary = summary.plus(parse_suite(ET.parse(path).getroot()))
+        except (ET.ParseError, OSError, ValueError) as error:
+            raise RuntimeError(f"Unable to parse JUnit report {path}: {error}") from error
+    return summary
+
+
+def reset_junit_reports(root: Path = REPO_ROOT / "target") -> None:
+    for directory in (root / "surefire-reports", root / "failsafe-reports"):
+        if directory.exists():
+            shutil.rmtree(directory)
+
+
+def overall_result(success: bool, results: Sequence[StepResult]) -> str:
+    if success and all(result.status in {"passed", "planned"} for result in results):
+        return "PASS"
+    return "FAIL"
+
+
+def write_summary(
+    output_dir: Path,
+    profile: str,
+    dry_run: bool,
+    started_at: str,
+    duration_seconds: float,
+    java_details: str,
+    results: list[StepResult],
+    junit: JunitSummary,
+    success: bool,
+) -> None:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    status = overall_result(success, results)
+    payload = {
+        "schema_version": 1,
+        "result": status,
+        "profile": profile,
+        "dry_run": dry_run,
+        "started_at": started_at,
+        "duration_seconds": round(duration_seconds, 3),
+        "platform": platform.platform(),
+        "python": sys.version.split()[0],
+        "java": java_details,
+        "git_sha": git_output("rev-parse", "HEAD"),
+        "junit": asdict(junit),
+        "steps": [asdict(result) for result in results],
+    }
+    (output_dir / "local-ci-summary.json").write_text(
+        json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8"
+    )
+    lines = [
+        "# Local CI summary",
+        "",
+        f"- Result: **{status}**",
+        f"- Profile: `{profile}`",
+        f"- Git SHA: `{payload['git_sha']}`",
+        f"- Duration: `{duration_seconds:.1f}s`",
+        (
+            "- JUnit: "
+            f"{junit.tests} tests, {junit.failures} failures, "
+            f"{junit.errors} errors, {junit.skipped} skipped"
+        ),
+        "",
+        "| Step | Result | Seconds |",
+        "| --- | --- | ---: |",
+    ]
+    lines.extend(
+        f"| {result.name.replace('|', '/')} | {result.status} | {result.duration_seconds:.1f} |"
+        for result in results
+    )
+    (output_dir / "local-ci-summary.md").write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def run(args: argparse.Namespace) -> int:
+    started_clock = time.monotonic()
+    started_at = datetime.now(timezone.utc).isoformat()
+    output_dir = (REPO_ROOT / args.summary_dir).resolve()
+    results: list[StepResult] = []
+    java_details = "not checked (dry run)"
+
+    try:
+        if args.require_clean:
+            require_clean_checkout()
+        if not args.dry_run:
+            reset_junit_reports()
+        maven = args.maven or ("mvn" if args.dry_run else resolve_maven())
+        bash = None
+        powershell = None
+        if args.profile in {"portable", "all"}:
+            bash = args.bash or ("bash" if args.dry_run else resolve_bash())
+        if args.profile in {"windows", "all"}:
+            powershell = args.powershell or (
+                "pwsh" if args.dry_run else resolve_powershell()
+            )
+        if not args.dry_run:
+            major, java_details = java_major_version(maven)
+            if major != 21:
+                raise RuntimeError(
+                    f"Local CI requires JDK 21, but Maven is using Java {major}. "
+                    "Set JAVA_HOME to a JDK 21 installation."
+                )
+        steps = build_steps(args.profile, maven, bash, powershell)
+        steps.append(Step("Verify working-tree diff", ("git", "diff", "--check")))
+
+        for index, step in enumerate(steps, start=1):
+            print(f"[{index}/{len(steps)}] {step.name}", flush=True)
+            print(f"  {command_display(step.command)}", flush=True)
+            if args.dry_run:
+                results.append(
+                    StepResult(step.name, list(step.command), "planned", None, 0.0)
+                )
+                continue
+            step_started = time.monotonic()
+            completed = subprocess.run(
+                step.command,
+                cwd=REPO_ROOT,
+                env={
+                    **os.environ,
+                    "PYTHONIOENCODING": "utf-8",
+                    "PYTHONUTF8": "1",
+                    **(step.env or {}),
+                },
+                check=False,
+            )
+            elapsed = time.monotonic() - step_started
+            status = "passed" if completed.returncode == 0 else "failed"
+            results.append(
+                StepResult(
+                    step.name,
+                    list(step.command),
+                    status,
+                    completed.returncode,
+                    round(elapsed, 3),
+                )
+            )
+            if completed.returncode != 0:
+                raise RuntimeError(
+                    f"Step failed with exit code {completed.returncode}: {step.name}"
+                )
+        if args.require_clean:
+            require_clean_checkout()
+        return_code = 0
+    except (OSError, RuntimeError, subprocess.CalledProcessError) as error:
+        print(f"Local CI failed: {error}", file=sys.stderr, flush=True)
+        return_code = 1
+
+    try:
+        junit = JunitSummary() if args.dry_run else collect_junit_summary()
+        write_summary(
+            output_dir,
+            args.profile,
+            args.dry_run,
+            started_at,
+            time.monotonic() - started_clock,
+            java_details,
+            results,
+            junit,
+            return_code == 0,
+        )
+        print(f"Local CI report: {output_dir}", flush=True)
+        print(
+            "JUnit: "
+            f"{junit.tests} tests, {junit.failures} failures, "
+            f"{junit.errors} errors, {junit.skipped} skipped",
+            flush=True,
+        )
+    except (OSError, RuntimeError) as error:
+        print(f"Unable to write local CI report: {error}", file=sys.stderr, flush=True)
+        return 1
+    return return_code
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--profile", choices=("windows", "portable", "all"), default="all"
+    )
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--require-clean", action="store_true")
+    parser.add_argument("--summary-dir", default="target/local-ci")
+    parser.add_argument("--maven")
+    parser.add_argument("--bash")
+    parser.add_argument("--powershell")
+    return parser.parse_args(argv)
+
+
+if __name__ == "__main__":
+    raise SystemExit(run(parse_args()))

--- a/scripts/run_local_ci.sh
+++ b/scripts/run_local_ci.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+profile="all"
+extra_args=()
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --profile)
+      profile="${2:?missing profile}"
+      shift 2
+      ;;
+    --dry-run|--require-clean)
+      extra_args+=("$1")
+      shift
+      ;;
+    --summary-dir)
+      extra_args+=("$1" "${2:?missing summary directory}")
+      shift 2
+      ;;
+    *)
+      printf 'Unknown argument: %s\n' "$1" >&2
+      exit 2
+      ;;
+  esac
+done
+
+python_bin="${LIZZIE_PYTHON:-}"
+if [[ -z "$python_bin" ]]; then
+  python_bin="$(command -v python3 || command -v python || true)"
+fi
+if [[ -z "$python_bin" ]]; then
+  echo 'Python 3 was not found. Set LIZZIE_PYTHON or add python3 to PATH.' >&2
+  exit 1
+fi
+
+if [[ -z "${LIZZIE_MAVEN:-}" ]]; then
+  if command -v mvn >/dev/null 2>&1; then
+    export LIZZIE_MAVEN="$(command -v mvn)"
+  else
+    candidate="$(find "$repo_root/.tools" -path '*/apache-maven-*/bin/mvn' -type f 2>/dev/null | sort | tail -n 1)"
+    [[ -n "$candidate" ]] && export LIZZIE_MAVEN="$candidate"
+  fi
+fi
+
+cd "$repo_root"
+exec "$python_bin" scripts/run_local_ci.py --profile "$profile" "${extra_args[@]}"

--- a/scripts/test_publish_release_request.py
+++ b/scripts/test_publish_release_request.py
@@ -937,11 +937,12 @@ class ReleaseWorkflowResilienceTest(unittest.TestCase):
         workflow = (
             SCRIPT_PATH.parents[1] / ".github" / "workflows" / "ci.yml"
         ).read_text(encoding="utf-8")
+        local_ci = SCRIPT_PATH.with_name("run_local_ci.py").read_text(encoding="utf-8")
 
-        self.assertIn(
-            "python3 -m unittest scripts.test_publish_release_request", workflow
-        )
-        self.assertNotIn("python3 scripts/test_publish_release_request.py", workflow)
+        self.assertIn("scripts/run_local_ci.py --profile portable", workflow)
+        self.assertIn('"scripts.test_publish_release_request"', local_ci)
+        self.assertIn('"-m", "unittest", module', local_ci)
+        self.assertNotIn('Step(f"Run {module}", (python, module))', local_ci)
 
     @unittest.skipIf(os.name == "nt", "behavior test runs with native bash in CI")
     def test_macos_signing_retries_transient_failures(self) -> None:

--- a/scripts/test_release_asset_topology.py
+++ b/scripts/test_release_asset_topology.py
@@ -3,6 +3,8 @@
 
 from __future__ import annotations
 
+import os
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -278,17 +280,42 @@ class LinuxValidatorSmokeTest(unittest.TestCase):
         self.assertNotRegex(validator_text, r"\b(?:mapfile|readarray)\b")
 
     def run_validator(self, release_dir: Path) -> subprocess.CompletedProcess[str]:
-        return subprocess.run(
-            [
-                "bash",
+        bash = os.environ.get("LIZZIE_BASH") or shutil.which("bash") or "bash"
+        env = os.environ.copy()
+        if os.name == "nt" and Path(bash).is_absolute():
+            env.update(
+                {
+                    "DATE_TAG": DATE_TAG,
+                    "LIZZIE_PYTHON": os.environ.get("LIZZIE_PYTHON", sys.executable),
+                    "RELEASE_DIR_PATH": str(release_dir),
+                    "VALIDATOR_PATH": str(self.validator),
+                }
+            )
+            command = [
+                bash,
+                "-lc",
+                (
+                    'export PYTHON_BIN="$(cygpath -u "$LIZZIE_PYTHON")"; '
+                    'bash "$(cygpath -u "$VALIDATOR_PATH")" linux '
+                    '"$(cygpath -u "$RELEASE_DIR_PATH")" "$DATE_TAG"'
+                ),
+            ]
+        else:
+            command = [
+                bash,
                 str(self.validator),
                 "linux",
                 str(release_dir),
                 DATE_TAG,
-            ],
+            ]
+        return subprocess.run(
+            command,
             check=False,
             capture_output=True,
             text=True,
+            encoding="utf-8",
+            errors="replace",
+            env=env,
         )
 
     def write_linux_inventory(self, release_dir: Path, names: tuple[str, ...]) -> None:

--- a/scripts/test_run_local_ci.py
+++ b/scripts/test_run_local_ci.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+
+from pathlib import Path
+import tempfile
+import unittest
+
+from scripts import run_local_ci
+
+
+class RunLocalCiTest(unittest.TestCase):
+    def test_all_profile_keeps_one_maven_verification(self):
+        steps = run_local_ci.build_steps("all", "mvn", "bash", "pwsh")
+        verify_steps = [step for step in steps if "verification gate" in step.name]
+        self.assertEqual(["Run full Windows verification gate"], [step.name for step in verify_steps])
+        self.assertIn("Verify local Markdown links", [step.name for step in steps])
+        self.assertIn("Parse RTX 50 benchmark PowerShell", [step.name for step in steps])
+
+    def test_windows_profile_does_not_require_bash(self):
+        steps = run_local_ci.build_steps("windows", "mvn", None, "pwsh")
+        self.assertIn("Run full Windows verification gate", [step.name for step in steps])
+        self.assertNotIn("Verify local Markdown links", [step.name for step in steps])
+
+    def test_portable_shell_steps_use_login_shell_and_explicit_python(self):
+        steps = run_local_ci.build_steps("portable", "mvn", "git-bash", None)
+        katago = next(
+            step for step in steps if step.name == "Verify bundled KataGo shell logic"
+        )
+        syntax = next(
+            step for step in steps if step.name == "Parse release shell scripts"
+        )
+        self.assertEqual(("git-bash", "-lc"), katago.command[:2])
+        self.assertEqual(run_local_ci.sys.executable, katago.env["PYTHON_BIN"])
+        self.assertEqual(("git-bash", "-lc"), syntax.command[:2])
+
+    def test_collect_junit_summary_combines_surefire_and_failsafe(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            target = Path(temporary)
+            surefire = target / "surefire-reports"
+            failsafe = target / "failsafe-reports"
+            surefire.mkdir()
+            failsafe.mkdir()
+            (surefire / "TEST-unit.xml").write_text(
+                '<testsuite tests="5" failures="1" errors="0" skipped="2"/>',
+                encoding="utf-8",
+            )
+            (failsafe / "TEST-it.xml").write_text(
+                '<testsuite tests="2" failures="0" errors="1" skipped="0"/>',
+                encoding="utf-8",
+            )
+            self.assertEqual(
+                run_local_ci.JunitSummary(
+                    suites=2, tests=7, failures=1, errors=1, skipped=2
+                ),
+                run_local_ci.collect_junit_summary(target),
+            )
+
+    def test_reset_junit_reports_removes_stale_results_only(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            target = Path(temporary)
+            surefire = target / "surefire-reports"
+            failsafe = target / "failsafe-reports"
+            classes = target / "classes"
+            surefire.mkdir()
+            failsafe.mkdir()
+            classes.mkdir()
+            (surefire / "TEST-stale.xml").write_text("stale", encoding="utf-8")
+            (failsafe / "TEST-stale.xml").write_text("stale", encoding="utf-8")
+            (classes / "keep.class").write_text("keep", encoding="utf-8")
+
+            run_local_ci.reset_junit_reports(target)
+
+            self.assertFalse(surefire.exists())
+            self.assertFalse(failsafe.exists())
+            self.assertTrue((classes / "keep.class").is_file())
+
+    def test_setup_failure_cannot_be_reported_as_pass(self):
+        self.assertEqual("FAIL", run_local_ci.overall_result(False, []))
+        self.assertEqual("PASS", run_local_ci.overall_result(True, []))
+        failed = run_local_ci.StepResult("failed", ["false"], "failed", 1, 0.1)
+        self.assertEqual("FAIL", run_local_ci.overall_result(True, [failed]))
+
+    def test_deduplicate_steps_preserves_first_occurrence(self):
+        first = run_local_ci.Step("first", ("python", "check.py"))
+        duplicate = run_local_ci.Step("duplicate", ("python", "check.py"))
+        second = run_local_ci.Step("second", ("git", "diff", "--check"))
+        self.assertEqual(
+            [first, second], run_local_ci.deduplicate_steps([first, duplicate, second])
+        )
+
+    def test_windows_wsl_bash_launcher_is_rejected(self):
+        self.assertTrue(
+            run_local_ci.is_windows_wsl_bash_launcher(
+                r"C:\Windows\System32\bash.exe", windows=True
+            )
+        )
+        self.assertFalse(
+            run_local_ci.is_windows_wsl_bash_launcher(
+                r"C:\Program Files\Git\bin\bash.exe", windows=True
+            )
+        )
+        self.assertFalse(
+            run_local_ci.is_windows_wsl_bash_launcher(
+                "/usr/bin/bash", windows=False
+            )
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_validate_windows_release_assets.py
+++ b/scripts/test_validate_windows_release_assets.py
@@ -293,19 +293,13 @@ class WindowsReleaseValidationWiringTest(unittest.TestCase):
 
     def test_windows_ci_runs_jcef_tests_with_isolated_work_directories(self) -> None:
         workflow = (self.root / ".github/workflows/ci.yml").read_text(encoding="utf-8")
-        self.assertIn("python scripts/test_prepare_bundled_jcef.py", workflow)
-        self.assertIn(
-            "python3 -m unittest scripts.test_validate_windows_release_assets",
-            workflow,
-        )
-        self.assertIn(
-            "-Dlizzie.work.dir=$env:RUNNER_TEMP\\lizzieyzy-next-credential-tests",
-            workflow,
-        )
-        self.assertIn(
-            "-Dlizzie.work.dir=$env:RUNNER_TEMP\\lizzieyzy-next-full-tests",
-            workflow,
-        )
+        local_ci = (self.root / "scripts/run_local_ci.py").read_text(encoding="utf-8")
+        self.assertIn("scripts/run_local_ci.py --profile windows", workflow)
+        self.assertIn('"scripts/test_prepare_bundled_jcef.py"', local_ci)
+        self.assertIn('"scripts.test_validate_windows_release_assets"', local_ci)
+        self.assertIn("tempfile.gettempdir()", local_ci)
+        self.assertIn("temp / 'credential-tests'", local_ci)
+        self.assertIn("temp / 'full-tests'", local_ci)
 
 
 if __name__ == "__main__":

--- a/scripts/validate_release_assets.sh
+++ b/scripts/validate_release_assets.sh
@@ -18,7 +18,7 @@ if [[ ! -d "$RELEASE_DIR" ]]; then
   exit 1
 fi
 
-PYTHON_BIN="python3"
+PYTHON_BIN="${PYTHON_BIN:-python3}"
 if ! command -v "$PYTHON_BIN" >/dev/null 2>&1; then
   PYTHON_BIN="python"
 fi


### PR DESCRIPTION
## Summary
- add one-command Windows and POSIX preflight entry points with `Windows`, `Portable`, `All`, `DryRun`, and `RequireClean` modes
- make GitHub Windows/Linux jobs invoke the same Python orchestrator used locally
- discover JDK 21, Maven, Python, PowerShell, and Git Bash; reject the WSL launcher when Git Bash is required
- emit machine-readable JSON and Markdown reports with exact JUnit totals, duration, step status, commit SHA, and a trustworthy PASS/FAIL result
- clear stale JUnit reports before real runs and report zero tests for dry runs
- make Linux release-asset smoke tests reliable on Windows Git Bash with explicit UTF-8 and Python path handling
- document that local preflight complements, rather than replaces, protected hosted runners and platform GUI/signing validation

## Local verification
- `scripts/run_local_ci.ps1 -Profile All -RequireClean`: **PASS**, 28/28 steps
- JUnit: **3,588 tests, 0 failures, 0 errors, 14 skipped** (includes `LoggingProviderSmokeIT`)
- Maven `verify` and shaded package: BUILD SUCCESS
- release/helper Python tests: 162 tests, 0 failures, 2 skipped
- Windows Git Bash Linux-asset smoke test: 20 consecutive runs, 0 failures
- dry run: PASS, 28 planned steps, 0 executed tests
- `git diff --check`: passed
- final worktree: clean

The hosted CI jobs remain the authoritative clean Windows/Ubuntu gates; this PR does not add a self-hosted runner.