### PR TITLE
fix(gui): keep manual analysis pause authoritative

### DIFF
--- a/src/main/java/featurecat/lizzie/analysis/AnalysisEngine.java
+++ b/src/main/java/featurecat/lizzie/analysis/AnalysisEngine.java
@@ -166,6 +166,9 @@ public class AnalysisEngine {
   private boolean sharedForegroundLeaseActive;
   private Leelaz.ForegroundAnalysisLease sharedForegroundLease;
   private ForegroundRequestTarget sharedForegroundHandoffOwner;
+  private boolean sharedForegroundRestoreInProgress;
+  private Runnable sharedForegroundRestoreCompletion;
+  private Runnable sharedForegroundRestoreFailure;
   private ForegroundRequestTarget pendingForegroundRequest;
   private boolean sharedForegroundRulesCapturePending;
   private long foregroundRequestGeneration;
@@ -1117,16 +1120,24 @@ public class AnalysisEngine {
 
   /** Stops this worker and runs {@code afterRestore} once any shared foreground lease is restored. */
   public void normalQuit(Runnable afterRestore) {
+    normalQuit(afterRestore, afterRestore);
+  }
+
+  /**
+   * Stops this worker and reports whether a pending shared foreground lease restore succeeded.
+   * Dedicated workers have no restore boundary and therefore use {@code afterRestore}.
+   */
+  public void normalQuit(Runnable afterRestore, Runnable afterRestoreFailure) {
     requestShutdown();
     isNormalEnd = true;
     AnalysisResourceCoordinator.processStopped(this, purpose, process);
     shutdownRemoteGtpSetupAckTimeoutExecutor();
     if (sharedForegroundEngine != null) {
       requestDispatchFailed = true;
-      finishFailedRequestDispatch(false, afterRestore);
+      finishFailedRequestDispatch(false, afterRestore, afterRestoreFailure);
     } else {
       boolean restorePending =
-          releaseSharedForegroundLease(afterRestore, afterRestore);
+          releaseSharedForegroundLease(afterRestore, afterRestoreFailure);
       if (!restorePending && afterRestore != null) {
         afterRestore.run();
       }
@@ -1658,6 +1669,14 @@ public class AnalysisEngine {
 
   private void finishFailedRequestDispatch(
       boolean showProgressDialog, Runnable afterForegroundRestore) {
+    finishFailedRequestDispatch(
+        showProgressDialog, afterForegroundRestore, afterForegroundRestore);
+  }
+
+  private void finishFailedRequestDispatch(
+      boolean showProgressDialog,
+      Runnable afterForegroundRestore,
+      Runnable afterForegroundRestoreFailure) {
     Runnable failedRequestCallback = failureCallback;
     analyzeMap.clear();
     remoteGtpQueue().clear();
@@ -1684,7 +1703,10 @@ public class AnalysisEngine {
             ? null
             : () -> javax.swing.SwingUtilities.invokeLater(failedRequestCallback);
     Runnable finishRestore = chainCallbacks(deliverFailure, afterForegroundRestore);
-    boolean restorePending = releaseSharedForegroundLease(finishRestore, finishRestore);
+    Runnable finishRestoreFailure =
+        chainCallbacks(deliverFailure, afterForegroundRestoreFailure);
+    boolean restorePending =
+        releaseSharedForegroundLease(finishRestore, finishRestoreFailure);
     resumeForegroundAnalysisIfRequested();
     if (Lizzie.frame.isBatchAnalysisMode) Lizzie.frame.isBatchAnalysisMode = false;
     if (waitFrame != null || showProgressDialog) {
@@ -2122,6 +2144,13 @@ public class AnalysisEngine {
 
   private synchronized boolean releaseSharedForegroundLease(
       Runnable afterRestore, Runnable afterRestoreFailure) {
+    if (sharedForegroundRestoreInProgress) {
+      sharedForegroundRestoreCompletion =
+          chainCallbacks(sharedForegroundRestoreCompletion, afterRestore);
+      sharedForegroundRestoreFailure =
+          chainCallbacks(sharedForegroundRestoreFailure, afterRestoreFailure);
+      return true;
+    }
     Leelaz.ForegroundAnalysisLease lease = sharedForegroundLease;
     ForegroundRequestTarget handoffOwner = sharedForegroundHandoffOwner;
     sharedForegroundLeaseStarting = false;
@@ -2129,14 +2158,43 @@ public class AnalysisEngine {
     sharedForegroundLease = null;
     sharedForegroundHandoffOwner = null;
     sharedForegroundRulesCapturePending = false;
-    if (lease != null) {
-      return lease.release(afterRestore, afterRestoreFailure);
+    if (lease == null && handoffOwner == null) {
+      return false;
     }
-    if (handoffOwner != null) {
-      return sharedForegroundEngine.endForegroundAnalysisLease(
-          handoffOwner, afterRestore, afterRestoreFailure);
+    sharedForegroundRestoreInProgress = true;
+    sharedForegroundRestoreCompletion = afterRestore;
+    sharedForegroundRestoreFailure = afterRestoreFailure;
+    boolean restorePending =
+        lease != null
+            ? lease.release(
+                () -> finishTrackedSharedForegroundRestore(true),
+                () -> finishTrackedSharedForegroundRestore(false))
+            : sharedForegroundEngine.endForegroundAnalysisLease(
+                handoffOwner,
+                () -> finishTrackedSharedForegroundRestore(true),
+                () -> finishTrackedSharedForegroundRestore(false));
+    if (!restorePending && sharedForegroundRestoreInProgress) {
+      sharedForegroundRestoreInProgress = false;
+      sharedForegroundRestoreCompletion = null;
+      sharedForegroundRestoreFailure = null;
     }
-    return false;
+    return restorePending;
+  }
+
+  private void finishTrackedSharedForegroundRestore(boolean successful) {
+    Runnable callback;
+    synchronized (this) {
+      if (!sharedForegroundRestoreInProgress) {
+        return;
+      }
+      callback = successful ? sharedForegroundRestoreCompletion : sharedForegroundRestoreFailure;
+      sharedForegroundRestoreInProgress = false;
+      sharedForegroundRestoreCompletion = null;
+      sharedForegroundRestoreFailure = null;
+    }
+    if (callback != null) {
+      callback.run();
+    }
   }
 
   private synchronized void finishSharedForegroundRestoreFailure() {

--- a/src/main/java/featurecat/lizzie/analysis/Leelaz.java
+++ b/src/main/java/featurecat/lizzie/analysis/Leelaz.java
@@ -15333,7 +15333,8 @@ public class Leelaz {
         && !isThinking
         && !EngineManager.occupiesEngineGameAdmission()
         && (Lizzie.frame == null
-            || (!Lizzie.frame.isPlayingAgainstLeelaz
+            || (!Lizzie.frame.isUserAnalysisPaused()
+                && !Lizzie.frame.isPlayingAgainstLeelaz
                 && !Lizzie.frame.isAnaPlayingAgainstLeelaz
                 && !Lizzie.frame.isContributing
                 && (Lizzie.frame.humanSlGame == null || Lizzie.frame.humanSlGame.isFinished())

--- a/src/main/java/featurecat/lizzie/analysis/Leelaz.java
+++ b/src/main/java/featurecat/lizzie/analysis/Leelaz.java
@@ -4076,7 +4076,8 @@ public class Leelaz {
               || foregroundRestoreInProgress
               || normalCommandSendInProgress
               || !commandQueue().isEmpty()
-              || !foregroundRestoreCommandQueue().isEmpty()) {
+              || !foregroundRestoreCommandQueue().isEmpty()
+              || (Lizzie.frame != null && Lizzie.frame.isUserAnalysisPaused())) {
             return false;
           }
           claimed = true;

--- a/src/main/java/featurecat/lizzie/analysis/Leelaz.java
+++ b/src/main/java/featurecat/lizzie/analysis/Leelaz.java
@@ -371,6 +371,7 @@ public class Leelaz {
   private Process process;
   private transient EngineTransport remoteTransport;
   private volatile Object engineArbitrationLock = new Object();
+  private volatile Object analysisControlPonderLock = new Object();
   /** Admission generations keep delayed local state publication from overwriting a newer command. */
   private volatile long komiAdmissionGeneration;
   private volatile long boardSizeAdmissionGeneration;
@@ -4076,13 +4077,14 @@ public class Leelaz {
               || foregroundRestoreInProgress
               || normalCommandSendInProgress
               || !commandQueue().isEmpty()
-              || !foregroundRestoreCommandQueue().isEmpty()
-              || (Lizzie.frame != null && Lizzie.frame.isUserAnalysisPaused())) {
+              || !foregroundRestoreCommandQueue().isEmpty()) {
             return false;
           }
           claimed = true;
           int commandNumberBeforePonder = cmdNumber;
-          ponder();
+          if (!ponderAfterTrackingIfAnalysisControlAllows()) {
+            return false;
+          }
           if (cmdNumber > commandNumberBeforePonder) {
             settleTrackingPonderResponseWatermark();
           }
@@ -12274,6 +12276,19 @@ public class Leelaz {
     }
   }
 
+  private Object analysisControlPonderLock() {
+    Object lock = analysisControlPonderLock;
+    if (lock != null) {
+      return lock;
+    }
+    synchronized (this) {
+      if (analysisControlPonderLock == null) {
+        analysisControlPonderLock = new Object();
+      }
+      return analysisControlPonderLock;
+    }
+  }
+
   private Object statefulOrdinaryPublicationLock() {
     Object lock = statefulOrdinaryPublicationLock;
     if (lock != null) {
@@ -15032,7 +15047,6 @@ public class Leelaz {
       runForegroundRestoreFailure(session);
       return;
     }
-    boolean resumePonder = false;
     try {
       synchronized (commandQueue()) {
         foregroundRestoreCommandQueue().clear();
@@ -15042,19 +15056,15 @@ public class Leelaz {
       } catch (RuntimeException ex) {
         ex.printStackTrace();
       }
-      resumePonder =
-          session.wasPondering
-              && Lizzie.leelaz == this
-              && canResumePonderAfterForegroundLease();
     } finally {
       finishForegroundRestoreLifecycle();
-    }
-    if (resumePonder) {
-      ponder();
     }
     if (releaseStopFailed) {
       runForegroundRestoreFailure(session);
     } else {
+      if (session.wasPondering) {
+        resumePonderAfterForegroundLeaseIfAllowed();
+      }
       runForegroundRestoreCompletion(session);
     }
   }
@@ -15341,6 +15351,26 @@ public class Leelaz {
                 && (Lizzie.frame.humanSlGame == null || Lizzie.frame.humanSlGame.isFinished())
                 && (Lizzie.frame.readBoard == null
                     || !Lizzie.frame.readBoard.isReadBoardGmaEngineBusy())));
+  }
+
+  private boolean resumePonderAfterForegroundLeaseIfAllowed() {
+    synchronized (analysisControlPonderLock()) {
+      if (Lizzie.leelaz != this || !canResumePonderAfterForegroundLease()) {
+        return false;
+      }
+      ponder();
+      return true;
+    }
+  }
+
+  private boolean ponderAfterTrackingIfAnalysisControlAllows() {
+    synchronized (analysisControlPonderLock()) {
+      if (Lizzie.frame != null && Lizzie.frame.isUserAnalysisPaused()) {
+        return false;
+      }
+      ponder();
+      return true;
+    }
   }
 
   private boolean writeExclusiveGtpCommand(
@@ -21267,6 +21297,23 @@ public class Leelaz {
       nameCmd();
     }
     YikeSyncDebugLog.log("Leelaz togglePonder after isPondering=" + isPondering);
+  }
+
+  /**
+   * Linearizes the analysis-control pause with tracking and ExclusiveGtp ponder handback.
+   *
+   * <p>The pause state must be recorded while holding the same lock used by both restore paths;
+   * otherwise a restore can pass its pause check, then send ponder after the pause latch is set.
+   */
+  public void pauseForAnalysisControl(Runnable recordPause) {
+    synchronized (analysisControlPonderLock()) {
+      if (recordPause != null) {
+        recordPause.run();
+      }
+    }
+    if (Lizzie.leelaz == this && isPondering()) {
+      togglePonder();
+    }
   }
 
   private String buildPonderCallerTrace() {

--- a/src/main/java/featurecat/lizzie/gui/AnalysisTable.java
+++ b/src/main/java/featurecat/lizzie/gui/AnalysisTable.java
@@ -244,6 +244,10 @@ public class AnalysisTable {
   }
 
   protected void verifyCurrentKifu() {
+    if (Lizzie.frame.deferKifuOpenUntilAutomaticQuickAnalysisRestored(
+        this::verifyCurrentKifu)) {
+      return;
+    }
     // TODO Auto-generated method stub
     String firstFileName = Lizzie.frame.Batchfiles.get(Lizzie.frame.BatchAnaNum).getName();
     if (!LizzieFrame.fileNameTitle.equals(firstFileName)) {

--- a/src/main/java/featurecat/lizzie/gui/BatchShareFrame.java
+++ b/src/main/java/featurecat/lizzie/gui/BatchShareFrame.java
@@ -181,6 +181,10 @@ public class BatchShareFrame extends JDialog {
     btnApply.addActionListener(
         new ActionListener() {
           public void actionPerformed(ActionEvent e) {
+            if (Lizzie.frame.deferKifuOpenUntilAutomaticQuickAnalysisRestored(
+                () -> actionPerformed(e))) {
+              return;
+            }
             String up = formatStr(txtUploader.getText());
             if (up.equals("")) {
               Message msg = new Message();

--- a/src/main/java/featurecat/lizzie/gui/BottomToolbar.java
+++ b/src/main/java/featurecat/lizzie/gui/BottomToolbar.java
@@ -2858,6 +2858,10 @@ public class BottomToolbar extends JPanel {
   }
 
   public void loadAutoBatchFile() {
+    if (Lizzie.frame.deferKifuOpenUntilAutomaticQuickAnalysisRestored(
+        this::loadAutoBatchFile)) {
+      return;
+    }
     Lizzie.frame.BatchAnaNum = Lizzie.frame.BatchAnaNum + 1;
     try {
       if (Lizzie.frame.analysisTable != null && Lizzie.frame.analysisTable.frame.isVisible()) {

--- a/src/main/java/featurecat/lizzie/gui/LizzieFrame.java
+++ b/src/main/java/featurecat/lizzie/gui/LizzieFrame.java
@@ -544,12 +544,15 @@ public class LizzieFrame extends JFrame {
   private volatile BoardHistoryNode loadedGameQuickAnalysisRoot;
   private volatile boolean loadedGameQuickAnalysisActive;
   private volatile boolean loadedGameQuickAnalysisRunning;
+  private volatile AnalysisEngine loadedGameQuickAnalysisEngine;
+  private volatile long loadedGameQuickAnalysisEngineGeneration = -1;
   private volatile long loadedGameQuickAnalysisDispatchStartedAt;
   private int loadedGameQuickAnalysisFailureCount;
   private volatile boolean userAnalysisPaused;
   private volatile BoardHistoryNode userCancelledQuickAnalysisRoot;
   private volatile boolean pendingForegroundResumeAfterCleanup;
   private volatile boolean analysisControlCleanupInProgress;
+  private volatile long analysisControlCleanupGeneration;
   private boolean kifuOpenWaitingForQuickAnalysisRestore;
   private DeferredKifuOpen pendingKifuOpen;
   private static final int LOADED_GAME_QUICK_ANALYSIS_RETRY_MS = 1800;
@@ -1280,62 +1283,7 @@ public class LizzieFrame extends JFrame {
         new TransferHandler() {
           @Override
           public boolean importData(JComponent comp, Transferable t) {
-            try {
-              Object o = t.getTransferData(DataFlavor.javaFileListFlavor);
-              String filepath = o.toString();
-              if (filepath.startsWith("[")) {
-                filepath = filepath.substring(1);
-              }
-              if (filepath.endsWith("]")) {
-                filepath = filepath.substring(0, filepath.length() - 1);
-              }
-              String[] filePaths = filepath.split(", ");
-              if (filePaths.length == 1) {
-                boolean ponder = Lizzie.leelaz.isPondering() || !Lizzie.leelaz.isLoaded;
-                File file = new File(filepath);
-                File files[] = new File[1];
-                files[0] = file;
-                loadFile(file, true, true);
-                curFile = file;
-                if (Lizzie.frame.analysisTable != null
-                    && Lizzie.frame.analysisTable.frame.isVisible()) {
-                  Lizzie.frame.analysisTable.refreshTable();
-                }
-                if (ponder) {
-                  Lizzie.leelaz.ponder();
-                }
-                refresh();
-                return true;
-              } else if (filePaths.length > 1) {
-                File files[] = new File[filePaths.length];
-                for (int i = 0; i < filePaths.length; i++) {
-                  files[i] = new File(filePaths[i]);
-                }
-                isBatchAna = true;
-                BatchAnaNum = 0;
-                Batchfiles = new ArrayList<File>();
-                for (int i = 0; i < files.length; i++) {
-                  Batchfiles.add(files[i]);
-                }
-                loadFile(files[0], true, true);
-                // 打开分析界面
-                StartAnaDialog newgame = new StartAnaDialog(false, Lizzie.frame);
-                newgame.setVisible(true);
-                if (newgame.isCancelled()) {
-                  isBatchAna = false;
-                  toolbar.resetAutoAna();
-                  if (Lizzie.frame.analysisTable != null
-                      && Lizzie.frame.analysisTable.frame.isVisible()) {
-                    Lizzie.frame.analysisTable.refreshTable();
-                  }
-                  Lizzie.frame.refresh();
-                  return true;
-                }
-              }
-            } catch (Exception e) {
-              e.printStackTrace();
-            }
-            return false;
+            return importDroppedKifuFiles(t);
           }
 
           @Override
@@ -4367,13 +4315,80 @@ public class LizzieFrame extends JFrame {
     refresh();
   }
 
-  private boolean deferKifuOpenUntilAutomaticQuickAnalysisRestored(Runnable continuation) {
+  boolean importDroppedKifuFiles(Transferable transferable) {
+    List<File> capturedFiles = new ArrayList<>();
+    try {
+      Object transferData = transferable.getTransferData(DataFlavor.javaFileListFlavor);
+      if (!(transferData instanceof List<?>)) {
+        return false;
+      }
+      for (Object entry : (List<?>) transferData) {
+        if (!(entry instanceof File)) {
+          return false;
+        }
+        capturedFiles.add((File) entry);
+      }
+    } catch (Exception e) {
+      e.printStackTrace();
+      return false;
+    }
+    if (capturedFiles.isEmpty()) {
+      return false;
+    }
+    if (deferKifuOpenUntilAutomaticQuickAnalysisRestored(
+        () -> finishDroppedKifuImport(capturedFiles))) {
+      return true;
+    }
+    return finishDroppedKifuImport(capturedFiles);
+  }
+
+  private boolean finishDroppedKifuImport(List<File> files) {
+    try {
+      if (files.size() == 1) {
+        boolean ponder = Lizzie.leelaz.isPondering() || !Lizzie.leelaz.isLoaded;
+        File file = files.get(0);
+        loadFile(file, true, true);
+        curFile = file;
+        if (Lizzie.frame.analysisTable != null && Lizzie.frame.analysisTable.frame.isVisible()) {
+          Lizzie.frame.analysisTable.refreshTable();
+        }
+        if (ponder) {
+          Lizzie.leelaz.ponder();
+        }
+        refresh();
+        return true;
+      }
+
+      isBatchAna = true;
+      BatchAnaNum = 0;
+      Batchfiles = new ArrayList<File>(files);
+      loadFile(files.get(0), true, true);
+      // 打开分析界面
+      StartAnaDialog newgame = new StartAnaDialog(false, Lizzie.frame);
+      newgame.setVisible(true);
+      if (newgame.isCancelled()) {
+        isBatchAna = false;
+        toolbar.resetAutoAna();
+        if (Lizzie.frame.analysisTable != null && Lizzie.frame.analysisTable.frame.isVisible()) {
+          Lizzie.frame.analysisTable.refreshTable();
+        }
+        Lizzie.frame.refresh();
+      }
+      return true;
+    } catch (Exception e) {
+      e.printStackTrace();
+      return false;
+    }
+  }
+
+  boolean deferKifuOpenUntilAutomaticQuickAnalysisRestored(Runnable continuation) {
     return deferKifuOpenUntilAutomaticQuickAnalysisRestored(continuation, null);
   }
 
   private boolean deferKifuOpenUntilAutomaticQuickAnalysisRestored(
       Runnable continuation, Runnable superseded) {
-    if (kifuOpenWaitingForQuickAnalysisRestore) {
+    if (kifuOpenWaitingForQuickAnalysisRestore || analysisControlCleanupInProgress) {
+      kifuOpenWaitingForQuickAnalysisRestore = true;
       DeferredKifuOpen previous = pendingKifuOpen;
       pendingKifuOpen = new DeferredKifuOpen(continuation, superseded);
       if (previous != null) {
@@ -4395,16 +4410,20 @@ public class LizzieFrame extends JFrame {
     analysisEngine = null;
     currentEngine.clearRequestCallbacks();
     currentEngine.normalQuit(
-        () ->
-            SwingUtilities.invokeLater(
-                () -> {
-                  kifuOpenWaitingForQuickAnalysisRestore = false;
-                  DeferredKifuOpen deferred = pendingKifuOpen;
-                  pendingKifuOpen = null;
-                  if (deferred != null) {
-                    deferred.run();
-                  }
-                }));
+        () -> SwingUtilities.invokeLater(this::finishDeferredKifuOpenAfterQuickAnalysisRestore));
+    return true;
+  }
+
+  private boolean finishDeferredKifuOpenAfterQuickAnalysisRestore() {
+    if (!kifuOpenWaitingForQuickAnalysisRestore) {
+      return false;
+    }
+    kifuOpenWaitingForQuickAnalysisRestore = false;
+    DeferredKifuOpen deferred = pendingKifuOpen;
+    pendingKifuOpen = null;
+    if (deferred != null) {
+      deferred.run();
+    }
     return true;
   }
 
@@ -4501,6 +4520,9 @@ public class LizzieFrame extends JFrame {
   }
 
   public void openSgfStart() {
+    if (deferKifuOpenUntilAutomaticQuickAnalysisRestored(this::openSgfStart)) {
+      return;
+    }
     if (Lizzie.leelaz.isPondering()) {
       Lizzie.leelaz.togglePonder();
     }
@@ -4538,6 +4560,9 @@ public class LizzieFrame extends JFrame {
   }
 
   public void openFileWithAna(boolean isFlashMode) {
+    if (deferKifuOpenUntilAutomaticQuickAnalysisRestored(() -> openFileWithAna(isFlashMode))) {
+      return;
+    }
     //   boolean ponder = false;
     //  double komi = Lizzie.board.getHistory().getGameInfo().getKomi();
     //    if (Lizzie.leelaz.isPondering()) {
@@ -4629,6 +4654,9 @@ public class LizzieFrame extends JFrame {
   }
 
   public void resumeFile() {
+    if (deferKifuOpenUntilAutomaticQuickAnalysisRestored(this::resumeFile)) {
+      return;
+    }
     File file = resolveAutoSaveFile(1, "sgf");
     if (file.exists()) loadFile(file, true, true);
     else {
@@ -5164,6 +5192,7 @@ public class LizzieFrame extends JFrame {
     fileNameTitle = file.getName();
     updateTitle();
     if (file.getPath().toLowerCase().endsWith(".gib")) {
+      startNewKifuAnalysisContextAfterSuccessfulLoad();
       scheduleResumeAnalysisAfterLoad(0);
     } else {
       // SGFParser finalizes last-move navigation on the next EDT turn. Queue the immutable
@@ -5254,7 +5283,7 @@ public class LizzieFrame extends JFrame {
     canGoAfterload = true;
     pendingKifuEngineSyncRoot = root;
     stopLoadedGameQuickAnalysisRetry();
-    clearUserAnalysisPauseForNewKifuLoadContext();
+    startNewKifuAnalysisContextAfterSuccessfulLoad();
     Runnable submit = () -> submitKifuEngineSync(root, delayMillis, action);
     if (stopBusyQuickAnalysisEngineBeforeLoadedKifuAnalysis(
         () -> SwingUtilities.invokeLater(submit))) {
@@ -12596,7 +12625,9 @@ public class LizzieFrame extends JFrame {
 
   public void togglePonderMannul() {
     if (Lizzie.leelaz == null) {
-      if (Lizzie.engineManager != null) {
+      if (loadedGameQuickAnalysisActive) {
+        pauseFromAnalysisControl();
+      } else if (Lizzie.engineManager != null) {
         Lizzie.engineManager.retryUnavailablePrimaryEngine();
       }
       return;
@@ -12621,13 +12652,20 @@ public class LizzieFrame extends JFrame {
   }
 
   private void pauseFromAnalysisControl() {
-    userAnalysisPaused = true;
-    pendingForegroundResumeAfterCleanup = false;
-    userCancelledQuickAnalysisRoot = currentHistoryRoot();
-    if (Lizzie.leelaz != null && Lizzie.leelaz.isPondering()) {
-      Lizzie.leelaz.togglePonder();
+    BoardHistoryNode cancelledRoot = currentHistoryRoot();
+    Leelaz primaryEngine = Lizzie.leelaz;
+    if (primaryEngine == null) {
+      recordUserAnalysisPause(cancelledRoot);
+    } else {
+      primaryEngine.pauseForAnalysisControl(() -> recordUserAnalysisPause(cancelledRoot));
     }
     cancelLoadedGameQuickAnalysisForUserPause();
+  }
+
+  private void recordUserAnalysisPause(BoardHistoryNode cancelledRoot) {
+    userAnalysisPaused = true;
+    pendingForegroundResumeAfterCleanup = false;
+    userCancelledQuickAnalysisRoot = cancelledRoot;
   }
 
   private void resumeFromAnalysisControl() {
@@ -13937,6 +13975,9 @@ public class LizzieFrame extends JFrame {
         new ActionListener() {
           @Override
           public void actionPerformed(ActionEvent e) {
+            if (deferKifuOpenUntilAutomaticQuickAnalysisRestored(() -> actionPerformed(e))) {
+              return;
+            }
             // TBD未完成
             canShowBigBoardImage = false;
             loadFile(
@@ -14489,6 +14530,9 @@ public class LizzieFrame extends JFrame {
     tempGamePanelMoveLis =
         new MouseAdapter() {
           public void mouseClicked(MouseEvent e) {
+            if (deferKifuOpenUntilAutomaticQuickAnalysisRestored(() -> mouseClicked(e))) {
+              return;
+            }
             int x = e.getX();
             int y = e.getY();
             for (TempGameData data : tempGameList) {
@@ -14559,6 +14603,9 @@ public class LizzieFrame extends JFrame {
     bigBoardPanelLis =
         new MouseAdapter() {
           public void mouseClicked(MouseEvent e) {
+            if (deferKifuOpenUntilAutomaticQuickAnalysisRestored(() -> mouseClicked(e))) {
+              return;
+            }
             if (e.getX() == 0 && e.getY() == 0) {
               canShowBigBoardImage = false;
               loadFile(
@@ -15543,6 +15590,7 @@ public class LizzieFrame extends JFrame {
       return;
     }
     if (!silentAnalyze) {
+      prepareForManualFlashAnalysis();
       releaseDedicatedLightweightQuickAnalysisEngine();
     }
     boolean hasAutomaticQuickAnalysisCommand =
@@ -15672,6 +15720,8 @@ public class LizzieFrame extends JFrame {
                       return;
                     }
                     AnalysisEngine targetEngine = analysisEngine;
+                    loadedGameQuickAnalysisEngine = targetEngine;
+                    loadedGameQuickAnalysisEngineGeneration = generation;
                     targetEngine.setCompletionCallback(
                         () -> finishLoadedGameQuickAnalysisAttempt(generation, root, false));
                     targetEngine.setFailureCallback(
@@ -15721,6 +15771,7 @@ public class LizzieFrame extends JFrame {
     if (!isCurrentLoadedGameQuickAnalysis(generation, root)) {
       return;
     }
+    clearLoadedGameQuickAnalysisEngine(generation);
     loadedGameQuickAnalysisRunning = false;
     loadedGameQuickAnalysisDispatchStartedAt = 0;
     if (failed) {
@@ -19876,10 +19927,6 @@ public class LizzieFrame extends JFrame {
     if (EngineGamePresentation.current().startingOrPlaying() || isPlayingAgainstLeelaz || isAnaPlayingAgainstLeelaz) {
       return false;
     }
-    if (userCancelledQuickAnalysisRoot != null
-        && userCancelledQuickAnalysisRoot != currentHistoryRoot()) {
-      clearUserAnalysisPauseForNewKifuLoadContext();
-    }
     if (userAnalysisPaused) {
       cancelLoadedGameQuickAnalysisForUserPause();
       return false;
@@ -19943,6 +19990,8 @@ public class LizzieFrame extends JFrame {
       loadedGameQuickAnalysisRoot = root;
       loadedGameQuickAnalysisActive = true;
       loadedGameQuickAnalysisRunning = false;
+      loadedGameQuickAnalysisEngine = null;
+      loadedGameQuickAnalysisEngineGeneration = -1;
       loadedGameQuickAnalysisFailureCount = 0;
       clearPendingQuickAnalysisCallback();
     }
@@ -20048,6 +20097,8 @@ public class LizzieFrame extends JFrame {
     loadedGameQuickAnalysisRoot = null;
     loadedGameQuickAnalysisActive = false;
     loadedGameQuickAnalysisRunning = false;
+    loadedGameQuickAnalysisEngine = null;
+    loadedGameQuickAnalysisEngineGeneration = -1;
     loadedGameQuickAnalysisDispatchStartedAt = 0;
     loadedGameQuickAnalysisFailureCount = 0;
     clearPendingQuickAnalysisCallback();
@@ -20056,7 +20107,29 @@ public class LizzieFrame extends JFrame {
     }
   }
 
+  void prepareForManualFlashAnalysis() {
+    if (!loadedGameQuickAnalysisActive) {
+      return;
+    }
+    AnalysisEngine automaticEngine = loadedGameQuickAnalysisEngine;
+    if (quickAnalysisEngineGeneration != null) {
+      quickAnalysisEngineGeneration.incrementAndGet();
+    }
+    stopQuickAnalysisWarmupTimer();
+    stopQuickAnalysisNavigationResumeTimer();
+    stopLoadedGameQuickAnalysisRetry();
+    if (automaticEngine != null) {
+      automaticEngine.clearRequestCallbacks();
+    }
+  }
+
   private void cancelLoadedGameQuickAnalysisForUserPause() {
+    boolean hadLoadedGameQuickAnalysis = loadedGameQuickAnalysisActive;
+    AnalysisEngine currentEngine = analysisEngine;
+    boolean currentEngineOwnsLoadedGameQuickAnalysis =
+        currentEngine != null
+            && currentEngine == loadedGameQuickAnalysisEngine
+            && loadedGameQuickAnalysisEngineGeneration == loadedGameQuickAnalysisGeneration;
     if (quickAnalysisEngineGeneration != null) {
       quickAnalysisEngineGeneration.incrementAndGet();
     }
@@ -20064,21 +20137,41 @@ public class LizzieFrame extends JFrame {
     stopQuickAnalysisNavigationResumeTimer();
     stopLoadedGameQuickAnalysisRetry();
     clearPendingQuickAnalysisCallback();
-    AnalysisEngine currentEngine = analysisEngine;
-    if (currentEngine == null || !currentEngine.isAutomaticBackgroundTask()) {
-      analysisControlCleanupInProgress = false;
+    if (!hadLoadedGameQuickAnalysis
+        || currentEngine == null
+        || (!currentEngineOwnsLoadedGameQuickAnalysis
+            && !currentEngine.isAutomaticBackgroundTask())) {
       return;
     }
     analysisControlCleanupInProgress = true;
+    long cleanupGeneration = ++analysisControlCleanupGeneration;
     analysisEngine = null;
     currentEngine.clearRequestCallbacks();
     currentEngine.normalQuit(
         () ->
-            SwingUtilities.invokeLater(this::finishUserAnalysisPauseCleanup));
+            SwingUtilities.invokeLater(
+                () -> finishUserAnalysisPauseCleanup(cleanupGeneration, true)),
+        () ->
+            SwingUtilities.invokeLater(
+                () -> finishUserAnalysisPauseCleanup(cleanupGeneration, false)));
   }
 
-  private void finishUserAnalysisPauseCleanup() {
+  private void finishUserAnalysisPauseCleanup(long cleanupGeneration, boolean restoreSucceeded) {
+    if (cleanupGeneration != analysisControlCleanupGeneration) {
+      return;
+    }
     analysisControlCleanupInProgress = false;
+    if (!restoreSucceeded) {
+      pendingForegroundResumeAfterCleanup = false;
+      userAnalysisPaused = true;
+      finishDeferredKifuOpenAfterQuickAnalysisRestore();
+      return;
+    }
+    if (kifuOpenWaitingForQuickAnalysisRestore) {
+      pendingForegroundResumeAfterCleanup = false;
+      finishDeferredKifuOpenAfterQuickAnalysisRestore();
+      return;
+    }
     if (!pendingForegroundResumeAfterCleanup || userAnalysisPaused) {
       return;
     }
@@ -20086,7 +20179,20 @@ public class LizzieFrame extends JFrame {
     resumeForegroundAnalysisForCurrentPosition();
   }
 
+  void startNewKifuAnalysisContextAfterSuccessfulLoad() {
+    clearUserAnalysisPauseForNewKifuLoadContext();
+  }
+
+  private void clearLoadedGameQuickAnalysisEngine(long generation) {
+    if (loadedGameQuickAnalysisEngineGeneration != generation) {
+      return;
+    }
+    loadedGameQuickAnalysisEngine = null;
+    loadedGameQuickAnalysisEngineGeneration = -1;
+  }
+
   private void clearUserAnalysisPauseForNewKifuLoadContext() {
+    analysisControlCleanupGeneration++;
     userAnalysisPaused = false;
     pendingForegroundResumeAfterCleanup = false;
     analysisControlCleanupInProgress = false;

--- a/src/main/java/featurecat/lizzie/gui/LizzieFrame.java
+++ b/src/main/java/featurecat/lizzie/gui/LizzieFrame.java
@@ -546,6 +546,10 @@ public class LizzieFrame extends JFrame {
   private volatile boolean loadedGameQuickAnalysisRunning;
   private volatile long loadedGameQuickAnalysisDispatchStartedAt;
   private int loadedGameQuickAnalysisFailureCount;
+  private volatile boolean userAnalysisPaused;
+  private volatile BoardHistoryNode userCancelledQuickAnalysisRoot;
+  private volatile boolean pendingForegroundResumeAfterCleanup;
+  private volatile boolean analysisControlCleanupInProgress;
   private boolean kifuOpenWaitingForQuickAnalysisRestore;
   private DeferredKifuOpen pendingKifuOpen;
   private static final int LOADED_GAME_QUICK_ANALYSIS_RETRY_MS = 1800;
@@ -5250,6 +5254,7 @@ public class LizzieFrame extends JFrame {
     canGoAfterload = true;
     pendingKifuEngineSyncRoot = root;
     stopLoadedGameQuickAnalysisRetry();
+    clearUserAnalysisPauseForNewKifuLoadContext();
     Runnable submit = () -> submitKifuEngineSync(root, delayMillis, action);
     if (stopBusyQuickAnalysisEngineBeforeLoadedKifuAnalysis(
         () -> SwingUtilities.invokeLater(submit))) {
@@ -12599,6 +12604,35 @@ public class LizzieFrame extends JFrame {
     if (stopAiPlayingAndPolicy()) {
       return;
     }
+    if (shouldPauseFromAnalysisControl()) {
+      pauseFromAnalysisControl();
+      return;
+    }
+    resumeFromAnalysisControl();
+  }
+
+  private boolean shouldPauseFromAnalysisControl() {
+    return (Lizzie.leelaz != null && Lizzie.leelaz.isPondering())
+        || loadedGameQuickAnalysisActive;
+  }
+
+  private void pauseFromAnalysisControl() {
+    userAnalysisPaused = true;
+    pendingForegroundResumeAfterCleanup = false;
+    userCancelledQuickAnalysisRoot = currentHistoryRoot();
+    if (Lizzie.leelaz != null && Lizzie.leelaz.isPondering()) {
+      Lizzie.leelaz.togglePonder();
+    }
+    cancelLoadedGameQuickAnalysisForUserPause();
+  }
+
+  private void resumeFromAnalysisControl() {
+    userAnalysisPaused = false;
+    if (analysisControlCleanupInProgress) {
+      pendingForegroundResumeAfterCleanup = true;
+      return;
+    }
+    pendingForegroundResumeAfterCleanup = false;
     if (!Lizzie.leelaz.isPondering()) {
       if (!syncCurrentPositionToPrimaryEngineForAnalysis()) {
         return;
@@ -19838,6 +19872,14 @@ public class LizzieFrame extends JFrame {
     if (EngineGamePresentation.current().startingOrPlaying() || isPlayingAgainstLeelaz || isAnaPlayingAgainstLeelaz) {
       return false;
     }
+    if (userCancelledQuickAnalysisRoot != null
+        && userCancelledQuickAnalysisRoot != currentHistoryRoot()) {
+      clearUserAnalysisPauseForNewKifuLoadContext();
+    }
+    if (userAnalysisPaused) {
+      cancelLoadedGameQuickAnalysisForUserPause();
+      return false;
+    }
     if (shouldAutoQuickAnalyzeLoadedGame()) {
       long generation = beginLoadedGameQuickAnalysis();
       QuickAnalysisWarmupAction action = currentQuickAnalysisWarmupAction(true);
@@ -19862,7 +19904,10 @@ public class LizzieFrame extends JFrame {
   }
 
   private boolean resumeForegroundAnalysisForCurrentPosition() {
-    if (isWholeGameAnalysisStartingOrRunning() || Lizzie.leelaz == null || EngineManager.isEmpty) {
+    if (userAnalysisPaused
+        || isWholeGameAnalysisStartingOrRunning()
+        || Lizzie.leelaz == null
+        || EngineManager.isEmpty) {
       return false;
     }
     if (!syncCurrentPositionToPrimaryEngineForAnalysis()) {
@@ -20007,6 +20052,43 @@ public class LizzieFrame extends JFrame {
     }
   }
 
+  private void cancelLoadedGameQuickAnalysisForUserPause() {
+    if (quickAnalysisEngineGeneration != null) {
+      quickAnalysisEngineGeneration.incrementAndGet();
+    }
+    stopQuickAnalysisWarmupTimer();
+    stopQuickAnalysisNavigationResumeTimer();
+    stopLoadedGameQuickAnalysisRetry();
+    clearPendingQuickAnalysisCallback();
+    AnalysisEngine currentEngine = analysisEngine;
+    if (currentEngine == null || !currentEngine.isAutomaticBackgroundTask()) {
+      analysisControlCleanupInProgress = false;
+      return;
+    }
+    analysisControlCleanupInProgress = true;
+    analysisEngine = null;
+    currentEngine.clearRequestCallbacks();
+    currentEngine.normalQuit(
+        () ->
+            SwingUtilities.invokeLater(this::finishUserAnalysisPauseCleanup));
+  }
+
+  private void finishUserAnalysisPauseCleanup() {
+    analysisControlCleanupInProgress = false;
+    if (!pendingForegroundResumeAfterCleanup || userAnalysisPaused) {
+      return;
+    }
+    pendingForegroundResumeAfterCleanup = false;
+    resumeForegroundAnalysisForCurrentPosition();
+  }
+
+  private void clearUserAnalysisPauseForNewKifuLoadContext() {
+    userAnalysisPaused = false;
+    pendingForegroundResumeAfterCleanup = false;
+    analysisControlCleanupInProgress = false;
+    userCancelledQuickAnalysisRoot = null;
+  }
+
   public void preloadQuickAnalysisEngineForKifuBrowsing() {
     if (!SwingUtilities.isEventDispatchThread()) {
       SwingUtilities.invokeLater(this::preloadQuickAnalysisEngineForKifuBrowsing);
@@ -20079,9 +20161,9 @@ public class LizzieFrame extends JFrame {
     }
   }
 
-
   private boolean isQuickAnalysisWarmupContextEligible(boolean requiresAutoAnalyze) {
     return Lizzie.config != null
+        && !userAnalysisPaused
         && (!requiresAutoAnalyze || Lizzie.config.autoQuickAnalyzeOnLoad)
         && !isWholeGameAnalysisStartingOrRunning()
         && !EngineGamePresentation.current().startingOrPlaying()
@@ -20259,7 +20341,7 @@ public class LizzieFrame extends JFrame {
       }
     } finally {
       quickAnalysisEngineStarting.set(false);
-      if (invalidated) {
+      if (invalidated && !userAnalysisPaused) {
         scheduleQuickAnalysisWarmupWhenPrimaryReady(1200, false);
       }
     }
@@ -20415,6 +20497,10 @@ public class LizzieFrame extends JFrame {
       return false;
     }
     if (!Lizzie.config.autoQuickAnalyzeOnLoad || isBatchAna || isEnginePKSgfStart || isTrying) {
+      return false;
+    }
+    if (userCancelledQuickAnalysisRoot != null
+        && userCancelledQuickAnalysisRoot == currentHistoryRoot()) {
       return false;
     }
     BoardHistoryNode node = Lizzie.board.getHistory().getStart();

--- a/src/main/java/featurecat/lizzie/gui/LizzieFrame.java
+++ b/src/main/java/featurecat/lizzie/gui/LizzieFrame.java
@@ -12616,6 +12616,10 @@ public class LizzieFrame extends JFrame {
         || loadedGameQuickAnalysisActive;
   }
 
+  public boolean isUserAnalysisPaused() {
+    return userAnalysisPaused;
+  }
+
   private void pauseFromAnalysisControl() {
     userAnalysisPaused = true;
     pendingForegroundResumeAfterCleanup = false;

--- a/src/main/java/featurecat/lizzie/gui/Menu.java
+++ b/src/main/java/featurecat/lizzie/gui/Menu.java
@@ -6719,6 +6719,10 @@ public class Menu extends JMenuBar {
                   new ActionListener() {
                     @Override
                     public void actionPerformed(ActionEvent e) {
+                      if (Lizzie.frame.deferKifuOpenUntilAutomaticQuickAnalysisRestored(
+                          () -> actionPerformed(e))) {
+                        return;
+                      }
                       Lizzie.frame.loadFile(recentF, true, false);
                     }
                   });

--- a/src/test/java/featurecat/lizzie/analysis/AnalysisEngineRequestTest.java
+++ b/src/test/java/featurecat/lizzie/analysis/AnalysisEngineRequestTest.java
@@ -1269,6 +1269,59 @@ class AnalysisEngineRequestTest {
   }
 
   @Test
+  void normalQuitContinuationJoinsAlreadyPendingSharedForegroundRestore() throws Exception {
+    try (TestEnvironment env = TestEnvironment.open()) {
+      boardWithHistory(new BoardHistoryList(BoardData.empty(BOARD_SIZE, BOARD_SIZE)));
+      TrackingAnalysisEngine engine = TrackingAnalysisEngine.create();
+      DeferredRestoreLeelaz foreground = new DeferredRestoreLeelaz();
+      AtomicInteger continuations = new AtomicInteger();
+      setField(AnalysisEngine.class, engine, "sharedForegroundEngine", foreground);
+      setField(AnalysisEngine.class, engine, "sharedForegroundLease", foregroundLease(foreground));
+      setField(
+          AnalysisEngine.class,
+          engine,
+          "analyzeMap",
+          new java.util.HashMap<Integer, BoardHistoryNode>(
+              java.util.Map.of(1, Lizzie.board.getHistory().getCurrentHistoryNode())));
+
+      invokeAnalysisEngineSetResult(engine);
+      engine.normalQuit(continuations::incrementAndGet);
+
+      assertEquals(0, continuations.get());
+      foreground.completeRestore();
+      assertEquals(1, continuations.get());
+    }
+  }
+
+  @Test
+  void normalQuitContinuationJoinsAlreadyPendingSharedForegroundRestoreFailure() throws Exception {
+    try (TestEnvironment env = TestEnvironment.open()) {
+      boardWithHistory(new BoardHistoryList(BoardData.empty(BOARD_SIZE, BOARD_SIZE)));
+      TrackingAnalysisEngine engine = TrackingAnalysisEngine.create();
+      DeferredRestoreLeelaz foreground = new DeferredRestoreLeelaz();
+      AtomicInteger completions = new AtomicInteger();
+      AtomicInteger failures = new AtomicInteger();
+      setField(AnalysisEngine.class, engine, "sharedForegroundEngine", foreground);
+      setField(AnalysisEngine.class, engine, "sharedForegroundLease", foregroundLease(foreground));
+      setField(
+          AnalysisEngine.class,
+          engine,
+          "analyzeMap",
+          new java.util.HashMap<Integer, BoardHistoryNode>(
+              java.util.Map.of(1, Lizzie.board.getHistory().getCurrentHistoryNode())));
+
+      invokeAnalysisEngineSetResult(engine);
+      engine.normalQuit(completions::incrementAndGet, failures::incrementAndGet);
+
+      assertEquals(0, completions.get());
+      assertEquals(0, failures.get());
+      foreground.failRestore();
+      assertEquals(0, completions.get());
+      assertEquals(1, failures.get());
+    }
+  }
+
+  @Test
   void normalQuitContinuationWaitsForSharedForegroundRestore() throws Exception {
     try (TestEnvironment env = TestEnvironment.open()) {
       TrackingAnalysisEngine engine = TrackingAnalysisEngine.create();

--- a/src/test/java/featurecat/lizzie/analysis/LeelazExclusiveRemoteGtpSessionTest.java
+++ b/src/test/java/featurecat/lizzie/analysis/LeelazExclusiveRemoteGtpSessionTest.java
@@ -1802,6 +1802,29 @@ class LeelazExclusiveRemoteGtpSessionTest {
   }
 
   @Test
+  void analysisControlPauseKeepsSharedLeaseRestoreFromResumingPonder() throws Exception {
+    RestoreHarness harness = RestoreHarness.open(true, false);
+    try {
+      Field active = LizzieFrame.class.getDeclaredField("loadedGameQuickAnalysisActive");
+      active.setAccessible(true);
+      active.setBoolean(Lizzie.frame, true);
+
+      Method pause = LizzieFrame.class.getDeclaredMethod("pauseFromAnalysisControl");
+      pause.setAccessible(true);
+      pause.invoke(Lizzie.frame);
+
+      harness.finishRestore();
+
+      assertEquals(
+          0,
+          harness.engine.ponderCount,
+          "analysis-control pause must keep ExclusiveGtp restore from sending ponder.");
+    } finally {
+      harness.close();
+    }
+  }
+
+  @Test
   void foregroundLeaseDoesNotRestoreOrPonderAfterForegroundEngineSwitch() throws Exception {
     RestoreHarness harness = RestoreHarness.open(true, false);
     try {

--- a/src/test/java/featurecat/lizzie/analysis/LeelazExclusiveRemoteGtpSessionTest.java
+++ b/src/test/java/featurecat/lizzie/analysis/LeelazExclusiveRemoteGtpSessionTest.java
@@ -1825,6 +1825,65 @@ class LeelazExclusiveRemoteGtpSessionTest {
   }
 
   @Test
+  void failedSharedLeaseRestoreAfterRapidResumeDoesNotPonder() throws Exception {
+    RestoreHarness harness = RestoreHarness.open(true, false);
+    AtomicInteger failures = new AtomicInteger();
+    try {
+      Field paused = LizzieFrame.class.getDeclaredField("userAnalysisPaused");
+      paused.setAccessible(true);
+      paused.setBoolean(Lizzie.frame, true);
+      Field cleanup = LizzieFrame.class.getDeclaredField("analysisControlCleanupInProgress");
+      cleanup.setAccessible(true);
+      cleanup.setBoolean(Lizzie.frame, true);
+      Field cleanupGeneration =
+          LizzieFrame.class.getDeclaredField("analysisControlCleanupGeneration");
+      cleanupGeneration.setAccessible(true);
+      cleanupGeneration.setLong(Lizzie.frame, 7L);
+
+      Method resume = LizzieFrame.class.getDeclaredMethod("resumeFromAnalysisControl");
+      resume.setAccessible(true);
+      resume.invoke(Lizzie.frame);
+      assertFalse(Lizzie.frame.isUserAnalysisPaused());
+
+      assertTrue(
+          harness.engine.endForegroundAnalysisLease(
+              harness.owner,
+              harness.completions::incrementAndGet,
+              () -> {
+                failures.incrementAndGet();
+                try {
+                  Method finish =
+                      LizzieFrame.class.getDeclaredMethod(
+                          "finishUserAnalysisPauseCleanup", long.class, boolean.class);
+                  finish.setAccessible(true);
+                  finish.invoke(Lizzie.frame, 7L, false);
+                } catch (ReflectiveOperationException failure) {
+                  throw new AssertionError(failure);
+                }
+              }));
+      assertTrue(dispatch(harness.engine, "=800000001"));
+      assertTrue(dispatch(harness.engine, ""));
+      waitUntil(() -> harness.board.resendCount == 1);
+
+      Field sessionField = Leelaz.class.getDeclaredField("foregroundRestoreSession");
+      sessionField.setAccessible(true);
+      Object session = sessionField.get(harness.engine);
+      Field releaseStopFailed = session.getClass().getDeclaredField("releaseStopFailed");
+      releaseStopFailed.setAccessible(true);
+      releaseStopFailed.setBoolean(session, true);
+      completeForegroundRestore(harness.engine);
+
+      assertEquals(0, harness.engine.ponderCount);
+      assertFalse(harness.engine.isPondering());
+      assertEquals(0, harness.completions.get());
+      assertEquals(1, failures.get());
+      assertTrue(Lizzie.frame.isUserAnalysisPaused());
+    } finally {
+      harness.close();
+    }
+  }
+
+  @Test
   void foregroundLeaseDoesNotRestoreOrPonderAfterForegroundEngineSwitch() throws Exception {
     RestoreHarness harness = RestoreHarness.open(true, false);
     try {

--- a/src/test/java/featurecat/lizzie/analysis/TrackingAnalysisControllerTest.java
+++ b/src/test/java/featurecat/lizzie/analysis/TrackingAnalysisControllerTest.java
@@ -196,6 +196,32 @@ class TrackingAnalysisControllerTest {
   }
 
   @Test
+  void analysisControlPauseKeepsTrackingRestoreFromResumingPonder() throws Exception {
+    RecordingPonderLeelaz engine = new RecordingPonderLeelaz();
+    try (TestState state = TestState.open(engine)) {
+      engine.Pondering();
+      TrackingAnalysisController controller =
+          new TrackingAnalysisController(new ManualTimeoutScheduler());
+
+      assertEquals(
+          TrackingAnalysisController.AddResult.ADDED, controller.addPoint("D4", state.context()));
+      completeInitialFence(engine, 800000000);
+
+      Method pause = LizzieFrame.class.getDeclaredMethod("pauseFromAnalysisControl");
+      pause.setAccessible(true);
+      pause.invoke(Lizzie.frame);
+
+      assertTrue(dispatch(engine, "info move D4 visits 100 winrate 0.55 pv D4"));
+      completeFinalFence(engine, 800000002);
+
+      assertEquals(
+          0,
+          engine.ponderCount.get(),
+          "analysis-control pause must keep tracking restore from sending ponder.");
+    }
+  }
+
+  @Test
   void safeOrdinaryReleaseFreezesThenOrdinaryUpgradeClearsWithoutReacquire() throws Exception {
     RecordingPonderLeelaz engine = new RecordingPonderLeelaz();
     try (TestState state = TestState.open(engine)) {

--- a/src/test/java/featurecat/lizzie/gui/LizzieFrameRegressionTest.java
+++ b/src/test/java/featurecat/lizzie/gui/LizzieFrameRegressionTest.java
@@ -2000,6 +2000,331 @@ class LizzieFrameRegressionTest {
   }
 
   @Test
+  void analysisControlPauseCancelsRunningAutomaticQuickAnalysisAndDoesNotPonder()
+      throws Exception {
+    TestEnvironment env = TestEnvironment.open();
+    try {
+      Lizzie.config = configWithAutoQuickAnalyze();
+      AnalysisSyncBoard board = analysisSyncBoardWith(historyWithUnanalyzedMove());
+      Lizzie.board = board;
+      TrackingLeelaz leelaz = allocate(TrackingLeelaz.class);
+      Lizzie.leelaz = leelaz;
+      EngineManager.isEmpty = false;
+      AnalysisResumeTrackingFrame frame = allocate(AnalysisResumeTrackingFrame.class);
+      ResourceTrackingAnalysisEngine engine = allocate(ResourceTrackingAnalysisEngine.class);
+      engine.automatic = true;
+      engine.localDedicated = true;
+      engine.analysisInProgress = true;
+      engine.reusable = true;
+      frame.analysisEngine = engine;
+      Lizzie.frame = frame;
+      BoardHistoryNode root = Lizzie.board.getHistory().getStart();
+      setField(frame, "loadedGameQuickAnalysisGeneration", 17L);
+      setField(frame, "loadedGameQuickAnalysisRoot", root);
+      setField(frame, "loadedGameQuickAnalysisActive", true);
+      setField(frame, "loadedGameQuickAnalysisRunning", true);
+      setField(frame, "quickAnalysisEngineGeneration", new AtomicLong(3L));
+      setField(frame, "quickAnalysisEngineStarting", new AtomicBoolean(false));
+      BoardHistoryNode viewed = Lizzie.board.getHistory().getCurrentHistoryNode();
+
+      frame.togglePonderMannul();
+      engine.completeExit();
+      drainEdt();
+
+      assertFalse(
+          (boolean) getField(frame, "loadedGameQuickAnalysisActive"),
+          "analysis control pause must cancel the current automatic kifu quick analysis.");
+      assertEquals(1, engine.normalQuitCount);
+      assertEquals(
+          0,
+          leelaz.ponderCount,
+          "pausing while automatic quick analysis occupies the control must not start ponder.");
+      assertFalse(leelaz.isPondering());
+      assertSame(viewed, Lizzie.board.getHistory().getCurrentHistoryNode());
+      assertEquals(0, frame.flashAnalyzeGameCount);
+    } finally {
+      env.close();
+    }
+  }
+
+  @Test
+  void analysisControlPauseWhileWaitingForResourcesBlocksLaterDispatch() throws Exception {
+    TestEnvironment env = TestEnvironment.open();
+    try {
+      Lizzie.config = configWithAutoQuickAnalyze();
+      Lizzie.board = boardWith(historyWithUnanalyzedMove());
+      TrackingLeelaz leelaz = allocate(TrackingLeelaz.class);
+      Lizzie.leelaz = leelaz;
+      EngineManager.isEmpty = false;
+      AnalysisResumeTrackingFrame frame = allocate(AnalysisResumeTrackingFrame.class);
+      Lizzie.frame = frame;
+      armLoadedGameQuickAnalysis(frame, Lizzie.board.getHistory().getStart(), false);
+
+      frame.togglePonderMannul();
+      invokeRetryLoadedGameQuickAnalysisIfMissing(frame);
+
+      assertFalse((boolean) getField(frame, "loadedGameQuickAnalysisActive"));
+      assertEquals(0, frame.flashAnalyzeGameCount);
+      assertEquals(0, leelaz.ponderCount);
+      assertTrue(Lizzie.config.autoQuickAnalyzeOnLoad);
+    } finally {
+      env.close();
+    }
+  }
+
+  @Test
+  void analysisControlPauseDiscardsLateAutomaticEngineWarmup() throws Exception {
+    TestEnvironment env = TestEnvironment.open();
+    try {
+      Lizzie.config = configWithAutoQuickAnalyze();
+      Lizzie.board = boardWith(historyWithUnanalyzedMove());
+      TrackingLeelaz leelaz = allocate(TrackingLeelaz.class);
+      Lizzie.leelaz = leelaz;
+      EngineManager.isEmpty = false;
+      AnalysisResumeTrackingFrame frame = allocate(AnalysisResumeTrackingFrame.class);
+      Lizzie.frame = frame;
+      armLoadedGameQuickAnalysis(frame, Lizzie.board.getHistory().getStart(), true);
+      setField(frame, "quickAnalysisEngineStarting", new AtomicBoolean(true));
+      setField(frame, "quickAnalysisEngineGeneration", new AtomicLong(7L));
+      ResourceTrackingAnalysisEngine warmed = allocate(ResourceTrackingAnalysisEngine.class);
+      warmed.automatic = true;
+      warmed.reusable = true;
+
+      frame.togglePonderMannul();
+      invokeFinishQuickAnalysisEngineWarmup(frame, warmed, 7L);
+
+      assertEquals(1, warmed.normalQuitCount);
+      assertNull(frame.analysisEngine);
+      assertEquals(0, leelaz.ponderCount);
+      assertFalse(leelaz.isPondering());
+    } finally {
+      env.close();
+    }
+  }
+
+  @Test
+  void analysisControlPauseReturnsSharedForegroundLeaseWithoutPonderOrProcessExit()
+      throws Exception {
+    TestEnvironment env = TestEnvironment.open();
+    try {
+      Lizzie.config = configWithAutoQuickAnalyze();
+      AnalysisSyncBoard board = analysisSyncBoardWith(historyWithUnanalyzedMove());
+      Lizzie.board = board;
+      TrackingLeelaz leelaz = allocate(TrackingLeelaz.class);
+      Lizzie.leelaz = leelaz;
+      EngineManager.isEmpty = false;
+      AnalysisResumeTrackingFrame frame = allocate(AnalysisResumeTrackingFrame.class);
+      ResourceTrackingAnalysisEngine engine = allocate(ResourceTrackingAnalysisEngine.class);
+      engine.automatic = true;
+      engine.shared = true;
+      engine.analysisInProgress = true;
+      engine.reusable = true;
+      frame.analysisEngine = engine;
+      Lizzie.frame = frame;
+      BoardHistoryNode move =
+          Lizzie.board.getHistory().getStart().next().orElseThrow();
+      move.getData().setPlayouts(10);
+      move.getData().analysisHeaderSlots = 3;
+      BoardHistoryNode viewed = Lizzie.board.getHistory().getCurrentHistoryNode();
+      armLoadedGameQuickAnalysis(frame, Lizzie.board.getHistory().getStart(), true);
+
+      frame.togglePonderMannul();
+      assertEquals(1, engine.normalQuitCount);
+      assertEquals(0, leelaz.ponderCount);
+      engine.completeExit();
+      drainEdt();
+
+      assertTrue(leelaz.isStarted());
+      assertFalse(leelaz.isPondering());
+      assertEquals(0, leelaz.ponderCount);
+      assertSame(viewed, Lizzie.board.getHistory().getCurrentHistoryNode());
+      assertEquals(10, move.getData().getPlayouts());
+      assertEquals(3, move.getData().analysisHeaderSlots);
+      assertFalse((boolean) getField(frame, "loadedGameQuickAnalysisActive"));
+    } finally {
+      env.close();
+    }
+  }
+
+  @Test
+  void staleAutomaticQuickAnalysisEventsAfterPauseDoNotPonderOrRestart() throws Exception {
+    TestEnvironment env = TestEnvironment.open();
+    try {
+      Lizzie.config = configWithAutoQuickAnalyze();
+      AnalysisSyncBoard board = analysisSyncBoardWith(historyWithUnanalyzedMove());
+      Lizzie.board = board;
+      TrackingLeelaz leelaz = allocate(TrackingLeelaz.class);
+      Lizzie.leelaz = leelaz;
+      EngineManager.isEmpty = false;
+      AnalysisResumeTrackingFrame frame = allocate(AnalysisResumeTrackingFrame.class);
+      ResourceTrackingAnalysisEngine engine = allocate(ResourceTrackingAnalysisEngine.class);
+      engine.automatic = true;
+      engine.localDedicated = true;
+      engine.reusable = true;
+      frame.analysisEngine = engine;
+      Lizzie.frame = frame;
+      BoardHistoryNode root = Lizzie.board.getHistory().getStart();
+      armLoadedGameQuickAnalysis(frame, root, true);
+
+      frame.togglePonderMannul();
+      engine.completeExit();
+      drainEdt();
+
+      invokeFinishLoadedGameQuickAnalysisAttempt(frame, 17L, root, false);
+      invokeFinishLoadedGameQuickAnalysisAttempt(frame, 17L, root, true);
+      setField(
+          frame,
+          "loadedGameQuickAnalysisDispatchStartedAt",
+          System.currentTimeMillis() - 60_000L);
+      invokeRetryLoadedGameQuickAnalysisIfMissing(frame);
+      SwingUtilities.invokeAndWait(frame::scheduleQuickAnalysisContinuationAfterHistoryNavigation);
+      SwingUtilities.invokeAndWait(frame::resumeForegroundAnalysisAfterQuickAnalysisComplete);
+
+      assertEquals(0, frame.flashAnalyzeGameCount);
+      assertEquals(0, leelaz.ponderCount);
+      assertFalse(leelaz.isPondering());
+      assertNull(getField(frame, "quickAnalysisNavigationResumeTimer"));
+    } finally {
+      env.close();
+    }
+  }
+
+  @Test
+  void analysisControlResumeAfterPauseStartsOnlyCurrentPositionForegroundAnalysis()
+      throws Exception {
+    TestEnvironment env = TestEnvironment.open();
+    try {
+      Lizzie.config = configWithAutoQuickAnalyze();
+      AnalysisSyncBoard board = analysisSyncBoardWith(historyWithUnanalyzedMove());
+      Lizzie.board = board;
+      TrackingLeelaz leelaz = allocate(TrackingLeelaz.class);
+      board.events = leelaz.commands();
+      Lizzie.leelaz = leelaz;
+      EngineManager.isEmpty = false;
+      AnalysisResumeTrackingFrame frame = allocate(AnalysisResumeTrackingFrame.class);
+      ResourceTrackingAnalysisEngine engine = allocate(ResourceTrackingAnalysisEngine.class);
+      engine.automatic = true;
+      engine.localDedicated = true;
+      engine.reusable = true;
+      frame.analysisEngine = engine;
+      Lizzie.frame = frame;
+      armLoadedGameQuickAnalysis(frame, Lizzie.board.getHistory().getStart(), true);
+
+      frame.togglePonderMannul();
+      frame.togglePonderMannul();
+      assertEquals(0, leelaz.ponderCount);
+      engine.completeExit();
+      drainEdt();
+
+      assertEquals(List.of("sync", "ponder"), leelaz.commands());
+      assertEquals(1, leelaz.ponderCount);
+      assertEquals(0, frame.flashAnalyzeGameCount);
+      assertFalse((boolean) getField(frame, "loadedGameQuickAnalysisActive"));
+    } finally {
+      env.close();
+    }
+  }
+
+  @Test
+  void analysisControlPauseDoesNotCancelManualOrWholeGameAnalysis() throws Exception {
+    TestEnvironment env = TestEnvironment.open();
+    try {
+      Lizzie.config = configWithAutoQuickAnalyze();
+      Lizzie.board = boardWith(historyWithUnanalyzedMove());
+      TrackingLeelaz leelaz = allocate(TrackingLeelaz.class);
+      leelaz.pondering = true;
+      Lizzie.leelaz = leelaz;
+      EngineManager.isEmpty = false;
+      AnalysisResumeTrackingFrame frame = allocate(AnalysisResumeTrackingFrame.class);
+      ResourceTrackingAnalysisEngine engine = allocate(ResourceTrackingAnalysisEngine.class);
+      engine.analysisInProgress = true;
+      frame.analysisEngine = engine;
+      WholeGameAnalysisSession session = allocate(WholeGameAnalysisSession.class);
+      setDeclaredField(
+          WholeGameAnalysisSession.class,
+          session,
+          "state",
+          WholeGameAnalysisSession.State.BASELINE);
+      setField(frame, "wholeGameAnalysisSession", session);
+      Lizzie.frame = frame;
+
+      frame.togglePonderMannul();
+
+      assertFalse(leelaz.isPondering());
+      assertEquals(0, engine.normalQuitCount);
+      assertSame(engine, frame.analysisEngine);
+      assertSame(session, getField(frame, "wholeGameAnalysisSession"));
+    } finally {
+      env.close();
+    }
+  }
+
+  @Test
+  void loadingANewKifuAfterPauseCanStartAFreshAutomaticQuickAnalysis() throws Exception {
+    TestEnvironment env = TestEnvironment.open();
+    try {
+      Lizzie.config = configWithAutoQuickAnalyze();
+      AnalysisSyncBoard board = analysisSyncBoardWith(historyWithUnanalyzedMove());
+      Lizzie.board = board;
+      TrackingLeelaz leelaz = allocate(TrackingLeelaz.class);
+      Lizzie.leelaz = leelaz;
+      EngineManager.isEmpty = false;
+      AnalysisResumeTrackingFrame frame = allocate(AnalysisResumeTrackingFrame.class);
+      ResourceTrackingAnalysisEngine engine = allocate(ResourceTrackingAnalysisEngine.class);
+      engine.automatic = true;
+      engine.reusable = true;
+      frame.analysisEngine = engine;
+      Lizzie.frame = frame;
+      armLoadedGameQuickAnalysis(frame, Lizzie.board.getHistory().getStart(), true);
+
+      frame.togglePonderMannul();
+      engine.completeExit();
+      drainEdt();
+      Lizzie.board = boardWith(historyWithUnanalyzedMove());
+
+      assertTrue(frame.ensureAnalysisResumedAfterLoad());
+      assertEquals(1, frame.flashAnalyzeGameCount);
+      assertTrue(frame.lastSilentAnalyze);
+      assertTrue(Lizzie.config.autoQuickAnalyzeOnLoad);
+      invokeStopLoadedGameQuickAnalysisRetry(frame);
+    } finally {
+      env.close();
+    }
+  }
+
+  @Test
+  void placingMovesAfterPauseDoesNotReviveCancelledAutomaticQuickAnalysis() throws Exception {
+    TestEnvironment env = TestEnvironment.open();
+    try {
+      Lizzie.config = configWithAutoQuickAnalyze();
+      AnalysisSyncBoard board = analysisSyncBoardWith(historyWithUnanalyzedMove());
+      Lizzie.board = board;
+      TrackingLeelaz leelaz = allocate(TrackingLeelaz.class);
+      Lizzie.leelaz = leelaz;
+      EngineManager.isEmpty = false;
+      AnalysisResumeTrackingFrame frame = allocate(AnalysisResumeTrackingFrame.class);
+      ResourceTrackingAnalysisEngine engine = allocate(ResourceTrackingAnalysisEngine.class);
+      engine.automatic = true;
+      engine.reusable = true;
+      frame.analysisEngine = engine;
+      Lizzie.frame = frame;
+      armLoadedGameQuickAnalysis(frame, Lizzie.board.getHistory().getStart(), true);
+
+      frame.togglePonderMannul();
+      engine.completeExit();
+      drainEdt();
+      SwingUtilities.invokeAndWait(frame::scheduleQuickAnalysisContinuationAfterHistoryNavigation);
+
+      assertEquals(0, frame.flashAnalyzeGameCount);
+      assertEquals(0, leelaz.ponderCount);
+      assertFalse((boolean) getField(frame, "loadedGameQuickAnalysisActive"));
+    } finally {
+      env.close();
+    }
+  }
+
+
+  @Test
   void finishKifuLoadDoesNotRefreshAgainBeforeHidingOverlay() throws Exception {
     TestEnvironment env = TestEnvironment.open();
     try {
@@ -2407,6 +2732,17 @@ class LizzieFrameRegressionTest {
     }
   }
 
+
+
+  private static void armLoadedGameQuickAnalysis(
+      LizzieFrame frame, BoardHistoryNode root, boolean running) throws Exception {
+    setField(frame, "loadedGameQuickAnalysisGeneration", 17L);
+    setField(frame, "loadedGameQuickAnalysisRoot", root);
+    setField(frame, "loadedGameQuickAnalysisActive", true);
+    setField(frame, "loadedGameQuickAnalysisRunning", running);
+    setField(frame, "quickAnalysisEngineGeneration", new AtomicLong(3L));
+    setField(frame, "quickAnalysisEngineStarting", new AtomicBoolean(false));
+  }
 
   private static boolean invokeShouldAutoQuickAnalyze(LizzieFrame frame) throws Exception {
     Method method = LizzieFrame.class.getDeclaredMethod("shouldAutoQuickAnalyzeLoadedGame");
@@ -2955,7 +3291,13 @@ class LizzieFrameRegressionTest {
     public void refresh() {
       refreshCount++;
     }
+
+    @Override
+    public boolean stopAiPlayingAndPolicy() {
+      return false;
+    }
   }
+
 
   private static final class QuickAnalysisResumeFrame extends LizzieFrame {
     private int refreshCount;
@@ -3217,6 +3559,16 @@ class LizzieFrameRegressionTest {
       } else {
         ponder();
       }
+    }
+
+    @Override
+    public void notPondering() {
+      pondering = false;
+    }
+
+    @Override
+    public void nameCmd() {
+      commands().add("name");
     }
   }
 

--- a/src/test/java/featurecat/lizzie/gui/LizzieFrameRegressionTest.java
+++ b/src/test/java/featurecat/lizzie/gui/LizzieFrameRegressionTest.java
@@ -29,6 +29,8 @@ import featurecat.lizzie.teacher.TeacherCommentCodec;
 import java.awt.Color;
 import java.awt.Font;
 import java.awt.GraphicsConfiguration;
+import java.awt.datatransfer.DataFlavor;
+import java.awt.datatransfer.Transferable;
 import java.awt.GraphicsDevice;
 import java.awt.Graphics2D;
 import java.awt.Rectangle;
@@ -2048,6 +2050,89 @@ class LizzieFrameRegressionTest {
   }
 
   @Test
+  void analysisControlPauseCancelsAutomaticRequestOnReusablePreloadedWorker()
+      throws Exception {
+    TestEnvironment env = TestEnvironment.open();
+    try {
+      Lizzie.config = configWithAutoQuickAnalyze();
+      Lizzie.board = boardWith(historyWithUnanalyzedMove());
+      TrackingLeelaz leelaz = allocate(TrackingLeelaz.class);
+      Lizzie.leelaz = leelaz;
+      EngineManager.isEmpty = false;
+      AnalysisResumeTrackingFrame frame = allocate(AnalysisResumeTrackingFrame.class);
+      ResourceTrackingAnalysisEngine engine = allocate(ResourceTrackingAnalysisEngine.class);
+      engine.automatic = false;
+      engine.analysisInProgress = true;
+      engine.reusable = true;
+      frame.analysisEngine = engine;
+      Lizzie.frame = frame;
+      armLoadedGameQuickAnalysis(frame, Lizzie.board.getHistory().getStart(), true);
+
+      frame.togglePonderMannul();
+
+      assertEquals(
+          1,
+          engine.normalQuitCount,
+          "the automatic request must stop even when it reused a preloaded worker.");
+      assertFalse((boolean) getField(frame, "loadedGameQuickAnalysisActive"));
+      assertEquals(0, leelaz.ponderCount);
+    } finally {
+      env.close();
+    }
+  }
+
+  @Test
+  void analysisControlPauseWithoutPrimaryCancelsWaitingAutomaticQuickAnalysis()
+      throws Exception {
+    TestEnvironment env = TestEnvironment.open();
+    try {
+      Lizzie.config = configWithAutoQuickAnalyze();
+      Lizzie.board = boardWith(historyWithUnanalyzedMove());
+      Lizzie.leelaz = null;
+      AnalysisResumeTrackingFrame frame = allocate(AnalysisResumeTrackingFrame.class);
+      Lizzie.frame = frame;
+      armLoadedGameQuickAnalysis(frame, Lizzie.board.getHistory().getStart(), false);
+
+      frame.togglePonderMannul();
+      invokeRetryLoadedGameQuickAnalysisIfMissing(frame);
+
+      assertTrue(frame.isUserAnalysisPaused());
+      assertFalse((boolean) getField(frame, "loadedGameQuickAnalysisActive"));
+      assertEquals(0, frame.flashAnalyzeGameCount);
+    } finally {
+      env.close();
+    }
+  }
+
+  @Test
+  void analysisControlPauseWithoutPrimaryStopsRunningDedicatedAutomaticWorker()
+      throws Exception {
+    TestEnvironment env = TestEnvironment.open();
+    try {
+      Lizzie.config = configWithAutoQuickAnalyze();
+      Lizzie.board = boardWith(historyWithUnanalyzedMove());
+      Lizzie.leelaz = null;
+      AnalysisResumeTrackingFrame frame = allocate(AnalysisResumeTrackingFrame.class);
+      ResourceTrackingAnalysisEngine engine = allocate(ResourceTrackingAnalysisEngine.class);
+      engine.automatic = true;
+      engine.localDedicated = true;
+      engine.analysisInProgress = true;
+      engine.reusable = true;
+      frame.analysisEngine = engine;
+      Lizzie.frame = frame;
+      armLoadedGameQuickAnalysis(frame, Lizzie.board.getHistory().getStart(), true);
+
+      frame.togglePonderMannul();
+
+      assertTrue(frame.isUserAnalysisPaused());
+      assertEquals(1, engine.normalQuitCount);
+      assertFalse((boolean) getField(frame, "loadedGameQuickAnalysisActive"));
+    } finally {
+      env.close();
+    }
+  }
+
+  @Test
   void analysisControlPauseWhileWaitingForResourcesBlocksLaterDispatch() throws Exception {
     TestEnvironment env = TestEnvironment.open();
     try {
@@ -2211,6 +2296,8 @@ class LizzieFrameRegressionTest {
       armLoadedGameQuickAnalysis(frame, Lizzie.board.getHistory().getStart(), true);
 
       frame.togglePonderMannul();
+      assertFalse(frame.ensureAnalysisResumedAfterLoad());
+      assertTrue((boolean) getField(frame, "analysisControlCleanupInProgress"));
       frame.togglePonderMannul();
       assertEquals(0, leelaz.ponderCount);
       engine.completeExit();
@@ -2220,6 +2307,182 @@ class LizzieFrameRegressionTest {
       assertEquals(1, leelaz.ponderCount);
       assertEquals(0, frame.flashAnalyzeGameCount);
       assertFalse((boolean) getField(frame, "loadedGameQuickAnalysisActive"));
+    } finally {
+      env.close();
+    }
+  }
+
+  @Test
+  void analysisControlResumeAfterFailedSharedCleanupStaysPaused() throws Exception {
+    TestEnvironment env = TestEnvironment.open();
+    try {
+      Lizzie.config = configWithAutoQuickAnalyze();
+      AnalysisSyncBoard board = analysisSyncBoardWith(historyWithUnanalyzedMove());
+      Lizzie.board = board;
+      TrackingLeelaz leelaz = allocate(TrackingLeelaz.class);
+      board.events = leelaz.commands();
+      Lizzie.leelaz = leelaz;
+      EngineManager.isEmpty = false;
+      AnalysisResumeTrackingFrame frame = allocate(AnalysisResumeTrackingFrame.class);
+      ResourceTrackingAnalysisEngine engine = allocate(ResourceTrackingAnalysisEngine.class);
+      engine.automatic = true;
+      engine.shared = true;
+      engine.reusable = true;
+      frame.analysisEngine = engine;
+      Lizzie.frame = frame;
+      armLoadedGameQuickAnalysis(frame, Lizzie.board.getHistory().getStart(), true);
+
+      frame.togglePonderMannul();
+      frame.togglePonderMannul();
+      engine.failExit();
+      drainEdt();
+
+      assertTrue(frame.isUserAnalysisPaused());
+      assertFalse((boolean) getField(frame, "analysisControlCleanupInProgress"));
+      assertEquals(0, leelaz.ponderCount);
+      assertTrue(leelaz.commands().isEmpty());
+    } finally {
+      env.close();
+    }
+  }
+
+  @Test
+  void newKifuLoadWaitsForSharedCleanupBeforeStartingFreshContext() throws Exception {
+    TestEnvironment env = TestEnvironment.open();
+    try {
+      Lizzie.config = configWithAutoQuickAnalyze();
+      Lizzie.board = boardWith(historyWithUnanalyzedMove());
+      TrackingLeelaz leelaz = allocate(TrackingLeelaz.class);
+      Lizzie.leelaz = leelaz;
+      EngineManager.isEmpty = false;
+      AnalysisResumeTrackingFrame frame = allocate(AnalysisResumeTrackingFrame.class);
+      ResourceTrackingAnalysisEngine engine = allocate(ResourceTrackingAnalysisEngine.class);
+      engine.automatic = true;
+      engine.shared = true;
+      engine.reusable = true;
+      frame.analysisEngine = engine;
+      Lizzie.frame = frame;
+      armLoadedGameQuickAnalysis(frame, Lizzie.board.getHistory().getStart(), true);
+      AtomicInteger newContexts = new AtomicInteger();
+
+      frame.togglePonderMannul();
+      Method defer =
+          LizzieFrame.class.getDeclaredMethod(
+              "deferKifuOpenUntilAutomaticQuickAnalysisRestored", Runnable.class);
+      defer.setAccessible(true);
+      assertTrue(
+          (boolean)
+              defer.invoke(
+                  frame,
+                  (Runnable)
+                      () -> {
+                        frame.startNewKifuAnalysisContextAfterSuccessfulLoad();
+                        newContexts.incrementAndGet();
+                      }));
+
+      assertEquals(0, newContexts.get());
+      assertTrue(frame.isUserAnalysisPaused());
+      assertTrue((boolean) getField(frame, "analysisControlCleanupInProgress"));
+
+      engine.completeExit();
+      drainEdt();
+
+      assertEquals(1, newContexts.get());
+      assertFalse(frame.isUserAnalysisPaused());
+      assertFalse((boolean) getField(frame, "analysisControlCleanupInProgress"));
+      assertEquals(0, leelaz.ponderCount);
+    } finally {
+      env.close();
+    }
+  }
+
+  @Test
+  void dragDropCapturesFilesBeforeWaitingForSharedCleanup(@TempDir Path tempDir) throws Exception {
+    TestEnvironment env = TestEnvironment.open();
+    try {
+      Lizzie.config = configWithAutoQuickAnalyze();
+      Lizzie.board = boardWith(historyWithUnanalyzedMove());
+      TrackingLeelaz leelaz = allocate(TrackingLeelaz.class);
+      Lizzie.leelaz = leelaz;
+      EngineManager.isEmpty = false;
+      AnalysisResumeTrackingFrame frame = allocate(AnalysisResumeTrackingFrame.class);
+      frame.interceptFileLoads = true;
+      ResourceTrackingAnalysisEngine engine = allocate(ResourceTrackingAnalysisEngine.class);
+      engine.automatic = true;
+      engine.shared = true;
+      engine.reusable = true;
+      frame.analysisEngine = engine;
+      Lizzie.frame = frame;
+      armLoadedGameQuickAnalysis(frame, Lizzie.board.getHistory().getStart(), true);
+      File droppedFile = tempDir.resolve("captured-before-cleanup.sgf").toFile();
+      AtomicInteger transferReads = new AtomicInteger();
+      Transferable transferable =
+          new Transferable() {
+            @Override
+            public DataFlavor[] getTransferDataFlavors() {
+              return new DataFlavor[] {DataFlavor.javaFileListFlavor};
+            }
+
+            @Override
+            public boolean isDataFlavorSupported(DataFlavor flavor) {
+              return DataFlavor.javaFileListFlavor.equals(flavor);
+            }
+
+            @Override
+            public Object getTransferData(DataFlavor flavor) {
+              if (!isDataFlavorSupported(flavor) || transferReads.incrementAndGet() != 1) {
+                throw new IllegalStateException("drop transferable is no longer live");
+              }
+              return Collections.singletonList(droppedFile);
+            }
+          };
+
+      frame.togglePonderMannul();
+      assertTrue(frame.importDroppedKifuFiles(transferable));
+
+      assertEquals(1, transferReads.get());
+      assertEquals(0, frame.loadFileCount);
+      assertNull(frame.curFile);
+
+      engine.completeExit();
+      drainEdt();
+
+      assertEquals(1, transferReads.get());
+      assertEquals(1, frame.loadFileCount);
+      assertSame(droppedFile, frame.loadedFile);
+      assertSame(droppedFile, frame.curFile);
+    } finally {
+      env.close();
+    }
+  }
+
+  @Test
+  void manualFlashAnalysisTakeoverIsNotCancelledByAnalysisControl() throws Exception {
+    TestEnvironment env = TestEnvironment.open();
+    try {
+      Lizzie.config = configWithAutoQuickAnalyze();
+      Lizzie.board = boardWith(historyWithUnanalyzedMove());
+      TrackingLeelaz leelaz = allocate(TrackingLeelaz.class);
+      leelaz.pondering = true;
+      Lizzie.leelaz = leelaz;
+      EngineManager.isEmpty = false;
+      ManualPonderTrackingFrame frame = allocate(ManualPonderTrackingFrame.class);
+      ResourceTrackingAnalysisEngine engine = allocate(ResourceTrackingAnalysisEngine.class);
+      engine.automatic = true;
+      engine.analysisInProgress = true;
+      engine.reusable = true;
+      engine.waitFrame = allocate(WaitForAnalysis.class);
+      frame.analysisEngine = engine;
+      Lizzie.frame = frame;
+      armLoadedGameQuickAnalysis(frame, Lizzie.board.getHistory().getStart(), true);
+
+      frame.flashAnalyzeGame(true, false);
+      assertTrue(engine.awaitManualRequestStarted());
+      frame.togglePonderMannul();
+
+      assertFalse((boolean) getField(frame, "loadedGameQuickAnalysisActive"));
+      assertEquals(0, engine.normalQuitCount);
+      assertFalse(leelaz.isPondering());
     } finally {
       env.close();
     }
@@ -2260,6 +2523,37 @@ class LizzieFrameRegressionTest {
   }
 
   @Test
+  void historyReplacementWithinCurrentLoadContextKeepsUserAnalysisPaused() throws Exception {
+    TestEnvironment env = TestEnvironment.open();
+    try {
+      Lizzie.config = configWithAutoQuickAnalyze();
+      Lizzie.board = boardWith(historyWithUnanalyzedMove());
+      TrackingLeelaz leelaz = allocate(TrackingLeelaz.class);
+      Lizzie.leelaz = leelaz;
+      EngineManager.isEmpty = false;
+      AnalysisResumeTrackingFrame frame = allocate(AnalysisResumeTrackingFrame.class);
+      ResourceTrackingAnalysisEngine engine = allocate(ResourceTrackingAnalysisEngine.class);
+      engine.automatic = true;
+      engine.reusable = true;
+      frame.analysisEngine = engine;
+      Lizzie.frame = frame;
+      armLoadedGameQuickAnalysis(frame, Lizzie.board.getHistory().getStart(), true);
+
+      frame.togglePonderMannul();
+      engine.completeExit();
+      drainEdt();
+      Lizzie.board = boardWith(historyWithUnanalyzedMove());
+
+      assertFalse(frame.ensureAnalysisResumedAfterLoad());
+      assertTrue(frame.isUserAnalysisPaused());
+      assertEquals(0, frame.flashAnalyzeGameCount);
+      assertEquals(0, leelaz.ponderCount);
+    } finally {
+      env.close();
+    }
+  }
+
+  @Test
   void loadingANewKifuAfterPauseCanStartAFreshAutomaticQuickAnalysis() throws Exception {
     TestEnvironment env = TestEnvironment.open();
     try {
@@ -2281,6 +2575,7 @@ class LizzieFrameRegressionTest {
       engine.completeExit();
       drainEdt();
       Lizzie.board = boardWith(historyWithUnanalyzedMove());
+      frame.startNewKifuAnalysisContextAfterSuccessfulLoad();
 
       assertTrue(frame.ensureAnalysisResumedAfterLoad());
       assertEquals(1, frame.flashAnalyzeGameCount);
@@ -2740,6 +3035,10 @@ class LizzieFrameRegressionTest {
     setField(frame, "loadedGameQuickAnalysisRoot", root);
     setField(frame, "loadedGameQuickAnalysisActive", true);
     setField(frame, "loadedGameQuickAnalysisRunning", running);
+    if (running && frame.analysisEngine != null) {
+      setField(frame, "loadedGameQuickAnalysisEngine", frame.analysisEngine);
+      setField(frame, "loadedGameQuickAnalysisEngineGeneration", 17L);
+    }
     setField(frame, "quickAnalysisEngineGeneration", new AtomicLong(3L));
     setField(frame, "quickAnalysisEngineStarting", new AtomicBoolean(false));
   }
@@ -3275,9 +3574,22 @@ class LizzieFrameRegressionTest {
   private static final class AnalysisResumeTrackingFrame extends LizzieFrame {
     private int flashAnalyzeGameCount;
     private int refreshCount;
+    private boolean interceptFileLoads;
+    private int loadFileCount;
+    private File loadedFile;
     private boolean lastIsAllGame;
     private boolean lastIsAllBranches;
     private boolean lastSilentAnalyze;
+
+    @Override
+    public boolean loadFile(File file, boolean fromTemp, boolean showHint) {
+      if (!interceptFileLoads) {
+        return super.loadFile(file, fromTemp, showHint);
+      }
+      loadFileCount++;
+      loadedFile = file;
+      return true;
+    }
 
     @Override
     public void flashAnalyzeGame(boolean isAllGame, boolean isAllBranches, boolean silentAnalyze) {
@@ -3315,8 +3627,10 @@ class LizzieFrameRegressionTest {
     private boolean automatic;
     private boolean reusable;
     private boolean requestLifecycleInProgress;
+    private CountDownLatch manualRequestStarted;
     private int normalQuitCount;
     private Runnable exitContinuation;
+    private Runnable exitFailureContinuation;
 
     @SuppressWarnings("unused")
     private ResourceTrackingAnalysisEngine() throws java.io.IOException {
@@ -3364,6 +3678,23 @@ class LizzieFrameRegressionTest {
     }
 
     @Override
+    public void startRequest(int startMove, int endMove, boolean showProgressDialog) {
+      analysisInProgress = true;
+      manualRequestStartedLatch().countDown();
+    }
+
+    private boolean awaitManualRequestStarted() throws InterruptedException {
+      return manualRequestStartedLatch().await(2, TimeUnit.SECONDS);
+    }
+
+    private synchronized CountDownLatch manualRequestStartedLatch() {
+      if (manualRequestStarted == null) {
+        manualRequestStarted = new CountDownLatch(1);
+      }
+      return manualRequestStarted;
+    }
+
+    @Override
     public void clearRequestCallbacks() {}
 
     @Override
@@ -3375,11 +3706,29 @@ class LizzieFrameRegressionTest {
     public void normalQuit(Runnable afterRestore) {
       normalQuitCount++;
       exitContinuation = afterRestore;
+      exitFailureContinuation = afterRestore;
+    }
+
+    @Override
+    public void normalQuit(Runnable afterRestore, Runnable afterRestoreFailure) {
+      normalQuitCount++;
+      exitContinuation = afterRestore;
+      exitFailureContinuation = afterRestoreFailure;
     }
 
     private void completeExit() {
       Runnable continuation = exitContinuation;
       exitContinuation = null;
+      exitFailureContinuation = null;
+      if (continuation != null) {
+        continuation.run();
+      }
+    }
+
+    private void failExit() {
+      Runnable continuation = exitFailureContinuation;
+      exitContinuation = null;
+      exitFailureContinuation = null;
       if (continuation != null) {
         continuation.run();
       }

--- a/src/test/java/featurecat/lizzie/rules/GIBParserTest.java
+++ b/src/test/java/featurecat/lizzie/rules/GIBParserTest.java
@@ -140,6 +140,27 @@ class GIBParserTest {
     }
   }
 
+  @Test
+  void successfulGibLoadStartsFreshAnalysisControlContext() throws Exception {
+    try (RulesLayerTestHarness env = openSizedHarness()) {
+      Lizzie.config.autoQuickAnalyzeOnLoad = true;
+      Lizzie.config.persisted =
+          new org.json.JSONObject().put("filesystem", new org.json.JSONObject());
+      Lizzie.config.loadSgfLast = false;
+      EngineManager.isEmpty = false;
+      LoadTrackingFrame frame = RulesLayerTestHarness.allocate(LoadTrackingFrame.class);
+      Lizzie.frame = frame;
+      setFrameField(frame, "loadedGameQuickAnalysisActive", true);
+
+      frame.togglePonderMannul();
+      assertTrue(frame.isUserAnalysisPaused());
+
+      assertTrue(frame.loadFile(writeGib("fresh-context.gib", MINIMAL_GIB).toFile(), true, false));
+      assertFalse(frame.isUserAnalysisPaused());
+      assertEquals(1, frame.scheduledResumeCount);
+    }
+  }
+
   private static RulesLayerTestHarness openSizedHarness() throws Exception {
     RulesLayerTestHarness env = RulesLayerTestHarness.open(SIZE);
     LizzieFrame.boardRenderer.setBoardLength(400, 400);
@@ -180,6 +201,42 @@ class GIBParserTest {
     assertFalse(pass.next().isPresent());
     assertEquals(Stone.BLACK, pass.getData().stones[Board.getIndex(BLACK_X, BLACK_Y)]);
     assertEquals(Stone.WHITE, pass.getData().stones[Board.getIndex(WHITE_X, WHITE_Y)]);
+  }
+
+  private static void setFrameField(LizzieFrame frame, String name, Object value)
+      throws ReflectiveOperationException {
+    java.lang.reflect.Field field = LizzieFrame.class.getDeclaredField(name);
+    field.setAccessible(true);
+    field.set(frame, value);
+  }
+
+  private static final class LoadTrackingFrame extends LizzieFrame {
+    private int scheduledResumeCount;
+
+    @Override
+    public void scheduleResumeAnalysisAfterLoad(int delayMillis) {
+      scheduledResumeCount++;
+    }
+
+    @Override
+    protected void scheduleMovelistRefreshAfterKifuLoad() {}
+
+    @Override
+    public void requestProblemListRefresh() {}
+
+    @Override
+    public void setPlayers(String whitePlayer, String blackPlayer) {}
+
+    @Override
+    public void updateTitle() {}
+
+    @Override
+    public void refresh() {}
+
+    @Override
+    public boolean stopAiPlayingAndPolicy() {
+      return false;
+    }
   }
 
   private static BoardHistoryNode lastRealAction(BoardHistoryNode root) {

--- a/src/test/java/featurecat/lizzie/rules/RulesLayerTestHarness.java
+++ b/src/test/java/featurecat/lizzie/rules/RulesLayerTestHarness.java
@@ -31,6 +31,8 @@ final class RulesLayerTestHarness implements AutoCloseable {
   private final boolean previousEngineEmpty;
   private final boolean previousSavingRaw;
   private final boolean previousUrlSgf;
+  private final boolean previousCanGoAfterload;
+  private final String previousFileNameTitle;
   private final featurecat.lizzie.analysis.EngineFollowController previousEngineFollowController;
 
   private RulesLayerTestHarness(
@@ -46,6 +48,8 @@ final class RulesLayerTestHarness implements AutoCloseable {
       boolean previousEngineEmpty,
       boolean previousSavingRaw,
       boolean previousUrlSgf,
+      boolean previousCanGoAfterload,
+      String previousFileNameTitle,
       featurecat.lizzie.analysis.EngineFollowController previousEngineFollowController) {
     this.previousBoardWidth = previousBoardWidth;
     this.previousBoardHeight = previousBoardHeight;
@@ -59,6 +63,8 @@ final class RulesLayerTestHarness implements AutoCloseable {
     this.previousEngineEmpty = previousEngineEmpty;
     this.previousSavingRaw = previousSavingRaw;
     this.previousUrlSgf = previousUrlSgf;
+    this.previousCanGoAfterload = previousCanGoAfterload;
+    this.previousFileNameTitle = previousFileNameTitle;
     this.previousEngineFollowController = previousEngineFollowController;
   }
 
@@ -79,6 +85,8 @@ final class RulesLayerTestHarness implements AutoCloseable {
     boolean previousEngineEmpty = EngineManager.isEmpty;
     boolean previousSavingRaw = LizzieFrame.isSavingRaw;
     boolean previousUrlSgf = LizzieFrame.urlSgf;
+    boolean previousCanGoAfterload = LizzieFrame.canGoAfterload;
+    String previousFileNameTitle = LizzieFrame.fileNameTitle;
     featurecat.lizzie.analysis.EngineFollowController previousEngineFollowController =
         Lizzie.engineFollowController;
 
@@ -131,6 +139,8 @@ final class RulesLayerTestHarness implements AutoCloseable {
         previousEngineEmpty,
         previousSavingRaw,
         previousUrlSgf,
+        previousCanGoAfterload,
+        previousFileNameTitle,
         previousEngineFollowController);
   }
 
@@ -161,6 +171,8 @@ final class RulesLayerTestHarness implements AutoCloseable {
     EngineManager.isEmpty = previousEngineEmpty;
     LizzieFrame.isSavingRaw = previousSavingRaw;
     LizzieFrame.urlSgf = previousUrlSgf;
+    LizzieFrame.canGoAfterload = previousCanGoAfterload;
+    LizzieFrame.fileNameTitle = previousFileNameTitle;
     Lizzie.engineFollowController = previousEngineFollowController;
   }
 


### PR DESCRIPTION
## Summary
- cancel the current automatic kifu quick analysis when the user pauses analysis, including waiting, startup, running, and retry stages
- preserve the latest user pause intent while shared foreground and tracking restores settle
- defer kifu loads until automatic-analysis cleanup completes so stale callbacks cannot restart pondering or affect the next load context

Fixes #406.

## Test plan
- [x] Run focused regression suites (310 tests, zero failures/errors)
- [x] Run `mvn -Djava.awt.headless=true test` (`BUILD SUCCESS`)
- [x] Run `git diff --check`
- [x] Run `python3 scripts/check_line_endings.py`