### PR TITLE
发布 next-2026-09-03.1 多平台预发布版

### DIFF
--- a/.github/release-notes/next-2026-09-03.1.md
+++ b/.github/release-notes/next-2026-09-03.1.md
@@ -1,0 +1,365 @@
+# LizzieYzy Next next-2026-09-03.1
+
+## 中文
+
+这是基于 next-2026-09-01.1 的 Windows 体验修复预发布版，重点解决棋谱快速胜率曲线、弈客同步和 KataGo 一键设置可能卡住的问题，并补齐六语字体与高缩放适配。
+
+### 本版主要更新
+
+- 快速胜率曲线的阶段性结果改为轻量刷新，不再反复重绘整个棋盘；最终结果会等待主线重建完成后再显示，避免长时间空白或少最后一段。
+- 后台 SGF 解析与前台棋盘状态彻底隔离，不会误触发计时器、PDA、渲染器或引擎同步；切换棋谱时旧任务不会覆盖新棋局。
+- 弈客列表、详情和棋谱主线处理移出界面线程；直播切换更流畅，无可用棋谱时会保留列表并给出明确状态。
+- KataGo 一键设置的本地扫描改为后台执行，支持取消过期刷新和失败恢复；打开时不再白屏或冻结，关闭、刷新和重新打开都保持可用。
+- 一键设置窗口按当前显示器的可用区域布局，在 Windows 100% / 150% / 200% 缩放和负坐标副屏上不会超出桌面。
+- 简中、繁中、英文、日文、韩文和泰文菜单及消息框会选择真正覆盖对应文字的系统字体，减少方框字与缺字。
+
+### 下载前先看
+
+- 已安装 next-2026-09-01.1 完整 Windows 包的用户，可用 windows64.core-update.zip 只更新程序；现有权重、引擎、TensorRT 和 user-data 不会被替换。
+- 新安装用户请下载与硬件匹配的完整包；仍内置 KataGo v1.18.1 和默认 B11。B11 单次判断更强但搜索较慢，追求速度可在“一键设置 → 权重”明确切换 B10。
+- RTX 20/30/40/50 继续统一使用 windows64.nvidia CUDA 包；TensorRT 是 RTX 30 系及以下的可选方案。
+- 这是预发布版，覆盖旧目录前建议备份 user-data、权重和棋谱。
+- DirectML、OpenVINO、ROCm、RTX 50 和 macOS 对应硬件未在本机冒充真机通过，欢迎对应设备用户反馈。
+
+### 下载建议
+
+| 你的电脑 | 直接下载这个 |
+| --- | --- |
+| Windows 64 位，RTX 20/30/40/50 NVIDIA CUDA 推荐版，免安装 | [2026-09-03-windows64.nvidia.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-03.1/2026-09-03-windows64.nvidia.portable.zip) |
+| 已有 Windows 免安装版，只更新主程序 | [2026-09-03-windows64.core-update.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-03.1/2026-09-03-windows64.core-update.zip) |
+| Windows 64 位，RTX 20/30/40/50 NVIDIA CUDA 推荐安装版 | [2026-09-03-windows64.nvidia.installer.exe](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-03.1/2026-09-03-windows64.nvidia.installer.exe) |
+| Windows 64 位，AMD / Intel / 旧 NVIDIA OpenCL 兼容版，免安装 | [2026-09-03-windows64.opencl.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-03.1/2026-09-03-windows64.opencl.portable.zip) |
+| Windows 64 位，AMD / Intel / 旧 NVIDIA OpenCL 兼容安装版 | [2026-09-03-windows64.opencl.installer.exe](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-03.1/2026-09-03-windows64.opencl.installer.exe) |
+| Windows 64 位，CPU 兼容版，免安装 | [2026-09-03-windows64.with-katago.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-03.1/2026-09-03-windows64.with-katago.portable.zip) |
+| Windows 64 位，CPU 兼容安装版 | [2026-09-03-windows64.with-katago.installer.exe](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-03.1/2026-09-03-windows64.with-katago.installer.exe) |
+| Windows DirectML 实验版 | [2026-09-03-windows64.experimental.directml.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-03.1/2026-09-03-windows64.experimental.directml.portable.zip) |
+| Windows Intel OpenVINO 实验版 | [2026-09-03-windows64.experimental.openvino.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-03.1/2026-09-03-windows64.experimental.openvino.portable.zip) |
+| Windows AMD RX 6000 ROCm 实验版 | [2026-09-03-windows64.experimental.rocm.gfx103x.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-03.1/2026-09-03-windows64.experimental.rocm.gfx103x.portable.zip) |
+| Windows AMD RX 7000 ROCm 实验版 | [2026-09-03-windows64.experimental.rocm.gfx110x.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-03.1/2026-09-03-windows64.experimental.rocm.gfx110x.portable.zip) |
+| Windows AMD Ryzen AI Max ROCm 实验版 | [2026-09-03-windows64.experimental.rocm.gfx1151.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-03.1/2026-09-03-windows64.experimental.rocm.gfx1151.portable.zip) |
+| Windows AMD RX 9000 ROCm 实验版 | [2026-09-03-windows64.experimental.rocm.gfx120x.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-03.1/2026-09-03-windows64.experimental.rocm.gfx120x.portable.zip) |
+| RTX 30 系及以下可选 TensorRT，需下载两个分卷 | [2026-09-03-windows64.nvidia.tensorrt.portable.7z.001](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-03.1/2026-09-03-windows64.nvidia.tensorrt.portable.7z.001)<br>[2026-09-03-windows64.nvidia.tensorrt.portable.7z.002](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-03.1/2026-09-03-windows64.nvidia.tensorrt.portable.7z.002) |
+| Windows 64 位，自行配置引擎，免安装 | [2026-09-03-windows64.without.engine.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-03.1/2026-09-03-windows64.without.engine.portable.zip) |
+| Windows 64 位，自行配置引擎，安装版 | [2026-09-03-windows64.without.engine.installer.exe](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-03.1/2026-09-03-windows64.without.engine.installer.exe) |
+| macOS Apple Silicon，Metal | [2026-09-03-mac-apple-silicon.with-katago.dmg](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-03.1/2026-09-03-mac-apple-silicon.with-katago.dmg) |
+| macOS Intel | [2026-09-03-mac-intel.with-katago.dmg](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-03.1/2026-09-03-mac-intel.with-katago.dmg) |
+| Linux 64 位，CPU 兼容版 | [2026-09-03-linux64.with-katago.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-03.1/2026-09-03-linux64.with-katago.zip) |
+| Linux 64 位，OpenCL 版 | [2026-09-03-linux64.opencl.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-03.1/2026-09-03-linux64.opencl.zip) |
+| Linux 64 位，NVIDIA CUDA 版 | [2026-09-03-linux64.nvidia.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-03.1/2026-09-03-linux64.nvidia.zip) |
+
+### 验证结果
+
+- Windows 11、RTX 3070、NVIDIA portable 使用包内 Java、KataGo v1.18.1、CUDA 与 B11 完成真实神经网络推理；测试过程保持单个 KataGo 进程。
+- 真实 EXE 打开 49 手 SGF 后约 0.9 秒出现首段快速曲线，约 15 秒完成；前台棋盘保持响应，完成后恢复当前局面分析。
+- Alt+O readboard、弈客直播、闪电分析、整盘精析、AI 陪练本地与智子云恢复、六语重启和 100% / 150% / 200% 缩放均完成可见界面复测。
+- 本地 CI 28/28；完整 JUnit 3799 项，0 failures、0 errors、17 skipped；Maven verify/package、Windows launcher、发布资产检查及 GitHub build/windows-script-validation 均通过。
+- 发布器只有在四个平台工作流、签名/公证、资产拓扑、SHA 与来源证明全部成功后才公开本预发布版。
+
+### 交流
+
+- QQ 群：299419120
+
+---
+
+## 繁體中文
+
+這是基於 next-2026-09-01.1 的 Windows 體驗修正預發布版，重點解決棋譜快速勝率曲線、弈客同步與 KataGo 一鍵設定可能卡住的問題，並補齊六語字型與高縮放支援。
+
+### 本版主要更新
+
+- 快速勝率曲線的階段性結果改為輕量更新，不再反覆重繪整個棋盤；最終結果會等待主線重建完成，避免長時間空白或缺少最後一段。
+- 背景 SGF 解析與前台棋盤狀態完全隔離，不會誤觸計時器、PDA、renderer 或引擎同步；切換棋譜時舊工作不會覆蓋新棋局。
+- 弈客列表、詳細資料與棋譜主線處理移出 UI thread；切換直播更順暢，沒有可用棋譜時會保留列表並顯示清楚狀態。
+- KataGo 一鍵設定的本機掃描改為背景執行，支援取消過期刷新與失敗恢復；開啟時不再白屏或凍結。
+- 一鍵設定視窗依目前顯示器可用區域配置，在 Windows 100% / 150% / 200% 縮放與負座標副螢幕上不會超出桌面。
+- 簡中、繁中、英文、日文、韓文與泰文選單及訊息框會選擇真正支援對應文字的系統字型，減少方框字與缺字。
+
+### 下載前先看
+
+- 已安裝 next-2026-09-01.1 完整 Windows 套件的使用者，可用 windows64.core-update.zip 只更新程式，不替換 weight、engine、TensorRT 或 user-data。
+- 新安裝請下載符合硬體的完整套件；仍內建 KataGo v1.18.1 與預設 B11。B11 單次判斷更強但搜尋較慢，重視速度可切換 B10。
+- RTX 20/30/40/50 繼續統一使用 windows64.nvidia CUDA 套件；TensorRT 是 RTX 30 系及以下的可選方案。
+- 這是預發布版，覆蓋舊目錄前建議備份 user-data、weight 與棋譜。
+- DirectML、OpenVINO、ROCm、RTX 50 與 macOS 對應硬體未在本機宣稱真機通過。
+
+### 下載建議
+
+| 你的電腦 | 直接下載這個 |
+| --- | --- |
+| Windows 64 位，RTX 20/30/40/50 NVIDIA CUDA 建議版，免安裝 | [2026-09-03-windows64.nvidia.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-03.1/2026-09-03-windows64.nvidia.portable.zip) |
+| 既有 Windows 免安裝版，只更新主程式 | [2026-09-03-windows64.core-update.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-03.1/2026-09-03-windows64.core-update.zip) |
+| Windows 64 位，RTX 20/30/40/50 NVIDIA CUDA 建議安裝版 | [2026-09-03-windows64.nvidia.installer.exe](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-03.1/2026-09-03-windows64.nvidia.installer.exe) |
+| Windows 64 位，AMD / Intel / 舊 NVIDIA OpenCL 相容版，免安裝 | [2026-09-03-windows64.opencl.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-03.1/2026-09-03-windows64.opencl.portable.zip) |
+| Windows 64 位，AMD / Intel / 舊 NVIDIA OpenCL 相容安裝版 | [2026-09-03-windows64.opencl.installer.exe](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-03.1/2026-09-03-windows64.opencl.installer.exe) |
+| Windows 64 位，CPU 相容版，免安裝 | [2026-09-03-windows64.with-katago.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-03.1/2026-09-03-windows64.with-katago.portable.zip) |
+| Windows 64 位，CPU 相容安裝版 | [2026-09-03-windows64.with-katago.installer.exe](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-03.1/2026-09-03-windows64.with-katago.installer.exe) |
+| Windows DirectML 實驗版 | [2026-09-03-windows64.experimental.directml.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-03.1/2026-09-03-windows64.experimental.directml.portable.zip) |
+| Windows Intel OpenVINO 實驗版 | [2026-09-03-windows64.experimental.openvino.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-03.1/2026-09-03-windows64.experimental.openvino.portable.zip) |
+| Windows AMD RX 6000 ROCm 實驗版 | [2026-09-03-windows64.experimental.rocm.gfx103x.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-03.1/2026-09-03-windows64.experimental.rocm.gfx103x.portable.zip) |
+| Windows AMD RX 7000 ROCm 實驗版 | [2026-09-03-windows64.experimental.rocm.gfx110x.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-03.1/2026-09-03-windows64.experimental.rocm.gfx110x.portable.zip) |
+| Windows AMD Ryzen AI Max ROCm 實驗版 | [2026-09-03-windows64.experimental.rocm.gfx1151.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-03.1/2026-09-03-windows64.experimental.rocm.gfx1151.portable.zip) |
+| Windows AMD RX 9000 ROCm 實驗版 | [2026-09-03-windows64.experimental.rocm.gfx120x.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-03.1/2026-09-03-windows64.experimental.rocm.gfx120x.portable.zip) |
+| RTX 30 系及以下可選 TensorRT，需下載兩個分卷 | [2026-09-03-windows64.nvidia.tensorrt.portable.7z.001](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-03.1/2026-09-03-windows64.nvidia.tensorrt.portable.7z.001)<br>[2026-09-03-windows64.nvidia.tensorrt.portable.7z.002](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-03.1/2026-09-03-windows64.nvidia.tensorrt.portable.7z.002) |
+| Windows 64 位，自行設定 engine，免安裝 | [2026-09-03-windows64.without.engine.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-03.1/2026-09-03-windows64.without.engine.portable.zip) |
+| Windows 64 位，自行設定 engine，安裝版 | [2026-09-03-windows64.without.engine.installer.exe](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-03.1/2026-09-03-windows64.without.engine.installer.exe) |
+| macOS Apple Silicon，Metal | [2026-09-03-mac-apple-silicon.with-katago.dmg](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-03.1/2026-09-03-mac-apple-silicon.with-katago.dmg) |
+| macOS Intel | [2026-09-03-mac-intel.with-katago.dmg](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-03.1/2026-09-03-mac-intel.with-katago.dmg) |
+| Linux 64 位，CPU 相容版 | [2026-09-03-linux64.with-katago.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-03.1/2026-09-03-linux64.with-katago.zip) |
+| Linux 64 位，OpenCL 版 | [2026-09-03-linux64.opencl.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-03.1/2026-09-03-linux64.opencl.zip) |
+| Linux 64 位，NVIDIA CUDA 版 | [2026-09-03-linux64.nvidia.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-03.1/2026-09-03-linux64.nvidia.zip) |
+
+### 驗證結果
+
+- Windows 11、RTX 3070、NVIDIA portable 使用套件內 Java、KataGo v1.18.1、CUDA 與 B11 完成真實神經網路推理；測試期間維持單一 KataGo 程序。
+- 真實 EXE 開啟 49 手 SGF 後約 0.9 秒顯示第一段快速曲線，約 15 秒完成；前台棋盤保持回應並恢復目前局面分析。
+- Alt+O readboard、弈客直播、閃電分析、整盤精析、AI 陪練本機與智子雲恢復、六語重啟及 100% / 150% / 200% 縮放均完成可見介面複測。
+- 本機 CI 28/28；完整 JUnit 3799 項，0 failures、0 errors、17 skipped；Maven verify/package、Windows launcher、發布資產檢查及 GitHub build/windows-script-validation 均通過。
+- 四平台 workflow、簽名/公證、資產拓撲、SHA 與來源證明全部成功後才會公開。
+
+### 交流
+
+- QQ 群：299419120
+
+---
+
+## English
+
+This Windows experience pre-release builds on next-2026-09-01.1. It fixes stalls in quick win-rate curves, Yike synchronization, and KataGo Auto Setup while improving six-language font coverage and high-scaling layouts.
+
+### Release highlights
+
+- Progressive quick-curve results now use a lightweight graph refresh instead of repainting the entire board. Final results wait for mainline rebuilding, preventing a long blank graph or a missing final segment.
+- Background SGF parsing is isolated from the live board and cannot trigger clocks, PDA, renderers, or engine synchronization. Stale work cannot overwrite a newly opened game.
+- Yike list, detail, and SGF-mainline processing run off the EDT. Switching live games stays responsive, and a game without SGF data keeps the list open with a clear status.
+- KataGo Auto Setup scans local files in the background with stale-refresh cancellation and recoverable failure states, avoiding the white or frozen window seen on slower storage.
+- Auto Setup fits the active monitor work area at Windows 100%, 150%, and 200% scaling, including secondary monitors with negative coordinates.
+- Menus and HTML messages select installed fonts that can render Simplified Chinese, Traditional Chinese, English, Japanese, Korean, and Thai labels.
+
+### Before downloading
+
+- Windows users with a complete next-2026-09-01.1 bundle can apply windows64.core-update.zip for the app-only update without replacing weights, engines, TensorRT, or user-data.
+- Fresh installs should use the full bundle matching the hardware. KataGo v1.18.1 and B11 remain bundled by default. B11 provides stronger individual evaluations at lower throughput; select B10 in Auto Setup when speed matters more.
+- RTX 20/30/40/50 continue to use the unified windows64.nvidia CUDA package. TensorRT is an optional path for RTX 30 series and older.
+- This is a pre-release; back up user-data, weights, and game records before overwriting an existing folder.
+- DirectML, OpenVINO, ROCm, RTX 50, and macOS hardware not present on the test machine are not claimed as hardware-tested.
+
+### Download guide
+
+| Your computer | Download this file |
+| --- | --- |
+| Windows x64, recommended RTX 20/30/40/50 NVIDIA CUDA portable | [2026-09-03-windows64.nvidia.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-03.1/2026-09-03-windows64.nvidia.portable.zip) |
+| Existing Windows portable, app-only update | [2026-09-03-windows64.core-update.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-03.1/2026-09-03-windows64.core-update.zip) |
+| Windows x64, recommended RTX 20/30/40/50 NVIDIA CUDA installer | [2026-09-03-windows64.nvidia.installer.exe](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-03.1/2026-09-03-windows64.nvidia.installer.exe) |
+| Windows x64, OpenCL portable for AMD / Intel / older NVIDIA | [2026-09-03-windows64.opencl.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-03.1/2026-09-03-windows64.opencl.portable.zip) |
+| Windows x64, OpenCL installer for AMD / Intel / older NVIDIA | [2026-09-03-windows64.opencl.installer.exe](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-03.1/2026-09-03-windows64.opencl.installer.exe) |
+| Windows x64, CPU compatibility portable | [2026-09-03-windows64.with-katago.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-03.1/2026-09-03-windows64.with-katago.portable.zip) |
+| Windows x64, CPU compatibility installer | [2026-09-03-windows64.with-katago.installer.exe](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-03.1/2026-09-03-windows64.with-katago.installer.exe) |
+| Windows DirectML experimental | [2026-09-03-windows64.experimental.directml.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-03.1/2026-09-03-windows64.experimental.directml.portable.zip) |
+| Windows Intel OpenVINO experimental | [2026-09-03-windows64.experimental.openvino.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-03.1/2026-09-03-windows64.experimental.openvino.portable.zip) |
+| Windows AMD RX 6000 ROCm experimental | [2026-09-03-windows64.experimental.rocm.gfx103x.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-03.1/2026-09-03-windows64.experimental.rocm.gfx103x.portable.zip) |
+| Windows AMD RX 7000 ROCm experimental | [2026-09-03-windows64.experimental.rocm.gfx110x.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-03.1/2026-09-03-windows64.experimental.rocm.gfx110x.portable.zip) |
+| Windows AMD Ryzen AI Max ROCm experimental | [2026-09-03-windows64.experimental.rocm.gfx1151.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-03.1/2026-09-03-windows64.experimental.rocm.gfx1151.portable.zip) |
+| Windows AMD RX 9000 ROCm experimental | [2026-09-03-windows64.experimental.rocm.gfx120x.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-03.1/2026-09-03-windows64.experimental.rocm.gfx120x.portable.zip) |
+| Optional TensorRT for RTX 30 series and older; download both parts | [2026-09-03-windows64.nvidia.tensorrt.portable.7z.001](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-03.1/2026-09-03-windows64.nvidia.tensorrt.portable.7z.001)<br>[2026-09-03-windows64.nvidia.tensorrt.portable.7z.002](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-03.1/2026-09-03-windows64.nvidia.tensorrt.portable.7z.002) |
+| Windows x64, bring your own engine, portable | [2026-09-03-windows64.without.engine.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-03.1/2026-09-03-windows64.without.engine.portable.zip) |
+| Windows x64, bring your own engine, installer | [2026-09-03-windows64.without.engine.installer.exe](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-03.1/2026-09-03-windows64.without.engine.installer.exe) |
+| macOS Apple Silicon, Metal | [2026-09-03-mac-apple-silicon.with-katago.dmg](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-03.1/2026-09-03-mac-apple-silicon.with-katago.dmg) |
+| macOS Intel | [2026-09-03-mac-intel.with-katago.dmg](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-03.1/2026-09-03-mac-intel.with-katago.dmg) |
+| Linux x64, CPU compatibility | [2026-09-03-linux64.with-katago.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-03.1/2026-09-03-linux64.with-katago.zip) |
+| Linux x64, OpenCL | [2026-09-03-linux64.opencl.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-03.1/2026-09-03-linux64.opencl.zip) |
+| Linux x64, NVIDIA CUDA | [2026-09-03-linux64.nvidia.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-03.1/2026-09-03-linux64.nvidia.zip) |
+
+### Verification
+
+- Windows 11 / RTX 3070 / NVIDIA portable completed real neural-network inference with bundled Java, KataGo v1.18.1, CUDA, and B11 while keeping one KataGo process.
+- In the real EXE, a 49-move SGF showed its first quick-curve segment in about 0.9 seconds and completed in about 15 seconds; the board stayed responsive and resumed foreground analysis.
+- Alt+O readboard, Yike Live, flash analysis, whole-game analysis, local and Zhizi Cloud AI Coach restoration, six-language restarts, and visible 100% / 150% / 200% checks passed.
+- Local CI passed 28/28 gates. The full suite ran 3,799 JUnit tests with 0 failures, 0 errors, and 17 skipped; Maven verify/package, Windows launcher, release-asset checks, and GitHub build/windows-script-validation passed.
+- The release remains fail-closed until all four platform workflows, signing/notarization, topology, SHA, and provenance checks succeed.
+
+### Contact
+
+- QQ group: 299419120
+
+---
+
+## 日本語
+
+next-2026-09-01.1 を基にした Windows 体験修正の pre-release です。quick win-rate curve、Yike 同期、KataGo Auto Setup の停止を修正し、6 言語 font と高 scaling 表示も改善しました。
+
+### 主な更新
+
+- quick curve の途中結果は盤全体ではなく graph だけを軽量更新します。最終結果は mainline rebuild 完了後に反映し、長い空白や最後の区間欠落を防ぎます。
+- background SGF parse を live board から分離し、clock、PDA、renderer、engine sync を誤って起動しません。古い task が新しい棋譜を上書きすることもありません。
+- Yike の list、detail、SGF mainline 処理を EDT 外へ移し、live game の切り替えを軽くしました。SGF がない場合も list を閉じず状態を表示します。
+- KataGo Auto Setup の local scan を background 化し、古い refresh の cancel と failure recovery を追加しました。遅い storage でも白画面や freeze を防ぎます。
+- Auto Setup は Windows 100% / 150% / 200% scaling と負座標の secondary monitor でも作業領域内に収まります。
+- 6 言語の menu と HTML message は、簡体字、繁体字、英語、日本語、韓国語、タイ語を表示できる installed font を選択します。
+
+### ダウンロード前に
+
+- next-2026-09-01.1 の Windows 完全版を利用中なら、windows64.core-update.zip で app のみ更新できます。
+- 新規ユーザーは hardware に合う完全版を選んでください。KataGo v1.18.1 と B11 を同梱します。B11 は一手の判断が強い一方で遅いため、速度優先なら Auto Setup で B10 を選べます。
+- RTX 20/30/40/50 は統一 windows64.nvidia CUDA package を使用します。TensorRT は RTX 30 系以前の optional 選択です。
+- pre-release のため、上書き前に user-data、weight、棋譜を backup してください。
+- この PC にない RTX 50、ROCm、Intel NPU、macOS hardware を実機検証済みとは表記していません。
+
+### ダウンロード案内
+
+| お使いの環境 | ダウンロードするファイル |
+| --- | --- |
+| Windows x64、RTX 20/30/40/50 NVIDIA CUDA 推奨 portable | [2026-09-03-windows64.nvidia.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-03.1/2026-09-03-windows64.nvidia.portable.zip) |
+| 既存 Windows portable、app のみ更新 | [2026-09-03-windows64.core-update.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-03.1/2026-09-03-windows64.core-update.zip) |
+| Windows x64、RTX 20/30/40/50 NVIDIA CUDA installer | [2026-09-03-windows64.nvidia.installer.exe](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-03.1/2026-09-03-windows64.nvidia.installer.exe) |
+| Windows x64、AMD / Intel / 旧 NVIDIA OpenCL portable | [2026-09-03-windows64.opencl.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-03.1/2026-09-03-windows64.opencl.portable.zip) |
+| Windows x64、AMD / Intel / 旧 NVIDIA OpenCL installer | [2026-09-03-windows64.opencl.installer.exe](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-03.1/2026-09-03-windows64.opencl.installer.exe) |
+| Windows x64、CPU 互換 portable | [2026-09-03-windows64.with-katago.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-03.1/2026-09-03-windows64.with-katago.portable.zip) |
+| Windows x64、CPU 互換 installer | [2026-09-03-windows64.with-katago.installer.exe](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-03.1/2026-09-03-windows64.with-katago.installer.exe) |
+| Windows DirectML experimental | [2026-09-03-windows64.experimental.directml.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-03.1/2026-09-03-windows64.experimental.directml.portable.zip) |
+| Windows Intel OpenVINO experimental | [2026-09-03-windows64.experimental.openvino.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-03.1/2026-09-03-windows64.experimental.openvino.portable.zip) |
+| Windows AMD RX 6000 ROCm experimental | [2026-09-03-windows64.experimental.rocm.gfx103x.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-03.1/2026-09-03-windows64.experimental.rocm.gfx103x.portable.zip) |
+| Windows AMD RX 7000 ROCm experimental | [2026-09-03-windows64.experimental.rocm.gfx110x.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-03.1/2026-09-03-windows64.experimental.rocm.gfx110x.portable.zip) |
+| Windows AMD Ryzen AI Max ROCm experimental | [2026-09-03-windows64.experimental.rocm.gfx1151.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-03.1/2026-09-03-windows64.experimental.rocm.gfx1151.portable.zip) |
+| Windows AMD RX 9000 ROCm experimental | [2026-09-03-windows64.experimental.rocm.gfx120x.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-03.1/2026-09-03-windows64.experimental.rocm.gfx120x.portable.zip) |
+| RTX 30 系以前の optional TensorRT、両 part が必要 | [2026-09-03-windows64.nvidia.tensorrt.portable.7z.001](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-03.1/2026-09-03-windows64.nvidia.tensorrt.portable.7z.001)<br>[2026-09-03-windows64.nvidia.tensorrt.portable.7z.002](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-03.1/2026-09-03-windows64.nvidia.tensorrt.portable.7z.002) |
+| Windows x64、独自 engine、portable | [2026-09-03-windows64.without.engine.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-03.1/2026-09-03-windows64.without.engine.portable.zip) |
+| Windows x64、独自 engine、installer | [2026-09-03-windows64.without.engine.installer.exe](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-03.1/2026-09-03-windows64.without.engine.installer.exe) |
+| macOS Apple Silicon、Metal | [2026-09-03-mac-apple-silicon.with-katago.dmg](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-03.1/2026-09-03-mac-apple-silicon.with-katago.dmg) |
+| macOS Intel | [2026-09-03-mac-intel.with-katago.dmg](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-03.1/2026-09-03-mac-intel.with-katago.dmg) |
+| Linux x64、CPU 互換 | [2026-09-03-linux64.with-katago.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-03.1/2026-09-03-linux64.with-katago.zip) |
+| Linux x64、OpenCL | [2026-09-03-linux64.opencl.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-03.1/2026-09-03-linux64.opencl.zip) |
+| Linux x64、NVIDIA CUDA | [2026-09-03-linux64.nvidia.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-03.1/2026-09-03-linux64.nvidia.zip) |
+
+### 検証
+
+- Windows 11 / RTX 3070 / NVIDIA portable で bundled Java、KataGo v1.18.1、CUDA、B11 の実 NN inference を完了し、KataGo process は 1 個に保たれました。
+- 実 EXE で 49 手 SGF の quick curve は約 0.9 秒で最初の区間を表示し、約 15 秒で完了しました。盤面は応答を保ち foreground analysis へ復帰しました。
+- Alt+O readboard、Yike Live、flash analysis、whole-game analysis、local / Zhizi Cloud AI Coach 復帰、6 言語再起動、100% / 150% / 200% scaling を可視 UI で確認しました。
+- local CI は 28/28。全体 JUnit は 3799 件、failure 0、error 0、skip 17。Maven verify/package、Windows launcher、release asset、GitHub build/windows-script-validation も成功しました。
+- 4 platform workflow、sign/notarization、asset topology、SHA、provenance が成功するまで公開しません。
+
+### 連絡先
+
+- QQ group: 299419120
+
+---
+
+## 한국어
+
+next-2026-09-01.1 기반 Windows 사용성 수정 pre-release입니다. quick win-rate curve, Yike 동기화, KataGo Auto Setup 멈춤을 수정하고 6개 언어 font와 고배율 layout을 개선했습니다.
+
+### 주요 업데이트
+
+- quick curve 중간 결과는 전체 board 대신 graph만 가볍게 갱신합니다. 최종 결과는 mainline rebuild 뒤에 표시되어 긴 공백이나 마지막 구간 누락을 막습니다.
+- background SGF parse를 live board와 분리해 clock, PDA, renderer, engine sync를 잘못 실행하지 않으며 오래된 task가 새 기보를 덮어쓰지 않습니다.
+- Yike list, detail, SGF mainline 처리를 EDT 밖으로 옮겨 live game 전환을 부드럽게 했습니다. SGF가 없어도 list를 유지하고 상태를 표시합니다.
+- KataGo Auto Setup local scan을 background에서 실행하고 오래된 refresh 취소와 failure recovery를 추가해 느린 storage에서도 흰 화면이나 freeze를 방지합니다.
+- Auto Setup은 Windows 100% / 150% / 200% scaling과 음수 좌표 secondary monitor에서도 작업 영역 안에 맞습니다.
+- 6개 언어 menu와 HTML message가 간체, 번체, 영어, 일본어, 한국어, 태국어를 표시할 수 있는 installed font를 선택합니다.
+
+### 다운로드 전 확인
+
+- next-2026-09-01.1 Windows full bundle 사용자는 windows64.core-update.zip으로 app만 업데이트할 수 있습니다.
+- 새 설치는 hardware에 맞는 full bundle을 사용하세요. KataGo v1.18.1과 B11이 기본 포함됩니다. B11은 한 번의 판단이 더 강하지만 느릴 수 있어 속도 우선이면 Auto Setup에서 B10을 선택할 수 있습니다.
+- RTX 20/30/40/50은 통합 windows64.nvidia CUDA package를 사용합니다. TensorRT는 RTX 30 series 이하의 optional 선택입니다.
+- pre-release이므로 덮어쓰기 전 user-data, weight, 기보를 backup하세요.
+- 이 PC에 없는 RTX 50, ROCm, Intel NPU, macOS hardware를 실기기 검증 완료로 표시하지 않습니다.
+
+### 다운로드 안내
+
+| 내 컴퓨터 | 다운로드할 파일 |
+| --- | --- |
+| Windows x64, RTX 20/30/40/50 NVIDIA CUDA 권장 portable | [2026-09-03-windows64.nvidia.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-03.1/2026-09-03-windows64.nvidia.portable.zip) |
+| 기존 Windows portable, app-only update | [2026-09-03-windows64.core-update.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-03.1/2026-09-03-windows64.core-update.zip) |
+| Windows x64, RTX 20/30/40/50 NVIDIA CUDA installer | [2026-09-03-windows64.nvidia.installer.exe](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-03.1/2026-09-03-windows64.nvidia.installer.exe) |
+| Windows x64, AMD / Intel / 구형 NVIDIA OpenCL portable | [2026-09-03-windows64.opencl.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-03.1/2026-09-03-windows64.opencl.portable.zip) |
+| Windows x64, AMD / Intel / 구형 NVIDIA OpenCL installer | [2026-09-03-windows64.opencl.installer.exe](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-03.1/2026-09-03-windows64.opencl.installer.exe) |
+| Windows x64, CPU compatibility portable | [2026-09-03-windows64.with-katago.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-03.1/2026-09-03-windows64.with-katago.portable.zip) |
+| Windows x64, CPU compatibility installer | [2026-09-03-windows64.with-katago.installer.exe](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-03.1/2026-09-03-windows64.with-katago.installer.exe) |
+| Windows DirectML experimental | [2026-09-03-windows64.experimental.directml.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-03.1/2026-09-03-windows64.experimental.directml.portable.zip) |
+| Windows Intel OpenVINO experimental | [2026-09-03-windows64.experimental.openvino.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-03.1/2026-09-03-windows64.experimental.openvino.portable.zip) |
+| Windows AMD RX 6000 ROCm experimental | [2026-09-03-windows64.experimental.rocm.gfx103x.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-03.1/2026-09-03-windows64.experimental.rocm.gfx103x.portable.zip) |
+| Windows AMD RX 7000 ROCm experimental | [2026-09-03-windows64.experimental.rocm.gfx110x.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-03.1/2026-09-03-windows64.experimental.rocm.gfx110x.portable.zip) |
+| Windows AMD Ryzen AI Max ROCm experimental | [2026-09-03-windows64.experimental.rocm.gfx1151.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-03.1/2026-09-03-windows64.experimental.rocm.gfx1151.portable.zip) |
+| Windows AMD RX 9000 ROCm experimental | [2026-09-03-windows64.experimental.rocm.gfx120x.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-03.1/2026-09-03-windows64.experimental.rocm.gfx120x.portable.zip) |
+| RTX 30 series 이하 optional TensorRT, 두 part 모두 필요 | [2026-09-03-windows64.nvidia.tensorrt.portable.7z.001](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-03.1/2026-09-03-windows64.nvidia.tensorrt.portable.7z.001)<br>[2026-09-03-windows64.nvidia.tensorrt.portable.7z.002](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-03.1/2026-09-03-windows64.nvidia.tensorrt.portable.7z.002) |
+| Windows x64, 사용자 engine, portable | [2026-09-03-windows64.without.engine.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-03.1/2026-09-03-windows64.without.engine.portable.zip) |
+| Windows x64, 사용자 engine, installer | [2026-09-03-windows64.without.engine.installer.exe](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-03.1/2026-09-03-windows64.without.engine.installer.exe) |
+| macOS Apple Silicon, Metal | [2026-09-03-mac-apple-silicon.with-katago.dmg](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-03.1/2026-09-03-mac-apple-silicon.with-katago.dmg) |
+| macOS Intel | [2026-09-03-mac-intel.with-katago.dmg](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-03.1/2026-09-03-mac-intel.with-katago.dmg) |
+| Linux x64, CPU compatibility | [2026-09-03-linux64.with-katago.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-03.1/2026-09-03-linux64.with-katago.zip) |
+| Linux x64, OpenCL | [2026-09-03-linux64.opencl.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-03.1/2026-09-03-linux64.opencl.zip) |
+| Linux x64, NVIDIA CUDA | [2026-09-03-linux64.nvidia.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-03.1/2026-09-03-linux64.nvidia.zip) |
+
+### 검증
+
+- Windows 11 / RTX 3070 / NVIDIA portable에서 bundled Java, KataGo v1.18.1, CUDA, B11로 실제 NN inference를 완료했고 KataGo process는 하나로 유지되었습니다.
+- 실제 EXE에서 49수 SGF quick curve는 약 0.9초 만에 첫 구간을 표시하고 약 15초 만에 완료했습니다. board는 응답을 유지하고 foreground analysis를 복원했습니다.
+- Alt+O readboard, Yike Live, flash analysis, whole-game analysis, local / Zhizi Cloud AI Coach 복원, 6개 언어 재시작, 100% / 150% / 200% scaling을 실제 UI로 확인했습니다.
+- local CI 28/28 통과. 전체 JUnit 3799개, failure 0, error 0, skip 17이며 Maven verify/package, Windows launcher, release asset, GitHub build/windows-script-validation도 통과했습니다.
+- 4개 platform workflow, signing/notarization, asset topology, SHA, provenance가 모두 성공해야 공개됩니다.
+
+### 연락처
+
+- QQ 그룹: 299419120
+
+---
+
+## ภาษาไทย
+
+pre-release นี้ต่อยอดจาก next-2026-09-01.1 โดยแก้การค้างของ quick win-rate curve, การ sync Yike และ KataGo Auto Setup พร้อมปรับ font 6 ภาษาและ layout สำหรับ scaling สูงบน Windows
+
+### ไฮไลต์ของเวอร์ชันนี้
+
+- ผลระหว่างทางของ quick curve จะ refresh เฉพาะ graph แทนการวาด board ใหม่ทั้งหมด และรอ mainline rebuild ก่อนแสดงผลสุดท้าย จึงไม่เว้นว่างนานหรือขาดช่วงสุดท้าย
+- แยก background SGF parse ออกจาก live board เพื่อไม่ให้เรียก clock, PDA, renderer หรือ engine sync โดยไม่ตั้งใจ และ task เก่าจะไม่เขียนทับเกมใหม่
+- ย้ายการประมวลผล Yike list, detail และ SGF mainline ออกจาก EDT ทำให้สลับ live game ได้ลื่นขึ้น ถ้าไม่มี SGF จะคง list ไว้พร้อมสถานะชัดเจน
+- KataGo Auto Setup scan ไฟล์ local ใน background พร้อมยกเลิก refresh เก่าและกู้คืนเมื่อผิดพลาด จึงไม่เกิดหน้าขาวหรือ freeze บน storage ที่ช้า
+- Auto Setup อยู่ภายในพื้นที่ใช้งานของจอที่ Windows scaling 100% / 150% / 200% รวมถึงจอรองพิกัดติดลบ
+- menu และ HTML message เลือก installed font ที่แสดงภาษาจีนตัวย่อ จีนตัวเต็ม อังกฤษ ญี่ปุ่น เกาหลี และไทยได้จริง
+
+### ก่อนดาวน์โหลด
+
+- ผู้ใช้ Windows full bundle next-2026-09-01.1 ใช้ windows64.core-update.zip เพื่ออัปเดตเฉพาะ app ได้ โดยไม่แทน weight, engine, TensorRT หรือ user-data
+- การติดตั้งใหม่ให้เลือก full bundle ตาม hardware ซึ่งยังมี KataGo v1.18.1 และ B11 เป็นค่าเริ่มต้น B11 ตัดสินต่อครั้งได้แข็งแรงกว่าแต่ช้ากว่า หากเน้นความเร็วเลือก B10 ใน Auto Setup
+- RTX 20/30/40/50 ใช้ windows64.nvidia CUDA package เดียวกัน TensorRT เป็นตัวเลือกสำหรับ RTX 30 series และรุ่นก่อนหน้า
+- นี่คือ pre-release ควร backup user-data, weight และ game records ก่อนเขียนทับ
+- ไม่อ้างว่า RTX 50, ROCm, Intel NPU หรือ macOS hardware ที่ไม่มีในเครื่องทดสอบผ่านการทดสอบจริง
+
+### คำแนะนำดาวน์โหลด
+
+| คอมพิวเตอร์ของคุณ | ดาวน์โหลดไฟล์นี้ |
+| --- | --- |
+| Windows x64, RTX 20/30/40/50 NVIDIA CUDA portable ที่แนะนำ | [2026-09-03-windows64.nvidia.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-03.1/2026-09-03-windows64.nvidia.portable.zip) |
+| Windows portable เดิม, อัปเดตเฉพาะ app | [2026-09-03-windows64.core-update.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-03.1/2026-09-03-windows64.core-update.zip) |
+| Windows x64, RTX 20/30/40/50 NVIDIA CUDA installer | [2026-09-03-windows64.nvidia.installer.exe](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-03.1/2026-09-03-windows64.nvidia.installer.exe) |
+| Windows x64, OpenCL portable สำหรับ AMD / Intel / NVIDIA รุ่นเก่า | [2026-09-03-windows64.opencl.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-03.1/2026-09-03-windows64.opencl.portable.zip) |
+| Windows x64, OpenCL installer สำหรับ AMD / Intel / NVIDIA รุ่นเก่า | [2026-09-03-windows64.opencl.installer.exe](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-03.1/2026-09-03-windows64.opencl.installer.exe) |
+| Windows x64, CPU compatibility portable | [2026-09-03-windows64.with-katago.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-03.1/2026-09-03-windows64.with-katago.portable.zip) |
+| Windows x64, CPU compatibility installer | [2026-09-03-windows64.with-katago.installer.exe](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-03.1/2026-09-03-windows64.with-katago.installer.exe) |
+| Windows DirectML experimental | [2026-09-03-windows64.experimental.directml.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-03.1/2026-09-03-windows64.experimental.directml.portable.zip) |
+| Windows Intel OpenVINO experimental | [2026-09-03-windows64.experimental.openvino.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-03.1/2026-09-03-windows64.experimental.openvino.portable.zip) |
+| Windows AMD RX 6000 ROCm experimental | [2026-09-03-windows64.experimental.rocm.gfx103x.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-03.1/2026-09-03-windows64.experimental.rocm.gfx103x.portable.zip) |
+| Windows AMD RX 7000 ROCm experimental | [2026-09-03-windows64.experimental.rocm.gfx110x.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-03.1/2026-09-03-windows64.experimental.rocm.gfx110x.portable.zip) |
+| Windows AMD Ryzen AI Max ROCm experimental | [2026-09-03-windows64.experimental.rocm.gfx1151.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-03.1/2026-09-03-windows64.experimental.rocm.gfx1151.portable.zip) |
+| Windows AMD RX 9000 ROCm experimental | [2026-09-03-windows64.experimental.rocm.gfx120x.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-03.1/2026-09-03-windows64.experimental.rocm.gfx120x.portable.zip) |
+| TensorRT สำหรับ RTX 30 และรุ่นก่อนหน้า ต้องโหลดทั้งสอง part | [2026-09-03-windows64.nvidia.tensorrt.portable.7z.001](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-03.1/2026-09-03-windows64.nvidia.tensorrt.portable.7z.001)<br>[2026-09-03-windows64.nvidia.tensorrt.portable.7z.002](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-03.1/2026-09-03-windows64.nvidia.tensorrt.portable.7z.002) |
+| Windows x64, ใช้ engine ของคุณเอง, portable | [2026-09-03-windows64.without.engine.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-03.1/2026-09-03-windows64.without.engine.portable.zip) |
+| Windows x64, ใช้ engine ของคุณเอง, installer | [2026-09-03-windows64.without.engine.installer.exe](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-03.1/2026-09-03-windows64.without.engine.installer.exe) |
+| macOS Apple Silicon, Metal | [2026-09-03-mac-apple-silicon.with-katago.dmg](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-03.1/2026-09-03-mac-apple-silicon.with-katago.dmg) |
+| macOS Intel | [2026-09-03-mac-intel.with-katago.dmg](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-03.1/2026-09-03-mac-intel.with-katago.dmg) |
+| Linux x64, CPU compatibility | [2026-09-03-linux64.with-katago.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-03.1/2026-09-03-linux64.with-katago.zip) |
+| Linux x64, OpenCL | [2026-09-03-linux64.opencl.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-03.1/2026-09-03-linux64.opencl.zip) |
+| Linux x64, NVIDIA CUDA | [2026-09-03-linux64.nvidia.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-03.1/2026-09-03-linux64.nvidia.zip) |
+
+### ผลการตรวจสอบ
+
+- Windows 11 / RTX 3070 / NVIDIA portable รัน NN inference จริงด้วย Java, KataGo v1.18.1, CUDA และ B11 ที่มากับ package โดยคง KataGo process ไว้หนึ่งตัว
+- EXE จริงเปิด SGF 49 move แล้วแสดงช่วงแรกของ quick curve ในประมาณ 0.9 วินาทีและครบในประมาณ 15 วินาที โดย board ยังตอบสนองและคืน foreground analysis
+- ทดสอบ Alt+O readboard, Yike Live, flash analysis, whole-game analysis, การคืน AI Coach แบบ local / Zhizi Cloud, การ restart 6 ภาษา และ scaling 100% / 150% / 200% บน UI จริงแล้ว
+- local CI ผ่าน 28/28; JUnit 3799 รายการ, failure 0, error 0, skipped 17 และ Maven verify/package, Windows launcher, release asset, GitHub build/windows-script-validation ผ่านทั้งหมด
+- จะเปิด pre-release เมื่อ workflow ทั้ง 4 platform, signing/notarization, asset topology, SHA และ provenance ผ่านทั้งหมดเท่านั้น
+
+### ติดต่อ
+
+- QQ group: 299419120

