### PR TITLE
Skip automatic benchmarking for remote engines

### DIFF
--- a/src/main/java/featurecat/lizzie/util/KataGoRuntimeHelper.java
+++ b/src/main/java/featurecat/lizzie/util/KataGoRuntimeHelper.java
@@ -6,6 +6,7 @@ import featurecat.lizzie.analysis.AnalysisEngine;
 import featurecat.lizzie.analysis.AnalysisResourceCoordinator;
 import featurecat.lizzie.analysis.EngineManager;
 import featurecat.lizzie.analysis.Leelaz;
+import featurecat.lizzie.analysis.remote.RemoteComputeConfig;
 import featurecat.lizzie.gui.EngineData;
 import featurecat.lizzie.logging.MaintenanceObservation;
 import featurecat.lizzie.rules.Board;
@@ -268,7 +269,7 @@ public final class KataGoRuntimeHelper {
   private static final int BENCHMARK_PROGRESS_VISIBLE_CAP = 995;
   private static final int APPLE_AUTO_OPTIMIZE_VERSION = 5;
   private static final int APPLE_AUTO_OPTIMIZE_DELAY_MILLIS = 8000;
-  private static final int APPLE_AUTO_OPTIMIZE_READY_TIMEOUT_MILLIS = 45000;
+  private static final int AUTO_BENCHMARK_READY_TIMEOUT_MILLIS = 45000;
   private static final long BENCHMARK_AUXILIARY_SHUTDOWN_WAIT_MILLIS = 2000L;
   private static final int MAX_APPLE_ANALYSIS_THREADS = 8;
   private static final String BENCHMARK_SIGNATURE_KEY = "katago-benchmark-signature";
@@ -4113,12 +4114,17 @@ public final class KataGoRuntimeHelper {
                   return;
                 }
 
-                snapshot = KataGoAutoSetupHelper.inspectLocalSetup();
-                if (!shouldRunAppleSiliconAutoBenchmark(snapshot)) {
+                if (!waitForPrimaryEngineReadyBeforeBenchmark(
+                    AUTO_BENCHMARK_READY_TIMEOUT_MILLIS)) {
                   return;
                 }
-                if (!waitForPrimaryEngineReadyBeforeBenchmark(
-                    APPLE_AUTO_OPTIMIZE_READY_TIMEOUT_MILLIS)) {
+                if (!isCurrentPrimaryEngineEligibleForAutomaticBenchmark()) {
+                  return;
+                }
+
+                snapshot = KataGoAutoSetupHelper.inspectLocalSetup();
+                if (!shouldRunAppleSiliconAutoBenchmark(snapshot)
+                    || !isCurrentPrimaryEngineEligibleForAutomaticBenchmark()) {
                   return;
                 }
 
@@ -4580,6 +4586,13 @@ public final class KataGoRuntimeHelper {
                 Thread.currentThread().interrupt();
                 return;
               }
+              if (!waitForPrimaryEngineReadyBeforeBenchmark(
+                  AUTO_BENCHMARK_READY_TIMEOUT_MILLIS)) {
+                return;
+              }
+              if (!isCurrentPrimaryEngineEligibleForAutomaticBenchmark()) {
+                return;
+              }
               SetupSnapshot snapshot;
               try {
                 snapshot = KataGoAutoSetupHelper.inspectLocalSetup();
@@ -4594,6 +4607,7 @@ public final class KataGoRuntimeHelper {
               }
               if (getStoredBenchmarkResult(snapshot) != null) return;
               if (isStartupBenchmarkDismissed(snapshot)) return;
+              if (!isCurrentPrimaryEngineEligibleForAutomaticBenchmark()) return;
 
               final DownloadSession benchmarkSession = new DownloadSession();
               final javax.swing.JDialog notice =
@@ -4648,6 +4662,23 @@ public final class KataGoRuntimeHelper {
             "katago-first-run-benchmark");
     worker.setDaemon(true);
     worker.start();
+  }
+
+  private static boolean isCurrentPrimaryEngineEligibleForAutomaticBenchmark() {
+    Leelaz engine = Lizzie.leelaz;
+    return engine != null
+        && isEngineEligibleForAutomaticStartupBenchmark(
+            engine.engineCommand(), engine.useRemoteCompute, engine.useJavaSSH, engine.isSSH);
+  }
+
+  static boolean isEngineEligibleForAutomaticStartupBenchmark(
+      String command, boolean usesRemoteCompute, boolean usesJavaSsh, boolean usesSsh) {
+    String normalizedCommand = command == null ? "" : command.trim();
+    return !normalizedCommand.isEmpty()
+        && !usesRemoteCompute
+        && !usesJavaSsh
+        && !usesSsh
+        && !RemoteComputeConfig.isRemoteComputeEngineCommand(normalizedCommand);
   }
 
   public static String optimizeAnalysisEngineCommand(

--- a/src/test/java/featurecat/lizzie/util/KataGoRuntimeHelperTest.java
+++ b/src/test/java/featurecat/lizzie/util/KataGoRuntimeHelperTest.java
@@ -13,6 +13,7 @@ import com.sun.net.httpserver.HttpServer;
 import featurecat.lizzie.Config;
 import featurecat.lizzie.ConfigTestHelper;
 import featurecat.lizzie.Lizzie;
+import featurecat.lizzie.analysis.remote.RemoteComputeConfig;
 import featurecat.lizzie.gui.EngineData;
 import featurecat.lizzie.logging.LogCategories;
 import featurecat.lizzie.logging.LoggingLimits;
@@ -2508,6 +2509,44 @@ public class KataGoRuntimeHelperTest {
                     "Fresh Apple Silicon setup should still offer the first auto benchmark.");
               });
         });
