### PR TITLE
release: request next-2026-08-31.2 pre-release

### DIFF
--- a/.github/release-notes/next-2026-08-31.2.md
+++ b/.github/release-notes/next-2026-08-31.2.md
@@ -1,0 +1,359 @@
+# LizzieYzy Next next-2026-08-31.2
+
+## 中文
+
+这是基于 next-2026-08-31.1 的界面体验预发布版，重点重做 AI 解说工作区，让解说、范围选择、状态反馈和追问更清楚、更稳定，也更适合 Windows 高缩放与键盘操作。
+
+### 本版主要更新
+
+- AI 解说采用新的三段式工作区：左侧紧凑切换“下一手 / 区间 / 整局”，中间专注阅读，底部集中显示状态、模型和追问。
+- 当前手数、区间选择和停止操作始终位于解说区顶部；最小窗口下仍保留主要操作，长内容只在阅读区内部滚动。
+- 空白、准备中、流式输出、完成、警告、失败和 SGF 历史解说都有明确状态，不再出现大片无意义空白或旧内容残留。
+- 模式、设置、停止、范围、追问、进度和状态补齐键盘焦点与读屏语义；错误和选中状态不再只依赖颜色。
+- 六种界面语言及繁中地区资源同步更新，100% / 150% / 200% Windows 缩放均完成真实 EXE 可见界面验收。
+- 本版包含 next-2026-08-31.1 的全部稳定性修复；AI 解说的现有证据约束、流式请求和写入 SGF 行为保持不变。
+
+### 下载前先看
+
+- 已安装 next-2026-08-31.1 完整 Windows 包的用户，可用 windows64.core-update.zip 只更新程序；现有权重、引擎、TensorRT 和 user-data 不会被替换。
+- 新安装用户请下载与硬件匹配的完整包；仍内置 KataGo v1.18.1 和默认 B11。B11 单次判断更强但搜索较慢，追求速度可在“一键设置 → 权重”明确切换 B10。
+- RTX 20/30/40/50 继续统一使用 windows64.nvidia CUDA 包；TensorRT 是 RTX 30 系及以下的可选方案。
+- 这是预发布版，覆盖旧目录前建议备份 user-data、权重和棋谱。
+- DirectML、OpenVINO、ROCm、RTX 50 和 macOS 对应硬件未在本机冒充真机通过，欢迎对应设备用户反馈。
+
+### 下载建议
+
+| 你的电脑 | 直接下载这个 |
+| --- | --- |
+| Windows 64 位，RTX 20/30/40/50 NVIDIA CUDA 推荐版，免安装 | [2026-08-31-windows64.nvidia.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.2/2026-08-31-windows64.nvidia.portable.zip) |
+| 已有 Windows 免安装版，只更新主程序 | [2026-08-31-windows64.core-update.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.2/2026-08-31-windows64.core-update.zip) |
+| Windows 64 位，RTX 20/30/40/50 NVIDIA CUDA 推荐安装版 | [2026-08-31-windows64.nvidia.installer.exe](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.2/2026-08-31-windows64.nvidia.installer.exe) |
+| Windows 64 位，AMD / Intel / 旧 NVIDIA OpenCL 兼容版，免安装 | [2026-08-31-windows64.opencl.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.2/2026-08-31-windows64.opencl.portable.zip) |
+| Windows 64 位，AMD / Intel / 旧 NVIDIA OpenCL 兼容安装版 | [2026-08-31-windows64.opencl.installer.exe](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.2/2026-08-31-windows64.opencl.installer.exe) |
+| Windows 64 位，CPU 兼容版，免安装 | [2026-08-31-windows64.with-katago.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.2/2026-08-31-windows64.with-katago.portable.zip) |
+| Windows 64 位，CPU 兼容安装版 | [2026-08-31-windows64.with-katago.installer.exe](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.2/2026-08-31-windows64.with-katago.installer.exe) |
+| Windows DirectML 实验版 | [2026-08-31-windows64.experimental.directml.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.2/2026-08-31-windows64.experimental.directml.portable.zip) |
+| Windows Intel OpenVINO 实验版 | [2026-08-31-windows64.experimental.openvino.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.2/2026-08-31-windows64.experimental.openvino.portable.zip) |
+| Windows AMD RX 6000 ROCm 实验版 | [2026-08-31-windows64.experimental.rocm.gfx103x.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.2/2026-08-31-windows64.experimental.rocm.gfx103x.portable.zip) |
+| Windows AMD RX 7000 ROCm 实验版 | [2026-08-31-windows64.experimental.rocm.gfx110x.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.2/2026-08-31-windows64.experimental.rocm.gfx110x.portable.zip) |
+| Windows AMD Ryzen AI Max ROCm 实验版 | [2026-08-31-windows64.experimental.rocm.gfx1151.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.2/2026-08-31-windows64.experimental.rocm.gfx1151.portable.zip) |
+| Windows AMD RX 9000 ROCm 实验版 | [2026-08-31-windows64.experimental.rocm.gfx120x.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.2/2026-08-31-windows64.experimental.rocm.gfx120x.portable.zip) |
+| RTX 30 系及以下可选 TensorRT，需下载两个分卷 | [2026-08-31-windows64.nvidia.tensorrt.portable.7z.001](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.2/2026-08-31-windows64.nvidia.tensorrt.portable.7z.001)<br>[2026-08-31-windows64.nvidia.tensorrt.portable.7z.002](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.2/2026-08-31-windows64.nvidia.tensorrt.portable.7z.002) |
+| Windows 64 位，自行配置引擎，免安装 | [2026-08-31-windows64.without.engine.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.2/2026-08-31-windows64.without.engine.portable.zip) |
+| Windows 64 位，自行配置引擎，安装版 | [2026-08-31-windows64.without.engine.installer.exe](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.2/2026-08-31-windows64.without.engine.installer.exe) |
+| macOS Apple Silicon，Metal | [2026-08-31-mac-apple-silicon.with-katago.dmg](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.2/2026-08-31-mac-apple-silicon.with-katago.dmg) |
+| macOS Intel | [2026-08-31-mac-intel.with-katago.dmg](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.2/2026-08-31-mac-intel.with-katago.dmg) |
+| Linux 64 位，CPU 兼容版 | [2026-08-31-linux64.with-katago.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.2/2026-08-31-linux64.with-katago.zip) |
+| Linux 64 位，OpenCL 版 | [2026-08-31-linux64.opencl.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.2/2026-08-31-linux64.opencl.zip) |
+| Linux 64 位，NVIDIA CUDA 版 | [2026-08-31-linux64.nvidia.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.2/2026-08-31-linux64.nvidia.zip) |
+
+### 验证结果
+
+- Windows 11 23H2、RTX 3070、NVIDIA portable 真机打开 AI 解说，完成空白状态、SGF 历史解说、最小窗口和内部滚动验收。
+- 100% / 150% / 200% 缩放及 760×540 逻辑最小尺寸无裁切、遮挡或外部异常滚动条；Tab、Shift+Tab、Space 和 Esc 均完成真实操作。
+- 聚焦测试 9 项全部通过；完整 JUnit 3681 项，0 failures、0 errors、18 skipped；Maven package、Windows launcher guard、GitHub build 与 Windows script validation 均通过。
+- 发布器只有在四个平台工作流、签名/公证、资产拓扑、SHA 与来源证明全部成功后才公开本预发布版。
+
+### 交流
+
+- QQ 群：299419120
+
+---
+
+## 繁體中文
+
+這是基於 next-2026-08-31.1 的介面體驗預發布版，重點重做 AI 解說工作區，讓解說、範圍選擇、狀態回饋與追問更清楚、更穩定，也更適合 Windows 高縮放與鍵盤操作。
+
+### 本版主要更新
+
+- AI 解說採用新的三區工作區：左側緊湊切換「下一手 / 區間 / 整局」，中央專注閱讀，底部集中顯示狀態、模型與追問。
+- 目前手數、區間選擇和停止操作固定在解說區頂部；最小視窗仍保留主要操作，長內容只在閱讀區內捲動。
+- 空白、準備中、串流輸出、完成、警告、失敗與 SGF 歷史解說都有明確狀態，不再殘留舊內容或大片無意義空白。
+- 模式、設定、停止、範圍、追問、進度與狀態補齊鍵盤焦點和讀屏語意；錯誤與選取狀態不再只靠顏色。
+- 六種介面語言與繁中地區資源同步更新，100% / 150% / 200% Windows 縮放均完成真實 EXE 可見介面驗收。
+- 本版包含 next-2026-08-31.1 的全部穩定性修正；AI 解說既有的證據約束、串流請求與寫入 SGF 行為保持不變。
+
+### 下載前先看
+
+- 已安裝 next-2026-08-31.1 完整 Windows 套件的使用者，可用 windows64.core-update.zip 只更新程式，不替換 weight、engine、TensorRT 或 user-data。
+- 新安裝請下載符合硬體的完整套件；仍內建 KataGo v1.18.1 與預設 B11。B11 單次判斷更強但搜尋較慢，重視速度可切換 B10。
+- RTX 20/30/40/50 繼續統一使用 windows64.nvidia CUDA 套件；TensorRT 是 RTX 30 系及以下的可選方案。
+- 這是預發布版，覆蓋舊目錄前建議備份 user-data、weight 與棋譜。
+- DirectML、OpenVINO、ROCm、RTX 50 與 macOS 對應硬體未在本機宣稱真機通過。
+
+### 下載建議
+
+| 你的電腦 | 直接下載這個 |
+| --- | --- |
+| Windows 64 位，RTX 20/30/40/50 NVIDIA CUDA 建議版，免安裝 | [2026-08-31-windows64.nvidia.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.2/2026-08-31-windows64.nvidia.portable.zip) |
+| 既有 Windows 免安裝版，只更新主程式 | [2026-08-31-windows64.core-update.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.2/2026-08-31-windows64.core-update.zip) |
+| Windows 64 位，RTX 20/30/40/50 NVIDIA CUDA 建議安裝版 | [2026-08-31-windows64.nvidia.installer.exe](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.2/2026-08-31-windows64.nvidia.installer.exe) |
+| Windows 64 位，AMD / Intel / 舊 NVIDIA OpenCL 相容版，免安裝 | [2026-08-31-windows64.opencl.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.2/2026-08-31-windows64.opencl.portable.zip) |
+| Windows 64 位，AMD / Intel / 舊 NVIDIA OpenCL 相容安裝版 | [2026-08-31-windows64.opencl.installer.exe](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.2/2026-08-31-windows64.opencl.installer.exe) |
+| Windows 64 位，CPU 相容版，免安裝 | [2026-08-31-windows64.with-katago.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.2/2026-08-31-windows64.with-katago.portable.zip) |
+| Windows 64 位，CPU 相容安裝版 | [2026-08-31-windows64.with-katago.installer.exe](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.2/2026-08-31-windows64.with-katago.installer.exe) |
+| Windows DirectML 實驗版 | [2026-08-31-windows64.experimental.directml.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.2/2026-08-31-windows64.experimental.directml.portable.zip) |
+| Windows Intel OpenVINO 實驗版 | [2026-08-31-windows64.experimental.openvino.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.2/2026-08-31-windows64.experimental.openvino.portable.zip) |
+| Windows AMD RX 6000 ROCm 實驗版 | [2026-08-31-windows64.experimental.rocm.gfx103x.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.2/2026-08-31-windows64.experimental.rocm.gfx103x.portable.zip) |
+| Windows AMD RX 7000 ROCm 實驗版 | [2026-08-31-windows64.experimental.rocm.gfx110x.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.2/2026-08-31-windows64.experimental.rocm.gfx110x.portable.zip) |
+| Windows AMD Ryzen AI Max ROCm 實驗版 | [2026-08-31-windows64.experimental.rocm.gfx1151.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.2/2026-08-31-windows64.experimental.rocm.gfx1151.portable.zip) |
+| Windows AMD RX 9000 ROCm 實驗版 | [2026-08-31-windows64.experimental.rocm.gfx120x.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.2/2026-08-31-windows64.experimental.rocm.gfx120x.portable.zip) |
+| RTX 30 系及以下可選 TensorRT，需下載兩個分卷 | [2026-08-31-windows64.nvidia.tensorrt.portable.7z.001](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.2/2026-08-31-windows64.nvidia.tensorrt.portable.7z.001)<br>[2026-08-31-windows64.nvidia.tensorrt.portable.7z.002](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.2/2026-08-31-windows64.nvidia.tensorrt.portable.7z.002) |
+| Windows 64 位，自行設定 engine，免安裝 | [2026-08-31-windows64.without.engine.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.2/2026-08-31-windows64.without.engine.portable.zip) |
+| Windows 64 位，自行設定 engine，安裝版 | [2026-08-31-windows64.without.engine.installer.exe](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.2/2026-08-31-windows64.without.engine.installer.exe) |
+| macOS Apple Silicon，Metal | [2026-08-31-mac-apple-silicon.with-katago.dmg](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.2/2026-08-31-mac-apple-silicon.with-katago.dmg) |
+| macOS Intel | [2026-08-31-mac-intel.with-katago.dmg](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.2/2026-08-31-mac-intel.with-katago.dmg) |
+| Linux 64 位，CPU 相容版 | [2026-08-31-linux64.with-katago.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.2/2026-08-31-linux64.with-katago.zip) |
+| Linux 64 位，OpenCL 版 | [2026-08-31-linux64.opencl.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.2/2026-08-31-linux64.opencl.zip) |
+| Linux 64 位，NVIDIA CUDA 版 | [2026-08-31-linux64.nvidia.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.2/2026-08-31-linux64.nvidia.zip) |
+
+### 驗證結果
+
+- Windows 11 23H2、RTX 3070、NVIDIA portable 真機開啟 AI 解說，完成空白狀態、SGF 歷史解說、最小視窗和內部捲動驗收。
+- 100% / 150% / 200% 縮放及 760×540 邏輯最小尺寸無裁切、遮擋或異常外部捲軸；Tab、Shift+Tab、Space 與 Esc 均完成真實操作。
+- 聚焦測試 9 項全部通過；完整 JUnit 3681 項，0 failures、0 errors、18 skipped；Maven package、Windows launcher guard、GitHub build 與 Windows script validation 均通過。
+- 四平台 workflow、簽名/公證、資產拓撲、SHA 與來源證明全部成功後才會公開。
+
+### 交流
+
+- QQ 群：299419120
+
+---
+
+## English
+
+This interface-focused pre-release builds on next-2026-08-31.1. It redesigns the AI Commentary workspace so explanations, range selection, request state, and follow-up questions are clearer, more stable, and better suited to Windows scaling and keyboard use.
+
+### Release highlights
+
+- AI Commentary now uses a three-region workspace: a compact Next/Range/Whole Game mode rail, a dominant reading surface, and a focused status/model/follow-up area.
+- Current move, range selection, and Stop remain available at the top of the reader. At minimum size, primary controls stay visible while long commentary scrolls only inside the reading area.
+- Empty, preparing, streaming, complete, warning, failure, and saved-SGF states are explicit, preventing stale output and unexplained blank space.
+- Modes, settings, stop, range fields, follow-up, progress, and status expose keyboard focus and screen-reader semantics. Selection and errors no longer rely on color alone.
+- Six UI languages and Traditional Chinese regional resources were updated. The real Windows EXE was inspected at 100%, 150%, and 200% scaling.
+- This build includes every stability fix from next-2026-08-31.1. Existing evidence constraints, streaming requests, and SGF write-back behavior are unchanged.
+
+### Before downloading
+
+- Windows users with a complete next-2026-08-31.1 bundle can apply windows64.core-update.zip for the app-only update without replacing weights, engines, TensorRT, or user-data.
+- Fresh installs should use the full bundle matching the hardware. KataGo v1.18.1 and B11 remain bundled by default. B11 provides stronger individual evaluations at lower throughput; select B10 in Auto Setup when speed matters more.
+- RTX 20/30/40/50 continue to use the unified windows64.nvidia CUDA package. TensorRT is an optional path for RTX 30 series and older.
+- This is a pre-release; back up user-data, weights, and game records before overwriting an existing folder.
+- DirectML, OpenVINO, ROCm, RTX 50, and macOS hardware not present on the test machine are not claimed as hardware-tested.
+
+### Download guide
+
+| Your computer | Download this file |
+| --- | --- |
+| Windows x64, recommended RTX 20/30/40/50 NVIDIA CUDA portable | [2026-08-31-windows64.nvidia.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.2/2026-08-31-windows64.nvidia.portable.zip) |
+| Existing Windows portable, app-only update | [2026-08-31-windows64.core-update.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.2/2026-08-31-windows64.core-update.zip) |
+| Windows x64, recommended RTX 20/30/40/50 NVIDIA CUDA installer | [2026-08-31-windows64.nvidia.installer.exe](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.2/2026-08-31-windows64.nvidia.installer.exe) |
+| Windows x64, OpenCL portable for AMD / Intel / older NVIDIA | [2026-08-31-windows64.opencl.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.2/2026-08-31-windows64.opencl.portable.zip) |
+| Windows x64, OpenCL installer for AMD / Intel / older NVIDIA | [2026-08-31-windows64.opencl.installer.exe](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.2/2026-08-31-windows64.opencl.installer.exe) |
+| Windows x64, CPU compatibility portable | [2026-08-31-windows64.with-katago.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.2/2026-08-31-windows64.with-katago.portable.zip) |
+| Windows x64, CPU compatibility installer | [2026-08-31-windows64.with-katago.installer.exe](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.2/2026-08-31-windows64.with-katago.installer.exe) |
+| Windows DirectML experimental | [2026-08-31-windows64.experimental.directml.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.2/2026-08-31-windows64.experimental.directml.portable.zip) |
+| Windows Intel OpenVINO experimental | [2026-08-31-windows64.experimental.openvino.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.2/2026-08-31-windows64.experimental.openvino.portable.zip) |
+| Windows AMD RX 6000 ROCm experimental | [2026-08-31-windows64.experimental.rocm.gfx103x.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.2/2026-08-31-windows64.experimental.rocm.gfx103x.portable.zip) |
+| Windows AMD RX 7000 ROCm experimental | [2026-08-31-windows64.experimental.rocm.gfx110x.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.2/2026-08-31-windows64.experimental.rocm.gfx110x.portable.zip) |
+| Windows AMD Ryzen AI Max ROCm experimental | [2026-08-31-windows64.experimental.rocm.gfx1151.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.2/2026-08-31-windows64.experimental.rocm.gfx1151.portable.zip) |
+| Windows AMD RX 9000 ROCm experimental | [2026-08-31-windows64.experimental.rocm.gfx120x.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.2/2026-08-31-windows64.experimental.rocm.gfx120x.portable.zip) |
+| Optional TensorRT for RTX 30 series and older; download both parts | [2026-08-31-windows64.nvidia.tensorrt.portable.7z.001](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.2/2026-08-31-windows64.nvidia.tensorrt.portable.7z.001)<br>[2026-08-31-windows64.nvidia.tensorrt.portable.7z.002](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.2/2026-08-31-windows64.nvidia.tensorrt.portable.7z.002) |
+| Windows x64, bring your own engine, portable | [2026-08-31-windows64.without.engine.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.2/2026-08-31-windows64.without.engine.portable.zip) |
+| Windows x64, bring your own engine, installer | [2026-08-31-windows64.without.engine.installer.exe](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.2/2026-08-31-windows64.without.engine.installer.exe) |
+| macOS Apple Silicon, Metal | [2026-08-31-mac-apple-silicon.with-katago.dmg](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.2/2026-08-31-mac-apple-silicon.with-katago.dmg) |
+| macOS Intel | [2026-08-31-mac-intel.with-katago.dmg](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.2/2026-08-31-mac-intel.with-katago.dmg) |
+| Linux x64, CPU compatibility | [2026-08-31-linux64.with-katago.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.2/2026-08-31-linux64.with-katago.zip) |
+| Linux x64, OpenCL | [2026-08-31-linux64.opencl.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.2/2026-08-31-linux64.opencl.zip) |
+| Linux x64, NVIDIA CUDA | [2026-08-31-linux64.nvidia.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.2/2026-08-31-linux64.nvidia.zip) |
+
+### Verification
+
+- Visible acceptance used Windows 11 23H2, RTX 3070, and the NVIDIA portable EXE to inspect empty commentary, saved SGF commentary, minimum-window layout, and internal scrolling.
+- The 100% / 150% / 200% scales and the 760×540 logical minimum had no clipped or overlapping controls; Tab, Shift+Tab, Space, and Escape were exercised in the running app.
+- Nine focused tests passed. The full suite ran 3,681 JUnit tests with 0 failures, 0 errors, and 18 skipped; Maven package, Windows launcher guards, GitHub build, and Windows script validation passed.
+- The release remains fail-closed until all four platform workflows, signing/notarization, topology, SHA, and provenance checks succeed.
+
+### Contact
+
+- QQ group: 299419120
+
+---
+
+## 日本語
+
+next-2026-08-31.1 を基にした UI 改善 pre-release です。AI 解説ワークスペースを再設計し、解説、範囲選択、request 状態、追加質問を分かりやすく安定させ、Windows の高 scaling と keyboard 操作にも対応しました。
+
+### 主な更新
+
+- AI 解説は 3 領域構成になりました。左の compact rail で「次の一手 / 範囲 / 全局」を切り替え、中央で解説を読み、下部で status、model、追加質問を扱います。
+- 現在手数、範囲選択、停止は reader 上部に常駐します。最小 window でも主要操作を維持し、長文だけを reader 内で scroll します。
+- 空、準備中、streaming、完了、警告、失敗、保存済み SGF 解説を明確に分け、古い結果や理由の分からない空白を残しません。
+- mode、設定、停止、範囲、追加質問、progress、status に keyboard focus と screen reader 用の意味を追加し、色だけに依存しません。
+- 6 言語と繁体字地域 resource を更新し、Windows 実行版を 100% / 150% / 200% scaling で確認しました。
+- next-2026-08-31.1 の安定性修正をすべて含みます。既存の evidence 制約、streaming request、SGF 書き戻し動作は変更していません。
+
+### ダウンロード前に
+
+- next-2026-08-31.1 の Windows 完全版を利用中なら、windows64.core-update.zip で app のみ更新できます。
+- 新規ユーザーは hardware に合う完全版を選んでください。KataGo v1.18.1 と B11 を同梱します。B11 は一手の判断が強い一方で遅いため、速度優先なら Auto Setup で B10 を選べます。
+- RTX 20/30/40/50 は統一 windows64.nvidia CUDA package を使用します。TensorRT は RTX 30 系以前の optional 選択です。
+- pre-release のため、上書き前に user-data、weight、棋譜を backup してください。
+- この PC にない RTX 50、ROCm、Intel NPU、macOS hardware を実機検証済みとは表記していません。
+
+### ダウンロード案内
+
+| お使いの環境 | ダウンロードするファイル |
+| --- | --- |
+| Windows x64、RTX 20/30/40/50 NVIDIA CUDA 推奨 portable | [2026-08-31-windows64.nvidia.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.2/2026-08-31-windows64.nvidia.portable.zip) |
+| 既存 Windows portable、app のみ更新 | [2026-08-31-windows64.core-update.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.2/2026-08-31-windows64.core-update.zip) |
+| Windows x64、RTX 20/30/40/50 NVIDIA CUDA installer | [2026-08-31-windows64.nvidia.installer.exe](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.2/2026-08-31-windows64.nvidia.installer.exe) |
+| Windows x64、AMD / Intel / 旧 NVIDIA OpenCL portable | [2026-08-31-windows64.opencl.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.2/2026-08-31-windows64.opencl.portable.zip) |
+| Windows x64、AMD / Intel / 旧 NVIDIA OpenCL installer | [2026-08-31-windows64.opencl.installer.exe](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.2/2026-08-31-windows64.opencl.installer.exe) |
+| Windows x64、CPU 互換 portable | [2026-08-31-windows64.with-katago.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.2/2026-08-31-windows64.with-katago.portable.zip) |
+| Windows x64、CPU 互換 installer | [2026-08-31-windows64.with-katago.installer.exe](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.2/2026-08-31-windows64.with-katago.installer.exe) |
+| Windows DirectML experimental | [2026-08-31-windows64.experimental.directml.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.2/2026-08-31-windows64.experimental.directml.portable.zip) |
+| Windows Intel OpenVINO experimental | [2026-08-31-windows64.experimental.openvino.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.2/2026-08-31-windows64.experimental.openvino.portable.zip) |
+| Windows AMD RX 6000 ROCm experimental | [2026-08-31-windows64.experimental.rocm.gfx103x.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.2/2026-08-31-windows64.experimental.rocm.gfx103x.portable.zip) |
+| Windows AMD RX 7000 ROCm experimental | [2026-08-31-windows64.experimental.rocm.gfx110x.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.2/2026-08-31-windows64.experimental.rocm.gfx110x.portable.zip) |
+| Windows AMD Ryzen AI Max ROCm experimental | [2026-08-31-windows64.experimental.rocm.gfx1151.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.2/2026-08-31-windows64.experimental.rocm.gfx1151.portable.zip) |
+| Windows AMD RX 9000 ROCm experimental | [2026-08-31-windows64.experimental.rocm.gfx120x.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.2/2026-08-31-windows64.experimental.rocm.gfx120x.portable.zip) |
+| RTX 30 系以前の optional TensorRT、両 part が必要 | [2026-08-31-windows64.nvidia.tensorrt.portable.7z.001](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.2/2026-08-31-windows64.nvidia.tensorrt.portable.7z.001)<br>[2026-08-31-windows64.nvidia.tensorrt.portable.7z.002](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.2/2026-08-31-windows64.nvidia.tensorrt.portable.7z.002) |
+| Windows x64、独自 engine、portable | [2026-08-31-windows64.without.engine.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.2/2026-08-31-windows64.without.engine.portable.zip) |
+| Windows x64、独自 engine、installer | [2026-08-31-windows64.without.engine.installer.exe](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.2/2026-08-31-windows64.without.engine.installer.exe) |
+| macOS Apple Silicon、Metal | [2026-08-31-mac-apple-silicon.with-katago.dmg](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.2/2026-08-31-mac-apple-silicon.with-katago.dmg) |
+| macOS Intel | [2026-08-31-mac-intel.with-katago.dmg](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.2/2026-08-31-mac-intel.with-katago.dmg) |
+| Linux x64、CPU 互換 | [2026-08-31-linux64.with-katago.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.2/2026-08-31-linux64.with-katago.zip) |
+| Linux x64、OpenCL | [2026-08-31-linux64.opencl.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.2/2026-08-31-linux64.opencl.zip) |
+| Linux x64、NVIDIA CUDA | [2026-08-31-linux64.nvidia.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.2/2026-08-31-linux64.nvidia.zip) |
+
+### 検証
+
+- Windows 11 23H2 / RTX 3070 / NVIDIA portable で、空状態、保存済み SGF 解説、最小 window、reader 内 scroll を可視 UI で確認しました。
+- 100% / 150% / 200% scaling と論理 760×540 の最小サイズで clipping や overlap はなく、Tab、Shift+Tab、Space、Esc を実際に操作しました。
+- focused test 9 件が成功。全体 JUnit は 3681 件、failure 0、error 0、skip 18。Maven package、Windows launcher guard、GitHub build、Windows script validation も成功しました。
+- 4 platform workflow、sign/notarization、asset topology、SHA、provenance が成功するまで公開しません。
+
+### 連絡先
+
+- QQ group: 299419120
+
+---
+
+## 한국어
+
+next-2026-08-31.1 기반 UI 개선 pre-release입니다. AI 해설 workspace를 다시 설계하여 해설, 범위 선택, request 상태, 추가 질문을 더 명확하고 안정적으로 만들고 Windows 고배율과 keyboard 조작을 개선했습니다.
+
+### 주요 업데이트
+
+- AI 해설은 3개 영역으로 구성됩니다. 왼쪽 compact rail에서 다음 수/범위/전체 게임을 전환하고, 중앙에서 해설을 읽으며, 아래에서 status, model, 추가 질문을 다룹니다.
+- 현재 수, 범위 선택, 중지 기능은 reader 상단에 유지됩니다. 최소 window에서도 주요 조작이 보이고 긴 내용만 reader 내부에서 scroll됩니다.
+- 빈 상태, 준비 중, streaming, 완료, 경고, 실패, 저장된 SGF 해설 상태를 명확히 구분하여 이전 결과나 이유 없는 빈 공간이 남지 않습니다.
+- mode, 설정, 중지, 범위, 추가 질문, progress, status에 keyboard focus와 screen reader 의미를 추가했습니다. 선택과 오류는 색상에만 의존하지 않습니다.
+- 6개 UI 언어와 번체 중국어 지역 resource를 갱신했으며 실제 Windows EXE를 100% / 150% / 200% scaling에서 확인했습니다.
+- next-2026-08-31.1의 모든 안정성 수정이 포함됩니다. 기존 evidence 제약, streaming request, SGF write-back 동작은 변경하지 않았습니다.
+
+### 다운로드 전 확인
+
+- next-2026-08-31.1 Windows full bundle 사용자는 windows64.core-update.zip으로 app만 업데이트할 수 있습니다.
+- 새 설치는 hardware에 맞는 full bundle을 사용하세요. KataGo v1.18.1과 B11이 기본 포함됩니다. B11은 한 번의 판단이 더 강하지만 느릴 수 있어 속도 우선이면 Auto Setup에서 B10을 선택할 수 있습니다.
+- RTX 20/30/40/50은 통합 windows64.nvidia CUDA package를 사용합니다. TensorRT는 RTX 30 series 이하의 optional 선택입니다.
+- pre-release이므로 덮어쓰기 전 user-data, weight, 기보를 backup하세요.
+- 이 PC에 없는 RTX 50, ROCm, Intel NPU, macOS hardware를 실기기 검증 완료로 표시하지 않습니다.
+
+### 다운로드 안내
+
+| 내 컴퓨터 | 다운로드할 파일 |
+| --- | --- |
+| Windows x64, RTX 20/30/40/50 NVIDIA CUDA 권장 portable | [2026-08-31-windows64.nvidia.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.2/2026-08-31-windows64.nvidia.portable.zip) |
+| 기존 Windows portable, app-only update | [2026-08-31-windows64.core-update.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.2/2026-08-31-windows64.core-update.zip) |
+| Windows x64, RTX 20/30/40/50 NVIDIA CUDA installer | [2026-08-31-windows64.nvidia.installer.exe](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.2/2026-08-31-windows64.nvidia.installer.exe) |
+| Windows x64, AMD / Intel / 구형 NVIDIA OpenCL portable | [2026-08-31-windows64.opencl.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.2/2026-08-31-windows64.opencl.portable.zip) |
+| Windows x64, AMD / Intel / 구형 NVIDIA OpenCL installer | [2026-08-31-windows64.opencl.installer.exe](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.2/2026-08-31-windows64.opencl.installer.exe) |
+| Windows x64, CPU compatibility portable | [2026-08-31-windows64.with-katago.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.2/2026-08-31-windows64.with-katago.portable.zip) |
+| Windows x64, CPU compatibility installer | [2026-08-31-windows64.with-katago.installer.exe](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.2/2026-08-31-windows64.with-katago.installer.exe) |
+| Windows DirectML experimental | [2026-08-31-windows64.experimental.directml.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.2/2026-08-31-windows64.experimental.directml.portable.zip) |
+| Windows Intel OpenVINO experimental | [2026-08-31-windows64.experimental.openvino.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.2/2026-08-31-windows64.experimental.openvino.portable.zip) |
+| Windows AMD RX 6000 ROCm experimental | [2026-08-31-windows64.experimental.rocm.gfx103x.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.2/2026-08-31-windows64.experimental.rocm.gfx103x.portable.zip) |
+| Windows AMD RX 7000 ROCm experimental | [2026-08-31-windows64.experimental.rocm.gfx110x.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.2/2026-08-31-windows64.experimental.rocm.gfx110x.portable.zip) |
+| Windows AMD Ryzen AI Max ROCm experimental | [2026-08-31-windows64.experimental.rocm.gfx1151.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.2/2026-08-31-windows64.experimental.rocm.gfx1151.portable.zip) |
+| Windows AMD RX 9000 ROCm experimental | [2026-08-31-windows64.experimental.rocm.gfx120x.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.2/2026-08-31-windows64.experimental.rocm.gfx120x.portable.zip) |
+| RTX 30 series 이하 optional TensorRT, 두 part 모두 필요 | [2026-08-31-windows64.nvidia.tensorrt.portable.7z.001](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.2/2026-08-31-windows64.nvidia.tensorrt.portable.7z.001)<br>[2026-08-31-windows64.nvidia.tensorrt.portable.7z.002](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.2/2026-08-31-windows64.nvidia.tensorrt.portable.7z.002) |
+| Windows x64, 사용자 engine, portable | [2026-08-31-windows64.without.engine.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.2/2026-08-31-windows64.without.engine.portable.zip) |
+| Windows x64, 사용자 engine, installer | [2026-08-31-windows64.without.engine.installer.exe](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.2/2026-08-31-windows64.without.engine.installer.exe) |
+| macOS Apple Silicon, Metal | [2026-08-31-mac-apple-silicon.with-katago.dmg](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.2/2026-08-31-mac-apple-silicon.with-katago.dmg) |
+| macOS Intel | [2026-08-31-mac-intel.with-katago.dmg](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.2/2026-08-31-mac-intel.with-katago.dmg) |
+| Linux x64, CPU compatibility | [2026-08-31-linux64.with-katago.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.2/2026-08-31-linux64.with-katago.zip) |
+| Linux x64, OpenCL | [2026-08-31-linux64.opencl.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.2/2026-08-31-linux64.opencl.zip) |
+| Linux x64, NVIDIA CUDA | [2026-08-31-linux64.nvidia.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.2/2026-08-31-linux64.nvidia.zip) |
+
+### 검증
+
+- Windows 11 23H2 / RTX 3070 / NVIDIA portable에서 빈 해설, 저장된 SGF 해설, 최소 window, reader 내부 scroll을 실제 UI로 확인했습니다.
+- 100% / 150% / 200% scaling과 논리 760×540 최소 크기에서 잘림이나 겹침이 없었고 Tab, Shift+Tab, Space, Esc를 실제로 조작했습니다.
+- focused test 9개가 통과했습니다. 전체 JUnit 3681개, failure 0, error 0, skip 18이며 Maven package, Windows launcher guard, GitHub build, Windows script validation도 통과했습니다.
+- 4개 platform workflow, signing/notarization, asset topology, SHA, provenance가 모두 성공해야 공개됩니다.
+
+### 연락처
+
+- QQ 그룹: 299419120
+
+---
+
+## ภาษาไทย
+
+pre-release นี้ต่อยอดจาก next-2026-08-31.1 และปรับโฉม workspace ของ AI Commentary ใหม่ เพื่อให้คำอธิบาย การเลือกช่วง สถานะ request และคำถามต่อเนื่องชัดเจนและเสถียรขึ้น พร้อมรองรับ scaling สูงและ keyboard บน Windows
+
+### ไฮไลต์ของเวอร์ชันนี้
+
+- AI Commentary ใช้ workspace สามส่วน: rail ด้านซ้ายสำหรับ Next/Range/Whole Game, พื้นที่อ่านหลักตรงกลาง และแถบ status/model/คำถามต่อเนื่องด้านล่าง
+- current move, การเลือกช่วง และ Stop อยู่ด้านบนของ reader เสมอ เมื่อย่อ window ปุ่มหลักยังมองเห็นและข้อความยาว scroll เฉพาะในพื้นที่อ่าน
+- แยกสถานะว่าง กำลังเตรียม streaming เสร็จสิ้น คำเตือน ล้มเหลว และคำอธิบายที่บันทึกใน SGF อย่างชัดเจน จึงไม่เหลือผลเก่าหรือพื้นที่ว่างที่ไม่ทราบสาเหตุ
+- mode, settings, stop, range, follow-up, progress และ status มี keyboard focus และความหมายสำหรับ screen reader โดยไม่พึ่งสีเพียงอย่างเดียว
+- อัปเดต 6 ภาษา UI และ resource ภาษาจีนตัวเต็ม พร้อมตรวจ EXE จริงบน Windows ที่ scaling 100% / 150% / 200%
+- รวมการแก้เสถียรภาพทั้งหมดจาก next-2026-08-31.1 โดยไม่เปลี่ยน evidence constraints, streaming request และการเขียนกลับ SGF เดิม
+
+### ก่อนดาวน์โหลด
+
+- ผู้ใช้ Windows full bundle next-2026-08-31.1 ใช้ windows64.core-update.zip เพื่ออัปเดตเฉพาะ app ได้ โดยไม่แทน weight, engine, TensorRT หรือ user-data
+- การติดตั้งใหม่ให้เลือก full bundle ตาม hardware ซึ่งยังมี KataGo v1.18.1 และ B11 เป็นค่าเริ่มต้น B11 ตัดสินต่อครั้งได้แข็งแรงกว่าแต่ช้ากว่า หากเน้นความเร็วเลือก B10 ใน Auto Setup
+- RTX 20/30/40/50 ใช้ windows64.nvidia CUDA package เดียวกัน TensorRT เป็นตัวเลือกสำหรับ RTX 30 series และรุ่นก่อนหน้า
+- นี่คือ pre-release ควร backup user-data, weight และ game records ก่อนเขียนทับ
+- ไม่อ้างว่า RTX 50, ROCm, Intel NPU หรือ macOS hardware ที่ไม่มีในเครื่องทดสอบผ่านการทดสอบจริง
+
+### คำแนะนำดาวน์โหลด
+
+| คอมพิวเตอร์ของคุณ | ดาวน์โหลดไฟล์นี้ |
+| --- | --- |
+| Windows x64, RTX 20/30/40/50 NVIDIA CUDA portable ที่แนะนำ | [2026-08-31-windows64.nvidia.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.2/2026-08-31-windows64.nvidia.portable.zip) |
+| Windows portable เดิม, อัปเดตเฉพาะ app | [2026-08-31-windows64.core-update.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.2/2026-08-31-windows64.core-update.zip) |
+| Windows x64, RTX 20/30/40/50 NVIDIA CUDA installer | [2026-08-31-windows64.nvidia.installer.exe](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.2/2026-08-31-windows64.nvidia.installer.exe) |
+| Windows x64, OpenCL portable สำหรับ AMD / Intel / NVIDIA รุ่นเก่า | [2026-08-31-windows64.opencl.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.2/2026-08-31-windows64.opencl.portable.zip) |
+| Windows x64, OpenCL installer สำหรับ AMD / Intel / NVIDIA รุ่นเก่า | [2026-08-31-windows64.opencl.installer.exe](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.2/2026-08-31-windows64.opencl.installer.exe) |
+| Windows x64, CPU compatibility portable | [2026-08-31-windows64.with-katago.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.2/2026-08-31-windows64.with-katago.portable.zip) |
+| Windows x64, CPU compatibility installer | [2026-08-31-windows64.with-katago.installer.exe](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.2/2026-08-31-windows64.with-katago.installer.exe) |
+| Windows DirectML experimental | [2026-08-31-windows64.experimental.directml.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.2/2026-08-31-windows64.experimental.directml.portable.zip) |
+| Windows Intel OpenVINO experimental | [2026-08-31-windows64.experimental.openvino.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.2/2026-08-31-windows64.experimental.openvino.portable.zip) |
+| Windows AMD RX 6000 ROCm experimental | [2026-08-31-windows64.experimental.rocm.gfx103x.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.2/2026-08-31-windows64.experimental.rocm.gfx103x.portable.zip) |
+| Windows AMD RX 7000 ROCm experimental | [2026-08-31-windows64.experimental.rocm.gfx110x.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.2/2026-08-31-windows64.experimental.rocm.gfx110x.portable.zip) |
+| Windows AMD Ryzen AI Max ROCm experimental | [2026-08-31-windows64.experimental.rocm.gfx1151.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.2/2026-08-31-windows64.experimental.rocm.gfx1151.portable.zip) |
+| Windows AMD RX 9000 ROCm experimental | [2026-08-31-windows64.experimental.rocm.gfx120x.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.2/2026-08-31-windows64.experimental.rocm.gfx120x.portable.zip) |
+| TensorRT สำหรับ RTX 30 และรุ่นก่อนหน้า ต้องโหลดทั้งสอง part | [2026-08-31-windows64.nvidia.tensorrt.portable.7z.001](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.2/2026-08-31-windows64.nvidia.tensorrt.portable.7z.001)<br>[2026-08-31-windows64.nvidia.tensorrt.portable.7z.002](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.2/2026-08-31-windows64.nvidia.tensorrt.portable.7z.002) |
+| Windows x64, ใช้ engine ของคุณเอง, portable | [2026-08-31-windows64.without.engine.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.2/2026-08-31-windows64.without.engine.portable.zip) |
+| Windows x64, ใช้ engine ของคุณเอง, installer | [2026-08-31-windows64.without.engine.installer.exe](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.2/2026-08-31-windows64.without.engine.installer.exe) |
+| macOS Apple Silicon, Metal | [2026-08-31-mac-apple-silicon.with-katago.dmg](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.2/2026-08-31-mac-apple-silicon.with-katago.dmg) |
+| macOS Intel | [2026-08-31-mac-intel.with-katago.dmg](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.2/2026-08-31-mac-intel.with-katago.dmg) |
+| Linux x64, CPU compatibility | [2026-08-31-linux64.with-katago.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.2/2026-08-31-linux64.with-katago.zip) |
+| Linux x64, OpenCL | [2026-08-31-linux64.opencl.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.2/2026-08-31-linux64.opencl.zip) |
+| Linux x64, NVIDIA CUDA | [2026-08-31-linux64.nvidia.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-08-31.2/2026-08-31-linux64.nvidia.zip) |
+
+### ผลการตรวจสอบ
+
+- ทดสอบ UI จริงบน Windows 11 23H2 / RTX 3070 / NVIDIA portable ครอบคลุมสถานะว่าง คำอธิบายจาก SGF, window ขนาดต่ำสุด และ scroll ภายใน reader
+- scaling 100% / 150% / 200% และขนาด logical ต่ำสุด 760×540 ไม่มีข้อความถูกตัดหรือ control ซ้อนกัน พร้อมทดสอบ Tab, Shift+Tab, Space และ Esc จริง
+- focused test 9 รายการผ่านทั้งหมด; JUnit เต็ม 3681 รายการ, failure 0, error 0, skipped 18 และ Maven package, Windows launcher guard, GitHub build, Windows script validation ผ่าน
+- จะเปิด pre-release เมื่อ workflow ทั้ง 4 platform, signing/notarization, asset topology, SHA และ provenance ผ่านทั้งหมดเท่านั้น
+
+### ติดต่อ
+
+- QQ group: 299419120

