### PR TITLE
修复 Windows 棋谱分析、弈客同步与一键设置卡顿

### DIFF
--- a/scripts/test_run_local_ci.py
+++ b/scripts/test_run_local_ci.py
@@ -2,6 +2,7 @@
 
 from pathlib import Path
 import os
+import shutil
 import subprocess
 import tempfile
 import unittest
@@ -12,6 +13,9 @@ from scripts import run_local_ci
 class RunLocalCiTest(unittest.TestCase):
     def test_shell_wrapper_accepts_profile_without_optional_arguments(self):
         repository = Path(__file__).resolve().parents[1]
+        bash = os.environ.get("LIZZIE_BASH") or shutil.which("bash")
+        if not bash:
+            self.skipTest("bash is required to exercise the POSIX local-CI wrapper")
         with tempfile.TemporaryDirectory() as temporary:
             temporary_path = Path(temporary)
             fake_python = temporary_path / "python"
@@ -31,7 +35,7 @@ class RunLocalCiTest(unittest.TestCase):
             )
 
             completed = subprocess.run(
-                ["/bin/bash", "scripts/run_local_ci.sh", "--profile", "all"],
+                [bash, "scripts/run_local_ci.sh", "--profile", "all"],
                 cwd=repository,
                 env=environment,
                 capture_output=True,

--- a/src/main/java/featurecat/lizzie/analysis/AnalysisEngine.java
+++ b/src/main/java/featurecat/lizzie/analysis/AnalysisEngine.java
@@ -569,7 +569,7 @@ public class AnalysisEngine {
       waitFrame.setProgress(resultCount, analyzeMap.size());
     } else if (silentProgress && shouldRefreshSilentProgress(resultCount, analyzeMap.size())) {
       Lizzie.board.setMovelistAll();
-      Lizzie.frame.refresh();
+      Lizzie.frame.refreshSilentAnalysisProgress();
     }
     if (canFinalizeCurrentRequest() && responseCount == analyzeMap.size()) setResult();
   }
@@ -932,7 +932,7 @@ public class AnalysisEngine {
       waitFrame.setProgress(resultCount, analyzeMap.size());
     } else if (silentProgress && shouldRefreshSilentProgress(resultCount, analyzeMap.size())) {
       Lizzie.board.setMovelistAll();
-      Lizzie.frame.refresh();
+      Lizzie.frame.refreshSilentAnalysisProgress();
     }
     return true;
   }
