### PR TITLE
发布 next-2026-09-04.1 预览版

### DIFF
--- a/.github/release-notes/next-2026-09-04.1.md
+++ b/.github/release-notes/next-2026-09-04.1.md
@@ -1,0 +1,371 @@
+# LizzieYzy Next next-2026-09-04.1
+
+## 中文
+
+这是基于 next-2026-09-03.1 的分析工作流增强预发布版，重点加快从自动快速胜率曲线切换到用户主动分析，并让整盘精析的搜索量可控、可记忆。
+
+### 本版主要更新
+
+- 用户启动逐手自动分析时，会优先结束仍在后台生成的自动快速胜率曲线，再平稳接管当前引擎，减少等待和重复启动。
+- 修复分析切换期间的并发竞态：若用户随后启动闪电分析或整盘精析，迟到的旧回调不会再抢回引擎，最后一次明确操作始终优先。
+- 整盘精析新增 500 到 1,000,000 次的搜索量预设与自定义输入，默认 1,000 次，并会记住上次使用值。
+- 整盘精析会根据局面数和搜索量给出耗时提示；开始、暂停、继续、停止和取消后的前台分析恢复均保持一致。
+- 自动快速曲线、逐手分析、闪电分析和整盘精析继续共享统一的独占任务保护，不会静默中断对局或棋盘同步。
+- 感谢 `qiyi71w` 提交这次分析体验改进并参与审查。
+
+### 下载前先看
+
+- 已安装 next-2026-09-03.1 完整 Windows 包的用户，可用 windows64.core-update.zip 只更新程序；现有权重、引擎、TensorRT 和 user-data 不会被替换。
+- 新安装用户请下载与硬件匹配的完整包；仍内置 KataGo v1.18.1 和默认 B11。B11 单次判断更强但搜索较慢，追求速度可在“一键设置 → 权重”明确切换 B10。
+- RTX 20/30/40/50 继续统一使用 windows64.nvidia CUDA 包；TensorRT 是 RTX 30 系及以下的可选方案。
+- 这是预发布版，覆盖旧目录前建议备份 user-data、权重和棋谱。
+- DirectML、OpenVINO、ROCm、RTX 50 和 macOS 对应硬件未在本机冒充真机通过，欢迎对应设备用户反馈。
+
+### 下载建议
+
+| 你的电脑 | 直接下载这个 |
+| --- | --- |
+| Windows 64 位，RTX 20/30/40/50 NVIDIA CUDA 推荐版，免安装 | [2026-09-04-windows64.nvidia.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-04.1/2026-09-04-windows64.nvidia.portable.zip) |
+| 已有 Windows 免安装版，只更新主程序 | [2026-09-04-windows64.core-update.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-04.1/2026-09-04-windows64.core-update.zip) |
+| Windows 64 位，RTX 20/30/40/50 NVIDIA CUDA 推荐安装版 | [2026-09-04-windows64.nvidia.installer.exe](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-04.1/2026-09-04-windows64.nvidia.installer.exe) |
+| Windows 64 位，AMD / Intel / 旧 NVIDIA OpenCL 兼容版，免安装 | [2026-09-04-windows64.opencl.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-04.1/2026-09-04-windows64.opencl.portable.zip) |
+| Windows 64 位，AMD / Intel / 旧 NVIDIA OpenCL 兼容安装版 | [2026-09-04-windows64.opencl.installer.exe](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-04.1/2026-09-04-windows64.opencl.installer.exe) |
+| Windows 64 位，CPU 兼容版，免安装 | [2026-09-04-windows64.with-katago.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-04.1/2026-09-04-windows64.with-katago.portable.zip) |
+| Windows 64 位，CPU 兼容安装版 | [2026-09-04-windows64.with-katago.installer.exe](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-04.1/2026-09-04-windows64.with-katago.installer.exe) |
+| Windows DirectML 实验版 | [2026-09-04-windows64.experimental.directml.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-04.1/2026-09-04-windows64.experimental.directml.portable.zip) |
+| Windows Intel OpenVINO 实验版 | [2026-09-04-windows64.experimental.openvino.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-04.1/2026-09-04-windows64.experimental.openvino.portable.zip) |
+| Windows AMD RX 6000 ROCm 实验版 | [2026-09-04-windows64.experimental.rocm.gfx103x.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-04.1/2026-09-04-windows64.experimental.rocm.gfx103x.portable.zip) |
+| Windows AMD RX 7000 ROCm 实验版 | [2026-09-04-windows64.experimental.rocm.gfx110x.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-04.1/2026-09-04-windows64.experimental.rocm.gfx110x.portable.zip) |
+| Windows AMD Ryzen AI Max ROCm 实验版 | [2026-09-04-windows64.experimental.rocm.gfx1151.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-04.1/2026-09-04-windows64.experimental.rocm.gfx1151.portable.zip) |
+| Windows AMD RX 9000 ROCm 实验版 | [2026-09-04-windows64.experimental.rocm.gfx120x.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-04.1/2026-09-04-windows64.experimental.rocm.gfx120x.portable.zip) |
+| RTX 30 系及以下可选 TensorRT，需下载两个分卷 | [2026-09-04-windows64.nvidia.tensorrt.portable.7z.001](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-04.1/2026-09-04-windows64.nvidia.tensorrt.portable.7z.001)<br>[2026-09-04-windows64.nvidia.tensorrt.portable.7z.002](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-04.1/2026-09-04-windows64.nvidia.tensorrt.portable.7z.002) |
+| Windows 64 位，自行配置引擎，免安装 | [2026-09-04-windows64.without.engine.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-04.1/2026-09-04-windows64.without.engine.portable.zip) |
+| Windows 64 位，自行配置引擎，安装版 | [2026-09-04-windows64.without.engine.installer.exe](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-04.1/2026-09-04-windows64.without.engine.installer.exe) |
+| macOS Apple Silicon，Metal | [2026-09-04-mac-apple-silicon.with-katago.dmg](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-04.1/2026-09-04-mac-apple-silicon.with-katago.dmg) |
+| macOS Intel | [2026-09-04-mac-intel.with-katago.dmg](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-04.1/2026-09-04-mac-intel.with-katago.dmg) |
+| Linux 64 位，CPU 兼容版 | [2026-09-04-linux64.with-katago.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-04.1/2026-09-04-linux64.with-katago.zip) |
+| Linux 64 位，OpenCL 版 | [2026-09-04-linux64.opencl.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-04.1/2026-09-04-linux64.opencl.zip) |
+| Linux 64 位，NVIDIA CUDA 版 | [2026-09-04-linux64.nvidia.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-04.1/2026-09-04-linux64.nvidia.zip) |
+
+### 验证结果
+
+- Windows 11 23H2（build 22631）、RTX 3070、NVIDIA portable 使用包内 Java、KataGo v1.18.1、CUDA 与 B11 完成真实神经网络推理。
+- 真实 EXE 打开 50 手 SGF 后快速曲线正常出现；逐手自动分析接管、闪电分析后发优先，以及整盘精析 700 次的开始、暂停、继续和取消均通过，前台引擎会正确恢复。
+- Alt+O 内置 readboard v3.0.6 与弈客直播列表、进入棋局和持续同步均完成真机复测，窗口和主界面保持响应。
+- 整盘精析窗口在本机 150% 缩放无裁切；8 个 locale 与 100% / 125% / 150% / 200% 的无裁切布局测试全部通过。
+- 本地 CI 28/28；331 个测试套件共 3816 项，0 failures、0 errors、19 skipped；GitHub `build` 与 `windows-script-validation` 均通过。
+- 发布器只有在四个平台工作流、签名/公证、资产拓扑、SHA 与来源证明全部成功后才公开本预发布版。
+
+### 交流
+
+- QQ 群：299419120
+
+---
+
+## 繁體中文
+
+這是基於 next-2026-09-03.1 的分析流程增強預發布版，重點加快自動 quick win-rate curve 切換到使用者主動分析，並讓整盤精析的搜尋量可控制且可記憶。
+
+### 本版主要更新
+
+- 啟動逐手自動分析時，會先結束仍在背景產生的自動 quick curve，再平順接管目前 engine，減少等待與重複啟動。
+- 修正分析切換期間的 concurrency race：若使用者接著啟動 flash analysis 或整盤精析，延遲的舊 callback 不會再搶回 engine，最後一次明確操作優先。
+- 整盤精析新增 500 到 1,000,000 次的搜尋量 preset 與自訂輸入，預設 1,000 次，並記住上次使用值。
+- 整盤精析會依局面數與搜尋量顯示時間提示；開始、暫停、繼續、停止與取消後的 foreground analysis 恢復行為一致。
+- 自動 quick curve、逐手分析、flash analysis 與整盤精析共用同一套 exclusive task 保護，不會靜默中斷對局或棋盤同步。
+- 感謝 `qiyi71w` 提交這次分析體驗改善並參與 review。
+
+### 下載前先看
+
+- 已安裝 next-2026-09-03.1 完整 Windows 套件的使用者，可用 windows64.core-update.zip 只更新程式，不替換 weight、engine、TensorRT 或 user-data。
+- 新安裝請下載符合硬體的完整套件；仍內建 KataGo v1.18.1 與預設 B11。B11 單次判斷更強但搜尋較慢，重視速度可切換 B10。
+- RTX 20/30/40/50 繼續統一使用 windows64.nvidia CUDA 套件；TensorRT 是 RTX 30 系及以下的可選方案。
+- 這是預發布版，覆蓋舊目錄前建議備份 user-data、weight 與棋譜。
+- DirectML、OpenVINO、ROCm、RTX 50 與 macOS 對應硬體未在本機宣稱真機通過。
+
+### 下載建議
+
+| 你的電腦 | 直接下載這個 |
+| --- | --- |
+| Windows 64 位，RTX 20/30/40/50 NVIDIA CUDA 建議版，免安裝 | [2026-09-04-windows64.nvidia.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-04.1/2026-09-04-windows64.nvidia.portable.zip) |
+| 既有 Windows 免安裝版，只更新主程式 | [2026-09-04-windows64.core-update.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-04.1/2026-09-04-windows64.core-update.zip) |
+| Windows 64 位，RTX 20/30/40/50 NVIDIA CUDA 建議安裝版 | [2026-09-04-windows64.nvidia.installer.exe](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-04.1/2026-09-04-windows64.nvidia.installer.exe) |
+| Windows 64 位，AMD / Intel / 舊 NVIDIA OpenCL 相容版，免安裝 | [2026-09-04-windows64.opencl.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-04.1/2026-09-04-windows64.opencl.portable.zip) |
+| Windows 64 位，AMD / Intel / 舊 NVIDIA OpenCL 相容安裝版 | [2026-09-04-windows64.opencl.installer.exe](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-04.1/2026-09-04-windows64.opencl.installer.exe) |
+| Windows 64 位，CPU 相容版，免安裝 | [2026-09-04-windows64.with-katago.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-04.1/2026-09-04-windows64.with-katago.portable.zip) |
+| Windows 64 位，CPU 相容安裝版 | [2026-09-04-windows64.with-katago.installer.exe](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-04.1/2026-09-04-windows64.with-katago.installer.exe) |
+| Windows DirectML 實驗版 | [2026-09-04-windows64.experimental.directml.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-04.1/2026-09-04-windows64.experimental.directml.portable.zip) |
+| Windows Intel OpenVINO 實驗版 | [2026-09-04-windows64.experimental.openvino.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-04.1/2026-09-04-windows64.experimental.openvino.portable.zip) |
+| Windows AMD RX 6000 ROCm 實驗版 | [2026-09-04-windows64.experimental.rocm.gfx103x.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-04.1/2026-09-04-windows64.experimental.rocm.gfx103x.portable.zip) |
+| Windows AMD RX 7000 ROCm 實驗版 | [2026-09-04-windows64.experimental.rocm.gfx110x.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-04.1/2026-09-04-windows64.experimental.rocm.gfx110x.portable.zip) |
+| Windows AMD Ryzen AI Max ROCm 實驗版 | [2026-09-04-windows64.experimental.rocm.gfx1151.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-04.1/2026-09-04-windows64.experimental.rocm.gfx1151.portable.zip) |
+| Windows AMD RX 9000 ROCm 實驗版 | [2026-09-04-windows64.experimental.rocm.gfx120x.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-04.1/2026-09-04-windows64.experimental.rocm.gfx120x.portable.zip) |
+| RTX 30 系及以下可選 TensorRT，需下載兩個分卷 | [2026-09-04-windows64.nvidia.tensorrt.portable.7z.001](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-04.1/2026-09-04-windows64.nvidia.tensorrt.portable.7z.001)<br>[2026-09-04-windows64.nvidia.tensorrt.portable.7z.002](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-04.1/2026-09-04-windows64.nvidia.tensorrt.portable.7z.002) |
+| Windows 64 位，自行設定 engine，免安裝 | [2026-09-04-windows64.without.engine.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-04.1/2026-09-04-windows64.without.engine.portable.zip) |
+| Windows 64 位，自行設定 engine，安裝版 | [2026-09-04-windows64.without.engine.installer.exe](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-04.1/2026-09-04-windows64.without.engine.installer.exe) |
+| macOS Apple Silicon，Metal | [2026-09-04-mac-apple-silicon.with-katago.dmg](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-04.1/2026-09-04-mac-apple-silicon.with-katago.dmg) |
+| macOS Intel | [2026-09-04-mac-intel.with-katago.dmg](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-04.1/2026-09-04-mac-intel.with-katago.dmg) |
+| Linux 64 位，CPU 相容版 | [2026-09-04-linux64.with-katago.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-04.1/2026-09-04-linux64.with-katago.zip) |
+| Linux 64 位，OpenCL 版 | [2026-09-04-linux64.opencl.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-04.1/2026-09-04-linux64.opencl.zip) |
+| Linux 64 位，NVIDIA CUDA 版 | [2026-09-04-linux64.nvidia.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-04.1/2026-09-04-linux64.nvidia.zip) |
+
+### 驗證結果
+
+- Windows 11 23H2（build 22631）、RTX 3070、NVIDIA portable 使用套件內 Java、KataGo v1.18.1、CUDA 與 B11 完成真實 NN inference。
+- 真實 EXE 開啟 50 手 SGF 後 quick curve 正常出現；逐手分析接管、後發 flash analysis 優先，以及整盤精析 700 次的開始、暫停、繼續與取消都通過，foreground engine 可正確恢復。
+- Alt+O 內建 readboard v3.0.6 與弈客直播 list、進入棋局和持續同步均完成真機複測，視窗與主介面保持回應。
+- 整盤精析視窗在本機 150% scaling 無裁切；8 個 locale 與 100% / 125% / 150% / 200% layout test 全部通過。
+- 本機 CI 28/28；331 個 test suite 共 3816 項，0 failures、0 errors、19 skipped；GitHub `build` 與 `windows-script-validation` 均通過。
+- 四平台 workflow、簽名/公證、資產拓撲、SHA 與來源證明全部成功後才會公開。
+
+### 交流
+
+- QQ 群：299419120
+
+---
+
+## English
+
+This analysis-workflow pre-release builds on next-2026-09-03.1. It speeds up handoff from the automatic quick win-rate curve to user-requested analysis and makes whole-game deep-analysis effort controllable and persistent.
+
+### Release highlights
+
+- Starting move-by-move auto analysis now finishes any automatic quick curve still running in the background before smoothly taking over the current engine, reducing waits and duplicate launches.
+- Fixed an analysis-switch race: if the user subsequently starts flash or whole-game analysis, a late callback can no longer reclaim the engine. The most recent explicit action wins.
+- Whole-game deep analysis now offers presets and a custom range from 500 to 1,000,000 visits per position, defaults to 1,000, and remembers the last value.
+- The dialog estimates work from the position count and visit limit; start, pause, resume, stop, cancel, and foreground-analysis restoration now follow one consistent lifecycle.
+- Automatic quick curves, move-by-move analysis, flash analysis, and whole-game deep analysis share the same exclusive-task protection and do not silently interrupt games or board synchronization.
+- Thanks to `qiyi71w` for contributing this analysis improvement and reviewing the race fix.
+
+### Before downloading
+
+- Windows users with a complete next-2026-09-03.1 bundle can apply windows64.core-update.zip for the app-only update without replacing weights, engines, TensorRT, or user-data.
+- Fresh installs should use the full bundle matching the hardware. KataGo v1.18.1 and B11 remain bundled by default. B11 provides stronger individual evaluations at lower throughput; select B10 in Auto Setup when speed matters more.
+- RTX 20/30/40/50 continue to use the unified windows64.nvidia CUDA package. TensorRT is an optional path for RTX 30 series and older.
+- This is a pre-release; back up user-data, weights, and game records before overwriting an existing folder.
+- DirectML, OpenVINO, ROCm, RTX 50, and macOS hardware not present on the test machine are not claimed as hardware-tested.
+
+### Download guide
+
+| Your computer | Download this file |
+| --- | --- |
+| Windows x64, recommended RTX 20/30/40/50 NVIDIA CUDA portable | [2026-09-04-windows64.nvidia.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-04.1/2026-09-04-windows64.nvidia.portable.zip) |
+| Existing Windows portable, app-only update | [2026-09-04-windows64.core-update.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-04.1/2026-09-04-windows64.core-update.zip) |
+| Windows x64, recommended RTX 20/30/40/50 NVIDIA CUDA installer | [2026-09-04-windows64.nvidia.installer.exe](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-04.1/2026-09-04-windows64.nvidia.installer.exe) |
+| Windows x64, OpenCL portable for AMD / Intel / older NVIDIA | [2026-09-04-windows64.opencl.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-04.1/2026-09-04-windows64.opencl.portable.zip) |
+| Windows x64, OpenCL installer for AMD / Intel / older NVIDIA | [2026-09-04-windows64.opencl.installer.exe](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-04.1/2026-09-04-windows64.opencl.installer.exe) |
+| Windows x64, CPU compatibility portable | [2026-09-04-windows64.with-katago.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-04.1/2026-09-04-windows64.with-katago.portable.zip) |
+| Windows x64, CPU compatibility installer | [2026-09-04-windows64.with-katago.installer.exe](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-04.1/2026-09-04-windows64.with-katago.installer.exe) |
+| Windows DirectML experimental | [2026-09-04-windows64.experimental.directml.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-04.1/2026-09-04-windows64.experimental.directml.portable.zip) |
+| Windows Intel OpenVINO experimental | [2026-09-04-windows64.experimental.openvino.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-04.1/2026-09-04-windows64.experimental.openvino.portable.zip) |
+| Windows AMD RX 6000 ROCm experimental | [2026-09-04-windows64.experimental.rocm.gfx103x.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-04.1/2026-09-04-windows64.experimental.rocm.gfx103x.portable.zip) |
+| Windows AMD RX 7000 ROCm experimental | [2026-09-04-windows64.experimental.rocm.gfx110x.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-04.1/2026-09-04-windows64.experimental.rocm.gfx110x.portable.zip) |
+| Windows AMD Ryzen AI Max ROCm experimental | [2026-09-04-windows64.experimental.rocm.gfx1151.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-04.1/2026-09-04-windows64.experimental.rocm.gfx1151.portable.zip) |
+| Windows AMD RX 9000 ROCm experimental | [2026-09-04-windows64.experimental.rocm.gfx120x.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-04.1/2026-09-04-windows64.experimental.rocm.gfx120x.portable.zip) |
+| Optional TensorRT for RTX 30 series and older; download both parts | [2026-09-04-windows64.nvidia.tensorrt.portable.7z.001](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-04.1/2026-09-04-windows64.nvidia.tensorrt.portable.7z.001)<br>[2026-09-04-windows64.nvidia.tensorrt.portable.7z.002](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-04.1/2026-09-04-windows64.nvidia.tensorrt.portable.7z.002) |
+| Windows x64, bring your own engine, portable | [2026-09-04-windows64.without.engine.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-04.1/2026-09-04-windows64.without.engine.portable.zip) |
+| Windows x64, bring your own engine, installer | [2026-09-04-windows64.without.engine.installer.exe](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-04.1/2026-09-04-windows64.without.engine.installer.exe) |
+| macOS Apple Silicon, Metal | [2026-09-04-mac-apple-silicon.with-katago.dmg](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-04.1/2026-09-04-mac-apple-silicon.with-katago.dmg) |
+| macOS Intel | [2026-09-04-mac-intel.with-katago.dmg](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-04.1/2026-09-04-mac-intel.with-katago.dmg) |
+| Linux x64, CPU compatibility | [2026-09-04-linux64.with-katago.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-04.1/2026-09-04-linux64.with-katago.zip) |
+| Linux x64, OpenCL | [2026-09-04-linux64.opencl.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-04.1/2026-09-04-linux64.opencl.zip) |
+| Linux x64, NVIDIA CUDA | [2026-09-04-linux64.nvidia.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-04.1/2026-09-04-linux64.nvidia.zip) |
+
+### Verification
+
+- Windows 11 23H2 build 22631 / RTX 3070 / NVIDIA portable completed real neural-network inference with bundled Java, KataGo v1.18.1, CUDA, and B11.
+- In the real EXE, a 50-move SGF produced its quick curve; move-by-move takeover, later flash-analysis priority, and whole-game analysis at 700 visits all passed start, pause, resume, and cancel checks with foreground-engine restoration.
+- Alt+O bundled readboard v3.0.6 and Yike Live list, game entry, and continued synchronization passed on the Windows machine while both windows remained responsive.
+- The whole-game dialog was unclipped at the machine's native 150% scaling; headful layout tests passed 8 locales at 100%, 125%, 150%, and 200%.
+- Local CI passed 28/28 gates: 331 suites, 3,816 tests, 0 failures, 0 errors, and 19 skipped. GitHub `build` and `windows-script-validation` also passed.
+- The release remains fail-closed until all four platform workflows, signing/notarization, topology, SHA, and provenance checks succeed.
+
+### Contact
+
+- QQ group: 299419120
+
+---
+
+## 日本語
+
+next-2026-09-03.1 を基にした analysis workflow 強化 pre-release です。自動 quick win-rate curve から user analysis への切り替えを高速化し、whole-game deep analysis の探索量を設定・保存できるようにしました。
+
+### 主な更新
+
+- 逐手 auto analysis の開始時、background の automatic quick curve を先に終了して current engine を滑らかに引き継ぎ、待ち時間と重複起動を減らします。
+- analysis 切り替えの race を修正しました。後から flash analysis または whole-game analysis を開始した場合、古い callback が engine を奪い返さず、最後の明示操作を優先します。
+- whole-game deep analysis は 1 局面 500 から 1,000,000 visits の preset / custom 入力に対応し、既定 1,000 と前回値を保存します。
+- position 数と visit limit から所要時間の目安を表示し、開始、一時停止、再開、停止、cancel、foreground analysis 復帰を統一しました。
+- automatic quick curve、逐手分析、flash analysis、whole-game analysis は同じ exclusive-task 保護を利用し、対局や board sync を暗黙に中断しません。
+- この改善を提供し race fix を review した `qiyi71w` に感謝します。
+
+### ダウンロード前に
+
+- next-2026-09-03.1 の Windows 完全版を利用中なら、windows64.core-update.zip で app のみ更新できます。
+- 新規ユーザーは hardware に合う完全版を選んでください。KataGo v1.18.1 と B11 を同梱します。B11 は一手の判断が強い一方で遅いため、速度優先なら Auto Setup で B10 を選べます。
+- RTX 20/30/40/50 は統一 windows64.nvidia CUDA package を使用します。TensorRT は RTX 30 系以前の optional 選択です。
+- pre-release のため、上書き前に user-data、weight、棋譜を backup してください。
+- この PC にない RTX 50、ROCm、Intel NPU、macOS hardware を実機検証済みとは表記していません。
+
+### ダウンロード案内
+
+| お使いの環境 | ダウンロードするファイル |
+| --- | --- |
+| Windows x64、RTX 20/30/40/50 NVIDIA CUDA 推奨 portable | [2026-09-04-windows64.nvidia.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-04.1/2026-09-04-windows64.nvidia.portable.zip) |
+| 既存 Windows portable、app のみ更新 | [2026-09-04-windows64.core-update.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-04.1/2026-09-04-windows64.core-update.zip) |
+| Windows x64、RTX 20/30/40/50 NVIDIA CUDA installer | [2026-09-04-windows64.nvidia.installer.exe](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-04.1/2026-09-04-windows64.nvidia.installer.exe) |
+| Windows x64、AMD / Intel / 旧 NVIDIA OpenCL portable | [2026-09-04-windows64.opencl.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-04.1/2026-09-04-windows64.opencl.portable.zip) |
+| Windows x64、AMD / Intel / 旧 NVIDIA OpenCL installer | [2026-09-04-windows64.opencl.installer.exe](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-04.1/2026-09-04-windows64.opencl.installer.exe) |
+| Windows x64、CPU 互換 portable | [2026-09-04-windows64.with-katago.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-04.1/2026-09-04-windows64.with-katago.portable.zip) |
+| Windows x64、CPU 互換 installer | [2026-09-04-windows64.with-katago.installer.exe](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-04.1/2026-09-04-windows64.with-katago.installer.exe) |
+| Windows DirectML experimental | [2026-09-04-windows64.experimental.directml.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-04.1/2026-09-04-windows64.experimental.directml.portable.zip) |
+| Windows Intel OpenVINO experimental | [2026-09-04-windows64.experimental.openvino.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-04.1/2026-09-04-windows64.experimental.openvino.portable.zip) |
+| Windows AMD RX 6000 ROCm experimental | [2026-09-04-windows64.experimental.rocm.gfx103x.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-04.1/2026-09-04-windows64.experimental.rocm.gfx103x.portable.zip) |
+| Windows AMD RX 7000 ROCm experimental | [2026-09-04-windows64.experimental.rocm.gfx110x.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-04.1/2026-09-04-windows64.experimental.rocm.gfx110x.portable.zip) |
+| Windows AMD Ryzen AI Max ROCm experimental | [2026-09-04-windows64.experimental.rocm.gfx1151.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-04.1/2026-09-04-windows64.experimental.rocm.gfx1151.portable.zip) |
+| Windows AMD RX 9000 ROCm experimental | [2026-09-04-windows64.experimental.rocm.gfx120x.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-04.1/2026-09-04-windows64.experimental.rocm.gfx120x.portable.zip) |
+| RTX 30 系以前の optional TensorRT、両 part が必要 | [2026-09-04-windows64.nvidia.tensorrt.portable.7z.001](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-04.1/2026-09-04-windows64.nvidia.tensorrt.portable.7z.001)<br>[2026-09-04-windows64.nvidia.tensorrt.portable.7z.002](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-04.1/2026-09-04-windows64.nvidia.tensorrt.portable.7z.002) |
+| Windows x64、独自 engine、portable | [2026-09-04-windows64.without.engine.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-04.1/2026-09-04-windows64.without.engine.portable.zip) |
+| Windows x64、独自 engine、installer | [2026-09-04-windows64.without.engine.installer.exe](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-04.1/2026-09-04-windows64.without.engine.installer.exe) |
+| macOS Apple Silicon、Metal | [2026-09-04-mac-apple-silicon.with-katago.dmg](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-04.1/2026-09-04-mac-apple-silicon.with-katago.dmg) |
+| macOS Intel | [2026-09-04-mac-intel.with-katago.dmg](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-04.1/2026-09-04-mac-intel.with-katago.dmg) |
+| Linux x64、CPU 互換 | [2026-09-04-linux64.with-katago.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-04.1/2026-09-04-linux64.with-katago.zip) |
+| Linux x64、OpenCL | [2026-09-04-linux64.opencl.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-04.1/2026-09-04-linux64.opencl.zip) |
+| Linux x64、NVIDIA CUDA | [2026-09-04-linux64.nvidia.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-04.1/2026-09-04-linux64.nvidia.zip) |
+
+### 検証
+
+- Windows 11 23H2 build 22631 / RTX 3070 / NVIDIA portable で bundled Java、KataGo v1.18.1、CUDA、B11 の実 NN inference を完了しました。
+- 実 EXE で 50 手 SGF の quick curve、逐手分析への引き継ぎ、後発 flash analysis の優先、700 visits の whole-game analysis の開始・一時停止・再開・cancel を確認し、foreground engine も復帰しました。
+- Alt+O bundled readboard v3.0.6 と Yike Live の list、game entry、継続 sync を Windows 実機で確認し、両 window は応答を保ちました。
+- whole-game dialog は native 150% scaling で clip なし。headful layout test は 8 locale、100% / 125% / 150% / 200% で成功しました。
+- local CI は 28/28。331 suite、3816 test、failure 0、error 0、skip 19。GitHub `build` と `windows-script-validation` も成功しました。
+- 4 platform workflow、sign/notarization、asset topology、SHA、provenance が成功するまで公開しません。
+
+### 連絡先
+
+- QQ group: 299419120
+
+---
+
+## 한국어
+
+next-2026-09-03.1 기반 analysis workflow 개선 pre-release입니다. automatic quick win-rate curve에서 user analysis로 더 빠르게 전환하고 whole-game deep analysis의 search visits를 설정하고 기억합니다.
+
+### 주요 업데이트
+
+- move-by-move auto analysis를 시작할 때 background automatic quick curve를 먼저 끝낸 뒤 current engine을 부드럽게 넘겨받아 대기와 중복 실행을 줄입니다.
+- analysis 전환 race를 수정했습니다. 사용자가 뒤이어 flash 또는 whole-game analysis를 시작하면 늦은 callback이 engine을 되찾지 않으며 마지막 명시적 동작이 우선합니다.
+- whole-game deep analysis에 position당 500부터 1,000,000 visits까지 preset과 custom 입력을 추가했고 기본값 1,000 및 최근 값을 기억합니다.
+- position 수와 visit limit에 따른 시간 안내를 표시하며 시작, pause, resume, stop, cancel, foreground analysis 복원을 같은 lifecycle로 처리합니다.
+- automatic quick curve, move-by-move analysis, flash analysis, whole-game analysis가 동일한 exclusive-task 보호를 사용하며 대국이나 board sync를 조용히 중단하지 않습니다.
+- 이 개선을 기여하고 race fix를 review한 `qiyi71w` 님께 감사드립니다.
+
+### 다운로드 전 확인
+
+- next-2026-09-03.1 Windows full bundle 사용자는 windows64.core-update.zip으로 app만 업데이트할 수 있습니다.
+- 새 설치는 hardware에 맞는 full bundle을 사용하세요. KataGo v1.18.1과 B11이 기본 포함됩니다. B11은 한 번의 판단이 더 강하지만 느릴 수 있어 속도 우선이면 Auto Setup에서 B10을 선택할 수 있습니다.
+- RTX 20/30/40/50은 통합 windows64.nvidia CUDA package를 사용합니다. TensorRT는 RTX 30 series 이하의 optional 선택입니다.
+- pre-release이므로 덮어쓰기 전 user-data, weight, 기보를 backup하세요.
+- 이 PC에 없는 RTX 50, ROCm, Intel NPU, macOS hardware를 실기기 검증 완료로 표시하지 않습니다.
+
+### 다운로드 안내
+
+| 내 컴퓨터 | 다운로드할 파일 |
+| --- | --- |
+| Windows x64, RTX 20/30/40/50 NVIDIA CUDA 권장 portable | [2026-09-04-windows64.nvidia.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-04.1/2026-09-04-windows64.nvidia.portable.zip) |
+| 기존 Windows portable, app-only update | [2026-09-04-windows64.core-update.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-04.1/2026-09-04-windows64.core-update.zip) |
+| Windows x64, RTX 20/30/40/50 NVIDIA CUDA installer | [2026-09-04-windows64.nvidia.installer.exe](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-04.1/2026-09-04-windows64.nvidia.installer.exe) |
+| Windows x64, AMD / Intel / 구형 NVIDIA OpenCL portable | [2026-09-04-windows64.opencl.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-04.1/2026-09-04-windows64.opencl.portable.zip) |
+| Windows x64, AMD / Intel / 구형 NVIDIA OpenCL installer | [2026-09-04-windows64.opencl.installer.exe](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-04.1/2026-09-04-windows64.opencl.installer.exe) |
+| Windows x64, CPU compatibility portable | [2026-09-04-windows64.with-katago.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-04.1/2026-09-04-windows64.with-katago.portable.zip) |
+| Windows x64, CPU compatibility installer | [2026-09-04-windows64.with-katago.installer.exe](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-04.1/2026-09-04-windows64.with-katago.installer.exe) |
+| Windows DirectML experimental | [2026-09-04-windows64.experimental.directml.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-04.1/2026-09-04-windows64.experimental.directml.portable.zip) |
+| Windows Intel OpenVINO experimental | [2026-09-04-windows64.experimental.openvino.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-04.1/2026-09-04-windows64.experimental.openvino.portable.zip) |
+| Windows AMD RX 6000 ROCm experimental | [2026-09-04-windows64.experimental.rocm.gfx103x.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-04.1/2026-09-04-windows64.experimental.rocm.gfx103x.portable.zip) |
+| Windows AMD RX 7000 ROCm experimental | [2026-09-04-windows64.experimental.rocm.gfx110x.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-04.1/2026-09-04-windows64.experimental.rocm.gfx110x.portable.zip) |
+| Windows AMD Ryzen AI Max ROCm experimental | [2026-09-04-windows64.experimental.rocm.gfx1151.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-04.1/2026-09-04-windows64.experimental.rocm.gfx1151.portable.zip) |
+| Windows AMD RX 9000 ROCm experimental | [2026-09-04-windows64.experimental.rocm.gfx120x.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-04.1/2026-09-04-windows64.experimental.rocm.gfx120x.portable.zip) |
+| RTX 30 series 이하 optional TensorRT, 두 part 모두 필요 | [2026-09-04-windows64.nvidia.tensorrt.portable.7z.001](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-04.1/2026-09-04-windows64.nvidia.tensorrt.portable.7z.001)<br>[2026-09-04-windows64.nvidia.tensorrt.portable.7z.002](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-04.1/2026-09-04-windows64.nvidia.tensorrt.portable.7z.002) |
+| Windows x64, 사용자 engine, portable | [2026-09-04-windows64.without.engine.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-04.1/2026-09-04-windows64.without.engine.portable.zip) |
+| Windows x64, 사용자 engine, installer | [2026-09-04-windows64.without.engine.installer.exe](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-04.1/2026-09-04-windows64.without.engine.installer.exe) |
+| macOS Apple Silicon, Metal | [2026-09-04-mac-apple-silicon.with-katago.dmg](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-04.1/2026-09-04-mac-apple-silicon.with-katago.dmg) |
+| macOS Intel | [2026-09-04-mac-intel.with-katago.dmg](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-04.1/2026-09-04-mac-intel.with-katago.dmg) |
+| Linux x64, CPU compatibility | [2026-09-04-linux64.with-katago.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-04.1/2026-09-04-linux64.with-katago.zip) |
+| Linux x64, OpenCL | [2026-09-04-linux64.opencl.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-04.1/2026-09-04-linux64.opencl.zip) |
+| Linux x64, NVIDIA CUDA | [2026-09-04-linux64.nvidia.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-04.1/2026-09-04-linux64.nvidia.zip) |
+
+### 검증
+
+- Windows 11 23H2 build 22631 / RTX 3070 / NVIDIA portable에서 bundled Java, KataGo v1.18.1, CUDA, B11 실제 NN inference를 완료했습니다.
+- 실제 EXE에서 50수 SGF quick curve, move-by-move takeover, 후발 flash-analysis 우선 처리, 700 visits whole-game analysis의 시작, pause, resume, cancel을 확인했고 foreground engine도 복원되었습니다.
+- Alt+O bundled readboard v3.0.6과 Yike Live list, game entry, 지속 sync를 Windows 실기기에서 확인했고 두 window 모두 응답을 유지했습니다.
+- whole-game dialog는 native 150% scaling에서 잘리지 않았고 headful layout test는 8 locale, 100% / 125% / 150% / 200%에서 통과했습니다.
+- local CI 28/28 통과. 331 suite, 3816 test, failure 0, error 0, skip 19이며 GitHub `build`, `windows-script-validation`도 통과했습니다.
+- 4개 platform workflow, signing/notarization, asset topology, SHA, provenance가 모두 성공해야 공개됩니다.
+
+### 연락처
+
+- QQ 그룹: 299419120
+
+---
+
+## ภาษาไทย
+
+pre-release นี้ต่อยอดจาก next-2026-09-03.1 โดยเร่งการส่งต่อจาก automatic quick win-rate curve ไปยัง analysis ที่ผู้ใช้สั่ง และทำให้กำหนดพร้อมจดจำจำนวน search visits ของ whole-game deep analysis ได้
+
+### ไฮไลต์ของเวอร์ชันนี้
+
+- เมื่อเริ่ม move-by-move auto analysis แอปจะจบ automatic quick curve ที่ยังทำงานใน background ก่อนรับช่วง current engine เพื่อลดการรอและการเปิดซ้ำ
+- แก้ race ระหว่างการสลับ analysis หากผู้ใช้เริ่ม flash หรือ whole-game analysis ภายหลัง callback เก่าจะไม่แย่ง engine คืน และคำสั่งล่าสุดของผู้ใช้จะมีสิทธิ์ก่อน
+- whole-game deep analysis รองรับ preset และ custom 500 ถึง 1,000,000 visits ต่อ position ใช้ค่าเริ่มต้น 1,000 และจำค่าล่าสุด
+- dialog แสดงคำแนะนำเวลาจากจำนวน position และ visit limit พร้อม lifecycle ที่สอดคล้องกันสำหรับ start, pause, resume, stop, cancel และคืน foreground analysis
+- automatic quick curve, move-by-move, flash และ whole-game analysis ใช้ exclusive-task protection ชุดเดียวกัน โดยไม่หยุด game หรือ board sync แบบเงียบ ๆ
+- ขอบคุณ `qiyi71w` ที่ส่งการปรับปรุงนี้และช่วย review race fix
+
+### ก่อนดาวน์โหลด
+
+- ผู้ใช้ Windows full bundle next-2026-09-03.1 ใช้ windows64.core-update.zip เพื่ออัปเดตเฉพาะ app ได้ โดยไม่แทน weight, engine, TensorRT หรือ user-data
+- การติดตั้งใหม่ให้เลือก full bundle ตาม hardware ซึ่งยังมี KataGo v1.18.1 และ B11 เป็นค่าเริ่มต้น B11 ตัดสินต่อครั้งได้แข็งแรงกว่าแต่ช้ากว่า หากเน้นความเร็วเลือก B10 ใน Auto Setup
+- RTX 20/30/40/50 ใช้ windows64.nvidia CUDA package เดียวกัน TensorRT เป็นตัวเลือกสำหรับ RTX 30 series และรุ่นก่อนหน้า
+- นี่คือ pre-release ควร backup user-data, weight และ game records ก่อนเขียนทับ
+- ไม่อ้างว่า RTX 50, ROCm, Intel NPU หรือ macOS hardware ที่ไม่มีในเครื่องทดสอบผ่านการทดสอบจริง
+
+### คำแนะนำดาวน์โหลด
+
+| คอมพิวเตอร์ของคุณ | ดาวน์โหลดไฟล์นี้ |
+| --- | --- |
+| Windows x64, RTX 20/30/40/50 NVIDIA CUDA portable ที่แนะนำ | [2026-09-04-windows64.nvidia.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-04.1/2026-09-04-windows64.nvidia.portable.zip) |
+| Windows portable เดิม, อัปเดตเฉพาะ app | [2026-09-04-windows64.core-update.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-04.1/2026-09-04-windows64.core-update.zip) |
+| Windows x64, RTX 20/30/40/50 NVIDIA CUDA installer | [2026-09-04-windows64.nvidia.installer.exe](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-04.1/2026-09-04-windows64.nvidia.installer.exe) |
+| Windows x64, OpenCL portable สำหรับ AMD / Intel / NVIDIA รุ่นเก่า | [2026-09-04-windows64.opencl.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-04.1/2026-09-04-windows64.opencl.portable.zip) |
+| Windows x64, OpenCL installer สำหรับ AMD / Intel / NVIDIA รุ่นเก่า | [2026-09-04-windows64.opencl.installer.exe](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-04.1/2026-09-04-windows64.opencl.installer.exe) |
+| Windows x64, CPU compatibility portable | [2026-09-04-windows64.with-katago.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-04.1/2026-09-04-windows64.with-katago.portable.zip) |
+| Windows x64, CPU compatibility installer | [2026-09-04-windows64.with-katago.installer.exe](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-04.1/2026-09-04-windows64.with-katago.installer.exe) |
+| Windows DirectML experimental | [2026-09-04-windows64.experimental.directml.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-04.1/2026-09-04-windows64.experimental.directml.portable.zip) |
+| Windows Intel OpenVINO experimental | [2026-09-04-windows64.experimental.openvino.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-04.1/2026-09-04-windows64.experimental.openvino.portable.zip) |
+| Windows AMD RX 6000 ROCm experimental | [2026-09-04-windows64.experimental.rocm.gfx103x.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-04.1/2026-09-04-windows64.experimental.rocm.gfx103x.portable.zip) |
+| Windows AMD RX 7000 ROCm experimental | [2026-09-04-windows64.experimental.rocm.gfx110x.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-04.1/2026-09-04-windows64.experimental.rocm.gfx110x.portable.zip) |
+| Windows AMD Ryzen AI Max ROCm experimental | [2026-09-04-windows64.experimental.rocm.gfx1151.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-04.1/2026-09-04-windows64.experimental.rocm.gfx1151.portable.zip) |
+| Windows AMD RX 9000 ROCm experimental | [2026-09-04-windows64.experimental.rocm.gfx120x.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-04.1/2026-09-04-windows64.experimental.rocm.gfx120x.portable.zip) |
+| TensorRT สำหรับ RTX 30 และรุ่นก่อนหน้า ต้องโหลดทั้งสอง part | [2026-09-04-windows64.nvidia.tensorrt.portable.7z.001](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-04.1/2026-09-04-windows64.nvidia.tensorrt.portable.7z.001)<br>[2026-09-04-windows64.nvidia.tensorrt.portable.7z.002](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-04.1/2026-09-04-windows64.nvidia.tensorrt.portable.7z.002) |
+| Windows x64, ใช้ engine ของคุณเอง, portable | [2026-09-04-windows64.without.engine.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-04.1/2026-09-04-windows64.without.engine.portable.zip) |
+| Windows x64, ใช้ engine ของคุณเอง, installer | [2026-09-04-windows64.without.engine.installer.exe](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-04.1/2026-09-04-windows64.without.engine.installer.exe) |
+| macOS Apple Silicon, Metal | [2026-09-04-mac-apple-silicon.with-katago.dmg](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-04.1/2026-09-04-mac-apple-silicon.with-katago.dmg) |
+| macOS Intel | [2026-09-04-mac-intel.with-katago.dmg](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-04.1/2026-09-04-mac-intel.with-katago.dmg) |
+| Linux x64, CPU compatibility | [2026-09-04-linux64.with-katago.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-04.1/2026-09-04-linux64.with-katago.zip) |
+| Linux x64, OpenCL | [2026-09-04-linux64.opencl.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-04.1/2026-09-04-linux64.opencl.zip) |
+| Linux x64, NVIDIA CUDA | [2026-09-04-linux64.nvidia.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-04.1/2026-09-04-linux64.nvidia.zip) |
+
+### ผลการตรวจสอบ
+
+- Windows 11 23H2 build 22631 / RTX 3070 / NVIDIA portable รัน NN inference จริงด้วย Java, KataGo v1.18.1, CUDA และ B11 ที่มากับ package
+- EXE จริงผ่าน quick curve ของ SGF 50 move, การรับช่วงแบบ move-by-move, สิทธิ์ของ flash analysis ที่สั่งภายหลัง และ whole-game 700 visits ทั้ง start, pause, resume, cancel พร้อมคืน foreground engine
+- Alt+O bundled readboard v3.0.6 และ Yike Live ทั้ง list, เข้า game และ sync ต่อเนื่องผ่านการทดสอบจริงบน Windows โดยทั้งสอง window ยังตอบสนอง
+- whole-game dialog ไม่ถูกตัดที่ native scaling 150%; headful layout test ผ่าน 8 locale ที่ 100% / 125% / 150% / 200%
+- local CI ผ่าน 28/28: 331 suite, 3816 test, failure 0, error 0, skipped 19 และ GitHub `build`, `windows-script-validation` ผ่านแล้ว
+- จะเปิด pre-release เมื่อ workflow ทั้ง 4 platform, signing/notarization, asset topology, SHA และ provenance ผ่านทั้งหมดเท่านั้น
+
+### ติดต่อ
+
+- QQ group: 299419120

