### PR TITLE
release: request next-2026-08-31.1 pre-release

### DIFF
--- a/.github/release-notes/next-2026-08-31.1.md
+++ b/.github/release-notes/next-2026-08-31.1.md
@@ -1,0 +1,365 @@
+# LizzieYzy Next next-2026-08-31.1
+
+## 中文
+
+这是基于 next-2026-08-30.1 的稳定性预发布版，重点修复 AI 陪练结束后的分析恢复、TensorRT 修复入口、自动分析停止状态，以及 Windows 首次启动和退出阶段的偶发界面异常。
+
+### 本版主要更新
+
+- AI 陪练结束后会安全恢复本地或智子云前台分析；只有引擎交接成功后才进入赛后复盘，失败时会保留清楚的修复状态。
+- AI 陪练会记住上一次真正启动成功的设置，工具栏按钮不再反复变宽，奇偶手数结束和智子云恢复路径均有回归覆盖。
+- TensorRT 修复资格现在按 NVIDIA 硬件判断，不再被当前 DirectML/OpenCL 后端误判；安装、替换和回滚采用事务式流程，失败不会留下半安装状态。
+- 手动停止自动分析时会明确显示“已停止”并保存当前结果，不再误报“已完成”，批量任务也不会擅自开始下一份棋谱。
+- 加固引擎尚未完全初始化或界面正在关闭时的生命周期，避免顶部菜单、引擎状态条和退出清理出现空指针异常。
+- 本地与 GitHub CI 现在共用同一套 preflight；日志滚动和崩溃持久化测试也改为等待真实异步落盘，不再靠不稳定的固定延时。
+- 感谢 @qiyi71w 通过 PR #392 持续完善 TensorRT 修复链路。
+
+### 下载前先看
+
+- 已安装 next-2026-08-30.1 完整 Windows 包的用户，可用 windows64.core-update.zip 只更新程序；现有权重、引擎、TensorRT 和 user-data 不会被替换。
+- 新安装用户请下载与硬件匹配的完整包；仍内置 KataGo v1.18.1 和默认 B11。B11 单次判断更强但搜索较慢，追求速度可在“一键设置 → 权重”明确切换 B10。
+- RTX 20/30/40/50 继续统一使用 windows64.nvidia CUDA 包；TensorRT 是 RTX 30 系及以下的可选方案。
+- 这是预发布版，覆盖旧目录前建议备份 user-data、权重和棋谱。
+- DirectML、OpenVINO、ROCm、RTX 50 和 macOS 对应硬件未在本机冒充真机通过，欢迎对应设备用户反馈。
+
+### 下载建议
+
+| 你的电脑 | 直接下载这个 |
+| --- | --- |
+| Windows 64 位，RTX 20/30/40/50 NVIDIA CUDA 推荐版，免安装 | [2026-08-31-windows64.nvidia.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.1/2026-08-31-windows64.nvidia.portable.zip) |
+| 已有 Windows 免安装版，只更新主程序 | [2026-08-31-windows64.core-update.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.1/2026-08-31-windows64.core-update.zip) |
+| Windows 64 位，RTX 20/30/40/50 NVIDIA CUDA 推荐安装版 | [2026-08-31-windows64.nvidia.installer.exe](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.1/2026-08-31-windows64.nvidia.installer.exe) |
+| Windows 64 位，AMD / Intel / 旧 NVIDIA OpenCL 兼容版，免安装 | [2026-08-31-windows64.opencl.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.1/2026-08-31-windows64.opencl.portable.zip) |
+| Windows 64 位，AMD / Intel / 旧 NVIDIA OpenCL 兼容安装版 | [2026-08-31-windows64.opencl.installer.exe](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.1/2026-08-31-windows64.opencl.installer.exe) |
+| Windows 64 位，CPU 兼容版，免安装 | [2026-08-31-windows64.with-katago.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.1/2026-08-31-windows64.with-katago.portable.zip) |
+| Windows 64 位，CPU 兼容安装版 | [2026-08-31-windows64.with-katago.installer.exe](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.1/2026-08-31-windows64.with-katago.installer.exe) |
+| Windows DirectML 实验版 | [2026-08-31-windows64.experimental.directml.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.1/2026-08-31-windows64.experimental.directml.portable.zip) |
+| Windows Intel OpenVINO 实验版 | [2026-08-31-windows64.experimental.openvino.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.1/2026-08-31-windows64.experimental.openvino.portable.zip) |
+| Windows AMD RX 6000 ROCm 实验版 | [2026-08-31-windows64.experimental.rocm.gfx103x.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.1/2026-08-31-windows64.experimental.rocm.gfx103x.portable.zip) |
+| Windows AMD RX 7000 ROCm 实验版 | [2026-08-31-windows64.experimental.rocm.gfx110x.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.1/2026-08-31-windows64.experimental.rocm.gfx110x.portable.zip) |
+| Windows AMD Ryzen AI Max ROCm 实验版 | [2026-08-31-windows64.experimental.rocm.gfx1151.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.1/2026-08-31-windows64.experimental.rocm.gfx1151.portable.zip) |
+| Windows AMD RX 9000 ROCm 实验版 | [2026-08-31-windows64.experimental.rocm.gfx120x.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.1/2026-08-31-windows64.experimental.rocm.gfx120x.portable.zip) |
+| RTX 30 系及以下可选 TensorRT，需下载两个分卷 | [2026-08-31-windows64.nvidia.tensorrt.portable.7z.001](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.1/2026-08-31-windows64.nvidia.tensorrt.portable.7z.001)<br>[2026-08-31-windows64.nvidia.tensorrt.portable.7z.002](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.1/2026-08-31-windows64.nvidia.tensorrt.portable.7z.002) |
+| Windows 64 位，自行配置引擎，免安装 | [2026-08-31-windows64.without.engine.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.1/2026-08-31-windows64.without.engine.portable.zip) |
+| Windows 64 位，自行配置引擎，安装版 | [2026-08-31-windows64.without.engine.installer.exe](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.1/2026-08-31-windows64.without.engine.installer.exe) |
+| macOS Apple Silicon，Metal | [2026-08-31-mac-apple-silicon.with-katago.dmg](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.1/2026-08-31-mac-apple-silicon.with-katago.dmg) |
+| macOS Intel | [2026-08-31-mac-intel.with-katago.dmg](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.1/2026-08-31-mac-intel.with-katago.dmg) |
+| Linux 64 位，CPU 兼容版 | [2026-08-31-linux64.with-katago.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.1/2026-08-31-linux64.with-katago.zip) |
+| Linux 64 位，OpenCL 版 | [2026-08-31-linux64.opencl.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.1/2026-08-31-linux64.opencl.zip) |
+| Linux 64 位，NVIDIA CUDA 版 | [2026-08-31-linux64.nvidia.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.1/2026-08-31-linux64.nvidia.zip) |
+
+### 验证结果
+
+- Windows 11 23H2、RTX 3070、NVIDIA portable 真机完成首次启动、B11 CUDA 推理、棋谱与快速曲线、闪电/自动/整盘分析、AI 陪练本地与智子云、引擎修复、Alt+O、弈客和更新检查。
+- 六种语言、100% / 150% / 200% 缩放、键盘操作和 Windows 讲述人均完成可见界面验收。
+- 本地 All preflight 28/28 通过；JUnit 3678 项，0 failures、0 errors、16 skipped。PR 的 Linux build 与 Windows script validation 均通过。
+- 发布器只有在四个平台工作流、签名/公证、资产拓扑、SHA 与来源证明全部成功后才公开本预发布版。
+
+### 交流
+
+- QQ 群：299419120
+
+---
+
+## 繁體中文
+
+這是基於 next-2026-08-30.1 的穩定性預發布版，重點修正 AI 陪練結束後的分析恢復、TensorRT 修復入口、自動分析停止狀態，以及 Windows 首次啟動與關閉階段的偶發介面錯誤。
+
+### 本版主要更新
+
+- AI 陪練結束後會安全恢復本機或智子雲前台分析；只有 engine handoff 成功才進入賽後復盤，失敗時保留清楚的修復狀態。
+- AI 陪練會記住上一次真正啟動成功的設定，工具列按鈕不再反覆變寬，奇偶手數結束與智子雲恢復均有回歸測試。
+- TensorRT 修復資格改按 NVIDIA 硬體判斷，不再受目前 DirectML/OpenCL backend 誤判；安裝、替換與回滾採交易式流程。
+- 手動停止自動分析會顯示「已停止」並保存目前結果，不再誤報「已完成」，batch 也不會自行開始下一份棋譜。
+- 強化 engine 尚未初始化完成或介面正在關閉時的生命週期，避免選單、狀態列和退出清理出現空指標錯誤。
+- 本機與 GitHub CI 共用同一套 preflight；非同步 log rollover 與 crash persistence 測試不再依賴固定延時。
+- 感謝 @qiyi71w 透過 PR #392 持續改善 TensorRT 修復流程。
+
+### 下載前先看
+
+- 已安裝 next-2026-08-30.1 完整 Windows 套件的使用者，可用 windows64.core-update.zip 只更新程式，不替換 weight、engine、TensorRT 或 user-data。
+- 新安裝請下載符合硬體的完整套件；仍內建 KataGo v1.18.1 與預設 B11。B11 單次判斷更強但搜尋較慢，重視速度可切換 B10。
+- RTX 20/30/40/50 繼續統一使用 windows64.nvidia CUDA 套件；TensorRT 是 RTX 30 系及以下的可選方案。
+- 這是預發布版，覆蓋舊目錄前建議備份 user-data、weight 與棋譜。
+- DirectML、OpenVINO、ROCm、RTX 50 與 macOS 對應硬體未在本機宣稱真機通過。
+
+### 下載建議
+
+| 你的電腦 | 直接下載這個 |
+| --- | --- |
+| Windows 64 位，RTX 20/30/40/50 NVIDIA CUDA 建議版，免安裝 | [2026-08-31-windows64.nvidia.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.1/2026-08-31-windows64.nvidia.portable.zip) |
+| 既有 Windows 免安裝版，只更新主程式 | [2026-08-31-windows64.core-update.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.1/2026-08-31-windows64.core-update.zip) |
+| Windows 64 位，RTX 20/30/40/50 NVIDIA CUDA 建議安裝版 | [2026-08-31-windows64.nvidia.installer.exe](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.1/2026-08-31-windows64.nvidia.installer.exe) |
+| Windows 64 位，AMD / Intel / 舊 NVIDIA OpenCL 相容版，免安裝 | [2026-08-31-windows64.opencl.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.1/2026-08-31-windows64.opencl.portable.zip) |
+| Windows 64 位，AMD / Intel / 舊 NVIDIA OpenCL 相容安裝版 | [2026-08-31-windows64.opencl.installer.exe](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.1/2026-08-31-windows64.opencl.installer.exe) |
+| Windows 64 位，CPU 相容版，免安裝 | [2026-08-31-windows64.with-katago.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.1/2026-08-31-windows64.with-katago.portable.zip) |
+| Windows 64 位，CPU 相容安裝版 | [2026-08-31-windows64.with-katago.installer.exe](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.1/2026-08-31-windows64.with-katago.installer.exe) |
+| Windows DirectML 實驗版 | [2026-08-31-windows64.experimental.directml.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.1/2026-08-31-windows64.experimental.directml.portable.zip) |
+| Windows Intel OpenVINO 實驗版 | [2026-08-31-windows64.experimental.openvino.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.1/2026-08-31-windows64.experimental.openvino.portable.zip) |
+| Windows AMD RX 6000 ROCm 實驗版 | [2026-08-31-windows64.experimental.rocm.gfx103x.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.1/2026-08-31-windows64.experimental.rocm.gfx103x.portable.zip) |
+| Windows AMD RX 7000 ROCm 實驗版 | [2026-08-31-windows64.experimental.rocm.gfx110x.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.1/2026-08-31-windows64.experimental.rocm.gfx110x.portable.zip) |
+| Windows AMD Ryzen AI Max ROCm 實驗版 | [2026-08-31-windows64.experimental.rocm.gfx1151.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.1/2026-08-31-windows64.experimental.rocm.gfx1151.portable.zip) |
+| Windows AMD RX 9000 ROCm 實驗版 | [2026-08-31-windows64.experimental.rocm.gfx120x.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.1/2026-08-31-windows64.experimental.rocm.gfx120x.portable.zip) |
+| RTX 30 系及以下可選 TensorRT，需下載兩個分卷 | [2026-08-31-windows64.nvidia.tensorrt.portable.7z.001](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.1/2026-08-31-windows64.nvidia.tensorrt.portable.7z.001)<br>[2026-08-31-windows64.nvidia.tensorrt.portable.7z.002](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.1/2026-08-31-windows64.nvidia.tensorrt.portable.7z.002) |
+| Windows 64 位，自行設定 engine，免安裝 | [2026-08-31-windows64.without.engine.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.1/2026-08-31-windows64.without.engine.portable.zip) |
+| Windows 64 位，自行設定 engine，安裝版 | [2026-08-31-windows64.without.engine.installer.exe](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.1/2026-08-31-windows64.without.engine.installer.exe) |
+| macOS Apple Silicon，Metal | [2026-08-31-mac-apple-silicon.with-katago.dmg](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.1/2026-08-31-mac-apple-silicon.with-katago.dmg) |
+| macOS Intel | [2026-08-31-mac-intel.with-katago.dmg](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.1/2026-08-31-mac-intel.with-katago.dmg) |
+| Linux 64 位，CPU 相容版 | [2026-08-31-linux64.with-katago.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.1/2026-08-31-linux64.with-katago.zip) |
+| Linux 64 位，OpenCL 版 | [2026-08-31-linux64.opencl.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.1/2026-08-31-linux64.opencl.zip) |
+| Linux 64 位，NVIDIA CUDA 版 | [2026-08-31-linux64.nvidia.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.1/2026-08-31-linux64.nvidia.zip) |
+
+### 驗證結果
+
+- Windows 11 23H2、RTX 3070、NVIDIA portable 完成真機引擎與主要使用流程驗收。
+- 六種語言、100% / 150% / 200% 縮放、鍵盤操作與 Windows 講述人均完成可見介面檢查。
+- 本機 All preflight 28/28 通過；JUnit 3678 項，0 failures、0 errors、16 skipped；GitHub Linux/Windows 門禁通過。
+- 四平台 workflow、簽名/公證、資產拓撲、SHA 與來源證明全部成功後才會公開。
+
+### 交流
+
+- QQ 群：299419120
+
+---
+
+## English
+
+This stability pre-release builds on next-2026-08-30.1. It focuses on restoring analysis after AI Coach, making TensorRT repair reachable and transactional, reporting manual auto-analysis stops correctly, and hardening early Windows startup and shutdown UI lifecycles.
+
+### Release highlights
+
+- AI Coach now safely restores local or Zhizi Cloud foreground analysis. Post-game review starts only after a successful engine handoff, while failures retain an actionable repair state.
+- The last successfully started AI Coach settings are remembered, toolbar button dimensions stay stable, and both odd/even move endings and Zhizi recovery have regression coverage.
+- TensorRT eligibility is based on NVIDIA hardware rather than the active DirectML/OpenCL backend. Installation, replacement, and rollback are transactional and do not leave partial state.
+- Manually stopping auto-analysis now reports Stopped and saves the current result instead of claiming completion; batch mode does not silently start the next record.
+- Engine startup, menu construction, status layout, and shutdown cleanup now tolerate partially initialized UI and engine objects.
+- Local and hosted CI use one shared preflight matrix. Asynchronous log rollover and crash-persistence tests wait for real completion instead of relying on timing guesses.
+- Thanks to @qiyi71w for the continued TensorRT repair work in PR #392.
+
+### Before downloading
+
+- Windows users with a complete next-2026-08-30.1 bundle can apply windows64.core-update.zip for the app-only fixes without replacing weights, engines, TensorRT, or user-data.
+- Fresh installs should use the full bundle matching the hardware. KataGo v1.18.1 and B11 remain bundled by default. B11 provides stronger individual evaluations at lower throughput; select B10 in Auto Setup when speed matters more.
+- RTX 20/30/40/50 continue to use the unified windows64.nvidia CUDA package. TensorRT is an optional path for RTX 30 series and older.
+- This is a pre-release; back up user-data, weights, and game records before overwriting an existing folder.
+- DirectML, OpenVINO, ROCm, RTX 50, and macOS hardware not present on the test machine are not claimed as hardware-tested.
+
+### Download guide
+
+| Your computer | Download this file |
+| --- | --- |
+| Windows x64, recommended RTX 20/30/40/50 NVIDIA CUDA portable | [2026-08-31-windows64.nvidia.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.1/2026-08-31-windows64.nvidia.portable.zip) |
+| Existing Windows portable, app-only update | [2026-08-31-windows64.core-update.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.1/2026-08-31-windows64.core-update.zip) |
+| Windows x64, recommended RTX 20/30/40/50 NVIDIA CUDA installer | [2026-08-31-windows64.nvidia.installer.exe](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.1/2026-08-31-windows64.nvidia.installer.exe) |
+| Windows x64, OpenCL portable for AMD / Intel / older NVIDIA | [2026-08-31-windows64.opencl.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.1/2026-08-31-windows64.opencl.portable.zip) |
+| Windows x64, OpenCL installer for AMD / Intel / older NVIDIA | [2026-08-31-windows64.opencl.installer.exe](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.1/2026-08-31-windows64.opencl.installer.exe) |
+| Windows x64, CPU compatibility portable | [2026-08-31-windows64.with-katago.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.1/2026-08-31-windows64.with-katago.portable.zip) |
+| Windows x64, CPU compatibility installer | [2026-08-31-windows64.with-katago.installer.exe](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.1/2026-08-31-windows64.with-katago.installer.exe) |
+| Windows DirectML experimental | [2026-08-31-windows64.experimental.directml.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.1/2026-08-31-windows64.experimental.directml.portable.zip) |
+| Windows Intel OpenVINO experimental | [2026-08-31-windows64.experimental.openvino.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.1/2026-08-31-windows64.experimental.openvino.portable.zip) |
+| Windows AMD RX 6000 ROCm experimental | [2026-08-31-windows64.experimental.rocm.gfx103x.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.1/2026-08-31-windows64.experimental.rocm.gfx103x.portable.zip) |
+| Windows AMD RX 7000 ROCm experimental | [2026-08-31-windows64.experimental.rocm.gfx110x.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.1/2026-08-31-windows64.experimental.rocm.gfx110x.portable.zip) |
+| Windows AMD Ryzen AI Max ROCm experimental | [2026-08-31-windows64.experimental.rocm.gfx1151.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.1/2026-08-31-windows64.experimental.rocm.gfx1151.portable.zip) |
+| Windows AMD RX 9000 ROCm experimental | [2026-08-31-windows64.experimental.rocm.gfx120x.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.1/2026-08-31-windows64.experimental.rocm.gfx120x.portable.zip) |
+| Optional TensorRT for RTX 30 series and older; download both parts | [2026-08-31-windows64.nvidia.tensorrt.portable.7z.001](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.1/2026-08-31-windows64.nvidia.tensorrt.portable.7z.001)<br>[2026-08-31-windows64.nvidia.tensorrt.portable.7z.002](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.1/2026-08-31-windows64.nvidia.tensorrt.portable.7z.002) |
+| Windows x64, bring your own engine, portable | [2026-08-31-windows64.without.engine.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.1/2026-08-31-windows64.without.engine.portable.zip) |
+| Windows x64, bring your own engine, installer | [2026-08-31-windows64.without.engine.installer.exe](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.1/2026-08-31-windows64.without.engine.installer.exe) |
+| macOS Apple Silicon, Metal | [2026-08-31-mac-apple-silicon.with-katago.dmg](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.1/2026-08-31-mac-apple-silicon.with-katago.dmg) |
+| macOS Intel | [2026-08-31-mac-intel.with-katago.dmg](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.1/2026-08-31-mac-intel.with-katago.dmg) |
+| Linux x64, CPU compatibility | [2026-08-31-linux64.with-katago.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.1/2026-08-31-linux64.with-katago.zip) |
+| Linux x64, OpenCL | [2026-08-31-linux64.opencl.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.1/2026-08-31-linux64.opencl.zip) |
+| Linux x64, NVIDIA CUDA | [2026-08-31-linux64.nvidia.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.1/2026-08-31-linux64.nvidia.zip) |
+
+### Verification
+
+- Visible Windows acceptance used Windows 11 23H2, RTX 3070, the NVIDIA portable EXE, bundled Java, B11 CUDA inference, SGF and quick curves, all analysis modes, local/Zhizi AI Coach, engine repair, Alt+O, Yike, and update checks.
+- Six languages, 100% / 150% / 200% scaling, keyboard navigation, and Windows Narrator were checked in the running app.
+- The local All preflight passed 28/28 steps: 3678 JUnit tests, 0 failures, 0 errors, 16 skipped. The PR Linux build and Windows script-validation gates also passed.
+- The release remains fail-closed until all four platform workflows, signing/notarization, topology, SHA, and provenance checks succeed.
+
+### Contact
+
+- QQ group: 299419120
+
+---
+
+## 日本語
+
+next-2026-08-30.1 を基にした安定性 pre-release です。AI 陪練終了後の analysis 復帰、TensorRT 修復、auto analysis の停止表示、Windows の初期起動・終了時 UI lifecycle を改善しました。
+
+### 主な更新
+
+- AI 陪練終了後、local または Zhizi Cloud の foreground analysis を安全に復帰します。engine handoff 成功後のみ post-game review を開始します。
+- 最後に正常起動した AI 陪練設定を記憶し、toolbar button の幅を固定しました。奇数/偶数手終了と Zhizi 復帰も回帰テスト済みです。
+- TensorRT 対応判定を active backend ではなく NVIDIA hardware に分離しました。DirectML/OpenCL 使用中でも正しい修復画面へ進めます。
+- auto analysis を手動停止すると「停止」と表示して現在結果を保存し、batch の次の棋譜を勝手に開始しません。
+- engine/UI が部分初期化状態でも、menu、status layout、shutdown cleanup が例外を出さないようにしました。
+- local/hosted CI は同じ preflight を使用し、log rollover と crash persistence は実際の非同期完了を待ちます。
+- PR #392 で TensorRT 修復を改善した @qiyi71w に感謝します。
+
+### ダウンロード前に
+
+- next-2026-08-30.1 の Windows 完全版を利用中なら、windows64.core-update.zip で app のみ更新できます。
+- 新規ユーザーは hardware に合う完全版を選んでください。KataGo v1.18.1 と B11 を同梱します。B11 は一手の判断が強い一方で遅いため、速度優先なら Auto Setup で B10 を選べます。
+- RTX 20/30/40/50 は統一 windows64.nvidia CUDA package を使用します。TensorRT は RTX 30 系以前の optional 選択です。
+- pre-release のため、上書き前に user-data、weight、棋譜を backup してください。
+- この PC にない RTX 50、ROCm、Intel NPU、macOS hardware を実機検証済みとは表記していません。
+
+### ダウンロード案内
+
+| お使いの環境 | ダウンロードするファイル |
+| --- | --- |
+| Windows x64、RTX 20/30/40/50 NVIDIA CUDA 推奨 portable | [2026-08-31-windows64.nvidia.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.1/2026-08-31-windows64.nvidia.portable.zip) |
+| 既存 Windows portable、app のみ更新 | [2026-08-31-windows64.core-update.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.1/2026-08-31-windows64.core-update.zip) |
+| Windows x64、RTX 20/30/40/50 NVIDIA CUDA installer | [2026-08-31-windows64.nvidia.installer.exe](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.1/2026-08-31-windows64.nvidia.installer.exe) |
+| Windows x64、AMD / Intel / 旧 NVIDIA OpenCL portable | [2026-08-31-windows64.opencl.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.1/2026-08-31-windows64.opencl.portable.zip) |
+| Windows x64、AMD / Intel / 旧 NVIDIA OpenCL installer | [2026-08-31-windows64.opencl.installer.exe](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.1/2026-08-31-windows64.opencl.installer.exe) |
+| Windows x64、CPU 互換 portable | [2026-08-31-windows64.with-katago.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.1/2026-08-31-windows64.with-katago.portable.zip) |
+| Windows x64、CPU 互換 installer | [2026-08-31-windows64.with-katago.installer.exe](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.1/2026-08-31-windows64.with-katago.installer.exe) |
+| Windows DirectML experimental | [2026-08-31-windows64.experimental.directml.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.1/2026-08-31-windows64.experimental.directml.portable.zip) |
+| Windows Intel OpenVINO experimental | [2026-08-31-windows64.experimental.openvino.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.1/2026-08-31-windows64.experimental.openvino.portable.zip) |
+| Windows AMD RX 6000 ROCm experimental | [2026-08-31-windows64.experimental.rocm.gfx103x.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.1/2026-08-31-windows64.experimental.rocm.gfx103x.portable.zip) |
+| Windows AMD RX 7000 ROCm experimental | [2026-08-31-windows64.experimental.rocm.gfx110x.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.1/2026-08-31-windows64.experimental.rocm.gfx110x.portable.zip) |
+| Windows AMD Ryzen AI Max ROCm experimental | [2026-08-31-windows64.experimental.rocm.gfx1151.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.1/2026-08-31-windows64.experimental.rocm.gfx1151.portable.zip) |
+| Windows AMD RX 9000 ROCm experimental | [2026-08-31-windows64.experimental.rocm.gfx120x.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.1/2026-08-31-windows64.experimental.rocm.gfx120x.portable.zip) |
+| RTX 30 系以前の optional TensorRT、両 part が必要 | [2026-08-31-windows64.nvidia.tensorrt.portable.7z.001](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.1/2026-08-31-windows64.nvidia.tensorrt.portable.7z.001)<br>[2026-08-31-windows64.nvidia.tensorrt.portable.7z.002](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.1/2026-08-31-windows64.nvidia.tensorrt.portable.7z.002) |
+| Windows x64、独自 engine、portable | [2026-08-31-windows64.without.engine.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.1/2026-08-31-windows64.without.engine.portable.zip) |
+| Windows x64、独自 engine、installer | [2026-08-31-windows64.without.engine.installer.exe](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.1/2026-08-31-windows64.without.engine.installer.exe) |
+| macOS Apple Silicon、Metal | [2026-08-31-mac-apple-silicon.with-katago.dmg](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.1/2026-08-31-mac-apple-silicon.with-katago.dmg) |
+| macOS Intel | [2026-08-31-mac-intel.with-katago.dmg](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.1/2026-08-31-mac-intel.with-katago.dmg) |
+| Linux x64、CPU 互換 | [2026-08-31-linux64.with-katago.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.1/2026-08-31-linux64.with-katago.zip) |
+| Linux x64、OpenCL | [2026-08-31-linux64.opencl.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.1/2026-08-31-linux64.opencl.zip) |
+| Linux x64、NVIDIA CUDA | [2026-08-31-linux64.nvidia.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.1/2026-08-31-linux64.nvidia.zip) |
+
+### 検証
+
+- Windows 11 23H2 / RTX 3070 / NVIDIA portable で bundled Java、B11 CUDA、主要な analysis、AI 陪練、engine repair、Alt+O、Yike を可視 UI で確認しました。
+- 6 言語、100% / 150% / 200% scaling、keyboard、Windows Narrator を確認しました。
+- local All preflight は 28/28、JUnit 3678、failure 0、error 0、skip 16。GitHub Linux/Windows gate も成功しました。
+- 4 platform workflow、sign/notarization、asset topology、SHA、provenance が成功するまで公開しません。
+
+### 連絡先
+
+- QQ group: 299419120
+
+---
+
+## 한국어
+
+next-2026-08-30.1 기반 안정성 pre-release입니다. AI 코치 종료 후 분석 복구, TensorRT 복구 진입, 자동 분석 중지 상태, Windows 초기 시작/종료 UI 수명 주기를 개선했습니다.
+
+### 주요 업데이트
+
+- AI 코치 종료 후 local 또는 Zhizi Cloud foreground analysis를 안전하게 복구합니다. engine handoff 성공 후에만 post-game review를 시작합니다.
+- 실제로 시작에 성공한 마지막 AI 코치 설정을 기억하고 toolbar button 크기를 고정했습니다. 홀수/짝수 수순 종료와 Zhizi 복구도 회귀 테스트했습니다.
+- TensorRT 자격 판정을 active DirectML/OpenCL backend가 아닌 NVIDIA hardware 기준으로 분리했습니다. 설치, 교체, rollback은 transactional하게 처리됩니다.
+- 자동 분석을 수동 중지하면 완료가 아니라 중지로 표시하고 현재 결과를 저장하며, batch의 다음 기보를 임의로 시작하지 않습니다.
+- engine/UI가 부분 초기화된 상태에서도 menu, status layout, shutdown cleanup이 예외 없이 동작합니다.
+- local과 GitHub CI가 동일한 preflight를 사용하며 log rollover와 crash persistence는 실제 비동기 완료를 기다립니다.
+- PR #392에서 TensorRT 복구를 개선한 @qiyi71w 님께 감사드립니다.
+
+### 다운로드 전 확인
+
+- next-2026-08-30.1 Windows full bundle 사용자는 windows64.core-update.zip으로 app만 업데이트할 수 있습니다.
+- 새 설치는 hardware에 맞는 full bundle을 사용하세요. KataGo v1.18.1과 B11이 기본 포함됩니다. B11은 한 번의 판단이 더 강하지만 느릴 수 있어 속도 우선이면 Auto Setup에서 B10을 선택할 수 있습니다.
+- RTX 20/30/40/50은 통합 windows64.nvidia CUDA package를 사용합니다. TensorRT는 RTX 30 series 이하의 optional 선택입니다.
+- pre-release이므로 덮어쓰기 전 user-data, weight, 기보를 backup하세요.
+- 이 PC에 없는 RTX 50, ROCm, Intel NPU, macOS hardware를 실기기 검증 완료로 표시하지 않습니다.
+
+### 다운로드 안내
+
+| 내 컴퓨터 | 다운로드할 파일 |
+| --- | --- |
+| Windows x64, RTX 20/30/40/50 NVIDIA CUDA 권장 portable | [2026-08-31-windows64.nvidia.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.1/2026-08-31-windows64.nvidia.portable.zip) |
+| 기존 Windows portable, app-only update | [2026-08-31-windows64.core-update.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.1/2026-08-31-windows64.core-update.zip) |
+| Windows x64, RTX 20/30/40/50 NVIDIA CUDA installer | [2026-08-31-windows64.nvidia.installer.exe](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.1/2026-08-31-windows64.nvidia.installer.exe) |
+| Windows x64, AMD / Intel / 구형 NVIDIA OpenCL portable | [2026-08-31-windows64.opencl.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.1/2026-08-31-windows64.opencl.portable.zip) |
+| Windows x64, AMD / Intel / 구형 NVIDIA OpenCL installer | [2026-08-31-windows64.opencl.installer.exe](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.1/2026-08-31-windows64.opencl.installer.exe) |
+| Windows x64, CPU compatibility portable | [2026-08-31-windows64.with-katago.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.1/2026-08-31-windows64.with-katago.portable.zip) |
+| Windows x64, CPU compatibility installer | [2026-08-31-windows64.with-katago.installer.exe](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.1/2026-08-31-windows64.with-katago.installer.exe) |
+| Windows DirectML experimental | [2026-08-31-windows64.experimental.directml.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.1/2026-08-31-windows64.experimental.directml.portable.zip) |
+| Windows Intel OpenVINO experimental | [2026-08-31-windows64.experimental.openvino.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.1/2026-08-31-windows64.experimental.openvino.portable.zip) |
+| Windows AMD RX 6000 ROCm experimental | [2026-08-31-windows64.experimental.rocm.gfx103x.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.1/2026-08-31-windows64.experimental.rocm.gfx103x.portable.zip) |
+| Windows AMD RX 7000 ROCm experimental | [2026-08-31-windows64.experimental.rocm.gfx110x.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.1/2026-08-31-windows64.experimental.rocm.gfx110x.portable.zip) |
+| Windows AMD Ryzen AI Max ROCm experimental | [2026-08-31-windows64.experimental.rocm.gfx1151.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.1/2026-08-31-windows64.experimental.rocm.gfx1151.portable.zip) |
+| Windows AMD RX 9000 ROCm experimental | [2026-08-31-windows64.experimental.rocm.gfx120x.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.1/2026-08-31-windows64.experimental.rocm.gfx120x.portable.zip) |
+| RTX 30 series 이하 optional TensorRT, 두 part 모두 필요 | [2026-08-31-windows64.nvidia.tensorrt.portable.7z.001](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.1/2026-08-31-windows64.nvidia.tensorrt.portable.7z.001)<br>[2026-08-31-windows64.nvidia.tensorrt.portable.7z.002](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.1/2026-08-31-windows64.nvidia.tensorrt.portable.7z.002) |
+| Windows x64, 사용자 engine, portable | [2026-08-31-windows64.without.engine.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.1/2026-08-31-windows64.without.engine.portable.zip) |
+| Windows x64, 사용자 engine, installer | [2026-08-31-windows64.without.engine.installer.exe](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.1/2026-08-31-windows64.without.engine.installer.exe) |
+| macOS Apple Silicon, Metal | [2026-08-31-mac-apple-silicon.with-katago.dmg](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.1/2026-08-31-mac-apple-silicon.with-katago.dmg) |
+| macOS Intel | [2026-08-31-mac-intel.with-katago.dmg](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.1/2026-08-31-mac-intel.with-katago.dmg) |
+| Linux x64, CPU compatibility | [2026-08-31-linux64.with-katago.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.1/2026-08-31-linux64.with-katago.zip) |
+| Linux x64, OpenCL | [2026-08-31-linux64.opencl.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.1/2026-08-31-linux64.opencl.zip) |
+| Linux x64, NVIDIA CUDA | [2026-08-31-linux64.nvidia.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.1/2026-08-31-linux64.nvidia.zip) |
+
+### 검증
+
+- Windows 11 23H2 / RTX 3070 / NVIDIA portable에서 bundled Java, B11 CUDA, 주요 분석, AI 코치, engine repair, Alt+O, Yike를 실제 UI로 확인했습니다.
+- 6개 언어, 100% / 150% / 200% scaling, keyboard, Windows Narrator를 확인했습니다.
+- local All preflight 28/28, JUnit 3678, failure 0, error 0, skip 16이며 GitHub Linux/Windows gate도 통과했습니다.
+- 4개 platform workflow, signing/notarization, asset topology, SHA, provenance가 모두 성공해야 공개됩니다.
+
+### 연락처
+
+- QQ 그룹: 299419120
+
+---
+
+## ภาษาไทย
+
+pre-release นี้ต่อยอดจาก next-2026-08-30.1 โดยเน้นการคืน analysis หลังจบ AI Coach, การซ่อม TensorRT ที่เข้าถึงได้ถูกต้อง, สถานะหยุด auto-analysis และความปลอดภัยของ UI lifecycle ตอนเปิด/ปิดบน Windows
+
+### ไฮไลต์ของเวอร์ชันนี้
+
+- หลังจบ AI Coach ระบบคืน foreground analysis ของ local หรือ Zhizi Cloud อย่างปลอดภัย และเริ่ม post-game review เฉพาะเมื่อ engine handoff สำเร็จ
+- จำค่าล่าสุดที่เริ่ม AI Coach สำเร็จจริง ขนาดปุ่ม toolbar ไม่ขยายซ้ำ และมี regression test สำหรับจบเกมจำนวนตาคี่/คู่กับ Zhizi recovery
+- ตรวจสิทธิ์ TensorRT จาก NVIDIA hardware ไม่ใช่ active DirectML/OpenCL backend; การติดตั้ง แทนที่ และ rollback เป็นแบบ transactional
+- เมื่อหยุด auto-analysis ด้วยตนเอง จะแสดง Stopped และบันทึกผลปัจจุบัน ไม่รายงาน Completed และไม่เริ่ม kifu ถัดไปเอง
+- menu, engine status layout และ shutdown cleanup รองรับช่วงที่ UI/engine ยัง initialize ไม่ครบโดยไม่เกิด null error
+- local และ hosted CI ใช้ preflight ชุดเดียวกัน ส่วน log rollover และ crash persistence รอ async completion จริง
+- ขอบคุณ @qiyi71w สำหรับการปรับปรุง TensorRT repair ใน PR #392
+
+### ก่อนดาวน์โหลด
+
+- ผู้ใช้ Windows full bundle next-2026-08-30.1 ใช้ windows64.core-update.zip เพื่ออัปเดตเฉพาะ app ได้ โดยไม่แทน weight, engine, TensorRT หรือ user-data
+- การติดตั้งใหม่ให้เลือก full bundle ตาม hardware ซึ่งยังมี KataGo v1.18.1 และ B11 เป็นค่าเริ่มต้น B11 ตัดสินต่อครั้งได้แข็งแรงกว่าแต่ช้ากว่า หากเน้นความเร็วเลือก B10 ใน Auto Setup
+- RTX 20/30/40/50 ใช้ windows64.nvidia CUDA package เดียวกัน TensorRT เป็นตัวเลือกสำหรับ RTX 30 series และรุ่นก่อนหน้า
+- นี่คือ pre-release ควร backup user-data, weight และ game records ก่อนเขียนทับ
+- ไม่อ้างว่า RTX 50, ROCm, Intel NPU หรือ macOS hardware ที่ไม่มีในเครื่องทดสอบผ่านการทดสอบจริง
+
+### คำแนะนำดาวน์โหลด
+
+| คอมพิวเตอร์ของคุณ | ดาวน์โหลดไฟล์นี้ |
+| --- | --- |
+| Windows x64, RTX 20/30/40/50 NVIDIA CUDA portable ที่แนะนำ | [2026-08-31-windows64.nvidia.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.1/2026-08-31-windows64.nvidia.portable.zip) |
+| Windows portable เดิม, อัปเดตเฉพาะ app | [2026-08-31-windows64.core-update.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.1/2026-08-31-windows64.core-update.zip) |
+| Windows x64, RTX 20/30/40/50 NVIDIA CUDA installer | [2026-08-31-windows64.nvidia.installer.exe](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.1/2026-08-31-windows64.nvidia.installer.exe) |
+| Windows x64, OpenCL portable สำหรับ AMD / Intel / NVIDIA รุ่นเก่า | [2026-08-31-windows64.opencl.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.1/2026-08-31-windows64.opencl.portable.zip) |
+| Windows x64, OpenCL installer สำหรับ AMD / Intel / NVIDIA รุ่นเก่า | [2026-08-31-windows64.opencl.installer.exe](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.1/2026-08-31-windows64.opencl.installer.exe) |
+| Windows x64, CPU compatibility portable | [2026-08-31-windows64.with-katago.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.1/2026-08-31-windows64.with-katago.portable.zip) |
+| Windows x64, CPU compatibility installer | [2026-08-31-windows64.with-katago.installer.exe](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.1/2026-08-31-windows64.with-katago.installer.exe) |
+| Windows DirectML experimental | [2026-08-31-windows64.experimental.directml.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.1/2026-08-31-windows64.experimental.directml.portable.zip) |
+| Windows Intel OpenVINO experimental | [2026-08-31-windows64.experimental.openvino.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.1/2026-08-31-windows64.experimental.openvino.portable.zip) |
+| Windows AMD RX 6000 ROCm experimental | [2026-08-31-windows64.experimental.rocm.gfx103x.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.1/2026-08-31-windows64.experimental.rocm.gfx103x.portable.zip) |
+| Windows AMD RX 7000 ROCm experimental | [2026-08-31-windows64.experimental.rocm.gfx110x.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.1/2026-08-31-windows64.experimental.rocm.gfx110x.portable.zip) |
+| Windows AMD Ryzen AI Max ROCm experimental | [2026-08-31-windows64.experimental.rocm.gfx1151.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.1/2026-08-31-windows64.experimental.rocm.gfx1151.portable.zip) |
+| Windows AMD RX 9000 ROCm experimental | [2026-08-31-windows64.experimental.rocm.gfx120x.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.1/2026-08-31-windows64.experimental.rocm.gfx120x.portable.zip) |
+| TensorRT สำหรับ RTX 30 และรุ่นก่อนหน้า ต้องโหลดทั้งสอง part | [2026-08-31-windows64.nvidia.tensorrt.portable.7z.001](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.1/2026-08-31-windows64.nvidia.tensorrt.portable.7z.001)<br>[2026-08-31-windows64.nvidia.tensorrt.portable.7z.002](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.1/2026-08-31-windows64.nvidia.tensorrt.portable.7z.002) |
+| Windows x64, ใช้ engine ของคุณเอง, portable | [2026-08-31-windows64.without.engine.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.1/2026-08-31-windows64.without.engine.portable.zip) |
+| Windows x64, ใช้ engine ของคุณเอง, installer | [2026-08-31-windows64.without.engine.installer.exe](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.1/2026-08-31-windows64.without.engine.installer.exe) |
+| macOS Apple Silicon, Metal | [2026-08-31-mac-apple-silicon.with-katago.dmg](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.1/2026-08-31-mac-apple-silicon.with-katago.dmg) |
+| macOS Intel | [2026-08-31-mac-intel.with-katago.dmg](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.1/2026-08-31-mac-intel.with-katago.dmg) |
+| Linux x64, CPU compatibility | [2026-08-31-linux64.with-katago.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.1/2026-08-31-linux64.with-katago.zip) |
+| Linux x64, OpenCL | [2026-08-31-linux64.opencl.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.1/2026-08-31-linux64.opencl.zip) |
+| Linux x64, NVIDIA CUDA | [2026-08-31-linux64.nvidia.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.1/2026-08-31-linux64.nvidia.zip) |
+
+### ผลการตรวจสอบ
+
+- ทดสอบ UI จริงบน Windows 11 23H2 / RTX 3070 / NVIDIA portable ครอบคลุม bundled Java, B11 CUDA, analysis, AI Coach, engine repair, Alt+O และ Yike
+- ตรวจ 6 ภาษา, scaling 100% / 150% / 200%, keyboard และ Windows Narrator
+- local All preflight ผ่าน 28/28; JUnit 3678, failure 0, error 0, skipped 16 และ GitHub Linux/Windows gate ผ่าน
+- จะเปิด pre-release เมื่อ workflow ทั้ง 4 platform, signing/notarization, asset topology, SHA และ provenance ผ่านทั้งหมดเท่านั้น
+
+### ติดต่อ
+
+- QQ group: 299419120