--- a/.github/release-requests/next-2026-08-31.2.json
+++ b/.github/release-requests/next-2026-08-31.2.json
@@ -1,0 +1,7 @@
+{
+  "date_tag": "2026-08-31",
+  "release_tag": "next-2026-08-31.2",
+  "title": "LizzieYzy Next next-2026-08-31.2",
+  "prerelease": true,
+  "notes_file": ".github/release-notes/next-2026-08-31.2.md"
+}


### PR DESCRIPTION
## Summary

- request the multi-platform `next-2026-08-31.2` pre-release from the exact post-PR #399 main tree
- add six-language release notes focused on the AI Commentary workspace redesign
- preserve the complete fail-closed Windows, Linux, macOS, TensorRT, experimental backend, B11, and CUDA download guidance
- direct existing `next-2026-08-31.1` Windows users to the app-only core update without replacing engines, weights, TensorRT, or user data

## Validation

- release notes validator: passed for `next-2026-08-31.2`
- release metadata/topology/provenance/publisher test suite: 137 tests, 0 failures, 2 skipped
- Windows Linux-validator smoke tests rerun with the repository's Git Bash path: passed
- stale prior-release summary scan: no matches
- `git diff --check`: passed

Merging this request triggers the fail-closed publisher. The GitHub pre-release remains draft until Windows, Linux, macOS Intel, macOS Apple Silicon, signing/notarization, asset topology, hashes, and provenance all pass.