### PR TITLE
feat(diagnostics): analysis-cache Full Trace decisions (#424)

### DIFF
--- a/src/main/java/featurecat/lizzie/logging/EngineObservation.java
+++ b/src/main/java/featurecat/lizzie/logging/EngineObservation.java
@@ -391,6 +391,81 @@ public final class EngineObservation {
         () -> TRACE.info("gtp raw stream={}", ObservationText.boundedRawEvent(line)));
   }
 
+  /**
+   * Records the final history-node analysis-cache accept/reject decision on the Full Trace
+   * {@code engine-gtp} channel. No-op when Full Trace is off; never throws to callers.
+   */
+  public static void traceAnalysisCacheDecision(
+      Object engineOwner,
+      int nodeMove,
+      long boardRevision,
+      boolean blackToPlay,
+      String engineName,
+      int incomingVisits,
+      double incomingWinrate,
+      double incomingScoreLead,
+      int cachedVisits,
+      double cachedWinrate,
+      double cachedScoreLead,
+      String decision,
+      String reason) {
+    try {
+      if (!traceEnabled()) {
+        return;
+      }
+      String safeEngine = ObservationText.boundedRawEvent(engineName == null ? "" : engineName);
+      String safeDecision = safeAnalysisCacheDecision(decision);
+      String safeReason = safeAnalysisCacheReason(reason);
+      inContext(
+          identityFor(engineOwner),
+          null,
+          () ->
+              TRACE.info(
+                  "analysis-cache nodeMove={} boardRevision={} blackToPlay={} engine={}"
+                      + " incomingVisits={} incomingWinrate={} incomingScoreLead={}"
+                      + " cachedVisits={} cachedWinrate={} cachedScoreLead={}"
+                      + " decision={} reason={}",
+                  nodeMove,
+                  boardRevision,
+                  blackToPlay,
+                  safeEngine,
+                  incomingVisits,
+                  incomingWinrate,
+                  incomingScoreLead,
+                  cachedVisits,
+                  cachedWinrate,
+                  cachedScoreLead,
+                  safeDecision,
+                  safeReason));
+    } catch (RuntimeException ignored) {
+    }
+  }
+
+  private static String safeAnalysisCacheDecision(String decision) {
+    if ("ACCEPT".equals(decision) || "REJECT".equals(decision)) {
+      return decision;
+    }
+    return "unknown";
+  }
+
+  private static String safeAnalysisCacheReason(String reason) {
+    return switch (reason == null ? "" : reason) {
+      case "HIGHER_VISITS",
+          "LOWER_VISITS",
+          "OWNERSHIP_BACKFILL",
+          "OWNERSHIP_FILL",
+          "FORCE_OVERRIDE",
+          "IS_CHANGED",
+          "PDA_CHANGED",
+          "EQUAL_VISITS",
+          "CACHE_DISABLED",
+          "AUTO_ANA",
+          "ENGINE_GAME" ->
+          reason;
+      default -> "unknown";
+    };
+  }
+
   public static void inContext(String engineId, String commandId, Runnable action) {
     if (action == null) {
       return;

--- a/src/main/java/featurecat/lizzie/rules/BoardData.java
+++ b/src/main/java/featurecat/lizzie/rules/BoardData.java
@@ -4,6 +4,7 @@ import featurecat.lizzie.Lizzie;
 import featurecat.lizzie.analysis.Leelaz;
 import featurecat.lizzie.analysis.MoveData;
 import featurecat.lizzie.gui.LizzieFrame;
+import featurecat.lizzie.logging.EngineObservation;
 import java.util.*;
 
 public class BoardData {
@@ -401,14 +402,57 @@ public class BoardData {
           || (metadataEngine != null && pda != metadataEngine.pda))) {
         if (totalplayouts < playouts) {
           // Requesting ownership restarts KataGo's stream at low visits. Backfill only the map.
-          if (estimateArray == null || estimateArray.isEmpty()) return false;
+          if (estimateArray == null || estimateArray.isEmpty()) {
+            traceAnalysisCacheDecision(
+                metadataEngine,
+                engName,
+                totalplayouts,
+                moves,
+                playouts,
+                winrate,
+                scoreMean,
+                "REJECT",
+                "LOWER_VISITS");
+            return false;
+          }
+          traceAnalysisCacheDecision(
+              metadataEngine,
+              engName,
+              totalplayouts,
+              moves,
+              playouts,
+              winrate,
+              scoreMean,
+              "ACCEPT",
+              "OWNERSHIP_BACKFILL");
           this.estimateArray = compactEstimateArray(estimateArray);
           return true;
         }
-        if (estimateArray == null || estimateArray.isEmpty() || this.estimateArray != null)
+        if (estimateArray == null || estimateArray.isEmpty() || this.estimateArray != null) {
+          traceAnalysisCacheDecision(
+              metadataEngine,
+              engName,
+              totalplayouts,
+              moves,
+              playouts,
+              winrate,
+              scoreMean,
+              "REJECT",
+              "EQUAL_VISITS");
           return false;
+        }
       }
     }
+    traceAnalysisCacheDecision(
+        metadataEngine,
+        engName,
+        totalplayouts,
+        moves,
+        playouts,
+        winrate,
+        scoreMean,
+        "ACCEPT",
+        primaryFullAcceptReason(forceOverride, totalplayouts, metadataEngine));
     // added for change bestmoves when playouts is not increased
     if (totalplayouts < playouts) isChanged = false;
     setPlayouts(totalplayouts);
@@ -539,13 +583,57 @@ public class BoardData {
           || (metadataEngine != null && pda2 != metadataEngine.pda))) { // ||Lizzie.frame.urlSgf
         if (totalplayouts < playouts2) {
           // Keep the stronger secondary analysis while accepting its restarted ownership stream.
-          if (estimateArray == null || estimateArray.isEmpty()) return;
+          if (estimateArray == null || estimateArray.isEmpty()) {
+            traceAnalysisCacheDecision(
+                metadataEngine,
+                engName,
+                totalplayouts,
+                moves,
+                playouts2,
+                winrate2,
+                scoreMean2,
+                "REJECT",
+                "LOWER_VISITS");
+            return;
+          }
+          traceAnalysisCacheDecision(
+              metadataEngine,
+              engName,
+              totalplayouts,
+              moves,
+              playouts2,
+              winrate2,
+              scoreMean2,
+              "ACCEPT",
+              "OWNERSHIP_BACKFILL");
           this.estimateArray2 = compactEstimateArray(estimateArray);
           return;
         }
-        if (estimateArray == null || estimateArray.isEmpty() || this.estimateArray2 != null) return;
+        if (estimateArray == null || estimateArray.isEmpty() || this.estimateArray2 != null) {
+          traceAnalysisCacheDecision(
+              metadataEngine,
+              engName,
+              totalplayouts,
+              moves,
+              playouts2,
+              winrate2,
+              scoreMean2,
+              "REJECT",
+              "EQUAL_VISITS");
+          return;
+        }
       }
     }