--- a/.github/release-requests/next-2026-09-03.1.json
+++ b/.github/release-requests/next-2026-09-03.1.json
@@ -1,0 +1,7 @@
+{
+  "date_tag": "2026-09-03",
+  "release_tag": "next-2026-09-03.1",
+  "title": "LizzieYzy Next next-2026-09-03.1",
+  "prerelease": true,
+  "notes_file": ".github/release-notes/next-2026-09-03.1.md"
+}


### PR DESCRIPTION
## 发布目标

请求从已验收并合并的 main `e883d575d7534717dba30fe6b3b1fc3eaaf260d1` 发布 `next-2026-09-03.1` 多平台 pre-release。

本 PR 仅包含：

- `.github/release-requests/next-2026-09-03.1.json`
- `.github/release-notes/next-2026-09-03.1.md`

合并后由 `Publish Requested Pre-release` fail-closed 流程创建 draft、触发 Windows/Linux/macOS Intel/macOS Apple Silicon 四个平台构建，只有全部工作流、签名/公证、资产拓扑、SHA、provenance 和六语正文校验成功后才公开。

## 本版重点

- 快速胜率曲线轻量渐进刷新与最终结果同步
- 后台 SGF 解析隔离
- 弈客列表和同步移出 EDT
- KataGo 一键设置后台扫描、失败恢复与高缩放布局
- 六语菜单和消息字体覆盖
- Windows 本地 CI Git Bash 兼容

## 发布前验证

- Windows 11 23H2 build 22631、RTX 3070、NVIDIA portable 真实 EXE 验收
- 本地 CI 28/28，3799 tests，0 failures，0 errors，17 skipped
- GitHub PR #416 的 `build` 与 `windows-script-validation` 成功
- release 专项测试 115/115 通过，1 项按平台跳过
- 六语 release notes、完整多平台直链、Markdown、行尾与 `git diff --check` 均通过

本机没有 RTX 50、AMD ROCm、Intel NPU 和 macOS 硬件，说明中未宣称这些硬件已真机通过。