### PR TITLE
Make logging recovery generation-aware

### DIFF
--- a/src/main/java/featurecat/lizzie/logging/BoundedAsyncAppender.java
+++ b/src/main/java/featurecat/lizzie/logging/BoundedAsyncAppender.java
@@ -18,10 +18,12 @@ import java.util.concurrent.atomic.AtomicLong;
 final class BoundedAsyncAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
   private static final class QueuedEvent {
     final long sequence;
+    final long incidentGeneration;
     final ILoggingEvent event;
 
-    QueuedEvent(long sequence, ILoggingEvent event) {
+    QueuedEvent(long sequence, long incidentGeneration, ILoggingEvent event) {
       this.sequence = sequence;
+      this.incidentGeneration = incidentGeneration;
       this.event = event;
     }
   }
@@ -242,7 +244,9 @@ final class BoundedAsyncAppender extends UnsynchronizedAppenderBase<ILoggingEven
         rejected = true;
       } else {
         long sequence = nextSequence.get() + 1L;
-        QueuedEvent queued = new QueuedEvent(sequence, event);
+        long incidentGeneration =
+            runtime == null ? 0L : runtime.incidentGeneration(stream);
+        QueuedEvent queued = new QueuedEvent(sequence, incidentGeneration, event);
         synchronized (progress) {
           outstanding++;
         }
@@ -305,7 +309,7 @@ final class BoundedAsyncAppender extends UnsynchronizedAppenderBase<ILoggingEven
               nested.isStarted()
                   && (runtime == null || runtime.failureGeneration(stream) == generation);
           if (persisted && runtime != null) {
-            runtime.recordSuccess(stream);
+            runtime.recordSuccess(stream, queued.incidentGeneration);
           }
         } finally {
           inFlight.decrementAndGet();

--- a/src/main/java/featurecat/lizzie/logging/LoggingRuntime.java
+++ b/src/main/java/featurecat/lizzie/logging/LoggingRuntime.java
@@ -373,22 +373,31 @@ public final class LoggingRuntime {
   void recordFailure(LogStream stream, String reason) {
     StreamState state = streams.get(stream);
     if (state != null) {
-      state.recordFailure(reason);
-    }
-    if (stream == LogStream.APP) {
-      persistenceEnabled.set(false);
+      synchronized (state) {
+        state.recordFailure(reason);
+        if (stream == LogStream.APP) {
+          persistenceEnabled.set(false);
+        }
+      }
     }
     notice(stream.name() + ":failure", reason);
   }
 
-  void recordSuccess(LogStream stream) {
+  void recordSuccess(LogStream stream, long incidentGeneration) {
     StreamState state = streams.get(stream);
     if (state != null) {
-      state.recordSuccess();
-      if (stream == LogStream.APP && state.recovered) {
-        persistenceEnabled.set(true);
+      synchronized (state) {
+        boolean recovered = state.recordSuccess(incidentGeneration);
+        if (stream == LogStream.APP && recovered) {
+          persistenceEnabled.set(true);
+        }
       }
     }
+  }
+
+  long incidentGeneration(LogStream stream) {
+    StreamState state = streams.get(stream);
+    return state == null ? 0L : state.incidentGeneration();
   }
 
   long failureGeneration(LogStream stream) {
@@ -772,6 +781,7 @@ public final class LoggingRuntime {
     private final LogStream stream;
     private final AtomicLong dropped = new AtomicLong();
     private final AtomicLong failures = new AtomicLong();
+    private final AtomicLong incidents = new AtomicLong();
     private volatile String reason;
     private volatile Instant firstOccurrence;
     private volatile Instant lastOccurrence;
@@ -781,8 +791,9 @@ public final class LoggingRuntime {
       this.stream = stream;
     }
 
-    private void recordDrop() {
+    private synchronized void recordDrop() {
       dropped.incrementAndGet();
+      incidents.incrementAndGet();
       Instant now = Instant.now();
       if (firstOccurrence == null) {
         firstOccurrence = now;
@@ -794,8 +805,9 @@ public final class LoggingRuntime {
       recovered = false;
     }
 
-    private void recordFailure(String failureReason) {
+    private synchronized void recordFailure(String failureReason) {
       failures.incrementAndGet();
+      incidents.incrementAndGet();
       Instant now = Instant.now();
       if (firstOccurrence == null) {
         firstOccurrence = now;
@@ -809,13 +821,19 @@ public final class LoggingRuntime {
       return failures.get();
     }
 
-    private void recordSuccess() {
-      if (reason != null || dropped.get() > 0) {
-        recovered = true;
-      }
+    private long incidentGeneration() {
+      return incidents.get();
     }
 
-    private LoggingStatus.StreamStatus snapshot() {
+    private synchronized boolean recordSuccess(long incidentGeneration) {
+      // A write admitted before the latest drop/failure does not prove that the stream recovered.
+      if (incidentGeneration == incidents.get() && (reason != null || dropped.get() > 0)) {
+        recovered = true;
+      }
+      return recovered;
+    }
+
+    private synchronized LoggingStatus.StreamStatus snapshot() {
       return new LoggingStatus.StreamStatus(
           stream, reason, firstOccurrence, lastOccurrence, dropped.get(), recovered);
     }

--- a/src/test/java/featurecat/lizzie/logging/LoggingRuntimeTest.java
+++ b/src/test/java/featurecat/lizzie/logging/LoggingRuntimeTest.java
@@ -384,18 +384,31 @@ class LoggingRuntimeTest {
             new WorkDirectoryResolution(tempDir, List.of()),
             new LoggingLimits(32, 4, 4, 4, 7, 10000, 1000));
     runtime.startFullTrace(EnumSet.of(TraceScope.ENGINE_GTP));
-    CountDownLatch gate = new CountDownLatch(1);
-    runtime.blockPersistenceForTests(LogStream.ENGINE_TRACE, gate);
+    runtime.awaitIdle();
+    CountDownLatch handoffEntered = new CountDownLatch(1);
+    CountDownLatch handoffHold = new CountDownLatch(1);
+    runtime.pauseHandoffForTests(LogStream.ENGINE_TRACE, handoffEntered, handoffHold);
     org.slf4j.Logger trace = LoggerFactory.getLogger(LogCategories.ENGINE_TRACE);
-    for (int i = 0; i < 64; i++) {
-      trace.info("flood-{}", i);
+    trace.info("accepted-before-saturation");
+    assertTrue(handoffEntered.await(1, TimeUnit.SECONDS));
+    try {
+      for (int i = 0; i < 64; i++) {
+        trace.info("flood-{}", i);
+      }
+      LoggingStatus.StreamStatus blocked =
+          runtime.status().stream(LogStream.ENGINE_TRACE).orElseThrow();
+      assertTrue(blocked.droppedCount() > 0);
+      assertEquals("queue saturation", blocked.reason());
+      assertFalse(blocked.recovered());
+    } finally {
+      handoffHold.countDown();
     }
-    LoggingStatus.StreamStatus blocked =
+    runtime.awaitIdle();
+    LoggingStatus.StreamStatus drained =
         runtime.status().stream(LogStream.ENGINE_TRACE).orElseThrow();
-    assertTrue(blocked.droppedCount() > 0);
-    assertEquals("queue saturation", blocked.reason());
-    assertFalse(blocked.recovered());
-    gate.countDown();
+    assertFalse(
+        drained.recovered(),
+        "events admitted before saturation must not report that the stream recovered");
     trace.info("after-drain");
     runtime.awaitIdle();
     LoggingStatus.StreamStatus recovered =


### PR DESCRIPTION
## Summary
- record the logging incident generation when an event enters the bounded queue
- prevent writes admitted before a later drop or file failure from incorrectly marking the stream as recovered
- linearize application persistence health updates with the corresponding stream state
- make the saturation recovery regression deterministic by pausing the worker at handoff

## Why
The post-merge full verification gate exposed a low-probability race in `LoggingRuntimeTest.queueSaturationThenSuccessfulWriteMarksRecovered`. On unchanged `main`, the reproducer failed at iteration 64: an event accepted before queue saturation could finish afterward and incorrectly report recovery.

## Verification
- targeted recovery regression: 100/100 consecutive passes
- `LoggingRuntimeTest`: 27 tests, 0 failures
- local CI `all`: 28/28 checks passed
- JDK 21 full verification: 3,750 tests, 0 failures, 0 errors, 12 skipped
- package, release scripts, Windows credential checks, line endings, Markdown links, macOS packaging, and R2 release tests passed
- `git diff --check` passed