+  }
+
+  @Test
+  void automaticStartupBenchmarkOnlyAcceptsLocalEngineCommands() {
+    assertTrue(
+        KataGoRuntimeHelper.isEngineEligibleForAutomaticStartupBenchmark(
+            "katago gtp -model weights/default.bin.gz -config gtp.cfg",
+            false,
+            false,
+            false));
+
+    assertFalse(
+        KataGoRuntimeHelper.isEngineEligibleForAutomaticStartupBenchmark(
+            RemoteComputeConfig.COMMAND_ZHIZI, false, false, false),
+        "Zhizi must not trigger a local benchmark during application startup.");
+    assertFalse(
+        KataGoRuntimeHelper.isEngineEligibleForAutomaticStartupBenchmark(
+            RemoteComputeConfig.COMMAND_CUSTOM_WS, false, false, false),
+        "Self-hosted remote compute must not trigger a local startup benchmark.");
+    assertFalse(
+        KataGoRuntimeHelper.isEngineEligibleForAutomaticStartupBenchmark(
+            "katago gtp -model weights/default.bin.gz -config gtp.cfg",
+            true,
+            false,
+            false),
+        "The runtime remote flag must win even if a command string looks local.");
+    assertFalse(
+        KataGoRuntimeHelper.isEngineEligibleForAutomaticStartupBenchmark(
+            "katago gtp", false, true, false),
+        "Java SSH engines are remote and must not trigger local startup tuning.");
+    assertFalse(
+        KataGoRuntimeHelper.isEngineEligibleForAutomaticStartupBenchmark(
+            "ssh host katago gtp", false, false, true),
+        "Legacy SSH engines are remote and must not trigger local startup tuning.");
+    assertFalse(
+        KataGoRuntimeHelper.isEngineEligibleForAutomaticStartupBenchmark(
+            "", false, false, false),
+        "No-engine startup must remain silent.");
   }
 
   @Test


### PR DESCRIPTION
## Summary
- skip automatic startup benchmarking when the active engine is Zhizi Cloud, self-hosted WebSocket, Java SSH, legacy SSH, or no engine
- wait for the primary engine to settle before deciding whether a local startup benchmark is appropriate, then recheck before showing the benchmark UI
- keep the manual local benchmark buttons in KataGo one-click setup fully available for remote-compute users

## Verification
- `mvn -B -Dfmt.skip=true -Dtest=KataGoRuntimeHelperTest,RemoteComputeConfigTest,ConfigFirstLaunchDefaultsTest test` (104 tests)
- `mvn -B -Dfmt.skip=true test` (3745 tests, 0 failures, 0 errors, 7 skipped)
- `mvn -B -Dfmt.skip=true -DskipTests package`
- `python3 scripts/check_line_endings.py`
- `python3 scripts/check_markdown_links.py`
- `git diff --check`

## User-facing behavior
When LizzieYzy Next starts with Zhizi Cloud or another remote engine, it remains quiet and does not launch a local performance benchmark. Users can still open **KataGo one-click setup > Performance optimization** and explicitly benchmark their local KataGo installation whenever they want.