+    traceAnalysisCacheDecision(
+        metadataEngine,
+        engName,
+        totalplayouts,
+        moves,
+        playouts2,
+        winrate2,
+        scoreMean2,
+        "ACCEPT",
+        secondaryFullAcceptReason(totalplayouts, metadataEngine));
     if (totalplayouts < playouts2) isChanged2 = false;
     setPlayouts2(totalplayouts);
     this.estimateArray2 = compactEstimateArray(estimateArray);
@@ -578,6 +666,89 @@ public class BoardData {
         });
     tryToLimitMoves(moves, bestMoves2, false);
     bestMoves2 = moves;
+  }
+
+  private void traceAnalysisCacheDecision(
+      Leelaz engineOwner,
+      String engName,
+      int incomingVisits,
+      List<MoveData> moves,
+      int cachedVisits,
+      double cachedWinrate,
+      double cachedScoreLead,
+      String decision,
+      String reason) {
+    try {
+      if (!EngineObservation.traceEnabled()) {
+        return;
+      }
+      MoveData incoming = moves == null || moves.isEmpty() ? null : moves.get(0);
+      EngineObservation.traceAnalysisCacheDecision(
+          engineOwner,
+          moveNumber,
+          currentBoardRevision(),
+          blackToPlay,
+          engName,
+          incomingVisits,
+          incoming == null ? 0.0 : incoming.winrate,
+          incoming == null ? 0.0 : incoming.scoreMean,
+          cachedVisits,
+          cachedWinrate,
+          cachedScoreLead,
+          decision,
+          reason);
+    } catch (RuntimeException ignored) {
+    }
+  }
+
+  private static long currentBoardRevision() {
+    Board board = Lizzie.board;
+    return board == null ? -1L : board.getContextRevision();
+  }
+
+  private String primaryFullAcceptReason(
+      boolean forceOverride, int totalplayouts, Leelaz metadataEngine) {
+    if (forceOverride) {
+      return "FORCE_OVERRIDE";
+    }
+    if (!Lizzie.config.enableLizzieCache) {
+      return "CACHE_DISABLED";
+    }
+    if (Lizzie.config.isAutoAna) {
+      return "AUTO_ANA";
+    }
+    if (Lizzie.engineGame.current().playing()) {
+      return "ENGINE_GAME";
+    }
+    if (totalplayouts > playouts) {
+      return "HIGHER_VISITS";
+    }
+    if (isChanged) {
+      return "IS_CHANGED";
+    }
+    if (metadataEngine != null && pda != metadataEngine.pda) {
+      return "PDA_CHANGED";
+    }
+    return "OWNERSHIP_FILL";
+  }
+
+  private String secondaryFullAcceptReason(int totalplayouts, Leelaz metadataEngine) {
+    if (!Lizzie.config.enableLizzieCache) {
+      return "CACHE_DISABLED";
+    }
+    if (Lizzie.config.isAutoAna) {
+      return "AUTO_ANA";
+    }
+    if (totalplayouts > playouts2) {
+      return "HIGHER_VISITS";
+    }
+    if (isChanged2) {
+      return "IS_CHANGED";
+    }
+    if (metadataEngine != null && pda2 != metadataEngine.pda) {
+      return "PDA_CHANGED";
+    }
+    return "OWNERSHIP_FILL";
   }
 
   public static double getWinrateFromBestMoves(List<MoveData> bestMoves) {

--- a/src/test/java/featurecat/lizzie/analysis/EngineManagerLifecycleReservationTest.java
+++ b/src/test/java/featurecat/lizzie/analysis/EngineManagerLifecycleReservationTest.java
@@ -916,20 +916,27 @@ class EngineManagerLifecycleReservationTest {
     try {
       Thread.setDefaultUncaughtExceptionHandler(
           (thread, failure) -> {
-            if (thread.getName().contains("Thread")) {
-              escaped.compareAndSet(null, failure);
-              escapedFailure.countDown();
+            if (failure == state.schedulerManager.schedulingFailure
+                || failure == state.schedulerManager.lifecycleCloseFailure) {
+              if (escaped.compareAndSet(null, failure)) {
+                escapedFailure.countDown();
+              }
             }
           });
       state.install();
       state.manager.updateEngines();
 
-      assertTrue(escapedFailure.await(10, TimeUnit.SECONDS));
+      assertTrue(
+          escapedFailure.await(10, TimeUnit.SECONDS),
+          "controlled scheduling failure should escape the replacement worker");
       Throwable failure = escaped.get();
       assertSame(state.schedulerManager.schedulingFailure, failure);
       assertTrue(
           java.util.Arrays.stream(failure.getSuppressed())
-              .anyMatch(suppressed -> suppressed == state.schedulerManager.lifecycleCloseFailure));
+              .anyMatch(suppressed -> suppressed == state.schedulerManager.lifecycleCloseFailure),
+          () ->
+              "lifecycle close failure should be suppressed onto the scheduling failure, suppressed="
+                  + java.util.Arrays.toString(failure.getSuppressed()));
       assertEquals(1, state.schedulerManager.lifecycleCloseCount.get());
     } finally {
       Thread.setDefaultUncaughtExceptionHandler(previousHandler);
@@ -9525,9 +9532,14 @@ class EngineManagerLifecycleReservationTest {
     @Override
     protected void closeUpdateEngineLifecycleSynchronization(
         EngineManager.InitialEngineStartupSynchronization synchronization) {
-      super.closeUpdateEngineLifecycleSynchronization(synchronization);
       lifecycleCloseCount.incrementAndGet();
-      throw lifecycleCloseFailure;
+      try {
+        super.closeUpdateEngineLifecycleSynchronization(synchronization);
+      } finally {
+        // Always throw the injected close failure. Real close() can also throw during
+        // racy engine teardown; Java then suppresses that onto this controlled Error.
+        throw lifecycleCloseFailure;
+      }
     }
   }
 

--- a/src/test/java/featurecat/lizzie/logging/EngineObservationTest.java
+++ b/src/test/java/featurecat/lizzie/logging/EngineObservationTest.java
@@ -9,6 +9,7 @@ import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.read.ListAppender;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.EnumSet;
 import java.util.List;
@@ -233,6 +234,100 @@ class EngineObservationTest {
 
     assertEquals(1, events.list.size(), events.list.toString());
     assertTrue(events.list.get(0).getFormattedMessage().contains("event=bootstrap"));
+  }
+
+  @Test
+  void analysisCacheDecisionUsesEngineTraceWhenFullTraceIsOn() throws Exception {
+    LoggingRuntime runtime =
+        LoggingRuntime.initialize(
+            new WorkDirectoryResolution(tempDir, List.of()),
+            new LoggingLimits(64, 32, 32, 32, 7, 1_000_000, 256_000));
+    runtime.startFullTrace(EnumSet.of(TraceScope.ENGINE_GTP));
+    Logger trace = (Logger) LoggerFactory.getLogger(LogCategories.ENGINE_TRACE);
+    ListAppender<ILoggingEvent> events = attach(trace);
+
+    EngineObservation.traceAnalysisCacheDecision(
+        null,
+        206,
+        1842L,
+        true,
+        "KataGo",
+        10621,
+        99.87,
+        30.6,
+        10555,
+        0.12,
+        -27.1,
+        "ACCEPT",
+        "HIGHER_VISITS");
+    runtime.awaitIdle();
+
+    assertEquals(1, events.list.size(), formatted(events));
+    String message = events.list.get(0).getFormattedMessage();
+    assertTrue(message.contains("analysis-cache "), message);
+    assertTrue(message.contains("nodeMove=206"), message);
+    assertTrue(message.contains("boardRevision=1842"), message);
+    assertTrue(message.contains("blackToPlay=true"), message);
+    assertTrue(message.contains("engine=KataGo"), message);
+    assertTrue(message.contains("incomingVisits=10621"), message);
+    assertTrue(message.contains("incomingWinrate=99.87"), message);
+    assertTrue(message.contains("incomingScoreLead=30.6"), message);
+    assertTrue(message.contains("cachedVisits=10555"), message);
+    assertTrue(message.contains("cachedWinrate=0.12"), message);
+    assertTrue(message.contains("cachedScoreLead=-27.1"), message);
+    assertTrue(message.contains("decision=ACCEPT"), message);
+    assertTrue(message.contains("reason=HIGHER_VISITS"), message);
+    String persisted =
+        Files.readString(tempDir.resolve("logs/engine-trace.log"), StandardCharsets.UTF_8);
+    assertTrue(persisted.contains("analysis-cache "), persisted);
+    assertTrue(persisted.contains("reason=HIGHER_VISITS"), persisted);
+  }
+
+  @Test
+  void analysisCacheDecisionIsSkippedWhenFullTraceIsOffEvenIfTraceLoggerIsInfo() {
+    LoggingRuntime.initialize(
+        new WorkDirectoryResolution(tempDir, List.of()),
+        new LoggingLimits(64, 32, 32, 32, 7, 1_000_000, 256_000));
+    Logger trace = (Logger) LoggerFactory.getLogger(LogCategories.ENGINE_TRACE);
+    trace.setLevel(Level.INFO);
+    ListAppender<ILoggingEvent> events = attach(trace);
+
+    assertFalse(EngineObservation.traceEnabled());
+    EngineObservation.traceAnalysisCacheDecision(
+        null,
+        206,
+        1842L,
+        true,
+        "KataGo",
+        868,
+        99.91,
+        30.4,
+        10555,
+        0.12,
+        -27.1,
+        "REJECT",
+        "LOWER_VISITS");
+
+    assertTrue(events.list.isEmpty(), formatted(events));
+  }
+
+  @Test
+  void analysisCacheDecisionSanitizesUnknownReasonTokens() {
+    LoggingRuntime runtime =
+        LoggingRuntime.initialize(
+            new WorkDirectoryResolution(tempDir, List.of()),
+            new LoggingLimits(64, 32, 32, 32, 7, 1_000_000, 256_000));
+    runtime.startFullTrace(EnumSet.of(TraceScope.ENGINE_GTP));
+    Logger trace = (Logger) LoggerFactory.getLogger(LogCategories.ENGINE_TRACE);
+    ListAppender<ILoggingEvent> events = attach(trace);
+
+    EngineObservation.traceAnalysisCacheDecision(
+        null, 1, 1L, false, "KataGo", 1, 50.0, 0.0, 1, 50.0, 0.0, "REJECT", "not-a-real-reason");
+
+    assertEquals(1, events.list.size(), formatted(events));
+    String message = events.list.get(0).getFormattedMessage();
+    assertTrue(message.contains("reason=unknown"), message);
+    assertFalse(message.contains("not-a-real-reason"), message);
   }
 
   private static String formatted(ListAppender<ILoggingEvent> events) {

--- a/src/test/java/featurecat/lizzie/rules/BoardDataAnalysisCacheTraceTest.java
+++ b/src/test/java/featurecat/lizzie/rules/BoardDataAnalysisCacheTraceTest.java
@@ -1,0 +1,476 @@
+package featurecat.lizzie.rules;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import featurecat.lizzie.Config;
+import featurecat.lizzie.ConfigTestHelper;
+import featurecat.lizzie.Lizzie;
+import featurecat.lizzie.analysis.Leelaz;
+import featurecat.lizzie.analysis.MoveData;
+import featurecat.lizzie.gui.LizzieFrame;
+import featurecat.lizzie.logging.LogCategories;
+import featurecat.lizzie.logging.LoggingLimits;
+import featurecat.lizzie.logging.LoggingRuntime;
+import featurecat.lizzie.logging.TraceScope;
+import featurecat.lizzie.logging.WorkDirectoryResolution;
+import java.lang.reflect.Field;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.slf4j.LoggerFactory;
+
+class BoardDataAnalysisCacheTraceTest {
+  private static final long BOARD_REVISION = 1842L;
+
+  @TempDir Path tempDir;
+  private Config previousConfig;
+  private Board previousBoard;
+  private Leelaz previousLeelaz;
+  private LizzieFrame previousFrame;
+  private ListAppender<ILoggingEvent> traceEvents;
+
+  @BeforeEach
+  void saveGlobals() {
+    previousConfig = Lizzie.config;
+    previousBoard = Lizzie.board;
+    previousLeelaz = Lizzie.leelaz;
+    previousFrame = Lizzie.frame;
+  }
+
+  @AfterEach
+  void restoreGlobals() {
+    LoggingRuntime.resetForTests();
+    Lizzie.config = previousConfig;
+    Lizzie.board = previousBoard;
+    Lizzie.leelaz = previousLeelaz;
+    Lizzie.frame = previousFrame;
+  }
+
+  @Test
+  void primaryHigherVisitsAcceptsAndEmitsStructuredDecisionWhenTraceIsOn() throws Exception {
+    startFullTrace();
+    installBoardGlobals();
+    BoardData node = primaryNode(10555, 0.12, -27.1);
+    MoveData incoming = kataMove(10621, 99.87, 30.6);
+
+    assertTrue(
+        node.tryToSetBestMovesFromEngine(
+            new ArrayList<>(List.of(incoming)), "KataGo", Lizzie.leelaz, 10621, null, false));
+
+    assertEquals(10621, node.getPlayouts());
+    assertEquals(99.87, node.winrate, 0.0001);
+    assertDecision(
+        "ACCEPT",
+        "HIGHER_VISITS",
+        10621,
+        99.87,
+        30.6,
+        10555,
+        0.12,
+        -27.1);
+  }
+
+  @Test
+  void primaryLowerVisitsRejectsAndEmitsStructuredDecisionWhenTraceIsOn() throws Exception {
+    startFullTrace();
+    installBoardGlobals();
+    BoardData node = primaryNode(10555, 0.12, -27.1);
+    MoveData incoming = kataMove(868, 99.91, 30.4);
+
+    assertFalse(
+        node.tryToSetBestMovesFromEngine(
+            new ArrayList<>(List.of(incoming)), "KataGo", Lizzie.leelaz, 868, null, false));
+
+    assertEquals(10555, node.getPlayouts());
+    assertEquals(0.12, node.winrate, 0.0001);
+    assertDecision("REJECT", "LOWER_VISITS", 868, 99.91, 30.4, 10555, 0.12, -27.1);
+  }
+
+  @Test
+  void primaryOwnershipBackfillAcceptsMapOnlyAndEmitsDistinctReason() throws Exception {
+    startFullTrace();
+    installBoardGlobals();
+    BoardData node = primaryNode(10555, 0.12, -27.1);
+    MoveData cached = kataMove(10555, 0.12, -27.1);
+    cached.coordinate = "A1";
+    node.bestMoves = new ArrayList<>(List.of(cached));
+    MoveData incoming = kataMove(868, 99.91, 30.4);
+    incoming.coordinate = "B1";
+    List<Double> ownership = List.of(0.9, -0.8, 0.7);
+
+    assertTrue(
+        node.tryToSetBestMovesFromEngine(
+            new ArrayList<>(List.of(incoming)),
+            "KataGo",
+            Lizzie.leelaz,
+            868,
+            ownership,
+            false));
+
+    assertEquals(10555, node.getPlayouts());
+    assertEquals("A1", node.bestMoves.get(0).coordinate);
+    assertEquals(0.12, node.winrate, 0.0001);
+    assertEquals(ownership, node.estimateArray);
+    assertDecision(
+        "ACCEPT", "OWNERSHIP_BACKFILL", 868, 99.91, 30.4, 10555, 0.12, -27.1);
+  }
+
+  @Test
+  void primaryEqualVisitsWithoutOwnershipFillRejects() throws Exception {
+    startFullTrace();
+    installBoardGlobals();
+    BoardData node = primaryNode(868, 50.0, 1.5);
+
+    assertFalse(
+        node.tryToSetBestMovesFromEngine(
+            new ArrayList<>(List.of(kataMove(868, 12.0, 9.0))),
+            "KataGo",
+            Lizzie.leelaz,
+            868,
+            null,
+            false));
+
+    assertEquals(50.0, node.winrate, 0.0001);
+    assertDecision("REJECT", "EQUAL_VISITS", 868, 12.0, 9.0, 868, 50.0, 1.5);
+  }
+
+  @Test
+  void primaryForceOverrideAcceptsLowerVisits() throws Exception {
+    startFullTrace();
+    installBoardGlobals();
+    BoardData node = primaryNode(10555, 0.12, -27.1);
+
+    assertTrue(
+        node.tryToSetBestMovesFromEngine(
+            new ArrayList<>(List.of(kataMove(868, 99.91, 30.4))),
+            "KataGo",
+            Lizzie.leelaz,
+            868,
+            null,
+            true));
+
+    assertEquals(868, node.getPlayouts());
+    assertDecision("ACCEPT", "FORCE_OVERRIDE", 868, 99.91, 30.4, 10555, 0.12, -27.1);
+  }
+
+  @Test
+  void primaryChangedFlagAcceptsEqualVisits() throws Exception {
+    startFullTrace();
+    installBoardGlobals();
+    BoardData node = primaryNode(868, 50.0, 1.5);
+    node.isChanged = true;
+
+    assertTrue(
+        node.tryToSetBestMovesFromEngine(
+            new ArrayList<>(List.of(kataMove(868, 12.0, 9.0))),
+            "KataGo",
+            Lizzie.leelaz,
+            868,
+            null,
+            false));
+
+    assertEquals(12.0, node.winrate, 0.0001);
+    assertDecision("ACCEPT", "IS_CHANGED", 868, 12.0, 9.0, 868, 50.0, 1.5);
+  }
+
+  @Test
+  void primaryPdaChangeAcceptsEqualVisits() throws Exception {
+    startFullTrace();
+    installBoardGlobals();
+    BoardData node = primaryNode(868, 50.0, 1.5);
+    node.pda = 0;
+    Lizzie.leelaz.pda = 1.25;
+
+    assertTrue(
+        node.tryToSetBestMovesFromEngine(
+            new ArrayList<>(List.of(kataMove(868, 12.0, 9.0))),
+            "KataGo",
+            Lizzie.leelaz,
+            868,
+            null,
+            false));
+
+    assertEquals(12.0, node.winrate, 0.0001);
+    assertDecision("ACCEPT", "PDA_CHANGED", 868, 12.0, 9.0, 868, 50.0, 1.5);
+  }
+
+  @Test
+  void secondaryHigherVisitsAcceptsAndEmitsStructuredDecisionWhenTraceIsOn() throws Exception {
+    startFullTrace();
+    installBoardGlobals();
+    BoardData node = secondaryNode(10555, 0.12, -27.1);
+
+    node.tryToSetBestMoves2FromEngine(
+        new ArrayList<>(List.of(kataMove(10621, 99.87, 30.6))),
+        "KataGo-2",
+        Lizzie.leelaz,
+        10621,
+        null);
+
+    assertEquals(10621, node.getPlayouts2());
+    assertDecision(
+        "ACCEPT",
+        "HIGHER_VISITS",
+        10621,
+        99.87,
+        30.6,
+        10555,
+        0.12,
+        -27.1,
+        "KataGo-2");
+  }
+
+  @Test
+  void secondaryLowerVisitsRejectsAndEmitsStructuredDecisionWhenTraceIsOn() throws Exception {
+    startFullTrace();
+    installBoardGlobals();
+    BoardData node = secondaryNode(10555, 0.12, -27.1);
+
+    node.tryToSetBestMoves2FromEngine(
+        new ArrayList<>(List.of(kataMove(868, 99.91, 30.4))),
+        "KataGo-2",
+        Lizzie.leelaz,
+        868,
+        null);
+
+    assertEquals(10555, node.getPlayouts2());
+    assertDecision(
+        "REJECT", "LOWER_VISITS", 868, 99.91, 30.4, 10555, 0.12, -27.1, "KataGo-2");
+  }
+
+  @Test
+  void secondaryOwnershipBackfillAcceptsMapOnlyAndEmitsDistinctReason() throws Exception {
+    startFullTrace();
+    installBoardGlobals();
+    BoardData node = secondaryNode(10555, 0.12, -27.1);
+    MoveData cached = kataMove(10555, 0.12, -27.1);
+    cached.coordinate = "A1";
+    node.bestMoves2 = new ArrayList<>(List.of(cached));
+    MoveData incoming = kataMove(868, 99.91, 30.4);
+    incoming.coordinate = "B1";
+    List<Double> ownership = List.of(0.4, 0.5);
+
+    node.tryToSetBestMoves2FromEngine(
+        new ArrayList<>(List.of(incoming)), "KataGo-2", Lizzie.leelaz, 868, ownership);
+
+    assertEquals(10555, node.getPlayouts2());
+    assertEquals("A1", node.bestMoves2.get(0).coordinate);
+    assertEquals(ownership, node.estimateArray2);
+    assertDecision(
+        "ACCEPT",
+        "OWNERSHIP_BACKFILL",
+        868,
+        99.91,
+        30.4,
+        10555,
+        0.12,
+        -27.1,
+        "KataGo-2");
+  }
+
+  @Test
+  void traceOffDoesNotEmitAnalysisCacheLinesAndStillAcceptsHigherVisits() throws Exception {
+    startRuntimeWithoutFullTrace();
+    installBoardGlobals();
+    BoardData node = primaryNode(100, 40.0, 2.0);
+
+    assertTrue(
+        node.tryToSetBestMovesFromEngine(
+            new ArrayList<>(List.of(kataMove(200, 55.0, 3.0))),
+            "KataGo",
+            Lizzie.leelaz,
+            200,
+            null,
+            false));
+    assertEquals(200, node.getPlayouts());
+    assertFalse(hasAnalysisCacheLine(), formattedTrace());
+  }
+
+  @Test
+  void traceOffDoesNotEmitAnalysisCacheLinesAndStillRejectsLowerVisits() throws Exception {
+    startRuntimeWithoutFullTrace();
+    installBoardGlobals();
+    BoardData node = primaryNode(10555, 0.12, -27.1);
+
+    assertFalse(
+        node.tryToSetBestMovesFromEngine(
+            new ArrayList<>(List.of(kataMove(868, 99.91, 30.4))),
+            "KataGo",
+            Lizzie.leelaz,
+            868,
+            null,
+            false));
+
+    assertEquals(10555, node.getPlayouts());
+    assertFalse(hasAnalysisCacheLine(), formattedTrace());
+  }
+
+  private void startFullTrace() {
+    LoggingRuntime.current().ifPresent(LoggingRuntime::shutdown);
+    LoggingRuntime runtime =
+        LoggingRuntime.initialize(
+            new WorkDirectoryResolution(tempDir, List.of()),
+            new LoggingLimits(64, 32, 32, 32, 7, 1_000_000, 256_000));
+    runtime.startFullTrace(EnumSet.of(TraceScope.ENGINE_GTP));
+    Logger trace = (Logger) LoggerFactory.getLogger(LogCategories.ENGINE_TRACE);
+    traceEvents = attach(trace);
+  }
+
+  private void startRuntimeWithoutFullTrace() {
+    LoggingRuntime.current().ifPresent(LoggingRuntime::shutdown);
+    LoggingRuntime.initialize(
+        new WorkDirectoryResolution(tempDir, List.of()),
+        new LoggingLimits(64, 32, 32, 32, 7, 1_000_000, 256_000));
+    Logger trace = (Logger) LoggerFactory.getLogger(LogCategories.ENGINE_TRACE);
+    trace.setLevel(Level.INFO);
+    traceEvents = attach(trace);
+  }
+
+  private void installBoardGlobals() throws Exception {
+    Lizzie.config = ConfigTestHelper.createForTests(tempDir);
+    Lizzie.config.enableLizzieCache = true;
+    Lizzie.config.isAutoAna = false;
+    Board board = allocate(Board.class);
+    board.setHistory(new BoardHistoryList(BoardData.empty(Board.boardWidth, Board.boardHeight)));
+    Field revision = Board.class.getDeclaredField("contextRevision");
+    revision.setAccessible(true);
+    revision.setLong(board, BOARD_REVISION);
+    Lizzie.board = board;
+    Lizzie.leelaz = new Leelaz("");
+    Lizzie.leelaz.pda = 0;
+    Lizzie.frame = null;
+  }
+
+  private static BoardData primaryNode(int visits, double winrate, double scoreLead) {
+    BoardData node = BoardData.empty(Board.boardWidth, Board.boardHeight);
+    node.moveNumber = 206;
+    node.blackToPlay = true;
+    node.setPlayouts(visits);
+    node.winrate = winrate;
+    node.scoreMean = scoreLead;
+    return node;
+  }
+
+  private static BoardData secondaryNode(int visits, double winrate, double scoreLead) {
+    BoardData node = BoardData.empty(Board.boardWidth, Board.boardHeight);
+    node.moveNumber = 206;
+    node.blackToPlay = true;
+    node.setPlayouts2(visits);
+    node.winrate2 = winrate;
+    node.scoreMean2 = scoreLead;
+    return node;
+  }
+
+  private static MoveData kataMove(int visits, double winrate, double scoreLead) {
+    MoveData move = new MoveData();
+    move.coordinate = "D4";
+    move.playouts = visits;
+    move.winrate = winrate;
+    move.scoreMean = scoreLead;
+    move.isKataData = true;
+    return move;
+  }
+
+  private void assertDecision(
+      String decision,
+      String reason,
+      int incomingVisits,
+      double incomingWinrate,
+      double incomingScoreLead,
+      int cachedVisits,
+      double cachedWinrate,
+      double cachedScoreLead) {
+    assertDecision(
+        decision,
+        reason,
+        incomingVisits,
+        incomingWinrate,
+        incomingScoreLead,
+        cachedVisits,
+        cachedWinrate,
+        cachedScoreLead,
+        "KataGo");
+  }
+
+  private void assertDecision(
+      String decision,
+      String reason,
+      int incomingVisits,
+      double incomingWinrate,
+      double incomingScoreLead,
+      int cachedVisits,
+      double cachedWinrate,
+      double cachedScoreLead,
+      String engine) {
+    List<String> lines = analysisCacheLines();
+    assertEquals(1, lines.size(), formattedTrace());
+    String line = lines.get(0);
+    assertTrue(line.contains("analysis-cache "), line);
+    assertTrue(line.contains("nodeMove=206"), line);
+    assertTrue(line.contains("boardRevision=" + BOARD_REVISION), line);
+    assertTrue(line.contains("blackToPlay=true"), line);
+    assertTrue(line.contains("engine=" + engine), line);
+    assertTrue(line.contains("incomingVisits=" + incomingVisits), line);
+    assertTrue(line.contains("incomingWinrate=" + incomingWinrate), line);
+    assertTrue(line.contains("incomingScoreLead=" + incomingScoreLead), line);
+    assertTrue(line.contains("cachedVisits=" + cachedVisits), line);
+    assertTrue(line.contains("cachedWinrate=" + cachedWinrate), line);
+    assertTrue(line.contains("cachedScoreLead=" + cachedScoreLead), line);
+    assertTrue(line.contains("decision=" + decision), line);
+    assertTrue(line.contains("reason=" + reason), line);
+  }
+
+  private boolean hasAnalysisCacheLine() {
+    return !analysisCacheLines().isEmpty();
+  }
+
+  private List<String> analysisCacheLines() {
+    List<String> lines = new ArrayList<>();
+    if (traceEvents == null) {
+      return lines;
+    }
+    for (ILoggingEvent event : traceEvents.list) {
+      String message = event.getFormattedMessage();
+      if (message.contains("analysis-cache ")) {
+        lines.add(message);
+      }
+    }
+    return lines;
+  }
+
+  private String formattedTrace() {
+    if (traceEvents == null) {
+      return "";
+    }
+    StringBuilder text = new StringBuilder();
+    for (ILoggingEvent event : traceEvents.list) {
+      text.append(event.getFormattedMessage()).append('\n');
+    }
+    return text.toString();
+  }
+
+  private static ListAppender<ILoggingEvent> attach(Logger logger) {
+    ListAppender<ILoggingEvent> appender = new ListAppender<>();
+    appender.start();
+    logger.addAppender(appender);
+    return appender;
+  }
+
+  @SuppressWarnings("unchecked")
+  private static <T> T allocate(Class<T> type) throws Exception {
+    Field field = sun.misc.Unsafe.class.getDeclaredField("theUnsafe");
+    field.setAccessible(true);
+    return (T) ((sun.misc.Unsafe) field.get(null)).allocateInstance(type);
+  }
+}


### PR DESCRIPTION
## Repro
With Full Trace / `engine-gtp` on, write an engine analysis result into a history node. The cache ACCEPT/REJECT decision (incoming vs cached visits/winrate/scoreLead, reason) does not appear in Full Trace, so analysis anomalies are hard to diagnose from the diagnostic pack alone.

## Cause
`BoardData.tryToSetBestMovesWithStatusFromEngine` and `tryToSetBestMoves2FromEngine` already gate writes with visits / `isChanged` / PDA / `forceOverride` / ownership backfill, but `BoardData` had no `EngineObservation` / ENGINE_TRACE calls and the repo had no `analysis-cache` decision log.

## Fix
- Emit one structured `analysis-cache` decision on existing `ENGINE_TRACE` / `engine-gtp` when `EngineObservation.traceEnabled()` is on.
- Primary and secondary paths: nodeMove, boardRevision, blackToPlay, engine, incoming vs cached visits/winrate/scoreLead, `ACCEPT`/`REJECT`, reason tokens aligned to real branches (`HIGHER_VISITS`, `LOWER_VISITS`, `OWNERSHIP_BACKFILL`, `FORCE_OVERRIDE`, `IS_CHANGED`, `PDA_CHANGED`, `EQUAL_VISITS`, ungated accept).
- Trace off: no expensive detail construction; cache return values unchanged.
- No ConfigDialog2, no new settings/UI/channel. Reuses existing diagnostic pack `engine-trace` export.
- CI follow-up (unrelated to #424 semantics): Windows `updateEnginesSchedulingFailureKeepsPrimaryWhenLifecycleCloseAlsoFails` — fixture always throws the injected lifecycle close failure in `finally` so a real teardown exception cannot skip it; uncaught handler matches by identity. Assertion unchanged.

## Verification
Local: `BoardDataAnalysisCacheTraceTest` / `EngineObservationTest` plus full `EngineManagerLifecycleReservationTest` (167) green. GitHub Checks on `fcda86f8`: Linux build PASS, Windows script validation PASS. No desktop shots.

Fixes #424
