### PR TITLE
fix(gui): prevent rules dialogs from interrupting engine games

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable maintenance updates to this fork are documented here.
 
 ## Unreleased
 
+- Prevented KataGo rules dialogs from interrupting engine games while their participants remain occupied (#421).
 - Added CI to build the shaded jar on push and pull request.
 - Added Dependabot configuration for Maven dependencies and GitHub Actions.
 - Added installation, troubleshooting, maintenance, and release-process docs.

--- a/src/main/java/featurecat/lizzie/gui/LizzieFrame.java
+++ b/src/main/java/featurecat/lizzie/gui/LizzieFrame.java
@@ -12225,6 +12225,7 @@ public class LizzieFrame extends JFrame {
   }
 
   public void setRules() {
+    if (SetKataRules.rejectEngineGameInteraction()) return;
     if (isWholeGameAnalysisStartingOrRunning()) {
       Utils.showMsg(Lizzie.resourceBundle.getString("WholeGameAnalysis.conflict.analysis"));
       return;

--- a/src/main/java/featurecat/lizzie/gui/SetKataRules.java
+++ b/src/main/java/featurecat/lizzie/gui/SetKataRules.java
@@ -1,6 +1,7 @@
 package featurecat.lizzie.gui;
 
 import featurecat.lizzie.Lizzie;
+import featurecat.lizzie.analysis.EngineManager;
 import featurecat.lizzie.analysis.Leelaz;
 import featurecat.lizzie.util.Utils;
 import java.awt.Dimension;
@@ -309,6 +310,7 @@ public class SetKataRules extends JDialog {
     btnApply.addActionListener(
         new ActionListener() {
           public void actionPerformed(ActionEvent e) {
+            if (rejectEngineGameInteraction()) return;
             if (!isCurrentEngine() || !engine.isLoaded() || !engine.isStarted()) {
               Utils.showMsg(resourceBundle.getString("LizzieFrame.setParamNoEngineHint"));
               setVisible(false);
@@ -461,6 +463,7 @@ public class SetKataRules extends JDialog {
       //      msg.setVisible(true);
       Utils.showMsg(resourceBundle.getString("SetKataRules.notKataGoHint"));
     }
+    if (rejectEngineGameInteraction()) return;
     engine.recentRulesLine = "";
     engine.getParameterScadule(false);
     engine.nameCmd();
@@ -468,7 +471,7 @@ public class SetKataRules extends JDialog {
   }
 
   private void closeDialog() {
-    if (isCurrentEngine() && engine.isPondering()) {
+    if (!rejectEngineGameInteraction() && isCurrentEngine() && engine.isPondering()) {
       engine.ponder();
     }
     setVisible(false);
@@ -517,6 +520,12 @@ public class SetKataRules extends JDialog {
 
       return true;
     }
+  }
+
+  static boolean rejectEngineGameInteraction() {
+    if (!EngineManager.occupiesEngineGameAdmission()) return false;
+    Utils.showMsg(Lizzie.resourceBundle.getString("AnalysisSettings.reuseStatus.engine_game"));
+    return true;
   }
 
   private boolean isCurrentEngine() {

--- a/src/test/java/featurecat/lizzie/analysis/EngineManagerEngineGameStateMachineTest.java
+++ b/src/test/java/featurecat/lizzie/analysis/EngineManagerEngineGameStateMachineTest.java
@@ -2191,6 +2191,22 @@ class EngineManagerEngineGameStateMachineTest {
   }
 
   @Test
+  void rulesEntryDuringEngineGameDoesNotInterruptAutomaticMoves() {
+    EngineManager.EngineGameOwnerTransaction transaction = startExactAnalysisGame();
+    startExactAnalyze(black, transaction, "B");
+    playExactAnalysisMove(black, "D4", 1);
+    playExactAnalysisMove(white, "Q16", 2);
+    Lizzie.setPrimaryEngine(black);
+    String before = black.commandText();
+
+    Lizzie.frame.setRules();
+
+    assertEquals(before, black.commandText());
+    playExactAnalysisMove(black, "C3", 3);
+    assertTrue(EngineManager.isCurrentEngineGameTransaction(transaction));
+  }
+
+  @Test
   void exactAnalysisParticipantsAlternateFourMovesAndRefreshCurrentOutput() {
     EngineManager.EngineGameOwnerTransaction transaction = startExactAnalysisGame();
     startExactAnalyze(black, transaction, "B");


### PR DESCRIPTION
## Summary

- Guard KataGo rules dialog entry, initial probes, apply, and close actions with the existing engine-game admission check.
- Reject conflicting interactions before sending ordinary GTP commands or changing analysis data and rule settings.
- Reuse localized engine-game occupancy feedback.
- Add a regression test verifying that opening rules during an engine game leaves the command stream unchanged and automatic moves continue.

Fixes #421.

## Type Of Change

- [x] Bug fix

## Testing

- [x] Tested locally: five focused engine-game state-machine tests and three localization parity tests passed.
- [x] The new rules-entry regression failed before the fix and passed afterward.
- [x] Headless smoke checks exercised the real rules apply/close handlers and command queue.
- [x] Windows Maven shaded-JAR build succeeded for commit 28b6c862.
- [x] Updated CHANGELOG.md.
- [x] Verified there is no unrelated formatting or line-ending churn.
- [x] Ran python3 scripts/check_line_endings.py.

Windows manual checks with native KataGo:
- Analysis-mode game: rules entry was rejected with explicit feedback; both engines continued playing.
- After ending the analysis-mode game: rules could be opened, changed, and read back correctly.
- Genmove-mode game: rules entry was rejected; both engines continued playing.
- Rules dialog opened before a genmove game: applying a change was rejected without sending rules commands; play continued.
- Cancelling that pre-opened dialog closed it after acknowledging the occupancy message; play continued without ordinary analysis commands being inserted.

Escape and the title-bar close button were not exercised separately. Screenshots and bounded logs were retained locally, not attached to this PR.

## Notes

Manual testing also exposed a pre-existing genmove-retirement defect:
after terminating a genmove game, the foreground engine could be
force-stopped and require reloading before rules were available again.

A controlled replay identified missing handling of a late, unnumbered
`play ...` terminal after transaction retirement, plus premature settlement
of an empty numbered analyze ACK received after retirement. The affected
Leelaz and EngineManager code is unchanged by this PR and already exists
in its upstream base.

This PR therefore does not claim that every post-genmove engine-recovery
scenario passes. That lifecycle defect needs a separate fix.

The change is in shared Java GUI code; desktop acceptance was performed
on Windows only.