### PR TITLE
Prevent engine presentation deadlocks

### DIFF
--- a/scripts/run_local_ci.sh
+++ b/scripts/run_local_ci.sh
@@ -45,4 +45,7 @@ if [[ -z "${LIZZIE_MAVEN:-}" ]]; then
 fi
 
 cd "$repo_root"
-exec "$python_bin" scripts/run_local_ci.py --profile "$profile" "${extra_args[@]}"
+if [[ ${#extra_args[@]} -gt 0 ]]; then
+  exec "$python_bin" scripts/run_local_ci.py --profile "$profile" "${extra_args[@]}"
+fi
+exec "$python_bin" scripts/run_local_ci.py --profile "$profile"

--- a/scripts/test_run_local_ci.py
+++ b/scripts/test_run_local_ci.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 
 from pathlib import Path
+import os
+import subprocess
 import tempfile
 import unittest
 
@@ -8,6 +10,42 @@ from scripts import run_local_ci
 
 
 class RunLocalCiTest(unittest.TestCase):
+    def test_shell_wrapper_accepts_profile_without_optional_arguments(self):
+        repository = Path(__file__).resolve().parents[1]
+        with tempfile.TemporaryDirectory() as temporary:
+            temporary_path = Path(temporary)
+            fake_python = temporary_path / "python"
+            captured_arguments = temporary_path / "arguments.txt"
+            fake_python.write_text(
+                '#!/usr/bin/env bash\nprintf "%s\\n" "$@" > "$LIZZIE_WRAPPER_ARGS"\n',
+                encoding="utf-8",
+            )
+            fake_python.chmod(0o755)
+            environment = os.environ.copy()
+            environment.update(
+                {
+                    "LIZZIE_PYTHON": str(fake_python),
+                    "LIZZIE_MAVEN": "/usr/bin/true",
+                    "LIZZIE_WRAPPER_ARGS": str(captured_arguments),
+                }
+            )
+
+            completed = subprocess.run(
+                ["/bin/bash", "scripts/run_local_ci.sh", "--profile", "all"],
+                cwd=repository,
+                env=environment,
+                capture_output=True,
+                text=True,
+                timeout=10,
+                check=False,
+            )
+
+            self.assertEqual(0, completed.returncode, completed.stderr)
+            self.assertEqual(
+                ["scripts/run_local_ci.py", "--profile", "all"],
+                captured_arguments.read_text(encoding="utf-8").splitlines(),
+            )
+
     def test_all_profile_keeps_one_maven_verification(self):
         steps = run_local_ci.build_steps("all", "mvn", "bash", "pwsh")
         verify_steps = [step for step in steps if "verification gate" in step.name]

--- a/src/main/java/featurecat/lizzie/analysis/EngineManager.java
+++ b/src/main/java/featurecat/lizzie/analysis/EngineManager.java
@@ -6154,7 +6154,7 @@ public class EngineManager {
       }
     }
 
-    Runnable update =
+    Runnable iconMutation =
         () -> {
           synchronized (ENGINE_SELECTION_STATE_LOCK) {
             if (Lizzie.engineManager != expectedManager
@@ -6163,29 +6163,30 @@ public class EngineManager {
                 || !isExactCatalogSlot(expectedManager, expectedIndex, engine)) {
               return;
             }
-            // Lock order is selection -> engine arbitration. Catalog/owner publication never
-            // acquires these locks in the reverse order. Holding both across the icon mutation
-            // prevents a same-object rebind from publishing its running icon between the final
-            // incarnation check and this stale stopped-icon write.
-            engine.runIfCurrentEngineIncarnation(
-                expectedIncarnation,
-                () -> {
-                  Menu currentMenu = LizzieFrame.menu;
-                  if (currentMenu != null) {
-                    if (main) {
-                      currentMenu.changeEngineIcon(expectedIndex, 0);
-                    } else {
-                      currentMenu.changeEngineIcon2(expectedIndex, 0);
-                    }
-                  }
-                });
+            Menu currentMenu = LizzieFrame.menu;
+            if (currentMenu != null) {
+              if (main) {
+                currentMenu.changeEngineIcon(expectedIndex, 0);
+              } else {
+                currentMenu.changeEngineIcon2(expectedIndex, 0);
+              }
+            }
           }
         };
-    if (SwingUtilities.isEventDispatchThread()) {
-      update.run();
-    } else {
-      SwingUtilities.invokeLater(update);
-    }
+    Runnable update =
+        () -> {
+          Leelaz.EngineRuntimeUiLease lease =
+              engine.claimEngineRuntimeUiLeaseIfCurrent(expectedIncarnation);
+          if (lease == null) {
+            return;
+          }
+          try {
+            iconMutation.run();
+          } finally {
+            lease.close();
+          }
+        };
+    dispatchEnginePresentationUpdate(update);
   }
 
   static void publishStartedEngineIconIfCurrent(Leelaz engine, Object expectedIncarnation) {
@@ -6223,13 +6224,8 @@ public class EngineManager {
       if (!isExactCatalogSlot(expectedManager, expectedIndex, engine)) {
         return;
       }
-      if (iconMode == 2
-          && !engine.runIfCurrentParserReadyPresentationIncarnation(
-              expectedIncarnation, () -> {})) {
-        return;
-      }
     }
-    Runnable update =
+    Runnable iconMutation =
         () -> {
           synchronized (ENGINE_SELECTION_STATE_LOCK) {
             if (Lizzie.engineManager != expectedManager
@@ -6238,26 +6234,38 @@ public class EngineManager {
                 || !isExactCatalogSlot(expectedManager, expectedIndex, engine)) {
               return;
             }
-            Runnable iconMutation =
-                () -> {
-                  Menu currentMenu = LizzieFrame.menu;
-                  if (currentMenu != null) {
-                    if (main) {
-                      currentMenu.changeEngineIcon(expectedIndex, iconMode);
-                    } else {
-                      currentMenu.changeEngineIcon2(expectedIndex, iconMode);
-                    }
-                  }
-                };
-            if (iconMode == 2) {
-              engine.runIfCurrentParserReadyPresentationIncarnation(
-                  expectedIncarnation, iconMutation);
-            } else {
-              engine.runIfCurrentEngineIncarnation(expectedIncarnation, iconMutation);
+            Menu currentMenu = LizzieFrame.menu;
+            if (currentMenu != null) {
+              if (main) {
+                currentMenu.changeEngineIcon(expectedIndex, iconMode);
+              } else {
+                currentMenu.changeEngineIcon2(expectedIndex, iconMode);
+              }
             }
           }
         };
-    if (SwingUtilities.isEventDispatchThread()) {
+    Runnable update =
+        () -> {
+          Leelaz.EngineRuntimeUiLease lease =
+              engine.claimEnginePresentationLeaseIfCurrent(expectedIncarnation, iconMode == 2);
+          if (lease == null) {
+            return;
+          }
+          try {
+            iconMutation.run();
+          } finally {
+            lease.close();
+          }
+        };
+    dispatchEnginePresentationUpdate(update);
+  }
+
+  private static void dispatchEnginePresentationUpdate(Runnable update) {
+    // Presentation callbacks claim a non-blocking incarnation lease before inspecting selection
+    // state, but never retain the endpoint monitor while doing so. Deferring an EDT caller that
+    // already owns selection state prevents either monitor from being nested in the other order.
+    if (SwingUtilities.isEventDispatchThread()
+        && !Thread.holdsLock(ENGINE_SELECTION_STATE_LOCK)) {
       update.run();
     } else {
       SwingUtilities.invokeLater(update);
@@ -12302,7 +12310,7 @@ public class EngineManager {
     if (engine == null || expectedIncarnation == null) {
       return;
     }
-    Runnable update =
+    Runnable menuMutation =
         () -> {
           synchronized (ENGINE_SELECTION_STATE_LOCK) {
             if (Lizzie.engineManager != this
@@ -12312,24 +12320,29 @@ public class EngineManager {
                 || !isExactCatalogSlot(this, expectedIndex, engine)) {
               return;
             }
-            engine.runIfCurrentEngineIncarnation(
-                expectedIncarnation,
-                () -> {
-                  if (Menu.engineMenu != null) {
-                    Menu.engineMenu.setText(title);
-                  }
-                  Menu currentMenu = LizzieFrame.menu;
-                  if (currentMenu != null) {
-                    currentMenu.changeEngineIcon(expectedIndex, iconMode);
-                  }
-                });
+            if (Menu.engineMenu != null) {
+              Menu.engineMenu.setText(title);
+            }
+            Menu currentMenu = LizzieFrame.menu;
+            if (currentMenu != null) {
+              currentMenu.changeEngineIcon(expectedIndex, iconMode);
+            }
           }
         };
-    if (SwingUtilities.isEventDispatchThread()) {
-      update.run();
-    } else {
-      SwingUtilities.invokeLater(update);
-    }
+    Runnable update =
+        () -> {
+          Leelaz.EngineRuntimeUiLease lease =
+              engine.claimEngineRuntimeUiLeaseIfCurrent(expectedIncarnation);
+          if (lease == null) {
+            return;
+          }
+          try {
+            menuMutation.run();
+          } finally {
+            lease.close();
+          }
+        };
+    dispatchEnginePresentationUpdate(update);
   }
 
   protected void synchronizeEngineWhenReady(

--- a/src/main/java/featurecat/lizzie/analysis/Leelaz.java
+++ b/src/main/java/featurecat/lizzie/analysis/Leelaz.java
@@ -2866,12 +2866,41 @@ public class Leelaz {
    * rebind from crossing the callback-time incarnation check while non-modal UI is constructed.
    */
   EngineRuntimeUiLease claimEngineRuntimeUiLeaseIfCurrent(Object expectedIncarnation) {
+    return claimEngineRuntimeUiLeaseIfCurrent(expectedIncarnation, false, false);
+  }
+
+  /**
+   * Pins one exact runtime for a global engine-status presentation without retaining the endpoint
+   * monitor while Swing selection state is inspected. Ready presentations additionally require an
+   * idle, fully live parser at lease-acquisition time.
+   */
+  EngineRuntimeUiLease claimEnginePresentationLeaseIfCurrent(
+      Object expectedIncarnation, boolean requireParserReady) {
+    return claimEngineRuntimeUiLeaseIfCurrent(expectedIncarnation, true, requireParserReady);
+  }
+
+  private EngineRuntimeUiLease claimEngineRuntimeUiLeaseIfCurrent(
+      Object expectedIncarnation,
+      boolean requireGlobalPresentation,
+      boolean requireParserReady) {
     if (!(expectedIncarnation instanceof ReaderStreamBinding)) {
       return null;
     }
     synchronized (engineArbitrationLock()) {
       ReaderStreamBinding expectedBinding = (ReaderStreamBinding) expectedIncarnation;
       if (readerStreamBinding != expectedBinding || readerStreamRebindInProgress) {
+        return null;
+      }
+      if (requireGlobalPresentation
+          && (expectedBinding.suppressGlobalEnginePresentation
+              || expectedBinding.deferredEngineGameRecoveryPresentationSuppressed)) {
+        return null;
+      }
+      if (requireParserReady
+          && (!isCurrentLiveEngineIncarnationLocked(expectedIncarnation)
+              || isOrdinaryForwardingOccupied()
+              || hasLifecycleCompletionLocked()
+              || activeUpdateEngineStartAttempt != null)) {
         return null;
       }
       expectedBinding.runtimeUiPresentationsInProgress++;

--- a/src/test/java/featurecat/lizzie/analysis/EngineManagerLifecycleReservationTest.java
+++ b/src/test/java/featurecat/lizzie/analysis/EngineManagerLifecycleReservationTest.java
@@ -2649,6 +2649,51 @@ class EngineManagerLifecycleReservationTest {
     }
   }
 
+  @Test
+  void enginePresentationLeasesIncarnationWithoutNestingSelectionState() throws Exception {
+    EngineManager previousManager = Lizzie.engineManager;
+    Leelaz previousPrimary = Lizzie.leelaz;
+    Leelaz previousSecondary = Lizzie.leelaz2;
+    Menu previousMenu = LizzieFrame.menu;
+    boolean previousEmpty = EngineManager.isEmpty;
+    int previousEngineNo = EngineManager.currentEngineNo;
+    PresentationLockOrderLeelaz engine =
+        new PresentationLockOrderLeelaz(engineSelectionStateLock());
+    EngineManager manager = new EngineManager(List.of(engine));
+    SilentUpdateMenu menu = allocate(SilentUpdateMenu.class);
+    try {
+      Lizzie.engineManager = manager;
+      Lizzie.setPrimaryEngine(engine);
+      Lizzie.leelaz2 = null;
+      LizzieFrame.menu = menu;
+      EngineManager.isEmpty = false;
+      EngineManager.currentEngineNo = 0;
+      engine.started = true;
+      engine.isLoaded = true;
+      Object incarnation = engine.currentEngineIncarnation();
+
+      EngineManager.publishStoppedEngineIconIfCurrent(engine, incarnation);
+      EngineManager.publishStartedEngineIconIfCurrent(engine, incarnation);
+      EngineManager.publishReadyEngineIconIfCurrent(engine, incarnation);
+      manager.publishReplacementEngineMenuStateIfCurrent(
+          0, engine, incarnation, "Current engine", 2);
+      SwingUtilities.invokeAndWait(() -> {});
+
+      assertEquals(2, engine.runtimeUiLeaseChecks.get());
+      assertEquals(2, engine.presentationLeaseChecks.get());
+      assertFalse(
+          engine.selectionLockHeldDuringLeaseClaim.get(),
+          "engine presentation must not nest selection and endpoint lock acquisition");
+    } finally {
+      Lizzie.engineManager = previousManager;
+      Lizzie.setPrimaryEngine(previousPrimary);
+      Lizzie.leelaz2 = previousSecondary;
+      LizzieFrame.menu = previousMenu;
+      EngineManager.isEmpty = previousEmpty;
+      EngineManager.currentEngineNo = previousEngineNo;
+    }
+  }
+
   private static void assertStaleBindingExitDoesNotAffectReplacement(
       boolean normalQuit, boolean retiredLocal, boolean replacementLocal) throws Exception {
     Leelaz previousPrimary = Lizzie.leelaz;
@@ -9178,6 +9223,35 @@ class EngineManagerLifecycleReservationTest {
 
     @Override
     public void leela0110StopPonder() {}
+  }
+
+  private static final class PresentationLockOrderLeelaz extends QuietExitLeelaz {
+    private final Object selectionLock;
+    private final AtomicBoolean selectionLockHeldDuringLeaseClaim = new AtomicBoolean();
+    private final AtomicInteger runtimeUiLeaseChecks = new AtomicInteger();
+    private final AtomicInteger presentationLeaseChecks = new AtomicInteger();
+
+    private PresentationLockOrderLeelaz(Object selectionLock) throws Exception {
+      this.selectionLock = selectionLock;
+    }
+
+    @Override
+    EngineRuntimeUiLease claimEngineRuntimeUiLeaseIfCurrent(Object expectedIncarnation) {
+      runtimeUiLeaseChecks.incrementAndGet();
+      selectionLockHeldDuringLeaseClaim.compareAndSet(
+          false, Thread.holdsLock(selectionLock));
+      return super.claimEngineRuntimeUiLeaseIfCurrent(expectedIncarnation);
+    }
+
+    @Override
+    EngineRuntimeUiLease claimEnginePresentationLeaseIfCurrent(
+        Object expectedIncarnation, boolean requireParserReady) {
+      presentationLeaseChecks.incrementAndGet();
+      selectionLockHeldDuringLeaseClaim.compareAndSet(
+          false, Thread.holdsLock(selectionLock));
+      return super.claimEnginePresentationLeaseIfCurrent(
+          expectedIncarnation, requireParserReady);
+    }
   }
 
   private static final class PartialPublishedStartLeelaz extends QuietExitLeelaz {


### PR DESCRIPTION
## Summary\n\n- prevent a three-way deadlock between engine selection state, endpoint arbitration, and physical writer ownership during engine status presentation\n- pin the exact engine incarnation with the existing runtime UI lease without nesting the endpoint and selection monitors\n- preserve same-object reader rebind serialization while discarding stale stopped/ready/replacement callbacks\n- make the local CI wrapper accept the default invocation on macOS Bash 3.2\n\n## Root cause\n\nThe post-merge full validation gate exposed a low-probability lock cycle:\n\n1. the EDT held engine selection state while waiting for endpoint arbitration\n2. deferred engine-game recovery held endpoint arbitration while waiting for the physical writer\n3. the writer needed engine selection state\n\nA first lock-order-only attempt still allowed a reverse cycle. The final implementation claims a short incarnation lease, releases the endpoint monitor, and only then inspects or updates Swing selection state.\n\n## Validation\n\n- 8 consecutive combined engine lifecycle stress runs: 2,432 test executions, no timeout or deadlock\n- full Maven suite: 3,749 tests, 0 failures, 0 errors\n- full local CI gate: 28/28 steps, 3,750 tests, 0 failures, 0 errors\n- package build, Windows PowerShell/parser checks, line endings, Markdown links, release helpers, R2 tests/signing, and Windows asset validation passed\n- real macOS smoke with bundled KataGo 1.18.1 + Transformer 11B Metal:\n  - analysis reached 42-58 searches/s\n  - forced KataGo termination produced a responsive repair state instead of a hang\n  - relaunch restored live analysis and candidate updates\n  - app and KataGo child process exited cleanly\n\n## Notes\n\nWindows build and script compatibility gates passed. A Windows interactive UI run was not performed in this local-only validation round.