### PR TITLE
release: request next-2026-09-01.1 pre-release

### DIFF
--- a/.github/release-notes/next-2026-09-01.1.md
+++ b/.github/release-notes/next-2026-09-01.1.md
@@ -1,0 +1,365 @@
+# LizzieYzy Next next-2026-09-01.1
+
+## 中文
+
+这是基于 next-2026-08-31.2 的分析可靠性预发布版，重点修复连续打开棋谱、快速胜率曲线和前台引擎交接，并让性能优化结果真正清楚、可用。
+
+### 本版主要更新
+
+- 连续打开本地或在线棋谱改为“最后一次操作生效”；加载过程不会把半盘棋发送给旧引擎，快速切换也不会卡在错误局面。
+- 无效、空白、不可读棋谱现在会完整回滚，原棋盘、当前手、标题、胜率曲线和正在分析的引擎都保持不变。
+- 自动快速胜率曲线会持续到缺失局面分析完成，再立即恢复当前局面的前台分析；切换棋谱或引擎时会安全取消旧任务。
+- 智子云与本地引擎切换会等待共享分析租约释放，不再出现“前台引擎未能安全恢复”的误报；繁中界面的“智子”名称也已统一。
+- “一键设置 → 性能优化”同时显示 NN 计算速度与实际搜索速度，并标明模型、后端、线程数和测速时间；六语、高缩放和读屏布局同步完善。
+- 自动分析保存失败会明确提示；没有源文件名的结果保存到应用工作目录，不再静默丢失。
+
+### 下载前先看
+
+- 已安装 next-2026-08-31.2 完整 Windows 包的用户，可用 windows64.core-update.zip 只更新程序；现有权重、引擎、TensorRT 和 user-data 不会被替换。
+- 新安装用户请下载与硬件匹配的完整包；仍内置 KataGo v1.18.1 和默认 B11。B11 单次判断更强但搜索较慢，追求速度可在“一键设置 → 权重”明确切换 B10。
+- RTX 20/30/40/50 继续统一使用 windows64.nvidia CUDA 包；TensorRT 是 RTX 30 系及以下的可选方案。
+- 这是预发布版，覆盖旧目录前建议备份 user-data、权重和棋谱。
+- DirectML、OpenVINO、ROCm、RTX 50 和 macOS 对应硬件未在本机冒充真机通过，欢迎对应设备用户反馈。
+
+### 下载建议
+
+| 你的电脑 | 直接下载这个 |
+| --- | --- |
+| Windows 64 位，RTX 20/30/40/50 NVIDIA CUDA 推荐版，免安装 | [2026-09-01-windows64.nvidia.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-01.1/2026-09-01-windows64.nvidia.portable.zip) |
+| 已有 Windows 免安装版，只更新主程序 | [2026-09-01-windows64.core-update.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-01.1/2026-09-01-windows64.core-update.zip) |
+| Windows 64 位，RTX 20/30/40/50 NVIDIA CUDA 推荐安装版 | [2026-09-01-windows64.nvidia.installer.exe](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-01.1/2026-09-01-windows64.nvidia.installer.exe) |
+| Windows 64 位，AMD / Intel / 旧 NVIDIA OpenCL 兼容版，免安装 | [2026-09-01-windows64.opencl.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-01.1/2026-09-01-windows64.opencl.portable.zip) |
+| Windows 64 位，AMD / Intel / 旧 NVIDIA OpenCL 兼容安装版 | [2026-09-01-windows64.opencl.installer.exe](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-01.1/2026-09-01-windows64.opencl.installer.exe) |
+| Windows 64 位，CPU 兼容版，免安装 | [2026-09-01-windows64.with-katago.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-01.1/2026-09-01-windows64.with-katago.portable.zip) |
+| Windows 64 位，CPU 兼容安装版 | [2026-09-01-windows64.with-katago.installer.exe](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-01.1/2026-09-01-windows64.with-katago.installer.exe) |
+| Windows DirectML 实验版 | [2026-09-01-windows64.experimental.directml.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-01.1/2026-09-01-windows64.experimental.directml.portable.zip) |
+| Windows Intel OpenVINO 实验版 | [2026-09-01-windows64.experimental.openvino.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-01.1/2026-09-01-windows64.experimental.openvino.portable.zip) |
+| Windows AMD RX 6000 ROCm 实验版 | [2026-09-01-windows64.experimental.rocm.gfx103x.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-01.1/2026-09-01-windows64.experimental.rocm.gfx103x.portable.zip) |
+| Windows AMD RX 7000 ROCm 实验版 | [2026-09-01-windows64.experimental.rocm.gfx110x.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-01.1/2026-09-01-windows64.experimental.rocm.gfx110x.portable.zip) |
+| Windows AMD Ryzen AI Max ROCm 实验版 | [2026-09-01-windows64.experimental.rocm.gfx1151.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-01.1/2026-09-01-windows64.experimental.rocm.gfx1151.portable.zip) |
+| Windows AMD RX 9000 ROCm 实验版 | [2026-09-01-windows64.experimental.rocm.gfx120x.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-01.1/2026-09-01-windows64.experimental.rocm.gfx120x.portable.zip) |
+| RTX 30 系及以下可选 TensorRT，需下载两个分卷 | [2026-09-01-windows64.nvidia.tensorrt.portable.7z.001](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-01.1/2026-09-01-windows64.nvidia.tensorrt.portable.7z.001)<br>[2026-09-01-windows64.nvidia.tensorrt.portable.7z.002](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-01.1/2026-09-01-windows64.nvidia.tensorrt.portable.7z.002) |
+| Windows 64 位，自行配置引擎，免安装 | [2026-09-01-windows64.without.engine.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-01.1/2026-09-01-windows64.without.engine.portable.zip) |
+| Windows 64 位，自行配置引擎，安装版 | [2026-09-01-windows64.without.engine.installer.exe](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-01.1/2026-09-01-windows64.without.engine.installer.exe) |
+| macOS Apple Silicon，Metal | [2026-09-01-mac-apple-silicon.with-katago.dmg](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-01.1/2026-09-01-mac-apple-silicon.with-katago.dmg) |
+| macOS Intel | [2026-09-01-mac-intel.with-katago.dmg](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-01.1/2026-09-01-mac-intel.with-katago.dmg) |
+| Linux 64 位，CPU 兼容版 | [2026-09-01-linux64.with-katago.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-01.1/2026-09-01-linux64.with-katago.zip) |
+| Linux 64 位，OpenCL 版 | [2026-09-01-linux64.opencl.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-01.1/2026-09-01-linux64.opencl.zip) |
+| Linux 64 位，NVIDIA CUDA 版 | [2026-09-01-linux64.nvidia.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-01.1/2026-09-01-linux64.nvidia.zip) |
+
+### 验证结果
+
+- Windows 11、RTX 3070、NVIDIA portable 使用包内 Java、KataGo v1.18.1、CUDA 与 B11 完成真实神经网络推理；全程只有一个 KataGo 进程。
+- 真实 EXE 连续打开 60 手与 40 手棋谱，最终棋盘、标题和快速胜率曲线均落在最后选择；损坏 SGF 提示后原 40 手棋局与分析完整保留。
+- 本地引擎、智子云继续分析与远程转本地交接、Alt+O readboard、自动分析、100% / 150% / 200% 缩放均完成可见界面复测。
+- 本地 CI 28/28；完整 JUnit 3745 项，0 failures、0 errors、18 skipped；Maven verify/package、Windows launcher、发布资产检查及 GitHub Linux/Windows 门禁均通过。
+- 发布器只有在四个平台工作流、签名/公证、资产拓扑、SHA 与来源证明全部成功后才公开本预发布版。
+
+### 交流
+
+- QQ 群：299419120
+
+---
+
+## 繁體中文
+
+這是基於 next-2026-08-31.2 的分析可靠性預發布版，重點修正連續開啟棋譜、快速勝率曲線與前台引擎交接，並讓效能最佳化結果真正清楚、可用。
+
+### 本版主要更新
+
+- 連續開啟本機或線上棋譜改為「最後一次操作生效」；載入中不會把半盤棋送到舊引擎，快速切換也不會卡在錯誤局面。
+- 無效、空白或不可讀棋譜會完整回復，原棋盤、目前手數、標題、勝率曲線與分析引擎都保持不變。
+- 自動快速勝率曲線會持續到缺少的局面分析完成，再立即恢復目前局面的前台分析；切換棋譜或引擎會安全取消舊任務。
+- 智子雲與本機引擎切換會等待共享分析租約釋放，不再誤報前台引擎無法安全恢復；繁中「智子」名稱亦已統一。
+- 「一鍵設定 → 效能最佳化」同時顯示 NN 計算速度與實際搜尋速度，並標明模型、後端、執行緒與測速時間；六語、高縮放與讀屏版面同步完善。
+- 自動分析儲存失敗會明確提示；沒有來源檔名的結果儲存在應用程式工作目錄，不再靜默遺失。
+
+### 下載前先看
+
+- 已安裝 next-2026-08-31.2 完整 Windows 套件的使用者，可用 windows64.core-update.zip 只更新程式，不替換 weight、engine、TensorRT 或 user-data。
+- 新安裝請下載符合硬體的完整套件；仍內建 KataGo v1.18.1 與預設 B11。B11 單次判斷更強但搜尋較慢，重視速度可切換 B10。
+- RTX 20/30/40/50 繼續統一使用 windows64.nvidia CUDA 套件；TensorRT 是 RTX 30 系及以下的可選方案。
+- 這是預發布版，覆蓋舊目錄前建議備份 user-data、weight 與棋譜。
+- DirectML、OpenVINO、ROCm、RTX 50 與 macOS 對應硬體未在本機宣稱真機通過。
+
+### 下載建議
+
+| 你的電腦 | 直接下載這個 |
+| --- | --- |
+| Windows 64 位，RTX 20/30/40/50 NVIDIA CUDA 建議版，免安裝 | [2026-09-01-windows64.nvidia.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-01.1/2026-09-01-windows64.nvidia.portable.zip) |
+| 既有 Windows 免安裝版，只更新主程式 | [2026-09-01-windows64.core-update.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-01.1/2026-09-01-windows64.core-update.zip) |
+| Windows 64 位，RTX 20/30/40/50 NVIDIA CUDA 建議安裝版 | [2026-09-01-windows64.nvidia.installer.exe](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-01.1/2026-09-01-windows64.nvidia.installer.exe) |
+| Windows 64 位，AMD / Intel / 舊 NVIDIA OpenCL 相容版，免安裝 | [2026-09-01-windows64.opencl.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-01.1/2026-09-01-windows64.opencl.portable.zip) |
+| Windows 64 位，AMD / Intel / 舊 NVIDIA OpenCL 相容安裝版 | [2026-09-01-windows64.opencl.installer.exe](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-01.1/2026-09-01-windows64.opencl.installer.exe) |
+| Windows 64 位，CPU 相容版，免安裝 | [2026-09-01-windows64.with-katago.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-01.1/2026-09-01-windows64.with-katago.portable.zip) |
+| Windows 64 位，CPU 相容安裝版 | [2026-09-01-windows64.with-katago.installer.exe](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-01.1/2026-09-01-windows64.with-katago.installer.exe) |
+| Windows DirectML 實驗版 | [2026-09-01-windows64.experimental.directml.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-01.1/2026-09-01-windows64.experimental.directml.portable.zip) |
+| Windows Intel OpenVINO 實驗版 | [2026-09-01-windows64.experimental.openvino.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-01.1/2026-09-01-windows64.experimental.openvino.portable.zip) |
+| Windows AMD RX 6000 ROCm 實驗版 | [2026-09-01-windows64.experimental.rocm.gfx103x.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-01.1/2026-09-01-windows64.experimental.rocm.gfx103x.portable.zip) |
+| Windows AMD RX 7000 ROCm 實驗版 | [2026-09-01-windows64.experimental.rocm.gfx110x.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-01.1/2026-09-01-windows64.experimental.rocm.gfx110x.portable.zip) |
+| Windows AMD Ryzen AI Max ROCm 實驗版 | [2026-09-01-windows64.experimental.rocm.gfx1151.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-01.1/2026-09-01-windows64.experimental.rocm.gfx1151.portable.zip) |
+| Windows AMD RX 9000 ROCm 實驗版 | [2026-09-01-windows64.experimental.rocm.gfx120x.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-01.1/2026-09-01-windows64.experimental.rocm.gfx120x.portable.zip) |
+| RTX 30 系及以下可選 TensorRT，需下載兩個分卷 | [2026-09-01-windows64.nvidia.tensorrt.portable.7z.001](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-01.1/2026-09-01-windows64.nvidia.tensorrt.portable.7z.001)<br>[2026-09-01-windows64.nvidia.tensorrt.portable.7z.002](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-01.1/2026-09-01-windows64.nvidia.tensorrt.portable.7z.002) |
+| Windows 64 位，自行設定 engine，免安裝 | [2026-09-01-windows64.without.engine.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-01.1/2026-09-01-windows64.without.engine.portable.zip) |
+| Windows 64 位，自行設定 engine，安裝版 | [2026-09-01-windows64.without.engine.installer.exe](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-01.1/2026-09-01-windows64.without.engine.installer.exe) |
+| macOS Apple Silicon，Metal | [2026-09-01-mac-apple-silicon.with-katago.dmg](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-01.1/2026-09-01-mac-apple-silicon.with-katago.dmg) |
+| macOS Intel | [2026-09-01-mac-intel.with-katago.dmg](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-01.1/2026-09-01-mac-intel.with-katago.dmg) |
+| Linux 64 位，CPU 相容版 | [2026-09-01-linux64.with-katago.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-01.1/2026-09-01-linux64.with-katago.zip) |
+| Linux 64 位，OpenCL 版 | [2026-09-01-linux64.opencl.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-01.1/2026-09-01-linux64.opencl.zip) |
+| Linux 64 位，NVIDIA CUDA 版 | [2026-09-01-linux64.nvidia.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-01.1/2026-09-01-linux64.nvidia.zip) |
+
+### 驗證結果
+
+- Windows 11、RTX 3070、NVIDIA portable 使用套件內 Java、KataGo v1.18.1、CUDA 與 B11 完成真實神經網路推理；全程只有一個 KataGo 程序。
+- 真實 EXE 連續開啟 60 手與 40 手棋譜，最終棋盤、標題與快速勝率曲線皆對應最後選擇；損壞 SGF 提示後原 40 手棋局與分析完整保留。
+- 本機引擎、智子雲繼續分析與遠端轉本機交接、Alt+O readboard、自動分析、100% / 150% / 200% 縮放均完成可見介面複測。
+- 本機 CI 28/28；完整 JUnit 3745 項，0 failures、0 errors、18 skipped；Maven verify/package、Windows launcher、發布資產檢查及 GitHub Linux/Windows 門禁均通過。
+- 四平台 workflow、簽名/公證、資產拓撲、SHA 與來源證明全部成功後才會公開。
+
+### 交流
+
+- QQ 群：299419120
+
+---
+
+## English
+
+This analysis-reliability pre-release builds on next-2026-08-31.2. It hardens rapid SGF loading, quick win-rate analysis, and foreground-engine handoffs, while making performance results genuinely useful.
+
+### Release highlights
+
+- Rapid local and online SGF opens are now latest-request-wins. Partial positions are never sent to the previous engine, even when files are switched quickly.
+- Invalid, empty, or unreadable SGFs roll back transactionally, preserving the prior board, move, title, win-rate curve, and active engine analysis.
+- Automatic quick win-rate analysis runs until missing positions are complete and then immediately restores foreground analysis. Switching kifu or engines cancels stale work safely.
+- Zhizi Cloud-to-local handoffs wait for the shared analysis lease to close, eliminating false foreground-restore warnings. Traditional Chinese Zhizi naming is now consistent.
+- Auto Setup → Performance Optimization shows NN evaluation speed and real search speed together with model, backend, thread count, and benchmark time, with responsive six-language and screen-reader support.
+- Automatic-analysis save failures are explicit, and unnamed results use the application work directory instead of disappearing silently.
+
+### Before downloading
+
+- Windows users with a complete next-2026-08-31.2 bundle can apply windows64.core-update.zip for the app-only update without replacing weights, engines, TensorRT, or user-data.
+- Fresh installs should use the full bundle matching the hardware. KataGo v1.18.1 and B11 remain bundled by default. B11 provides stronger individual evaluations at lower throughput; select B10 in Auto Setup when speed matters more.
+- RTX 20/30/40/50 continue to use the unified windows64.nvidia CUDA package. TensorRT is an optional path for RTX 30 series and older.
+- This is a pre-release; back up user-data, weights, and game records before overwriting an existing folder.
+- DirectML, OpenVINO, ROCm, RTX 50, and macOS hardware not present on the test machine are not claimed as hardware-tested.
+
+### Download guide
+
+| Your computer | Download this file |
+| --- | --- |
+| Windows x64, recommended RTX 20/30/40/50 NVIDIA CUDA portable | [2026-09-01-windows64.nvidia.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-01.1/2026-09-01-windows64.nvidia.portable.zip) |
+| Existing Windows portable, app-only update | [2026-09-01-windows64.core-update.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-01.1/2026-09-01-windows64.core-update.zip) |
+| Windows x64, recommended RTX 20/30/40/50 NVIDIA CUDA installer | [2026-09-01-windows64.nvidia.installer.exe](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-01.1/2026-09-01-windows64.nvidia.installer.exe) |
+| Windows x64, OpenCL portable for AMD / Intel / older NVIDIA | [2026-09-01-windows64.opencl.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-01.1/2026-09-01-windows64.opencl.portable.zip) |
+| Windows x64, OpenCL installer for AMD / Intel / older NVIDIA | [2026-09-01-windows64.opencl.installer.exe](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-01.1/2026-09-01-windows64.opencl.installer.exe) |
+| Windows x64, CPU compatibility portable | [2026-09-01-windows64.with-katago.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-01.1/2026-09-01-windows64.with-katago.portable.zip) |
+| Windows x64, CPU compatibility installer | [2026-09-01-windows64.with-katago.installer.exe](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-01.1/2026-09-01-windows64.with-katago.installer.exe) |
+| Windows DirectML experimental | [2026-09-01-windows64.experimental.directml.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-01.1/2026-09-01-windows64.experimental.directml.portable.zip) |
+| Windows Intel OpenVINO experimental | [2026-09-01-windows64.experimental.openvino.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-01.1/2026-09-01-windows64.experimental.openvino.portable.zip) |
+| Windows AMD RX 6000 ROCm experimental | [2026-09-01-windows64.experimental.rocm.gfx103x.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-01.1/2026-09-01-windows64.experimental.rocm.gfx103x.portable.zip) |
+| Windows AMD RX 7000 ROCm experimental | [2026-09-01-windows64.experimental.rocm.gfx110x.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-01.1/2026-09-01-windows64.experimental.rocm.gfx110x.portable.zip) |
+| Windows AMD Ryzen AI Max ROCm experimental | [2026-09-01-windows64.experimental.rocm.gfx1151.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-01.1/2026-09-01-windows64.experimental.rocm.gfx1151.portable.zip) |
+| Windows AMD RX 9000 ROCm experimental | [2026-09-01-windows64.experimental.rocm.gfx120x.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-01.1/2026-09-01-windows64.experimental.rocm.gfx120x.portable.zip) |
+| Optional TensorRT for RTX 30 series and older; download both parts | [2026-09-01-windows64.nvidia.tensorrt.portable.7z.001](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-01.1/2026-09-01-windows64.nvidia.tensorrt.portable.7z.001)<br>[2026-09-01-windows64.nvidia.tensorrt.portable.7z.002](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-01.1/2026-09-01-windows64.nvidia.tensorrt.portable.7z.002) |
+| Windows x64, bring your own engine, portable | [2026-09-01-windows64.without.engine.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-01.1/2026-09-01-windows64.without.engine.portable.zip) |
+| Windows x64, bring your own engine, installer | [2026-09-01-windows64.without.engine.installer.exe](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-01.1/2026-09-01-windows64.without.engine.installer.exe) |
+| macOS Apple Silicon, Metal | [2026-09-01-mac-apple-silicon.with-katago.dmg](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-01.1/2026-09-01-mac-apple-silicon.with-katago.dmg) |
+| macOS Intel | [2026-09-01-mac-intel.with-katago.dmg](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-01.1/2026-09-01-mac-intel.with-katago.dmg) |
+| Linux x64, CPU compatibility | [2026-09-01-linux64.with-katago.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-01.1/2026-09-01-linux64.with-katago.zip) |
+| Linux x64, OpenCL | [2026-09-01-linux64.opencl.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-01.1/2026-09-01-linux64.opencl.zip) |
+| Linux x64, NVIDIA CUDA | [2026-09-01-linux64.nvidia.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-01.1/2026-09-01-linux64.nvidia.zip) |
+
+### Verification
+
+- Windows 11 / RTX 3070 / NVIDIA portable completed real neural-network inference with the bundled Java, KataGo v1.18.1, CUDA, and B11; exactly one KataGo process remained active.
+- The real EXE rapidly opened 60-move then 40-move SGFs; the final board, title, and complete quick curve matched the latest choice. A malformed SGF left the prior 40-move game and analysis intact after the error.
+- Local analysis, Zhizi Cloud continue-analysis and remote-to-local handoff, Alt+O readboard, automatic analysis, and visible 100% / 150% / 200% scaling checks all passed.
+- Local CI passed 28/28 gates. The full suite ran 3,745 JUnit tests with 0 failures, 0 errors, and 18 skipped; Maven verify/package, Windows launcher, release-asset checks, and GitHub Linux/Windows gates passed.
+- The release remains fail-closed until all four platform workflows, signing/notarization, topology, SHA, and provenance checks succeed.
+
+### Contact
+
+- QQ group: 299419120
+
+---
+
+## 日本語
+
+next-2026-08-31.2 を基にした分析信頼性の pre-release です。棋譜の高速切り替え、quick win-rate curve、foreground engine の引き継ぎを強化し、性能最適化の結果も分かりやすくしました。
+
+### 主な更新
+
+- local / online SGF の連続読み込みは最後の操作だけを採用します。途中局面を古い engine へ送らず、高速切り替えでも誤った局面に残りません。
+- 無効、空、読めない SGF は transactional に rollback し、以前の盤面、手数、title、勝率曲線、engine 分析を保持します。
+- automatic quick win-rate analysis は不足局面の完了まで継続し、その後すぐ foreground analysis を復元します。棋譜や engine の切り替え時は古い task を安全に停止します。
+- Zhizi Cloud から local engine への切り替えは shared analysis lease の解放を待ち、foreground restore の誤警告を防ぎます。繁体字の Zhizi 表記も統一しました。
+- Auto Setup → Performance Optimization に NN evaluation speed と実際の search speed、model、backend、thread、計測時刻を表示し、6 言語、高 scaling、screen reader に対応しました。
+- automatic analysis の保存失敗を明示し、元 file 名がない結果は application work directory に保存します。
+
+### ダウンロード前に
+
+- next-2026-08-31.2 の Windows 完全版を利用中なら、windows64.core-update.zip で app のみ更新できます。
+- 新規ユーザーは hardware に合う完全版を選んでください。KataGo v1.18.1 と B11 を同梱します。B11 は一手の判断が強い一方で遅いため、速度優先なら Auto Setup で B10 を選べます。
+- RTX 20/30/40/50 は統一 windows64.nvidia CUDA package を使用します。TensorRT は RTX 30 系以前の optional 選択です。
+- pre-release のため、上書き前に user-data、weight、棋譜を backup してください。
+- この PC にない RTX 50、ROCm、Intel NPU、macOS hardware を実機検証済みとは表記していません。
+
+### ダウンロード案内
+
+| お使いの環境 | ダウンロードするファイル |
+| --- | --- |
+| Windows x64、RTX 20/30/40/50 NVIDIA CUDA 推奨 portable | [2026-09-01-windows64.nvidia.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-01.1/2026-09-01-windows64.nvidia.portable.zip) |
+| 既存 Windows portable、app のみ更新 | [2026-09-01-windows64.core-update.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-01.1/2026-09-01-windows64.core-update.zip) |
+| Windows x64、RTX 20/30/40/50 NVIDIA CUDA installer | [2026-09-01-windows64.nvidia.installer.exe](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-01.1/2026-09-01-windows64.nvidia.installer.exe) |
+| Windows x64、AMD / Intel / 旧 NVIDIA OpenCL portable | [2026-09-01-windows64.opencl.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-01.1/2026-09-01-windows64.opencl.portable.zip) |
+| Windows x64、AMD / Intel / 旧 NVIDIA OpenCL installer | [2026-09-01-windows64.opencl.installer.exe](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-01.1/2026-09-01-windows64.opencl.installer.exe) |
+| Windows x64、CPU 互換 portable | [2026-09-01-windows64.with-katago.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-01.1/2026-09-01-windows64.with-katago.portable.zip) |
+| Windows x64、CPU 互換 installer | [2026-09-01-windows64.with-katago.installer.exe](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-01.1/2026-09-01-windows64.with-katago.installer.exe) |
+| Windows DirectML experimental | [2026-09-01-windows64.experimental.directml.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-01.1/2026-09-01-windows64.experimental.directml.portable.zip) |
+| Windows Intel OpenVINO experimental | [2026-09-01-windows64.experimental.openvino.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-01.1/2026-09-01-windows64.experimental.openvino.portable.zip) |
+| Windows AMD RX 6000 ROCm experimental | [2026-09-01-windows64.experimental.rocm.gfx103x.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-01.1/2026-09-01-windows64.experimental.rocm.gfx103x.portable.zip) |
+| Windows AMD RX 7000 ROCm experimental | [2026-09-01-windows64.experimental.rocm.gfx110x.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-01.1/2026-09-01-windows64.experimental.rocm.gfx110x.portable.zip) |
+| Windows AMD Ryzen AI Max ROCm experimental | [2026-09-01-windows64.experimental.rocm.gfx1151.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-01.1/2026-09-01-windows64.experimental.rocm.gfx1151.portable.zip) |
+| Windows AMD RX 9000 ROCm experimental | [2026-09-01-windows64.experimental.rocm.gfx120x.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-01.1/2026-09-01-windows64.experimental.rocm.gfx120x.portable.zip) |
+| RTX 30 系以前の optional TensorRT、両 part が必要 | [2026-09-01-windows64.nvidia.tensorrt.portable.7z.001](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-01.1/2026-09-01-windows64.nvidia.tensorrt.portable.7z.001)<br>[2026-09-01-windows64.nvidia.tensorrt.portable.7z.002](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-01.1/2026-09-01-windows64.nvidia.tensorrt.portable.7z.002) |
+| Windows x64、独自 engine、portable | [2026-09-01-windows64.without.engine.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-01.1/2026-09-01-windows64.without.engine.portable.zip) |
+| Windows x64、独自 engine、installer | [2026-09-01-windows64.without.engine.installer.exe](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-01.1/2026-09-01-windows64.without.engine.installer.exe) |
+| macOS Apple Silicon、Metal | [2026-09-01-mac-apple-silicon.with-katago.dmg](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-01.1/2026-09-01-mac-apple-silicon.with-katago.dmg) |
+| macOS Intel | [2026-09-01-mac-intel.with-katago.dmg](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-01.1/2026-09-01-mac-intel.with-katago.dmg) |
+| Linux x64、CPU 互換 | [2026-09-01-linux64.with-katago.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-01.1/2026-09-01-linux64.with-katago.zip) |
+| Linux x64、OpenCL | [2026-09-01-linux64.opencl.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-01.1/2026-09-01-linux64.opencl.zip) |
+| Linux x64、NVIDIA CUDA | [2026-09-01-linux64.nvidia.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-01.1/2026-09-01-linux64.nvidia.zip) |
+
+### 検証
+
+- Windows 11 / RTX 3070 / NVIDIA portable で bundled Java、KataGo v1.18.1、CUDA、B11 の実 NN inference を完了し、KataGo process は常に 1 個でした。
+- 実 EXE で 60 手から 40 手の SGF へ高速切り替えし、最終盤面、title、quick curve が最後の選択と一致しました。壊れた SGF の error 後も 40 手の棋局と分析を保持しました。
+- local analysis、Zhizi Cloud の継続分析と remote-to-local handoff、Alt+O readboard、automatic analysis、100% / 150% / 200% scaling を可視 UI で再確認しました。
+- local CI は 28/28。全体 JUnit は 3745 件、failure 0、error 0、skip 18。Maven verify/package、Windows launcher、release asset、GitHub Linux/Windows gate も成功しました。
+- 4 platform workflow、sign/notarization、asset topology、SHA、provenance が成功するまで公開しません。
+
+### 連絡先
+
+- QQ group: 299419120
+
+---
+
+## 한국어
+
+next-2026-08-31.2 기반 분석 안정성 pre-release입니다. 빠른 SGF 전환, quick win-rate curve, foreground engine 전환을 강화하고 성능 최적화 결과를 더 명확하게 만들었습니다.
+
+### 주요 업데이트
+
+- local/online SGF를 연속으로 열면 마지막 요청만 적용됩니다. 불완전한 position을 이전 engine에 보내지 않아 빠른 전환 중 잘못된 국면에 멈추지 않습니다.
+- 잘못되었거나 비어 있거나 읽을 수 없는 SGF는 transactional rollback되어 이전 board, move, title, win-rate curve와 engine 분석을 그대로 유지합니다.
+- automatic quick win-rate analysis는 누락 국면이 끝날 때까지 계속되고 즉시 foreground analysis를 복원합니다. 기보나 engine 전환 시 오래된 task를 안전하게 취소합니다.
+- Zhizi Cloud에서 local engine으로 전환할 때 shared analysis lease 해제를 기다려 foreground restore 오경고를 없앴고 번체 중국어 Zhizi 명칭도 통일했습니다.
+- Auto Setup → Performance Optimization에서 NN evaluation speed와 실제 search speed, model, backend, thread, benchmark time을 함께 보여 주며 6개 언어, 고배율, screen reader를 지원합니다.
+- automatic analysis 저장 실패를 명확히 알리고, 원본 file 이름이 없는 결과는 application work directory에 저장합니다.
+
+### 다운로드 전 확인
+
+- next-2026-08-31.2 Windows full bundle 사용자는 windows64.core-update.zip으로 app만 업데이트할 수 있습니다.
+- 새 설치는 hardware에 맞는 full bundle을 사용하세요. KataGo v1.18.1과 B11이 기본 포함됩니다. B11은 한 번의 판단이 더 강하지만 느릴 수 있어 속도 우선이면 Auto Setup에서 B10을 선택할 수 있습니다.
+- RTX 20/30/40/50은 통합 windows64.nvidia CUDA package를 사용합니다. TensorRT는 RTX 30 series 이하의 optional 선택입니다.
+- pre-release이므로 덮어쓰기 전 user-data, weight, 기보를 backup하세요.
+- 이 PC에 없는 RTX 50, ROCm, Intel NPU, macOS hardware를 실기기 검증 완료로 표시하지 않습니다.
+
+### 다운로드 안내
+
+| 내 컴퓨터 | 다운로드할 파일 |
+| --- | --- |
+| Windows x64, RTX 20/30/40/50 NVIDIA CUDA 권장 portable | [2026-09-01-windows64.nvidia.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-01.1/2026-09-01-windows64.nvidia.portable.zip) |
+| 기존 Windows portable, app-only update | [2026-09-01-windows64.core-update.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-01.1/2026-09-01-windows64.core-update.zip) |
+| Windows x64, RTX 20/30/40/50 NVIDIA CUDA installer | [2026-09-01-windows64.nvidia.installer.exe](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-01.1/2026-09-01-windows64.nvidia.installer.exe) |
+| Windows x64, AMD / Intel / 구형 NVIDIA OpenCL portable | [2026-09-01-windows64.opencl.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-01.1/2026-09-01-windows64.opencl.portable.zip) |
+| Windows x64, AMD / Intel / 구형 NVIDIA OpenCL installer | [2026-09-01-windows64.opencl.installer.exe](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-01.1/2026-09-01-windows64.opencl.installer.exe) |
+| Windows x64, CPU compatibility portable | [2026-09-01-windows64.with-katago.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-01.1/2026-09-01-windows64.with-katago.portable.zip) |
+| Windows x64, CPU compatibility installer | [2026-09-01-windows64.with-katago.installer.exe](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-01.1/2026-09-01-windows64.with-katago.installer.exe) |
+| Windows DirectML experimental | [2026-09-01-windows64.experimental.directml.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-01.1/2026-09-01-windows64.experimental.directml.portable.zip) |
+| Windows Intel OpenVINO experimental | [2026-09-01-windows64.experimental.openvino.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-01.1/2026-09-01-windows64.experimental.openvino.portable.zip) |
+| Windows AMD RX 6000 ROCm experimental | [2026-09-01-windows64.experimental.rocm.gfx103x.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-01.1/2026-09-01-windows64.experimental.rocm.gfx103x.portable.zip) |
+| Windows AMD RX 7000 ROCm experimental | [2026-09-01-windows64.experimental.rocm.gfx110x.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-01.1/2026-09-01-windows64.experimental.rocm.gfx110x.portable.zip) |
+| Windows AMD Ryzen AI Max ROCm experimental | [2026-09-01-windows64.experimental.rocm.gfx1151.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-01.1/2026-09-01-windows64.experimental.rocm.gfx1151.portable.zip) |
+| Windows AMD RX 9000 ROCm experimental | [2026-09-01-windows64.experimental.rocm.gfx120x.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-01.1/2026-09-01-windows64.experimental.rocm.gfx120x.portable.zip) |
+| RTX 30 series 이하 optional TensorRT, 두 part 모두 필요 | [2026-09-01-windows64.nvidia.tensorrt.portable.7z.001](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-01.1/2026-09-01-windows64.nvidia.tensorrt.portable.7z.001)<br>[2026-09-01-windows64.nvidia.tensorrt.portable.7z.002](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-01.1/2026-09-01-windows64.nvidia.tensorrt.portable.7z.002) |
+| Windows x64, 사용자 engine, portable | [2026-09-01-windows64.without.engine.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-01.1/2026-09-01-windows64.without.engine.portable.zip) |
+| Windows x64, 사용자 engine, installer | [2026-09-01-windows64.without.engine.installer.exe](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-01.1/2026-09-01-windows64.without.engine.installer.exe) |
+| macOS Apple Silicon, Metal | [2026-09-01-mac-apple-silicon.with-katago.dmg](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-01.1/2026-09-01-mac-apple-silicon.with-katago.dmg) |
+| macOS Intel | [2026-09-01-mac-intel.with-katago.dmg](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-01.1/2026-09-01-mac-intel.with-katago.dmg) |
+| Linux x64, CPU compatibility | [2026-09-01-linux64.with-katago.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-01.1/2026-09-01-linux64.with-katago.zip) |
+| Linux x64, OpenCL | [2026-09-01-linux64.opencl.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-01.1/2026-09-01-linux64.opencl.zip) |
+| Linux x64, NVIDIA CUDA | [2026-09-01-linux64.nvidia.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-01.1/2026-09-01-linux64.nvidia.zip) |
+
+### 검증
+
+- Windows 11 / RTX 3070 / NVIDIA portable에서 bundled Java, KataGo v1.18.1, CUDA, B11로 실제 NN inference를 완료했고 KataGo process는 항상 하나였습니다.
+- 실제 EXE에서 60수 SGF 다음 40수 SGF를 빠르게 열어 최종 board, title, quick curve가 마지막 선택과 일치함을 확인했습니다. 손상된 SGF 오류 뒤에도 이전 40수 기보와 분석이 유지되었습니다.
+- local analysis, Zhizi Cloud 계속 분석과 remote-to-local handoff, Alt+O readboard, automatic analysis, 100% / 150% / 200% scaling을 실제 UI로 재검증했습니다.
+- local CI 28/28 통과. 전체 JUnit 3745개, failure 0, error 0, skip 18이며 Maven verify/package, Windows launcher, release asset, GitHub Linux/Windows gate도 통과했습니다.
+- 4개 platform workflow, signing/notarization, asset topology, SHA, provenance가 모두 성공해야 공개됩니다.
+
+### 연락처
+
+- QQ 그룹: 299419120
+
+---
+
+## ภาษาไทย
+
+pre-release นี้ต่อยอดจาก next-2026-08-31.2 โดยเพิ่มความเสถียรของการเปิด SGF อย่างรวดเร็ว, quick win-rate curve และการส่งต่อ foreground engine พร้อมทำให้ผล Performance Optimization อ่านและใช้งานได้จริง
+
+### ไฮไลต์ของเวอร์ชันนี้
+
+- เมื่อเปิด SGF จากเครื่องหรือออนไลน์ต่อเนื่อง จะใช้คำขอล่าสุดเท่านั้น และไม่ส่ง position ที่ยังโหลดไม่ครบไปยัง engine เดิม
+- SGF ที่ไม่ถูกต้อง ว่าง หรืออ่านไม่ได้จะ rollback ทั้งหมด โดยคง board, move, title, win-rate curve และการวิเคราะห์เดิมไว้
+- automatic quick win-rate analysis ทำงานจนวิเคราะห์ position ที่ขาดครบ แล้วคืน foreground analysis ทันที การเปลี่ยน SGF หรือ engine จะยกเลิก task เก่าอย่างปลอดภัย
+- การสลับจาก Zhizi Cloud ไป local engine จะรอ shared analysis lease ปิดก่อน จึงไม่แจ้งเตือน foreground restore ผิด และปรับชื่อ Zhizi ในภาษาจีนตัวเต็มให้ถูกต้อง
+- Auto Setup → Performance Optimization แสดงทั้ง NN evaluation speed และ search speed จริง พร้อม model, backend, thread และเวลา benchmark โดยรองรับ 6 ภาษา, scaling สูง และ screen reader
+- หาก automatic analysis บันทึกไม่สำเร็จจะแจ้งชัดเจน และผลที่ไม่มีชื่อไฟล์ต้นทางจะเก็บใน application work directory
+
+### ก่อนดาวน์โหลด
+
+- ผู้ใช้ Windows full bundle next-2026-08-31.2 ใช้ windows64.core-update.zip เพื่ออัปเดตเฉพาะ app ได้ โดยไม่แทน weight, engine, TensorRT หรือ user-data
+- การติดตั้งใหม่ให้เลือก full bundle ตาม hardware ซึ่งยังมี KataGo v1.18.1 และ B11 เป็นค่าเริ่มต้น B11 ตัดสินต่อครั้งได้แข็งแรงกว่าแต่ช้ากว่า หากเน้นความเร็วเลือก B10 ใน Auto Setup
+- RTX 20/30/40/50 ใช้ windows64.nvidia CUDA package เดียวกัน TensorRT เป็นตัวเลือกสำหรับ RTX 30 series และรุ่นก่อนหน้า
+- นี่คือ pre-release ควร backup user-data, weight และ game records ก่อนเขียนทับ
+- ไม่อ้างว่า RTX 50, ROCm, Intel NPU หรือ macOS hardware ที่ไม่มีในเครื่องทดสอบผ่านการทดสอบจริง
+
+### คำแนะนำดาวน์โหลด
+
+| คอมพิวเตอร์ของคุณ | ดาวน์โหลดไฟล์นี้ |
+| --- | --- |
+| Windows x64, RTX 20/30/40/50 NVIDIA CUDA portable ที่แนะนำ | [2026-09-01-windows64.nvidia.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-01.1/2026-09-01-windows64.nvidia.portable.zip) |
+| Windows portable เดิม, อัปเดตเฉพาะ app | [2026-09-01-windows64.core-update.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-01.1/2026-09-01-windows64.core-update.zip) |
+| Windows x64, RTX 20/30/40/50 NVIDIA CUDA installer | [2026-09-01-windows64.nvidia.installer.exe](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-01.1/2026-09-01-windows64.nvidia.installer.exe) |
+| Windows x64, OpenCL portable สำหรับ AMD / Intel / NVIDIA รุ่นเก่า | [2026-09-01-windows64.opencl.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-01.1/2026-09-01-windows64.opencl.portable.zip) |
+| Windows x64, OpenCL installer สำหรับ AMD / Intel / NVIDIA รุ่นเก่า | [2026-09-01-windows64.opencl.installer.exe](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-01.1/2026-09-01-windows64.opencl.installer.exe) |
+| Windows x64, CPU compatibility portable | [2026-09-01-windows64.with-katago.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-01.1/2026-09-01-windows64.with-katago.portable.zip) |
+| Windows x64, CPU compatibility installer | [2026-09-01-windows64.with-katago.installer.exe](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-01.1/2026-09-01-windows64.with-katago.installer.exe) |
+| Windows DirectML experimental | [2026-09-01-windows64.experimental.directml.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-01.1/2026-09-01-windows64.experimental.directml.portable.zip) |
+| Windows Intel OpenVINO experimental | [2026-09-01-windows64.experimental.openvino.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-01.1/2026-09-01-windows64.experimental.openvino.portable.zip) |
+| Windows AMD RX 6000 ROCm experimental | [2026-09-01-windows64.experimental.rocm.gfx103x.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-01.1/2026-09-01-windows64.experimental.rocm.gfx103x.portable.zip) |
+| Windows AMD RX 7000 ROCm experimental | [2026-09-01-windows64.experimental.rocm.gfx110x.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-01.1/2026-09-01-windows64.experimental.rocm.gfx110x.portable.zip) |
+| Windows AMD Ryzen AI Max ROCm experimental | [2026-09-01-windows64.experimental.rocm.gfx1151.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-01.1/2026-09-01-windows64.experimental.rocm.gfx1151.portable.zip) |
+| Windows AMD RX 9000 ROCm experimental | [2026-09-01-windows64.experimental.rocm.gfx120x.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-01.1/2026-09-01-windows64.experimental.rocm.gfx120x.portable.zip) |
+| TensorRT สำหรับ RTX 30 และรุ่นก่อนหน้า ต้องโหลดทั้งสอง part | [2026-09-01-windows64.nvidia.tensorrt.portable.7z.001](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-01.1/2026-09-01-windows64.nvidia.tensorrt.portable.7z.001)<br>[2026-09-01-windows64.nvidia.tensorrt.portable.7z.002](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-01.1/2026-09-01-windows64.nvidia.tensorrt.portable.7z.002) |
+| Windows x64, ใช้ engine ของคุณเอง, portable | [2026-09-01-windows64.without.engine.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-01.1/2026-09-01-windows64.without.engine.portable.zip) |
+| Windows x64, ใช้ engine ของคุณเอง, installer | [2026-09-01-windows64.without.engine.installer.exe](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-01.1/2026-09-01-windows64.without.engine.installer.exe) |
+| macOS Apple Silicon, Metal | [2026-09-01-mac-apple-silicon.with-katago.dmg](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-01.1/2026-09-01-mac-apple-silicon.with-katago.dmg) |
+| macOS Intel | [2026-09-01-mac-intel.with-katago.dmg](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-01.1/2026-09-01-mac-intel.with-katago.dmg) |
+| Linux x64, CPU compatibility | [2026-09-01-linux64.with-katago.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-01.1/2026-09-01-linux64.with-katago.zip) |
+| Linux x64, OpenCL | [2026-09-01-linux64.opencl.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-01.1/2026-09-01-linux64.opencl.zip) |
+| Linux x64, NVIDIA CUDA | [2026-09-01-linux64.nvidia.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-01.1/2026-09-01-linux64.nvidia.zip) |
+
+### ผลการตรวจสอบ
+
+- Windows 11 / RTX 3070 / NVIDIA portable รัน NN inference จริงด้วย Java, KataGo v1.18.1, CUDA และ B11 ที่มากับ package โดยมี KataGo process เพียงหนึ่งตัวตลอดการทดสอบ
+- EXE จริงเปิด SGF 60 move แล้ว 40 move อย่างรวดเร็ว โดย board, title และ quick curve สุดท้ายตรงกับไฟล์ล่าสุด และ SGF ที่เสียไม่ทำให้เกม 40 move หรือการวิเคราะห์เดิมหาย
+- ทดสอบ local analysis, Zhizi Cloud continue-analysis และ remote-to-local handoff, Alt+O readboard, automatic analysis รวมถึง scaling 100% / 150% / 200% บน UI จริงแล้ว
+- local CI ผ่าน 28/28; JUnit 3745 รายการ, failure 0, error 0, skipped 18 และ Maven verify/package, Windows launcher, release asset, GitHub Linux/Windows gate ผ่านทั้งหมด
+- จะเปิด pre-release เมื่อ workflow ทั้ง 4 platform, signing/notarization, asset topology, SHA และ provenance ผ่านทั้งหมดเท่านั้น
+
+### ติดต่อ
+
+- QQ group: 299419120