@@ -1048,13 +1048,16 @@ public class AnalysisEngine {
     if (resultCount <= 0) {
       return false;
     }
+    if (resultCount == totalCount) {
+      return true;
+    }
     if (resultCount <= 12) {
       return true;
     }
     if (resultCount <= 64) {
       return resultCount % 4 == 0;
     }
-    return resultCount % 8 == 0 || resultCount == totalCount;
+    return resultCount % 8 == 0;
   }
 
   private boolean shouldKeepForegroundAnalysis(BoardHistoryNode node) {

--- a/src/main/java/featurecat/lizzie/gui/HtmlMessage.java
+++ b/src/main/java/featurecat/lizzie/gui/HtmlMessage.java
@@ -1,7 +1,10 @@
 package featurecat.lizzie.gui;
 
+import featurecat.lizzie.AppLocale;
 import featurecat.lizzie.Config;
+import featurecat.lizzie.Lizzie;
 import featurecat.lizzie.gui.LizzieFrame.HtmlKit;
+import featurecat.lizzie.util.LocaleFontSupport;
 import java.awt.Desktop;
 import java.awt.Font;
 import java.awt.Toolkit;
@@ -9,6 +12,7 @@ import java.awt.Window;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
 import java.io.IOException;
+import java.util.Locale;
 import javax.imageio.ImageIO;
 import javax.swing.JDialog;
 import javax.swing.JEditorPane;
@@ -46,6 +50,12 @@ public class HtmlMessage extends JDialog {
     HtmlKit htmlKit;
     StyleSheet htmlStyle;
 
+    Locale appLocale =
+        Lizzie.config == null
+            ? Locale.getDefault()
+            : AppLocale.fromConfigValue(Lizzie.config.useLanguage).locale();
+    String messageFontName = resolveMessageFontName(Config.sysDefaultFontName, appLocale);
+
     htmlKit = new HtmlKit();
     htmlDoc = (HTMLDocument) htmlKit.createDefaultDocument();
     htmlStyle = htmlKit.getStyleSheet();
@@ -56,8 +66,9 @@ public class HtmlMessage extends JDialog {
             + background
             + "; color:#"
             + foreground
-            + "; font-family:"
-            + Config.sysDefaultFontName
+            + "; font-family:'"
+            + messageFontName
+            + "'"
             + ", 'Microsoft YaHei', 'PingFang SC', Consolas, Menlo, Monaco, 'Ubuntu Mono', monospace;"
             + "}";
     htmlStyle.addRule(style);
@@ -66,7 +77,7 @@ public class HtmlMessage extends JDialog {
     lblMessage.setDocument(htmlDoc);
     lblMessage.setText(content);
     lblMessage.setEditable(false);
-    lblMessage.setFont(new Font(Config.sysDefaultFontName, Font.PLAIN, Config.frameFontSize));
+    lblMessage.setFont(new Font(messageFontName, Font.PLAIN, Config.frameFontSize));
     lblMessage.putClientProperty(JEditorPane.HONOR_DISPLAY_PROPERTIES, Boolean.TRUE);
     lblMessage.addHyperlinkListener(
         new HyperlinkListener() {
@@ -90,5 +101,9 @@ public class HtmlMessage extends JDialog {
     }
     pack();
     setLocationRelativeTo(owner);
+  }
+
+  static String resolveMessageFontName(String preferredName, Locale locale) {
+    return LocaleFontSupport.resolveLanguageFontName(preferredName, locale);
   }
 }

--- a/src/main/java/featurecat/lizzie/gui/KataGoAutoSetupDialog.java
+++ b/src/main/java/featurecat/lizzie/gui/KataGoAutoSetupDialog.java
@@ -50,6 +50,7 @@ import java.awt.Polygon;
 import java.awt.Rectangle;
 import java.awt.RenderingHints;
 import java.awt.Shape;
+import java.awt.Toolkit;
 import java.awt.Window;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
@@ -71,6 +72,10 @@ import java.util.Collections;
 import java.util.IllegalFormatException;
 import java.util.List;
 import java.util.Locale;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.ExecutionException;
+import java.util.function.Consumer;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import javax.swing.AbstractAction;
@@ -99,6 +104,7 @@ import javax.swing.ListSelectionModel;
 import javax.swing.Scrollable;
 import javax.swing.SwingConstants;
 import javax.swing.SwingUtilities;
+import javax.swing.SwingWorker;
 import javax.swing.filechooser.FileNameExtensionFilter;
 import javax.swing.plaf.basic.BasicButtonUI;
 import javax.swing.plaf.basic.BasicScrollBarUI;
@@ -167,6 +173,8 @@ public class KataGoAutoSetupDialog extends JDialog {
   private volatile boolean nvidiaGpuDetectionRunning;
   private volatile EngineValidationResult engineValidationResult;
   private long engineValidationRequestId;
+  private long stateRefreshRequestId;
+  private SwingWorker<SetupSnapshot, Void> stateRefreshWorker;
   private long progressStartedAtMillis;
   private String lastBackgroundErrorMessage = "";
   private long lastBackgroundErrorMillis = 0L;
@@ -303,8 +311,9 @@ public class KataGoAutoSetupDialog extends JDialog {
     setModal(false);
     setTitle(text("AutoSetup.title"));
     configureNativeWindowChrome();
-    setSize(initialDialogSize());
-    setMinimumSize(new Dimension(900, 620));
+    Rectangle availableBounds = availableBoundsFor(owner);
+    setSize(dialogSizeForBounds(availableBounds));
+    setMinimumSize(minimumDialogSizeForBounds(availableBounds));
     setDefaultCloseOperation(DO_NOTHING_ON_CLOSE);
     setAlwaysOnTop(owner instanceof LizzieFrame && ((LizzieFrame) owner).isAlwaysOnTop());
     placeOnOwnerScreen(owner);
@@ -415,12 +424,25 @@ public class KataGoAutoSetupDialog extends JDialog {
     return System.getProperty("os.name", "").toLowerCase(Locale.ROOT).contains("mac");
   }
 
-  private static Dimension initialDialogSize() {
-    Rectangle available =
-        GraphicsEnvironment.getLocalGraphicsEnvironment().getMaximumWindowBounds();
-    int width = Math.max(900, Math.min(DIALOG_WIDTH, available.width - 72));
-    int height = Math.max(620, Math.min(DIALOG_HEIGHT, available.height - 72));
+  static Dimension dialogSizeForBounds(Rectangle available) {
+    int width = Math.max(1, Math.min(DIALOG_WIDTH, available.width - 72));
+    int height = Math.max(1, Math.min(DIALOG_HEIGHT, available.height - 72));
     return new Dimension(width, height);
+  }
+
+  static Dimension minimumDialogSizeForBounds(Rectangle available) {
+    Dimension initial = dialogSizeForBounds(available);
+    return new Dimension(Math.min(900, initial.width), Math.min(620, initial.height));
+  }
+
+  static Point dialogLocationForBounds(Rectangle available, Dimension dialogSize) {
+    int offsetX = Math.max(24, Math.min(48, available.width / 20));
+    int offsetY = Math.max(24, Math.min(48, available.height / 20));
+    int maxX = available.x + Math.max(0, available.width - dialogSize.width);
+    int maxY = available.y + Math.max(0, available.height - dialogSize.height);
+    int x = Math.max(available.x, Math.min(available.x + offsetX, maxX));
+    int y = Math.max(available.y, Math.min(available.y + offsetY, maxY));
+    return new Point(x, y);
   }
 
   /** Opens the dialog directly on the Weights card (nav index 1 maps to CARD_WEIGHTS). */
@@ -488,12 +510,59 @@ public class KataGoAutoSetupDialog extends JDialog {
 
 
   public void refreshState() {
+    refreshState(null);
+  }
+
+  private void refreshState(Runnable afterRefresh) {
+    if (!SwingUtilities.isEventDispatchThread()) {
+      SwingUtilities.invokeLater(() -> refreshState(afterRefresh));
+      return;
+    }
     benchmarkDisplayState = BenchmarkDisplayState.IDLE;
     benchmarkTransientStatus = "";
     if (!nvidiaGpuDetectionRunning) {
       nvidiaGpuDetection = null;
     }
-    SetupSnapshot discoveredSnapshot = KataGoAutoSetupHelper.inspectLocalSetup();
+    cancelStateRefresh();
+    final long requestId = ++stateRefreshRequestId;
+    setStateRefreshPending(true);
+    SwingWorker<SetupSnapshot, Void> worker =
+        createUiBackgroundWorker(
+            KataGoAutoSetupHelper::inspectLocalSetup,
+            discoveredSnapshot -> {
+              if (requestId != stateRefreshRequestId) {
+                return;
+              }
+              stateRefreshWorker = null;
+              setStateRefreshPending(false);
+              applyDiscoveredSnapshot(discoveredSnapshot);
+              if (afterRefresh != null) {
+                afterRefresh.run();
+              }
+            },
+            error -> {
+              if (requestId != stateRefreshRequestId) {
+                return;
+              }
+              stateRefreshWorker = null;
+              setStateRefreshPending(false);
+              setRefreshDependentControlsEnabled(false);
+              btnRefresh.setEnabled(true);
+              btnOpenAppFolder.setEnabled(true);
+              btnViewFullDownloads.setEnabled(true);
+              btnClose.setEnabled(true);
+              String detail = error == null || error.getMessage() == null ? "" : error.getMessage();
+              lblStatus.setText(detail.trim().isEmpty() ? text("AutoSetup.failed") : detail);
+              lblStatus.setForeground(ERROR_COLOR);
+              footerPanel.setVisible(true);
+              revalidate();
+              repaint();
+            });
+    stateRefreshWorker = worker;
+    worker.execute();
+  }
+
+  private void applyDiscoveredSnapshot(SetupSnapshot discoveredSnapshot) {
     boolean discoveredSetupIsActive =
         isDiscoveredSetupActive(discoveredSnapshot, Lizzie.engineManager, Lizzie.leelaz);
     weightSwitchDisplayState =
@@ -506,8 +575,109 @@ public class KataGoAutoSetupDialog extends JDialog {
     snapshot = weightSwitchDisplayState.displayedSnapshot();
     engineValidationResult = null;
     renderSnapshot();
+    refreshIdleControls();
     validateDiscoveredEngineAsync();
     loadRemoteWeightInfo();
+  }
+
+  private void setStateRefreshPending(boolean pending) {
+    if (pending) {
+      String status = text("AutoSetup.validationChecking");
+      String previousStatus = progressStatusLabel.getText();
+      lblStatus.setText(status);
+      lblStatus.setForeground(WARN_COLOR);
+      progressStatusLabel.setText(status);
+      progressStatusLabel.setForeground(WARN_COLOR);
+      progressPanel.setVisible(true);
+      footerPanel.setVisible(true);
+      progressBar.setIndeterminate(true);
+      progressBar.setString("");
+      sectionNav.setEnabled(false);
+      btnRemoteCompute.setEnabled(false);
+      setRefreshDependentControlsEnabled(false);
+      btnClose.setEnabled(true);
+      setCursor(Cursor.getPredefinedCursor(Cursor.WAIT_CURSOR));
+      AccessibilitySupport.announce(progressStatusLabel, previousStatus, status);
+    } else {
+      progressBar.setIndeterminate(false);
+      progressBar.setValue(0);
+      progressBar.setString("");
+      progressPanel.setVisible(false);
+      footerPanel.setVisible(false);
+      sectionNav.setEnabled(true);
+      btnRemoteCompute.setEnabled(true);
+      setCursor(Cursor.getDefaultCursor());
+    }
+    revalidate();
+    repaint();
+  }
+
+  private void setRefreshDependentControlsEnabled(boolean enabled) {
+    btnRefresh.setEnabled(enabled);
+    btnChooseLocalEngine.setEnabled(enabled);
+    btnRepairAnalysisConfig.setEnabled(enabled);
+    btnOpenAppFolder.setEnabled(enabled);
+    btnViewFullDownloads.setEnabled(enabled);
+    btnReloadRemoteWeights.setEnabled(enabled);
+    btnDownloadWeight.setEnabled(enabled);
+    btnImportWeight.setEnabled(enabled);
+    btnUseWeight.setEnabled(enabled);
+    btnDownloadHumanSlModel.setEnabled(enabled);
+    btnImportHumanSlModel.setEnabled(enabled);
+    btnDownloadQuickAnalysisModel.setEnabled(enabled);
+    chkUseQuickAnalysisModel.setEnabled(enabled);
+    weightCatalogList.setEnabled(enabled);
+    btnOfficialWeightTab.setEnabled(enabled);
+    btnCustomWeightTab.setEnabled(enabled);
+    balancedRecommendation.setEnabled(enabled);
+    strongestRecommendation.setEnabled(enabled);
+    lightweightRecommendation.setEnabled(enabled);
+    btnInstallNvidiaRuntime.setEnabled(enabled);
+    btnInstallTensorRt.setEnabled(enabled);
+    btnEnableTensorRt.setEnabled(enabled);
+    btnSwitchBackCuda.setEnabled(enabled);
+    btnCleanTensorRtCache.setEnabled(enabled);
+    cmbExperimentalBackend.setEnabled(enabled);
+    btnInstallExperimentalBackend.setEnabled(enabled);
+    btnOptimizePerformance.setEnabled(enabled);
+    btnExperimentalPerformance.setEnabled(enabled);
+    btnStopDownload.setEnabled(false);
+  }
+
+  private void cancelStateRefresh() {
+    SwingWorker<SetupSnapshot, Void> worker = stateRefreshWorker;
+    stateRefreshWorker = null;
+    if (worker != null) {
+      worker.cancel(true);
+    }
+  }
+
+  static <T> SwingWorker<T, Void> createUiBackgroundWorker(
+      Callable<T> task, Consumer<T> onSuccess, Consumer<Throwable> onFailure) {
+    return new SwingWorker<T, Void>() {
+      @Override
+      protected T doInBackground() throws Exception {
+        return task.call();
+      }
+
+      @Override
+      protected void done() {
+        if (isCancelled()) {
+          return;
+        }
+        try {
+          onSuccess.accept(get());
+        } catch (CancellationException ignored) {
+          // A superseding refresh owns the UI now.
+        } catch (InterruptedException interrupted) {
+          Thread.currentThread().interrupt();
+          onFailure.accept(interrupted);
+        } catch (ExecutionException failed) {
+          Throwable cause = failed.getCause();
+          onFailure.accept(cause == null ? failed : cause);
+        }
+      }
+    };
   }
 
   public void startRecommendedWeightDownload() {
@@ -1735,18 +1905,44 @@ public class KataGoAutoSetupDialog extends JDialog {
   }
 
   private void placeOnOwnerScreen(Window owner) {
+    Rectangle available = availableBoundsFor(owner);
+    Dimension maximumSize = dialogSizeForBounds(available);
+    Dimension currentSize = getSize();
+    Dimension fittedSize =
+        new Dimension(
+            Math.min(currentSize.width, maximumSize.width),
+            Math.min(currentSize.height, maximumSize.height));
+    setMinimumSize(minimumDialogSizeForBounds(available));
+    if (!fittedSize.equals(currentSize)) {
+      setSize(fittedSize);
+    }
+    setLocation(dialogLocationForBounds(available, fittedSize));
+  }
+
+  private static Rectangle availableBoundsFor(Window owner) {
     GraphicsConfiguration graphicsConfiguration =
-        owner != null ? owner.getGraphicsConfiguration() : getGraphicsConfiguration();
+        owner != null ? owner.getGraphicsConfiguration() : null;
     if (graphicsConfiguration == null) {
       graphicsConfiguration =
           GraphicsEnvironment.getLocalGraphicsEnvironment()
               .getDefaultScreenDevice()
               .getDefaultConfiguration();
     }
-    Rectangle bounds = graphicsConfiguration.getBounds();
-    int x = bounds.x + Math.max(24, Math.min(48, bounds.width / 20));
-    int y = bounds.y + Math.max(24, Math.min(48, bounds.height / 20));
-    setLocation(x, y);
+    Rectangle bounds = new Rectangle(graphicsConfiguration.getBounds());
+    try {
+      Insets insets = Toolkit.getDefaultToolkit().getScreenInsets(graphicsConfiguration);
+      bounds.x += insets.left;
+      bounds.y += insets.top;
+      bounds.width = Math.max(1, bounds.width - insets.left - insets.right);
+      bounds.height = Math.max(1, bounds.height - insets.top - insets.bottom);
+    } catch (UnsupportedOperationException ignored) {
+      Rectangle maximum =
+          GraphicsEnvironment.getLocalGraphicsEnvironment().getMaximumWindowBounds();
+      if (maximum.intersects(bounds)) {
+        bounds = bounds.intersection(maximum);
+      }
+    }
+    return bounds;
   }
 
   private void styleInfoLabel(JLabel valueLabel) {
@@ -2198,12 +2394,14 @@ public class KataGoAutoSetupDialog extends JDialog {
                 KataGoAutoSetupHelper.rememberSelectedLocalKataGo(selected);
                 SwingUtilities.invokeLater(
                     () -> {
-                      refreshState();
-                      lblStatus.setText(
-                          text("AutoSetup.analysisConfigRepaired")
-                              + " · "
-                              + repaired.getFileName());
-                      lblStatus.setForeground(OK_COLOR);
+                      refreshState(
+                          () -> {
+                            lblStatus.setText(
+                                text("AutoSetup.analysisConfigRepaired")
+                                    + " · "
+                                    + repaired.getFileName());
+                            lblStatus.setForeground(OK_COLOR);
+                          });
                     });
               } catch (IOException e) {
                 SwingUtilities.invokeLater(
@@ -4213,6 +4411,8 @@ public class KataGoAutoSetupDialog extends JDialog {
   }
 
   private void closeOrCancelActiveTask() {
+    stateRefreshRequestId++;
+    cancelStateRefresh();
     if (pendingWeightSwitchTimer != null) {
       pendingWeightSwitchTimer.stop();
       pendingWeightSwitchTimer = null;
@@ -4398,7 +4598,8 @@ public class KataGoAutoSetupDialog extends JDialog {
   }
 
   private boolean hasActiveBackgroundTask() {
-    return activeDownloadSession != null
+    return stateRefreshWorker != null
+        || activeDownloadSession != null
         || activeWorkerThread != null
         || pendingWeightSwitchTimer != null;
   }

--- a/src/main/java/featurecat/lizzie/gui/LizzieFrame.java
+++ b/src/main/java/featurecat/lizzie/gui/LizzieFrame.java
@@ -564,6 +564,7 @@ public class LizzieFrame extends JFrame {
   private static final int YIKE_CURVE_COMPLETION_BUSY_RETRY_MS = 3000;
   private javax.swing.Timer yikeCurveCompletionTimer;
   private String pendingYikeCurveCompletionUrl = "";
+  private long yikeCurveCompletionGeneration;
 
   /** Web 试下模式下的渲染节点覆盖。null 表示无 override，渲染端读 Board.history 当前节点。 */
   private volatile featurecat.lizzie.rules.BoardHistoryNode displayNodeOverride;
@@ -7131,6 +7132,42 @@ public class LizzieFrame extends JFrame {
     notifyWebBoard(false);
   }
 
+  /** Repaints graph progress without rebuilding the board and suggestion surfaces. */
+  public void refreshSilentAnalysisProgress() {
+    if (!SwingUtilities.isEventDispatchThread()) {
+      SwingUtilities.invokeLater(this::refreshSilentAnalysisProgress);
+      return;
+    }
+    redrawWinratePaneOnly = true;
+    if (mainPanel != null) mainPanel.repaint();
+    if (listTable != null && listTable.isVisible()) listTable.repaint();
+    if (analysisSidebarRefreshCoalescer != null) analysisSidebarRefreshCoalescer.request();
+    notifyWebBoard(true);
+  }
+
+  void refreshCompletedSilentAnalysisProgress() {
+    if (!SwingUtilities.isEventDispatchThread()) {
+      SwingUtilities.invokeLater(this::refreshCompletedSilentAnalysisProgress);
+      return;
+    }
+    if (Lizzie.board == null || Lizzie.board.getHistory() == null) {
+      return;
+    }
+    Board completedBoard = Lizzie.board;
+    BoardHistoryList completedHistory = completedBoard.getHistory();
+    completedBoard.setMovelistAll(
+        () ->
+            SwingUtilities.invokeLater(
+                () -> {
+                  if (Lizzie.board != completedBoard
+                      || completedBoard.getHistory() != completedHistory) {
+                    return;
+                  }
+                  refreshProblemListSnapshot();
+                  refreshSilentAnalysisProgress();
+                }));
+  }
+
   public void refresh(int mode) {
     // 分开各部分刷新,1代表来自info move的刷新
     if (independentSubBoard != null && independentSubBoard.isVisible())
@@ -11477,6 +11514,19 @@ public class LizzieFrame extends JFrame {
         });
   }
 
+  public void revealYikeLiveSyncStatus(String url, String status) {
+    SwingUtilities.invokeLater(
+        new Runnable() {
+          @Override
+          public void run() {
+            if (yikeLiveDialog != null && yikeLiveDialog.isDisplayable()) {
+              yikeLiveDialog.updateSyncStatus(url, status);
+              yikeLiveDialog.showAndActivate();
+            }
+          }
+        });
+  }
+
   public void scheduleYikeLiveCurveCompletion(String sourceUrl) {
     if (!SwingUtilities.isEventDispatchThread()) {
       SwingUtilities.invokeLater(() -> scheduleYikeLiveCurveCompletion(sourceUrl));
@@ -11486,6 +11536,7 @@ public class LizzieFrame extends JFrame {
       return;
     }
     pendingYikeCurveCompletionUrl = sourceUrl == null ? "" : sourceUrl;
+    yikeCurveCompletionGeneration++;
     if (yikeCurveCompletionTimer == null) {
       yikeCurveCompletionTimer =
           new javax.swing.Timer(
@@ -11504,6 +11555,7 @@ public class LizzieFrame extends JFrame {
       return;
     }
     pendingYikeCurveCompletionUrl = "";
+    yikeCurveCompletionGeneration++;
     if (yikeCurveCompletionTimer != null) {
       yikeCurveCompletionTimer.stop();
     }
@@ -11514,6 +11566,8 @@ public class LizzieFrame extends JFrame {
       return;
     }
     String statusUrl = pendingYikeCurveCompletionUrl;
+    long generation = yikeCurveCompletionGeneration;
+    BoardHistoryNode root = currentHistoryRoot();
     int missingMoves = countMissingMainlineAnalysisNodes();
     if (missingMoves <= 0) {
       if (fromBusyRetry) {
@@ -11539,9 +11593,9 @@ public class LizzieFrame extends JFrame {
             text("YikeLiveDialog.curveCompleting", "Completing winrate/score graph (%d moves)..."),
             missingMoves));
     if (needsNewFlashAnalysisEngine()) {
-      startYikeCurveCompletionWithNewEngine(statusUrl);
+      startYikeCurveCompletionWithNewEngine(statusUrl, generation, root);
     } else {
-      startYikeCurveCompletionRequests(analysisEngine, statusUrl);
+      startYikeCurveCompletionRequests(analysisEngine, statusUrl, generation, root);
     }
   }
 
@@ -11567,22 +11621,29 @@ public class LizzieFrame extends JFrame {
         && Lizzie.board.getHistory() != null;
   }
 
-  private void startYikeCurveCompletionWithNewEngine(String statusUrl) {
+  private void startYikeCurveCompletionWithNewEngine(
+      String statusUrl, long generation, BoardHistoryNode root) {
     Thread starter =
         new Thread(
             () -> {
               try {
-                AnalysisEngine newAnalysisEngine = new AnalysisEngine(false);
+                AnalysisEngine newAnalysisEngine = createYikeCurveAnalysisEngine();
                 SwingUtilities.invokeLater(
                     () -> {
-                      analysisEngine = newAnalysisEngine;
+                      if (!isCurrentYikeCurveCompletion(generation, root)) {
+                        newAnalysisEngine.normalQuit();
+                        return;
+                      }
                       if (!newAnalysisEngine.isLoaded()) {
+                        newAnalysisEngine.normalQuit();
                         updateYikeLiveSyncStatus(
                             statusUrl,
                             text("YikeLiveDialog.curveFailed", "Failed to start graph completion"));
                         return;
                       }
-                      startYikeCurveCompletionRequests(newAnalysisEngine, statusUrl);
+                      analysisEngine = newAnalysisEngine;
+                      startYikeCurveCompletionRequests(
+                          newAnalysisEngine, statusUrl, generation, root);
                     });
               } catch (IOException e) {
                 SwingUtilities.invokeLater(
@@ -11599,29 +11660,112 @@ public class LizzieFrame extends JFrame {
     starter.start();
   }
 
+  AnalysisEngine createYikeCurveAnalysisEngine() throws IOException {
+    return AnalysisEngine.createAutomaticQuickAnalysis();
+  }
+
   private void startYikeCurveCompletionRequests(AnalysisEngine targetEngine, String statusUrl) {
-    if (targetEngine == null || !targetEngine.isLoaded()) {
+    startYikeCurveCompletionRequests(
+        targetEngine, statusUrl, yikeCurveCompletionGeneration, currentHistoryRoot());
+  }
+
+  private void startYikeCurveCompletionRequests(
+      AnalysisEngine targetEngine, String statusUrl, long generation, BoardHistoryNode root) {
+    if (targetEngine == null
+        || !targetEngine.isLoaded()
+        || !isCurrentYikeCurveCompletion(generation, root)) {
       updateYikeLiveSyncStatus(
           statusUrl, text("YikeLiveDialog.curveFailed", "Failed to start graph completion"));
       return;
     }
+    AtomicBoolean finished = new AtomicBoolean(false);
     targetEngine.setCompletionCallback(
         () ->
-            updateYikeLiveSyncStatus(
-                statusUrl, text("YikeLiveDialog.curveUpdated", "Graph updated.")));
+            finishYikeCurveCompletion(
+                targetEngine, statusUrl, generation, root, false, finished));
     targetEngine.setFailureCallback(
         () ->
-            updateYikeLiveSyncStatus(
-                statusUrl, text("YikeLiveDialog.curveFailed", "Failed to start graph completion")));
-    int requestCount = targetEngine.startRequestMissingMainline(false);
-    if (requestCount < 0) {
-      targetEngine.setCompletionCallback(null);
+            finishYikeCurveCompletion(
+                targetEngine, statusUrl, generation, root, true, finished));
+    Thread requestSender =
+        new Thread(
+            () -> {
+              if (!isCurrentYikeCurveCompletion(generation, root)
+                  || targetEngine != analysisEngine) {
+                targetEngine.clearRequestCallbacks();
+                finishYikeCurveCompletion(
+                    targetEngine, statusUrl, generation, root, true, finished);
+                return;
+              }
+              int requestCount = targetEngine.startRequestMissingMainline(false);
+              if (requestCount < 0) {
+                targetEngine.clearRequestCallbacks();
+                finishYikeCurveCompletion(
+                    targetEngine, statusUrl, generation, root, true, finished);
+              } else if (requestCount == 0) {
+                targetEngine.clearRequestCallbacks();
+                finishYikeCurveCompletion(
+                    targetEngine, statusUrl, generation, root, false, finished);
+              }
+            },
+            "yike-curve-analysis-request");
+    requestSender.setDaemon(true);
+    requestSender.start();
+  }
+
+  private void finishYikeCurveCompletion(
+      AnalysisEngine targetEngine,
+      String statusUrl,
+      long generation,
+      BoardHistoryNode root,
+      boolean failed,
+      AtomicBoolean finished) {
+    if (!SwingUtilities.isEventDispatchThread()) {
+      SwingUtilities.invokeLater(
+          () ->
+              finishYikeCurveCompletion(
+                  targetEngine, statusUrl, generation, root, failed, finished));
       return;
     }
-    if (requestCount <= 0) {
-      targetEngine.clearRequestCallbacks();
+    if (!finished.compareAndSet(false, true)) {
+      return;
+    }
+    boolean current = isCurrentYikeCurveCompletion(generation, root);
+    if (current) {
       updateYikeLiveSyncStatus(
-          statusUrl, text("YikeLiveDialog.curveUpToDate", "Graph is up to date."));
+          statusUrl,
+          failed
+              ? text("YikeLiveDialog.curveFailed", "Failed to start graph completion")
+              : (countMissingMainlineAnalysisNodes() > 0
+                  ? text("YikeLiveDialog.curveUpdated", "Graph updated.")
+                  : text("YikeLiveDialog.curveUpToDate", "Graph is up to date.")));
+    }
+    releaseCompletedYikeCurveEngine(targetEngine);
+    if (current) {
+      if (!failed) {
+        refreshCompletedSilentAnalysisProgress();
+      }
+      resumeForegroundAnalysisAfterQuickAnalysisComplete();
+    }
+  }
+
+  private boolean isCurrentYikeCurveCompletion(long generation, BoardHistoryNode root) {
+    return generation == yikeCurveCompletionGeneration
+        && root != null
+        && root == currentHistoryRoot();
+  }
+
+  private void releaseCompletedYikeCurveEngine(AnalysisEngine targetEngine) {
+    if (targetEngine == null
+        || !targetEngine.isAutomaticBackgroundTask()
+        || targetEngine.usesSharedForegroundEngine()
+        || targetEngine.hasRequestLifecycleInProgress()) {
+      return;
+    }
+    targetEngine.clearRequestCallbacks();
+    targetEngine.normalQuit();
+    if (analysisEngine == targetEngine) {
+      analysisEngine = null;
     }
   }
 
@@ -15783,6 +15927,8 @@ public class LizzieFrame extends JFrame {
     if (shouldAutoQuickAnalyzeLoadedGame()) {
       if (failed) {
         releaseIdleAutomaticQuickAnalysisEngine();
+      } else {
+        refreshCompletedSilentAnalysisProgress();
       }
       scheduleLoadedGameQuickAnalysisRetry();
       if (failed) {
@@ -15792,6 +15938,9 @@ public class LizzieFrame extends JFrame {
     }
     releaseIdleAutomaticQuickAnalysisEngine();
     stopLoadedGameQuickAnalysisRetry();
+    if (!failed) {
+      refreshCompletedSilentAnalysisProgress();
+    }
     resumeForegroundAnalysisAfterQuickAnalysisComplete();
   }
 

--- a/src/main/java/featurecat/lizzie/gui/Menu.java
+++ b/src/main/java/featurecat/lizzie/gui/Menu.java
@@ -15,6 +15,7 @@ import featurecat.lizzie.theme.MorandiPalette;
 import featurecat.lizzie.theme.Theme;
 import featurecat.lizzie.training.HumanSlTrainingSession;
 import featurecat.lizzie.update.WindowsUpdateController;
+import featurecat.lizzie.util.LocaleFontSupport;
 import featurecat.lizzie.util.Utils;
 import featurecat.lizzie.logging.LoggingRuntime;
 import java.awt.Color;
@@ -71,6 +72,12 @@ public class Menu extends JMenuBar {
   JFontMenuItem shutdownOtherEngine;
   JFontMenuItem minPlayoutsForNextMove;
   private TencentKifuDownload tencentKifuDownload;
+
+  static Font languageOptionFont(AppLocale locale, String preferredName, int size) {
+    String fontName =
+        LocaleFontSupport.resolveLanguageFontName(preferredName, locale.locale());
+    return new Font(fontName, Font.PLAIN, size);
+  }
 
   public static JFontMenuItem[] engine2 = new JFontMenuItem[21];
   public static JFontMenu engineMenu2;
@@ -5351,10 +5358,13 @@ public class Menu extends JMenuBar {
     languageDefault.addActionListener(event -> selectLanguage(AppLocale.SYSTEM));
 
     final JFontCheckBoxMenuItem languageZH = new JFontCheckBoxMenuItem("简体中文");
+    languageZH.setFont(languageOptionFont(AppLocale.SIMPLIFIED_CHINESE, "Dialog", Config.frameFontSize));
     language.add(languageZH);
     languageZH.addActionListener(event -> selectLanguage(AppLocale.SIMPLIFIED_CHINESE));
 
     final JFontCheckBoxMenuItem languageTW = new JFontCheckBoxMenuItem("繁體中文");
+    languageTW.setFont(
+        languageOptionFont(AppLocale.TRADITIONAL_CHINESE, "Dialog", Config.frameFontSize));
     language.add(languageTW);
     languageTW.addActionListener(event -> selectLanguage(AppLocale.TRADITIONAL_CHINESE));
 
@@ -5363,17 +5373,19 @@ public class Menu extends JMenuBar {
     languageEN.addActionListener(event -> selectLanguage(AppLocale.ENGLISH));
 
     final JFontCheckBoxMenuItem languageJP = new JFontCheckBoxMenuItem("日本語");
-    languageJP.setFont(new Font("Yu Gothic UI", Font.PLAIN, Config.frameFontSize));
+    languageJP.setFont(
+        languageOptionFont(AppLocale.JAPANESE, "Yu Gothic UI", Config.frameFontSize));
     language.add(languageJP);
     languageJP.addActionListener(event -> selectLanguage(AppLocale.JAPANESE));
 
     final JFontCheckBoxMenuItem languageKR = new JFontCheckBoxMenuItem("한국어");
-    languageKR.setFont(new Font("맑은 고딕", Font.PLAIN, Config.frameFontSize));
+    languageKR.setFont(
+        languageOptionFont(AppLocale.KOREAN, "Malgun Gothic", Config.frameFontSize));
     language.add(languageKR);
     languageKR.addActionListener(event -> selectLanguage(AppLocale.KOREAN));
 
     final JFontCheckBoxMenuItem languageTH = new JFontCheckBoxMenuItem("ไทย");
-    languageTH.setFont(new Font("Dialog", Font.PLAIN, Config.frameFontSize));
+    languageTH.setFont(languageOptionFont(AppLocale.THAI, "Dialog", Config.frameFontSize));
     language.add(languageTH);
     languageTH.addActionListener(event -> selectLanguage(AppLocale.THAI));
 

--- a/src/main/java/featurecat/lizzie/gui/OnlineDialog.java
+++ b/src/main/java/featurecat/lizzie/gui/OnlineDialog.java
@@ -867,7 +867,7 @@ public class OnlineDialog extends JDialog {
       } catch (Exception ignored) {
       }
     }
-    if (!hasActiveYikeSession()) {
+    if (shouldClearBoardBeforeSync(hasActiveYikeSession(), syncType)) {
       Lizzie.board.clearForOnline();
     }
     switch (syncType) {
@@ -894,7 +894,7 @@ public class OnlineDialog extends JDialog {
         break;
       case 6:
         reqNewYikeRoom(
-            true, syncAjaxUrl, syncRoomId, syncRefreshTime, syncSourceUrl, syncType, syncSessionId);
+            false, syncAjaxUrl, syncRoomId, syncRefreshTime, syncSourceUrl, syncType, syncSessionId);
         break;
       case 7:
         startYikeUnitePolling(syncRoomId, syncRefreshTime, syncAjaxUrl);
@@ -920,6 +920,10 @@ public class OnlineDialog extends JDialog {
     if (online == null || online.isShutdown() || online.isTerminated()) {
       online = Executors.newScheduledThreadPool(1);
     }
+  }
+
+  static boolean shouldClearBoardBeforeSync(boolean hasActiveSession, int syncType) {
+    return !hasActiveSession && syncType != YikeUrlInfo.TYPE_NEW_LIVE_ROOM;
   }
 
   private int nextYikeLiveSessionId() {
@@ -1103,9 +1107,10 @@ public class OnlineDialog extends JDialog {
       }
       if (Utils.isBlank(sgf)) {
         YikeSyncDebugLog.log("OnlineDialog.parseSgf no sgf in live payload");
-        updateYikeSyncStatus(
-            currentYikeSourceUrl(), text("YikeLiveDialog.syncNoSgf", "No SGF is available yet."));
-        error(true);
+        String sourceUrl = currentYikeSourceUrl();
+        String status = text("YikeLiveDialog.syncNoSgf", "No SGF is available yet.");
+        updateYikeSyncStatus(sourceUrl, status);
+        Lizzie.frame.revealYikeLiveSyncStatus(sourceUrl, status);
         return;
       }
     }
@@ -1543,7 +1548,17 @@ public class OnlineDialog extends JDialog {
                       + " sgfLen="
                       + (detail.getSgf() == null ? -1 : detail.getSgf().length()));
               if (Utils.isBlank(detail.getSgf())) {
-                throw new IOException(text("YikeLiveDialog.syncNoSgf", "No SGF is available yet."));
+                String noSgfStatus =
+                    text("YikeLiveDialog.syncNoSgf", "No SGF is available yet.");
+                updateYikeSyncStatus(sourceUrl, noSgfStatus);
+                Lizzie.frame.revealYikeLiveSyncStatus(sourceUrl, noSgfStatus);
+                if (detail.getStatus() >= 3
+                    && schedule != null
+                    && !schedule.isCancelled()
+                    && !schedule.isDone()) {
+                  schedule.cancel(false);
+                }
+                return;
               }
               String mainlineSgf = YikeSgfMainline.withoutVariations(detail.getSgf());
               boolean hasNewMoves = !mainlineSgf.equals(lastYikeMainlineSgf);

--- a/src/main/java/featurecat/lizzie/gui/YikeApiClient.java
+++ b/src/main/java/featurecat/lizzie/gui/YikeApiClient.java
@@ -275,6 +275,10 @@ public class YikeApiClient {
       return handsCount;
     }
 
+    public boolean isPreviewWithoutMoves() {
+      return status == 1 && handsCount <= 0;
+    }
+
     public String toRoomUrl() {
       String roomPath = version == 2 ? "new-room" : "room";
       return "https://home.yikeweiqi.com/#/live/" + roomPath + "/" + id + "/" + hall + "/" + room;

--- a/src/main/java/featurecat/lizzie/gui/YikeLiveDialog.java
+++ b/src/main/java/featurecat/lizzie/gui/YikeLiveDialog.java
@@ -287,9 +287,21 @@ public class YikeLiveDialog extends JFrame {
       statusLabel.setText(text("YikeLiveDialog.noSelection", "Select a live game first."));
       return;
     }
+    if (!canStartSync(game)) {
+      activeSyncUrl = "";
+      statusLabel.setText(
+          text("YikeLiveDialog.syncNoSgf", "No SGF is available yet.")
+              + " "
+              + game.getGameName());
+      return;
+    }
     activeSyncUrl = game.toRoomUrl();
     statusLabel.setText(text("YikeLiveDialog.syncing", "Syncing") + ": " + game.getGameName());
     Lizzie.frame.syncOnline(activeSyncUrl);
+  }
+
+  static boolean canStartSync(YikeLiveGame game) {
+    return game != null && !game.isPreviewWithoutMoves();
   }
 
   private YikeLiveGame selectedGame() {

--- a/src/main/java/featurecat/lizzie/rules/Board.java
+++ b/src/main/java/featurecat/lizzie/rules/Board.java
@@ -5672,6 +5672,11 @@ public class Board {
   }
 
   public void setMovelistAll() {
+    setMovelistAll(null);
+  }
+
+  /** Rebuilds move-list metadata asynchronously and runs {@code onComplete} after it is coherent. */
+  public void setMovelistAll(Runnable onComplete) {
     final int generation = ++movelistRefreshGeneration;
     final BoardHistoryList refreshHistory = history;
     if (refreshHistory == null) {
@@ -5708,6 +5713,11 @@ public class Board {
                   if (processed % 128 == 0 && !sleepMovelistRefresh(1)) {
                     return;
                   }
+                }
+                if (generation == movelistRefreshGeneration
+                    && history == refreshHistory
+                    && onComplete != null) {
+                  onComplete.run();
                 }
               }
             },

--- a/src/main/java/featurecat/lizzie/rules/BoardHistoryNode.java
+++ b/src/main/java/featurecat/lizzie/rules/BoardHistoryNode.java
@@ -12,6 +12,9 @@ import java.util.Optional;
 
 /** Node structure for the board history / sgf tree */
 public class BoardHistoryNode {
+  private static final ThreadLocal<Integer> DETACHED_HISTORY_MUTATION_DEPTH =
+      ThreadLocal.withInitial(() -> 0);
+
   private Optional<BoardHistoryNode> previous;
   public ArrayList<BoardHistoryNode> variations;
   public NodeInfo nodeInfo;
@@ -28,6 +31,25 @@ public class BoardHistoryNode {
 
   // Save the children for restore to branch
   private int fromBackChildren;
+
+  static void runWithoutGlobalMoveSideEffects(Runnable action) {
+    Objects.requireNonNull(action, "action");
+    int previousDepth = DETACHED_HISTORY_MUTATION_DEPTH.get();
+    DETACHED_HISTORY_MUTATION_DEPTH.set(previousDepth + 1);
+    try {
+      action.run();
+    } finally {
+      if (previousDepth == 0) {
+        DETACHED_HISTORY_MUTATION_DEPTH.remove();
+      } else {
+        DETACHED_HISTORY_MUTATION_DEPTH.set(previousDepth);
+      }
+    }
+  }
+
+  private static boolean suppressGlobalMoveSideEffects() {
+    return DETACHED_HISTORY_MUTATION_DEPTH.get() > 0;
+  }
 
   /** Initializes a new list node */
   public BoardHistoryNode(BoardData data) {
@@ -174,12 +196,15 @@ public class BoardHistoryNode {
 
   public BoardHistoryNode addOrGoto(
       BoardData data, boolean newBranch, boolean changeMove, boolean tsumego) {
-    if (!Lizzie.board.isLoadingFile
+    boolean suppressSideEffects = suppressGlobalMoveSideEffects();
+    if (!suppressSideEffects
+        && !Lizzie.board.isLoadingFile
         && Lizzie.leelaz != null
         && !Lizzie.engineGame.current().playing()) {
       Lizzie.leelaz.clearBestMoves();
     }
-    if (Lizzie.frame.isPlayingAgainstLeelaz || Lizzie.frame.isAnaPlayingAgainstLeelaz) {
+    if (!suppressSideEffects
+        && (Lizzie.frame.isPlayingAgainstLeelaz || Lizzie.frame.isAnaPlayingAgainstLeelaz)) {
       if (Lizzie.frame.playerIsBlack == Lizzie.board.getHistory().isBlacksTurn())
         Lizzie.frame.tryToResetByoTime();
     }
@@ -201,7 +226,9 @@ public class BoardHistoryNode {
             break;
           }
           // if (Lizzie.config.playSound) Utils.playVoiceFile();
-          Lizzie.board.clearAfterMove();
+          if (!suppressSideEffects) {
+            Lizzie.board.clearAfterMove();
+          }
           return variations.get(i);
         }
       }
@@ -241,8 +268,12 @@ public class BoardHistoryNode {
     }
     node.previous = Optional.of(this);
     // if (Lizzie.config.playSound) Utils.playVoiceFile();
-    Lizzie.board.clearAfterMove();
-    Lizzie.leelaz.maybeAjustPDA(node);
+    if (!suppressSideEffects) {
+      Lizzie.board.clearAfterMove();
+      if (Lizzie.leelaz != null) {
+        Lizzie.leelaz.maybeAjustPDA(node);
+      }
+    }
     return node;
   }
 

--- a/src/main/java/featurecat/lizzie/rules/SGFParser.java
+++ b/src/main/java/featurecat/lizzie/rules/SGFParser.java
@@ -3539,8 +3539,12 @@ public class SGFParser {
       if (switchedBoardContext) {
         applyParseBoardContext(boardWidth, boardHeight);
       }
-      history = new BoardHistoryList(BoardData.empty(boardWidth, boardHeight));
-      parseValue(value, history, false, first);
+      String detachedSgf = value;
+      BoardHistoryList detachedHistory =
+          new BoardHistoryList(BoardData.empty(boardWidth, boardHeight));
+      BoardHistoryNode.runWithoutGlobalMoveSideEffects(
+          () -> parseValue(detachedSgf, detachedHistory, false, first));
+      history = detachedHistory;
     } finally {
       if (switchedBoardContext) {
         restoreParseBoardContext(boardContext);

--- a/src/main/java/featurecat/lizzie/util/LocaleFontSupport.java
+++ b/src/main/java/featurecat/lizzie/util/LocaleFontSupport.java
@@ -12,8 +12,46 @@ import java.util.function.Predicate;
 /** Selects a physical UI font when a platform logical font cannot render the active locale. */
 public final class LocaleFontSupport {
   private static final String DEFAULT_FONT = "Dialog";
+  private static final String SIMPLIFIED_CHINESE_SAMPLE = "简体中文";
+  private static final String TRADITIONAL_CHINESE_SAMPLE = "繁體中文";
+  private static final String JAPANESE_SAMPLE = "日本語";
+  private static final String KOREAN_SAMPLE = "한국어";
   private static final String THAI_SAMPLE =
       "\u0e20\u0e32\u0e29\u0e32\u0e44\u0e17\u0e22 \u0e01\u0e32\u0e23\u0e15\u0e31\u0e49\u0e07\u0e04\u0e48\u0e32 \u0e40\u0e04\u0e23\u0e37\u0e48\u0e2d\u0e07\u0e21\u0e37\u0e2d";
+  private static final List<String> SIMPLIFIED_CHINESE_FONT_CANDIDATES =
+      Arrays.asList(
+          "Microsoft YaHei UI",
+          "Microsoft YaHei",
+          "PingFang SC",
+          "Noto Sans CJK SC",
+          "Source Han Sans SC",
+          "SimHei",
+          "Arial Unicode MS");
+  private static final List<String> TRADITIONAL_CHINESE_FONT_CANDIDATES =
+      Arrays.asList(
+          "Microsoft JhengHei UI",
+          "Microsoft JhengHei",
+          "PingFang TC",
+          "Noto Sans CJK TC",
+          "Source Han Sans TC",
+          "MingLiU",
+          "Arial Unicode MS");
+  private static final List<String> JAPANESE_FONT_CANDIDATES =
+      Arrays.asList(
+          "Yu Gothic UI",
+          "Yu Gothic",
+          "Meiryo UI",
+          "Meiryo",
+          "Hiragino Sans",
+          "Noto Sans CJK JP",
+          "Arial Unicode MS");
+  private static final List<String> KOREAN_FONT_CANDIDATES =
+      Arrays.asList(
+          "Malgun Gothic",
+          "Apple SD Gothic Neo",
+          "Noto Sans CJK KR",
+          "NanumGothic",
+          "Arial Unicode MS");
   private static final List<String> THAI_FONT_CANDIDATES =
       Arrays.asList(
           "Leelawadee UI",
@@ -35,6 +73,21 @@ public final class LocaleFontSupport {
     return resolveThaiFontName(configured, configured, LocaleFontSupport::canRenderThai);
   }
 
+  /** Selects a font that can render the native label for a language picker option. */
+  public static String resolveLanguageFontName(String preferredName, Locale locale) {
+    String preferred = normalized(preferredName, DEFAULT_FONT);
+    String sample = languageSample(locale);
+    List<String> candidates = languageFontCandidates(locale);
+    if (sample == null || candidates.isEmpty()) {
+      return preferred;
+    }
+    return resolveFontName(
+        preferred,
+        preferred,
+        candidates,
+        requestedName -> canRender(requestedName, sample));
+  }
+
   public static String resolveConfiguredFontName(
       String configuredName, Locale locale, String fallbackName) {
     String fallback = normalized(fallbackName, DEFAULT_FONT);
@@ -48,16 +101,25 @@ public final class LocaleFontSupport {
 
   static String resolveThaiFontName(
       String configuredName, String fallbackName, Predicate<String> supportsThai) {
+    return resolveFontName(
+        configuredName, fallbackName, THAI_FONT_CANDIDATES, supportsThai);
+  }
+
+  private static String resolveFontName(
+      String configuredName,
+      String fallbackName,
+      List<String> candidates,
+      Predicate<String> supportsText) {
     String fallback = normalized(fallbackName, DEFAULT_FONT);
     String configured = normalized(configuredName, fallback);
-    if (supportsThai.test(configured)) {
+    if (supportsText.test(configured)) {
       return configured;
     }
-    if (!configured.equalsIgnoreCase(fallback) && supportsThai.test(fallback)) {
+    if (!configured.equalsIgnoreCase(fallback) && supportsText.test(fallback)) {
       return fallback;
     }
-    for (String candidate : THAI_FONT_CANDIDATES) {
-      if (supportsThai.test(candidate)) {
+    for (String candidate : candidates) {
+      if (supportsText.test(candidate)) {
         return candidate;
       }
     }
@@ -76,16 +138,71 @@ public final class LocaleFontSupport {
     return locale != null && "th".equalsIgnoreCase(locale.getLanguage());
   }
 
+  private static String languageSample(Locale locale) {
+    if (locale == null) {
+      return null;
+    }
+    switch (locale.getLanguage().toLowerCase(Locale.ROOT)) {
+      case "zh":
+        return isTraditionalChinese(locale)
+            ? TRADITIONAL_CHINESE_SAMPLE
+            : SIMPLIFIED_CHINESE_SAMPLE;
+      case "ja":
+        return JAPANESE_SAMPLE;
+      case "ko":
+        return KOREAN_SAMPLE;
+      case "th":
+        return THAI_SAMPLE;
+      default:
+        return null;
+    }
+  }
+
+  private static List<String> languageFontCandidates(Locale locale) {
+    if (locale == null) {
+      return List.of();
+    }
+    switch (locale.getLanguage().toLowerCase(Locale.ROOT)) {
+      case "zh":
+        return isTraditionalChinese(locale)
+            ? TRADITIONAL_CHINESE_FONT_CANDIDATES
+            : SIMPLIFIED_CHINESE_FONT_CANDIDATES;
+      case "ja":
+        return JAPANESE_FONT_CANDIDATES;
+      case "ko":
+        return KOREAN_FONT_CANDIDATES;
+      case "th":
+        return THAI_FONT_CANDIDATES;
+      default:
+        return List.of();
+    }
+  }
+
+  private static boolean isTraditionalChinese(Locale locale) {
+    String script = locale.getScript();
+    if ("Hant".equalsIgnoreCase(script)) {
+      return true;
+    }
+    String country = locale.getCountry();
+    return "TW".equalsIgnoreCase(country)
+        || "HK".equalsIgnoreCase(country)
+        || "MO".equalsIgnoreCase(country);
+  }
+
   private static String normalized(String fontName, String fallback) {
     return fontName == null || fontName.trim().isEmpty() ? fallback : fontName.trim();
   }
 
   private static boolean canRenderThai(String requestedName) {
+    return canRender(requestedName, THAI_SAMPLE);
+  }
+
+  private static boolean canRender(String requestedName, String sample) {
     String family = availableFontFamilies().get(requestedName.toLowerCase(Locale.ROOT));
     if (family == null) {
       return false;
     }
-    return new Font(family, Font.PLAIN, 12).canDisplayUpTo(THAI_SAMPLE) < 0;
+    return new Font(family, Font.PLAIN, 12).canDisplayUpTo(sample) < 0;
   }
 
   private static Map<String, String> availableFontFamilies() {

--- a/src/test/java/featurecat/lizzie/analysis/AnalysisEngineRequestTest.java
+++ b/src/test/java/featurecat/lizzie/analysis/AnalysisEngineRequestTest.java
@@ -1621,6 +1621,49 @@ class AnalysisEngineRequestTest {
   }
 
   @Test
+  void silentProgressRefreshesGraphWithoutTriggeringFullBoardRefresh() throws Exception {
+    try (TestEnvironment env = TestEnvironment.open()) {
+      BoardHistoryList history = new BoardHistoryList(BoardData.empty(BOARD_SIZE, BOARD_SIZE));
+      history.add(
+          moveNode(stones(placement(0, 0, Stone.BLACK)), new int[] {0, 0}, Stone.BLACK, false, 1));
+      history.add(
+          moveNode(
+              stones(placement(0, 0, Stone.BLACK), placement(1, 1, Stone.WHITE)),
+              new int[] {1, 1},
+              Stone.WHITE,
+              true,
+              2));
+      boardWithHistory(history);
+      SilentProgressTrackingFrame frame = allocate(SilentProgressTrackingFrame.class);
+      Lizzie.frame = frame;
+      TrackingAnalysisEngine engine = TrackingAnalysisEngine.create();
+
+      assertEquals(2, engine.startRequestMissingMainline(false));
+      engine.parseResult(analysisResult(1, 200, 62.0));
+
+      assertEquals(1, frame.silentProgressRefreshCalls);
+      assertEquals(
+          0,
+          frame.fullRefreshCalls,
+          "an intermediate silent result must not rebuild the full board render surface.");
+      waitForMovelistRefreshThreads();
+    }
+  }
+
+  @Test
+  void silentProgressAlwaysRefreshesTheFinalResultBetweenThrottleIntervals() throws Exception {
+    Method method =
+        AnalysisEngine.class.getDeclaredMethod(
+            "shouldRefreshSilentProgress", int.class, int.class);
+    method.setAccessible(true);
+
+    assertTrue((boolean) method.invoke(null, 13, 13));
+    assertTrue((boolean) method.invoke(null, 49, 49));
+    assertFalse((boolean) method.invoke(null, 49, 50));
+    assertTrue((boolean) method.invoke(null, 48, 50));
+  }
+
+  @Test
   void wholeGameRequestNeverDowngradesCachedResultsEvenWhenOverrideIsEnabled() throws Exception {
     try (TestEnvironment env = TestEnvironment.open()) {
       Lizzie.config.analysisAlwaysOverride = true;
@@ -3945,6 +3988,26 @@ class AnalysisEngineRequestTest {
     protected void showContributeBenchmarkConflict() {
       contributeBenchmarkConflictCount++;
     }
+  }
+
+  private static final class SilentProgressTrackingFrame extends LizzieFrame {
+    private int silentProgressRefreshCalls;
+    private int fullRefreshCalls;
+
+    private SilentProgressTrackingFrame() {}
+
+    @Override
+    public void refreshSilentAnalysisProgress() {
+      silentProgressRefreshCalls++;
+    }
+
+    @Override
+    public void refresh() {
+      fullRefreshCalls++;
+    }
+
+    @Override
+    public void requestProblemListRefresh() {}
   }
 
   private static final class SilentGtpConsole extends GtpConsolePane {

--- a/src/test/java/featurecat/lizzie/gui/HtmlMessageLocaleFontTest.java
+++ b/src/test/java/featurecat/lizzie/gui/HtmlMessageLocaleFontTest.java
@@ -1,0 +1,35 @@
+package featurecat.lizzie.gui;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.awt.Font;
+import java.util.LinkedHashMap;
+import java.util.Locale;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+
+class HtmlMessageLocaleFontTest {
+  @Test
+  @EnabledOnOs(OS.WINDOWS)
+  void localizedMessageFontsCanRenderAllSupportedLanguagesOnWindows() {
+    Map<Locale, String> messages = new LinkedHashMap<>();
+    messages.put(Locale.SIMPLIFIED_CHINESE, "重新打开后设置生效");
+    messages.put(Locale.TRADITIONAL_CHINESE, "重新開啟後設定生效");
+    messages.put(Locale.US, "Restart to apply changes");
+    messages.put(Locale.JAPAN, "再起動すると反映されます");
+    messages.put(Locale.KOREA, "변경 사항은 재시작 후 적용됩니다");
+    messages.put(Locale.forLanguageTag("th-TH"), "การเปลี่ยนภาษา");
+
+    messages.forEach(
+        (locale, message) -> {
+          String fontName = HtmlMessage.resolveMessageFontName("Dialog", locale);
+          Font font = new Font(fontName, Font.PLAIN, 14);
+          assertEquals(
+              -1,
+              font.canDisplayUpTo(message),
+              () -> locale + " resolved to a font that cannot display its message");
+        });
+  }
+}

--- a/src/test/java/featurecat/lizzie/gui/KataGoAutoSetupDialogLayoutTest.java
+++ b/src/test/java/featurecat/lizzie/gui/KataGoAutoSetupDialogLayoutTest.java
@@ -15,6 +15,7 @@ import java.awt.Dimension;
 import java.awt.FlowLayout;
 import java.awt.Font;
 import java.awt.FontMetrics;
+import java.awt.Point;
 import java.awt.Rectangle;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -31,10 +32,108 @@ import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JTextArea;
 import javax.swing.SwingUtilities;
+import javax.swing.SwingWorker;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 class KataGoAutoSetupDialogLayoutTest {
+  @Test
+  void localSetupDiscoveryRunsOffTheEventDispatchThreadAndReturnsOnIt() throws Exception {
+    AtomicBoolean discoveryRanOnEdt = new AtomicBoolean(true);
+    AtomicBoolean callbackRanOnEdt = new AtomicBoolean(false);
+    CountDownLatch completed = new CountDownLatch(1);
+
+    SwingUtilities.invokeAndWait(
+        () -> {
+          SwingWorker<Integer, Void> worker =
+              KataGoAutoSetupDialog.createUiBackgroundWorker(
+                  () -> {
+                    discoveryRanOnEdt.set(SwingUtilities.isEventDispatchThread());
+                    return 42;
+                  },
+                  value -> {
+                    callbackRanOnEdt.set(SwingUtilities.isEventDispatchThread() && value == 42);
+                    completed.countDown();
+                  },
+                  error -> completed.countDown());
+          worker.execute();
+        });
+
+    assertTrue(completed.await(3, TimeUnit.SECONDS));
+    assertFalse(discoveryRanOnEdt.get());
+    assertTrue(callbackRanOnEdt.get());
+  }
+
+  @Test
+  void localSetupDiscoveryFailureReturnsItsCauseOnTheEventDispatchThread() throws Exception {
+    IllegalStateException expected = new IllegalStateException("controlled discovery failure");
+    AtomicReference<Throwable> failure = new AtomicReference<>();
+    AtomicBoolean callbackRanOnEdt = new AtomicBoolean(false);
+    CountDownLatch completed = new CountDownLatch(1);
+
+    SwingUtilities.invokeAndWait(
+        () -> {
+          SwingWorker<Integer, Void> worker =
+              KataGoAutoSetupDialog.createUiBackgroundWorker(
+                  () -> {
+                    throw expected;
+                  },
+                  value -> completed.countDown(),
+                  error -> {
+                    failure.set(error);
+                    callbackRanOnEdt.set(SwingUtilities.isEventDispatchThread());
+                    completed.countDown();
+                  });
+          worker.execute();
+        });
+
+    assertTrue(completed.await(3, TimeUnit.SECONDS));
+    assertSame(expected, failure.get());
+    assertTrue(callbackRanOnEdt.get());
+  }
+
+  @Test
+  void dialogRetainsItsDesignedSizeWhenTheWorkAreaCanFitIt() {
+    Rectangle workArea = new Rectangle(0, 0, 1920, 1040);
+
+    assertEquals(new Dimension(1200, 900), KataGoAutoSetupDialog.dialogSizeForBounds(workArea));
+    assertEquals(
+        new Dimension(900, 620),
+        KataGoAutoSetupDialog.minimumDialogSizeForBounds(workArea));
+  }
+
+  @Test
+  void dialogShrinksBelowItsDesktopMinimumAtHighDisplayScaling() {
+    Rectangle scaledWorkArea = new Rectangle(0, 0, 853, 533);
+
+    Dimension size = KataGoAutoSetupDialog.dialogSizeForBounds(scaledWorkArea);
+    Dimension minimum = KataGoAutoSetupDialog.minimumDialogSizeForBounds(scaledWorkArea);
+
+    assertEquals(new Dimension(781, 461), size);
+    assertEquals(size, minimum);
+    assertTrue(size.width <= scaledWorkArea.width);
+    assertTrue(size.height <= scaledWorkArea.height);
+  }
+
+  @Test
+  void dialogPlacementStaysInsidePositiveAndNegativeMonitorCoordinates() {
+    Rectangle rightMonitor = new Rectangle(1920, 0, 853, 533);
+    Dimension rightSize = KataGoAutoSetupDialog.dialogSizeForBounds(rightMonitor);
+    Point rightLocation = KataGoAutoSetupDialog.dialogLocationForBounds(rightMonitor, rightSize);
+    assertTrue(rightLocation.x >= rightMonitor.x);
+    assertTrue(rightLocation.y >= rightMonitor.y);
+    assertTrue(rightLocation.x + rightSize.width <= rightMonitor.x + rightMonitor.width);
+    assertTrue(rightLocation.y + rightSize.height <= rightMonitor.y + rightMonitor.height);
+
+    Rectangle leftMonitor = new Rectangle(-1600, 0, 1600, 900);
+    Dimension leftSize = KataGoAutoSetupDialog.dialogSizeForBounds(leftMonitor);
+    Point leftLocation = KataGoAutoSetupDialog.dialogLocationForBounds(leftMonitor, leftSize);
+    assertTrue(leftLocation.x >= leftMonitor.x);
+    assertTrue(leftLocation.y >= leftMonitor.y);
+    assertTrue(leftLocation.x + leftSize.width <= leftMonitor.x + leftMonitor.width);
+    assertTrue(leftLocation.y + leftSize.height <= leftMonitor.y + leftMonitor.height);
+  }
+
   @Test
   void missingSetupPathsAreHandledAsAbsentFiles() {
     assertFalse(KataGoAutoSetupDialog.isRegularFile(null));

--- a/src/test/java/featurecat/lizzie/gui/LizzieFrameRegressionTest.java
+++ b/src/test/java/featurecat/lizzie/gui/LizzieFrameRegressionTest.java
@@ -1586,6 +1586,8 @@ class LizzieFrameRegressionTest {
           .analysisHeaderSlots = 3;
 
       SwingUtilities.invokeAndWait(engine.completionCallback);
+      waitForMovelistRefreshThreads();
+      drainEdt();
 
       assertEquals(
           1,
@@ -1593,6 +1595,37 @@ class LizzieFrameRegressionTest {
           "foreground candidate analysis should restart immediately after fast curve completion.");
       assertEquals(1, board.syncCount);
       assertEquals(1, frame.refreshCount);
+      assertEquals(1, frame.problemSnapshotRefreshCount);
+      assertEquals(1, frame.silentProgressRefreshCount);
+    } finally {
+      env.close();
+    }
+  }
+
+  @Test
+  void completedQuickAnalysisRefreshesFinalProgressWithoutOverridingUserPause()
+      throws Exception {
+    TestEnvironment env = TestEnvironment.open();
+    try {
+      Lizzie.config = configWithAutoQuickAnalyze();
+      Lizzie.board = boardWith(historyWithTargetVisitAnalyzedMove());
+      TrackingLeelaz leelaz = allocate(TrackingLeelaz.class);
+      Lizzie.leelaz = leelaz;
+      EngineManager.isEmpty = false;
+      QuickAnalysisResumeFrame frame = allocate(QuickAnalysisResumeFrame.class);
+      Lizzie.frame = frame;
+      BoardHistoryNode root = Lizzie.board.getHistory().getStart();
+      armLoadedGameQuickAnalysis(frame, root, true);
+      setField(frame, "userAnalysisPaused", true);
+
+      invokeFinishLoadedGameQuickAnalysisAttempt(frame, 17L, root, false);
+      waitForMovelistRefreshThreads();
+      drainEdt();
+
+      assertEquals(1, frame.problemSnapshotRefreshCount);
+      assertEquals(1, frame.silentProgressRefreshCount);
+      assertEquals(0, leelaz.ponderCount);
+      assertFalse(leelaz.isPondering());
     } finally {
       env.close();
     }
@@ -1772,6 +1805,7 @@ class LizzieFrameRegressionTest {
           leelaz.ponderCount,
           "foreground analysis should restart after navigation-triggered curve completion.");
       assertEquals(1, board.syncCount);
+      waitForMovelistRefreshThreads();
     } finally {
       env.close();
     }
@@ -1815,15 +1849,58 @@ class LizzieFrameRegressionTest {
       Lizzie.board = boardWith(historyWithUnanalyzedMove());
       LizzieFrame frame = allocate(LizzieFrame.class);
       NavigationQuickAnalysisEngine engine = allocate(NavigationQuickAnalysisEngine.class);
+      frame.analysisEngine = engine;
       Lizzie.frame = frame;
 
       Method method =
           LizzieFrame.class.getDeclaredMethod(
               "startYikeCurveCompletionRequests", AnalysisEngine.class, String.class);
       method.setAccessible(true);
-      method.invoke(frame, engine, "test-status");
+      AtomicReference<Throwable> invocationFailure = new AtomicReference<>();
+      SwingUtilities.invokeAndWait(
+          () -> {
+            try {
+              method.invoke(frame, engine, "test-status");
+            } catch (Throwable failure) {
+              invocationFailure.set(failure);
+            }
+          });
 
+      assertNull(invocationFailure.get());
+      assertTrue(engine.awaitRequestStarted());
       assertTrue(engine.failureCallback != null);
+      assertFalse(
+          engine.requestStartedOnEdt,
+          "Yike curve request serialization and pipe writes must stay off the Swing EDT.");
+    } finally {
+      env.close();
+    }
+  }
+
+  @Test
+  void completedYikeCurveRefreshesFinalProgressWithoutOverridingUserPause()
+      throws Exception {
+    TestEnvironment env = TestEnvironment.open();
+    try {
+      Lizzie.config = configWithAutoQuickAnalyze();
+      Lizzie.board = boardWith(historyWithTargetVisitAnalyzedMove());
+      TrackingLeelaz leelaz = allocate(TrackingLeelaz.class);
+      Lizzie.leelaz = leelaz;
+      EngineManager.isEmpty = false;
+      QuickAnalysisResumeFrame frame = allocate(QuickAnalysisResumeFrame.class);
+      Lizzie.frame = frame;
+      BoardHistoryNode root = Lizzie.board.getHistory().getStart();
+      setField(frame, "yikeCurveCompletionGeneration", 23L);
+      setField(frame, "userAnalysisPaused", true);
+
+      invokeFinishYikeCurveCompletion(frame, 23L, root, false);
+      waitForMovelistRefreshThreads();
+      drainEdt();
+
+      assertEquals(1, frame.problemSnapshotRefreshCount);
+      assertEquals(1, frame.silentProgressRefreshCount);
+      assertEquals(0, leelaz.ponderCount);
+      assertFalse(leelaz.isPondering());
     } finally {
       env.close();
     }
@@ -3074,6 +3151,31 @@ class LizzieFrameRegressionTest {
         () -> invokeReflectiveResult(method, frame, generation, root, failed));
   }
 
+  private static void invokeFinishYikeCurveCompletion(
+      LizzieFrame frame, long generation, BoardHistoryNode root, boolean failed) throws Exception {
+    Method method =
+        LizzieFrame.class.getDeclaredMethod(
+            "finishYikeCurveCompletion",
+            AnalysisEngine.class,
+            String.class,
+            long.class,
+            BoardHistoryNode.class,
+            boolean.class,
+            AtomicBoolean.class);
+    method.setAccessible(true);
+    SwingUtilities.invokeAndWait(
+        () ->
+            invokeReflectiveResult(
+                method,
+                frame,
+                null,
+                "test-status",
+                generation,
+                root,
+                failed,
+                new AtomicBoolean(false)));
+  }
+
   private static boolean invokeStopBusyQuickAnalysisEngineBeforeLoadedKifuAnalysis(
       LizzieFrame frame, Runnable continuation) throws Exception {
     Method method =
@@ -3304,6 +3406,14 @@ class LizzieFrameRegressionTest {
 
   private static void drainEdt() throws Exception {
     SwingUtilities.invokeAndWait(() -> {});
+  }
+
+  private static void waitForMovelistRefreshThreads() throws InterruptedException {
+    for (Thread thread : Thread.getAllStackTraces().keySet()) {
+      if ("lizzie-movelist-refresh".equals(thread.getName()) && thread.isAlive()) {
+        thread.join(1000);
+      }
+    }
   }
 
   @SuppressWarnings("unchecked")
@@ -3613,10 +3723,22 @@ class LizzieFrameRegressionTest {
 
   private static final class QuickAnalysisResumeFrame extends LizzieFrame {
     private int refreshCount;
+    private int problemSnapshotRefreshCount;
+    private int silentProgressRefreshCount;
 
     @Override
     public void refresh() {
       refreshCount++;
+    }
+
+    @Override
+    public void refreshProblemListSnapshot() {
+      problemSnapshotRefreshCount++;
+    }
+
+    @Override
+    public void refreshSilentAnalysisProgress() {
+      silentProgressRefreshCount++;
     }
   }
 
@@ -3795,6 +3917,7 @@ class LizzieFrameRegressionTest {
     private CountDownLatch requestStarted = new CountDownLatch(1);
     private Runnable completionCallback;
     private Runnable failureCallback;
+    private volatile boolean requestStartedOnEdt;
 
     @SuppressWarnings("unused")
     private NavigationQuickAnalysisEngine() throws java.io.IOException {
@@ -3841,6 +3964,7 @@ class LizzieFrameRegressionTest {
     @Override
     public int startRequestMissingMainline(boolean showProgressDialog) {
       missingMainlineRequestCount++;
+      requestStartedOnEdt = SwingUtilities.isEventDispatchThread();
       requestStartedLatch().countDown();
       return 1;
     }

--- a/src/test/java/featurecat/lizzie/gui/MenuLanguageFontTest.java
+++ b/src/test/java/featurecat/lizzie/gui/MenuLanguageFontTest.java
@@ -1,0 +1,34 @@
+package featurecat.lizzie.gui;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import featurecat.lizzie.AppLocale;
+import java.awt.Font;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+
+class MenuLanguageFontTest {
+  @Test
+  @EnabledOnOs(OS.WINDOWS)
+  void languageMenuFontsCanRenderEveryNativeLabelOnWindows() {
+    Map<AppLocale, String> nativeLabels = new LinkedHashMap<>();
+    nativeLabels.put(AppLocale.SIMPLIFIED_CHINESE, "简体中文");
+    nativeLabels.put(AppLocale.TRADITIONAL_CHINESE, "繁體中文");
+    nativeLabels.put(AppLocale.ENGLISH, "English");
+    nativeLabels.put(AppLocale.JAPANESE, "日本語");
+    nativeLabels.put(AppLocale.KOREAN, "한국어");
+    nativeLabels.put(AppLocale.THAI, "ไทย");
+
+    nativeLabels.forEach(
+        (locale, label) -> {
+          Font font = Menu.languageOptionFont(locale, "Dialog", 14);
+          assertEquals(
+              -1,
+              font.canDisplayUpTo(label),
+              () -> locale + " resolved to a font that cannot display " + label);
+        });
+  }
+}

--- a/src/test/java/featurecat/lizzie/gui/OnlineDialogYikeSessionStateTest.java
+++ b/src/test/java/featurecat/lizzie/gui/OnlineDialogYikeSessionStateTest.java
@@ -103,6 +103,16 @@ class OnlineDialogYikeSessionStateTest {
   }
 
   @Test
+  void newLiveRoomKeepsCurrentBoardUntilUsableSgfArrives() {
+    assertFalse(
+        OnlineDialog.shouldClearBoardBeforeSync(false, YikeUrlInfo.TYPE_NEW_LIVE_ROOM));
+    assertFalse(
+        OnlineDialog.shouldClearBoardBeforeSync(true, YikeUrlInfo.TYPE_NEW_LIVE_ROOM));
+    assertTrue(OnlineDialog.shouldClearBoardBeforeSync(false, YikeUrlInfo.TYPE_OLD_LIVE_ROOM));
+    assertFalse(OnlineDialog.shouldClearBoardBeforeSync(true, YikeUrlInfo.TYPE_OLD_LIVE_ROOM));
+  }
+
+  @Test
   void yikeLiveKomiKeepsManualOverrideOnRefresh() {
     GameInfo current = new GameInfo();
     current.setKomiNoMenu(7.0);

--- a/src/test/java/featurecat/lizzie/gui/YikeApiClientTest.java
+++ b/src/test/java/featurecat/lizzie/gui/YikeApiClientTest.java
@@ -1,6 +1,8 @@
 package featurecat.lizzie.gui;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import featurecat.lizzie.gui.YikeApiClient.YikeLiveDetail;
 import featurecat.lizzie.gui.YikeApiClient.YikeLiveGame;
@@ -68,6 +70,34 @@ class YikeApiClientTest {
 
     assertEquals("(;GM[1]SZ[19];B[aa];W[bb])", detail.getSgf());
     assertEquals(2, detail.getStatus());
+  }
+
+  @Test
+  void previewWithoutMovesDoesNotStartAWebSyncSession() throws Exception {
+    String response =
+        "{\"Status\":1200,\"Result\":{\"since\":1,\"list\":[{"
+            + "\"Id\":1,\"Version\":2,\"GameName\":\"Upcoming\","
+            + "\"Status\":1,\"HandsCount\":0,\"hall\":0,\"room\":0"
+            + "}]}}";
+
+    YikeLiveGame preview = YikeApiClient.parseLiveList(response).getGames().get(0);
+
+    assertTrue(preview.isPreviewWithoutMoves());
+    assertFalse(YikeLiveDialog.canStartSync(preview));
+  }
+
+  @Test
+  void liveRoomCanBeWatchedBeforeItsFirstMoveArrives() throws Exception {
+    String response =
+        "{\"Status\":1200,\"Result\":{\"since\":2,\"list\":[{"
+            + "\"Id\":2,\"Version\":2,\"GameName\":\"Starting\","
+            + "\"Status\":2,\"HandsCount\":0,\"hall\":0,\"room\":0"
+            + "}]}}";
+
+    YikeLiveGame live = YikeApiClient.parseLiveList(response).getGames().get(0);
+
+    assertFalse(live.isPreviewWithoutMoves());
+    assertTrue(YikeLiveDialog.canStartSync(live));
   }
 
   @Test

--- a/src/test/java/featurecat/lizzie/rules/BoardMovelistRefreshLifecycleTest.java
+++ b/src/test/java/featurecat/lizzie/rules/BoardMovelistRefreshLifecycleTest.java
@@ -58,6 +58,47 @@ class BoardMovelistRefreshLifecycleTest {
     }
   }
 
+  @Test
+  void completionRunsOnlyAfterEveryMoveListNodeIsUpdated() throws Exception {
+    Board previousBoard = Lizzie.board;
+    TrackingBoard board = trackingBoard(twoNodeHistory());
+    CountDownLatch completed = new CountDownLatch(1);
+    try {
+      Lizzie.board = board;
+
+      board.setMovelistAll(completed::countDown);
+
+      assertTrue(completed.await(2, TimeUnit.SECONDS), "refresh completion should be delivered.");
+      assertEquals(2, board.updates.get(), "completion must observe a fully rebuilt move list.");
+    } finally {
+      board.releaseFirstUpdate.countDown();
+      Lizzie.board = previousBoard;
+    }
+  }
+
+  @Test
+  void staleRefreshDoesNotDeliverItsCompletionAfterHistoryReplacement() throws Exception {
+    Board previousBoard = Lizzie.board;
+    TrackingBoard board = trackingBoard(twoNodeHistory());
+    CountDownLatch completed = new CountDownLatch(1);
+    try {
+      Lizzie.board = board;
+      board.blockFirstUpdate = true;
+      board.setMovelistAll(completed::countDown);
+      assertTrue(board.firstUpdate.await(2, TimeUnit.SECONDS), "refresh should reach its first node.");
+
+      board.setHistory(singleNodeHistory());
+      board.releaseFirstUpdate.countDown();
+
+      assertFalse(
+          completed.await(500, TimeUnit.MILLISECONDS),
+          "a refresh for replaced history must not publish a stale completion.");
+    } finally {
+      board.releaseFirstUpdate.countDown();
+      Lizzie.board = previousBoard;
+    }
+  }
+
   private static TrackingBoard trackingBoard(BoardHistoryList history) throws Exception {
     TrackingBoard board = allocate(TrackingBoard.class);
     board.updates = new AtomicInteger();

--- a/src/test/java/featurecat/lizzie/rules/BoardNodeKindHistoryPipelineTest.java
+++ b/src/test/java/featurecat/lizzie/rules/BoardNodeKindHistoryPipelineTest.java
@@ -1040,6 +1040,27 @@ class BoardNodeKindHistoryPipelineTest {
   }
 
   @Test
+  void detachedParseSgfDoesNotRunLiveMoveSideEffects() throws Exception {
+    TestEnvironment env = TestEnvironment.open();
+    try {
+      TrackingBoard board = (TrackingBoard) Lizzie.board;
+      TrackingLeelaz leelaz = (TrackingLeelaz) Lizzie.leelaz;
+      int initialClearAfterMoveCalls = board.clearAfterMoveCallCount;
+      int initialClearBestMovesCalls = leelaz.clearBestMovesCallCount;
+      int initialPdaAdjustmentCalls = leelaz.pdaAdjustmentCallCount;
+
+      BoardHistoryList parsed = SGFParser.parseSgf("(;SZ[3];B[aa];W[bb];B[cc])", false);
+
+      assertTrue(parsed.getStart().next().isPresent(), "detached SGF should still parse its moves.");
+      assertEquals(initialClearAfterMoveCalls, board.clearAfterMoveCallCount);
+      assertEquals(initialClearBestMovesCalls, leelaz.clearBestMovesCallCount);
+      assertEquals(initialPdaAdjustmentCalls, leelaz.pdaAdjustmentCallCount);
+    } finally {
+      env.close();
+    }
+  }
+
+  @Test
   void setHistoryAndGenerateNodeKeepParseSgfRectangularBoardSize() throws Exception {
     TestEnvironment env = TestEnvironment.open();
     try {
@@ -5993,6 +6014,7 @@ class BoardNodeKindHistoryPipelineTest {
     private volatile String blockedHistoryNavigationRootReplayCommand;
     private volatile CountDownLatch blockedHistoryNavigationRootReplayCommandStarted;
     private volatile CountDownLatch blockedHistoryNavigationRootReplayCommandRelease;
+    private int clearAfterMoveCallCount;
 
     @Override
     void beforeHistoryNavigationRootReplayCommand(String command) {
@@ -6100,7 +6122,9 @@ class BoardNodeKindHistoryPipelineTest {
     }
 
     @Override
-    public void clearAfterMove() {}
+    public void clearAfterMove() {
+      clearAfterMoveCallCount++;
+    }
   }
 
   private static final class TrackingFrame extends LizzieFrame {
@@ -6237,6 +6261,8 @@ class BoardNodeKindHistoryPipelineTest {
     private boolean pretendingToPonder;
     private int ponderCallCount;
     private int notPonderingCallCount;
+    private int clearBestMovesCallCount;
+    private int pdaAdjustmentCallCount;
 
     private TrackingLeelaz() throws IOException {
       super("");
@@ -6253,10 +6279,14 @@ class BoardNodeKindHistoryPipelineTest {
     }
 
     @Override
-    public void clearBestMoves() {}
+    public void clearBestMoves() {
+      clearBestMovesCallCount++;
+    }
 
     @Override
-    public void maybeAjustPDA(BoardHistoryNode node) {}
+    public void maybeAjustPDA(BoardHistoryNode node) {
+      pdaAdjustmentCallCount++;
+    }
 
     @Override
     public boolean isPonderingOrWasPonderingBeforeTracking() {


### PR DESCRIPTION
## 变更概述

本 PR 来自最新 main 的 Windows 普通用户完整验收，修复了验收中真实复现的几组问题：

- 快速胜率曲线的静默进度不再触发整块棋盘重绘；异步主线重建完成后再发布最终曲线，避免末段结果丢失或长时间不出现。
- 隔离后台 SGF 解析与前台棋盘状态，避免解析过程触发计时器、PDA、渲染器和引擎同步副作用。
- 弈客列表与棋谱同步的网络、SGF 主线处理移出 EDT；隔离过期回调，无棋谱时保留列表并给出状态，切换棋局后不再被旧结果覆盖。
- KataGo 一键设置的本地扫描移出 EDT，增加刷新取消与过期请求保护；加载失败可恢复操作；窗口按当前显示器工作区适配 100%/150%/200% 缩放和负坐标副屏。
- 六语菜单和 HTML 消息按实际文字覆盖选择物理字体，修复 Windows 上繁中、日文、韩文、泰文缺字。
- 修复 Windows 下本地 CI 的 Git Bash 路径假设。

## 自动化验证

本地完整门禁：

- 28/28 步通过
- 330 个测试套件
- 3799 个测试
- 0 failures
- 0 errors
- 17 skipped
- 总耗时 253.625 秒
- 包含 Maven `verify`、`LoggingProviderSmokeIT`、Windows launcher、JCEF、NVIDIA runtime、KataGo/release 资产、发布脚本、行尾与 `git diff --check`

补充复测：

- Windows 六语字体测试 2/2 通过
- `scripts/check_line_endings.py` 通过
- staged `git diff --check` 通过

## Windows 真机验收

环境：Windows 11 23H2 build 22631、RTX 3070、NVIDIA portable，使用包内 EXE、JDK 与 KataGo B11。

已真实操作验证：

- 全新启动与包内 CUDA 引擎真实推理
- SGF 加载和快速胜率曲线：约 0.9 秒出现首段，约 15 秒完成 49 手
- Alt+O 启动内置 readboard v3.0.6
- 弈客直播列表、无 SGF 棋局、直播棋局加载与更新
- 闪电分析、整盘精析暂停/继续/完成
- AI 陪练本地与智子云模式、结束后复盘、前台引擎恢复、设置记忆
- 简中、繁中、英文、日文、韩文、泰文和跟随系统逐项重启
- 原生 150% 及隔离 100%/200% 缩放下主界面与一键设置
- launcher smoke 普通启动及 `-OpenAutoSetup` 均通过，无 `Failed to launch JVM`

## 边界

本机未具备 RTX 50、AMD ROCm、Intel NPU 与 macOS 硬件，本 PR 不宣称这些硬件已完成真机验证。