--- a/.github/release-requests/next-2026-08-31.1.json
+++ b/.github/release-requests/next-2026-08-31.1.json
@@ -1,0 +1,7 @@
+{
+  "date_tag": "2026-08-31",
+  "release_tag": "next-2026-08-31.1",
+  "title": "LizzieYzy Next next-2026-08-31.1",
+  "prerelease": true,
+  "notes_file": ".github/release-notes/next-2026-08-31.1.md"
+}


### PR DESCRIPTION
## Summary

- add the reviewed six-language notes for `next-2026-08-31.1`
- add the fail-closed pre-release request targeting the exact post-#397 main tree
- cover only changes since `next-2026-08-30.1`: AI Coach restoration/settings, transactional TensorRT repair, truthful auto-analysis stop state, startup/shutdown lifecycle hardening, and shared local/hosted CI

## Validation

- release-notes fail-closed validator: passed
- release metadata/publisher suite: 137 tests, 0 failures, 2 platform-condition skips
- line-ending policy: passed
- local Markdown links: passed
- JSON parse: passed
- `git diff --check`: passed
- source candidate acceptance before this request: local All preflight 28/28; JUnit 3678, 0 failures, 0 errors, 16 skipped; GitHub Linux and Windows PR gates passed
- Windows 11 23H2 / RTX 3070 visible EXE acceptance completed with NVIDIA portable, B11 CUDA, six languages, 100%/150%/200% scaling, keyboard, and Narrator

Merging this PR intentionally triggers the repository's fail-closed publisher. The release must remain draft until Windows, Linux, macOS Intel, and macOS Apple Silicon workflows, signing/notarization, asset topology, SHA, and provenance checks all succeed.