--- a/.github/release-requests/next-2026-09-04.1.json
+++ b/.github/release-requests/next-2026-09-04.1.json
@@ -1,0 +1,7 @@
+{
+  "date_tag": "2026-09-04",
+  "release_tag": "next-2026-09-04.1",
+  "title": "LizzieYzy Next next-2026-09-04.1",
+  "prerelease": true,
+  "notes_file": ".github/release-notes/next-2026-09-04.1.md"
+}


### PR DESCRIPTION
## 目标

发布 `next-2026-09-04.1` 多平台 pre-release。该请求只增加经审核的发布元数据和六语发布说明，程序代码来自已合并并通过验收的 PR #418。

## 本次更新

- 加快自动快速胜率曲线切换到用户主动逐手分析的引擎交接。
- 修复切换等待期间后发闪电分析/整盘精析被旧回调抢回引擎的竞态，最后一次明确操作优先。
- 整盘精析支持每局面 500 到 1,000,000 次自定义搜索量，默认 1,000，并记忆上次设置。

## 验证

- Windows 11 23H2 build 22631、RTX 3070、NVIDIA portable、包内 Java、KataGo v1.18.1 CUDA、B11 真机推理通过。
- 真实 EXE：快速曲线、逐手自动分析接管、后发闪电分析优先、整盘精析 700 次开始/暂停/继续/取消、前台引擎恢复均通过。
- Alt+O readboard v3.0.6、弈客直播列表与棋局同步通过。
- 本地 CI 28/28：331 suites、3816 tests、0 failures、0 errors、19 skipped。
- PR #418 的 GitHub `build` 与 `windows-script-validation` 均成功。
- 六语发布说明、请求结构、Markdown 链接及 `git diff --check` 已通过。

发布器仍会保持 fail-closed：四平台构建、macOS 签名/公证、资产拓扑、SHA 与 provenance 全部成功后才公开 pre-release。