--- a/.github/release-requests/next-2026-09-01.1.json
+++ b/.github/release-requests/next-2026-09-01.1.json
@@ -1,0 +1,7 @@
+{
+  "date_tag": "2026-09-01",
+  "release_tag": "next-2026-09-01.1",
+  "title": "LizzieYzy Next next-2026-09-01.1",
+  "prerelease": true,
+  "notes_file": ".github/release-notes/next-2026-09-01.1.md"
+}


### PR DESCRIPTION
## Summary

- request the multi-platform `next-2026-09-01.1` pre-release from final main after PR #402 and PR #403
- add six-language release notes for transactional SGF loading, rapid latest-request-wins switching, reliable automatic quick win-rate analysis, safe Zhizi Cloud/local-engine handoff, and the new NN/search performance report
- preserve the complete fail-closed Windows, Linux, macOS, TensorRT, experimental backend, B11, and unified CUDA download guidance
- direct existing `next-2026-08-31.2` Windows users to the app-only core update without replacing engines, weights, TensorRT, or user data

## Validation

- exact source tree: same Git tree as the Windows candidate tested before merging
- local CI: 28/28 gates; 3,745 JUnit tests, 0 failures, 0 errors, 18 environment skips
- release-note validator, Markdown links, line-ending policy, and staged diff: passed
- release publisher/topology/provenance suite: 147 tests passed, 1 environment skip, with Git Bash explicitly selected on Windows
- real Windows 11 / RTX 3070 NVIDIA portable: bundled Java and B11 CUDA inference, rapid 60→40 move SGF switching, malformed-SGF rollback, quick curve completion, Zhizi remote/local handoff, Alt+O, automatic analysis, and 100%/150%/200% scaling
- PR #402 GitHub CI #958 and PR #403 rebased GitHub CI #960: Linux and Windows required checks passed

Merging this request triggers the fail-closed publisher. The GitHub pre-release must remain draft until Windows, Linux, macOS Intel, macOS Apple Silicon, signing/notarization, asset topology, hashes, and provenance all pass.