### PR TITLE
fix(engine): retire streaming genmove safely and restore foreground state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable maintenance updates to this fork are documented here.
 
 ## Unreleased
 
+- Fixed stopped streaming-genmove requests to keep the initial ACK separate from the final move, drain late results without changing client history, and restore the foreground engine position before reuse.
 - Added CI to build the shaded jar on push and pull request.
 - Added Dependabot configuration for Maven dependencies and GitHub Actions.
 - Added installation, troubleshooting, maintenance, and release-process docs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,6 @@ All notable maintenance updates to this fork are documented here.
 
 ## Unreleased
 
-- Fixed stopped streaming-genmove requests to keep the initial ACK separate from the final move, drain late results without changing client history, and restore the foreground engine position before reuse.
-- Fixed engine-game startup when the foreground engine moves first by handing the settings dialog's mode reservation to the new game before genmove dispatch; failed starts retain reservation-protected editing for retry.
 - Added CI to build the shaded jar on push and pull request.
 - Added Dependabot configuration for Maven dependencies and GitHub Actions.
 - Added installation, troubleshooting, maintenance, and release-process docs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable maintenance updates to this fork are documented here.
 ## Unreleased
 
 - Fixed stopped streaming-genmove requests to keep the initial ACK separate from the final move, drain late results without changing client history, and restore the foreground engine position before reuse.
+- Fixed engine-game startup when the foreground engine moves first by handing the settings dialog's mode reservation to the new game before genmove dispatch; failed starts retain reservation-protected editing for retry.
 - Added CI to build the shaded jar on push and pull request.
 - Added Dependabot configuration for Maven dependencies and GitHub Actions.
 - Added installation, troubleshooting, maintenance, and release-process docs.

--- a/docs/SNAPSHOT_NODE_KIND.md
+++ b/docs/SNAPSHOT_NODE_KIND.md
@@ -124,6 +124,8 @@ ReadBoard 协议里的 `pass` 行在自动落子/交换顺序链路中表示用�
 - foreground/GMA adapter 只负责把自己的 session/reservation identity 映射为 opaque admission，再调用 generic history/current-position capture；产品-specific stop、name、komi、clear、quarantine 与 completion policy 留在 adapter/owner。
 - 自动/直接 restart 的 exact 与 root 路线都经过同一个 owner board synchronization fence；owner 只能在 fence 成功后恢复 captured ponder，失败或不可用时不启动分析，并在既有 completion boundary 释放 reservation。
 - `Leelaz` 继续唯一拥有 ordinary command queue、response handler、timeout、late-response retirement、output-stream invalidation 与 engine arbitration；exact module 只通过窄 admission-aware seam 使用这些能力。
+- 手动终止 genmove 对局后，空 numbered ACK 仍是非终态；迟到的合法 analyze `play` 只结清原 reader binding 的 pending handler，不追加应用的真实 `MOVE/PASS` 或比赛结果。缺失终态继续按既有五秒物理请求 watchdog 回收。
+- 已停止对局的前台引擎在物理请求退役后，由 `EngineManager` 异步冻结并执行当前应用盘面的 root/exact 恢复；退役屏障保留到既有稳定 board synchronization fence 完成。恢复命令仅获该 lifecycle owner 对原 binding 的写入授权，失败将原目标标为 unavailable，替换实例不受旧归还影响；手动停止不自动恢复 ponder。
 - `PreparedRestore` 可在首次 `execute()` 前由捕获它的 owner 调用 one-shot `discard()` 释放 captured admission；`discard()` 不写临时 SGF、不发任何命令。首次 `execute()` 或 `discard()` 后，另一操作必须以既有 `Exact snapshot restore has already been executed` 失败；一旦 execute 开始，所有失败仍按 owner 的既有 fail-closed 语义处理。
 - 没有可用静态锚点时，调用方保留既有 root replay；默认空 root 不是 exact 锚点。exact 一旦开始，`loadsgf`、tail 或 arbitration 失败都原样失败，禁止猜测性 root fallback。
 - lifecycle exact/root 抛错时，owner 将 frozen target 标为 unavailable，并在既有 completion boundary 释放 reservation；不因本票据新建 `ENGINE_STATE_UNRESTORED` 或通用 retry。ReadBoard GMA 固定点既有 quarantine/retirement 行为保持独立。

--- a/src/main/java/featurecat/lizzie/analysis/EngineManager.java
+++ b/src/main/java/featurecat/lizzie/analysis/EngineManager.java
@@ -222,6 +222,8 @@ public class EngineManager {
     private final AtomicBoolean rollbackFinished = new AtomicBoolean();
     private final AtomicBoolean retirementCompletionClaimed = new AtomicBoolean();
     private final AtomicBoolean retirementFinished = new AtomicBoolean();
+    private Runnable foregroundHandback;
+    private volatile InitialEngineStartupSynchronization foregroundSynchronization;
     private final AtomicReference<EngineGameRetirementContinuation> retirementContinuation =
         new AtomicReference<>();
     /** Guarded by {@link #ENGINE_SELECTION_STATE_LOCK}. */
@@ -236,6 +238,7 @@ public class EngineManager {
     private volatile EngineCountDown whiteCountDown;
     private volatile boolean gameWasActiveBeforeTerminal;
     private volatile boolean gameWasStartingBeforeTerminal;
+    private volatile boolean gameHadUnfinishedWork;
     private volatile Throwable terminalFailure;
     private volatile boolean externalTerminalOwner;
     private volatile long inactiveEpoch = -1L;
@@ -2266,6 +2269,21 @@ public class EngineManager {
       throw stopFailure;
     } finally {
       if (stoppedTransaction != null) {
+        if (mannul && stopClaim.wasActive && plan != null && plan.genmove()
+            && stoppedTransaction.gameHadUnfinishedWork) {
+          Leelaz target = Lizzie.leelaz;
+          Board board = Lizzie.board;
+          Object incarnation =
+              target == stoppedTransaction.blackEngine
+                  ? stoppedTransaction.blackIncarnation
+                  : target == stoppedTransaction.whiteEngine
+                      ? stoppedTransaction.whiteIncarnation
+                      : null;
+          if (target != null && incarnation != null) {
+            stoppedTransaction.foregroundHandback =
+                () -> restoreStoppedEngineGameForeground(stoppedTransaction, target, incarnation, board);
+          }
+        }
         finishEngineGameTransactionRetirement(stoppedTransaction, restoreOnFailure);
       }
     }
@@ -7318,7 +7336,7 @@ public class EngineManager {
    * authorize a quarantine write.
    */
   static TransactionlessAnalysisWriteLease claimTransactionlessAnalysisWrite(
-      Leelaz engine, Object expectedIncarnation, Object recoveryToken) {
+      Leelaz engine, Object expectedIncarnation, Object recoveryToken, Object restoreOwner) {
     if (engine == null || expectedIncarnation == null) {
       return null;
     }
@@ -7342,7 +7360,17 @@ public class EngineManager {
           }
           kind = TransactionlessAnalysisWriteKind.RECOVERY_TOMBSTONE;
         } else if (hasBarrier) {
-          return null;
+          EngineGameOwnerTransaction retiring = retiringEngineGameTransaction;
+          InitialEngineStartupSynchronization handback =
+              retiring == null ? null : retiring.foregroundSynchronization;
+          if (handback == null || restoreOwner != handback.lifecycleOwner
+              || handback.targetEngine != engine || Lizzie.board != handback.board
+              || Lizzie.leelaz != engine
+              || (engine == retiring.blackEngine ? retiring.blackIncarnation : retiring.whiteIncarnation)
+                  != expectedIncarnation) {
+            return null;
+          }
+          kind = TransactionlessAnalysisWriteKind.ORDINARY;
         } else {
           kind = TransactionlessAnalysisWriteKind.ORDINARY;
         }
@@ -7689,6 +7717,7 @@ public class EngineManager {
           transaction.gameWasStartingBeforeTerminal =
               transaction.phase == EngineGamePhase.PREPARING
                   || transaction.phase == EngineGamePhase.DISPATCHED;
+          transaction.gameHadUnfinishedWork = transaction.operationsInFlight.get() != 0;
           transaction.phase = terminalPhase;
           transaction.terminalFailure = failure;
           transaction.externalTerminalOwner = externalTerminalOwner;
@@ -8002,7 +8031,69 @@ public class EngineManager {
       transaction.terminalFailure =
           appendEngineGameFailure(transaction.terminalFailure, cleanupFailure);
     }
-    completeEngineGameTransactionRetirement(transaction);
+    if (transaction.foregroundHandback != null) {
+      try {
+        Thread worker =
+            transaction.manager.createEngineGameRetirementContinuationWorker(
+                transaction.foregroundHandback, "engine-game-handback-" + transaction.epoch);
+        worker.setDaemon(true);
+        worker.start();
+      } catch (RuntimeException | Error failure) {
+        transaction.terminalFailure = appendEngineGameFailure(transaction.terminalFailure, failure);
+        transaction.blackEngine.runIfCurrentEngineIncarnation(
+            transaction.blackIncarnation, () -> transaction.blackEngine.isLoaded = false);
+        transaction.whiteEngine.runIfCurrentEngineIncarnation(
+            transaction.whiteIncarnation, () -> transaction.whiteEngine.isLoaded = false);
+        completeEngineGameTransactionRetirement(transaction);
+      }
+    } else {
+      completeEngineGameTransactionRetirement(transaction);
+    }
+  }
+
+  private static void restoreStoppedEngineGameForeground(
+      EngineGameOwnerTransaction transaction, Leelaz target, Object incarnation, Board board) {
+    InitialEngineStartupSynchronization synchronization = null;
+    try {
+      if (!target.isCurrentLiveEngineIncarnation(incarnation)) {
+        completeEngineGameTransactionRetirement(transaction);
+        return;
+      }
+      synchronization =
+          InitialEngineStartupSynchronization.capturePrepared(null, target, null, board, false, false);
+      InitialEngineStartupSynchronization handback = synchronization;
+      transaction.foregroundSynchronization = handback;
+      handback.beforeRestore =
+          () -> {
+            if (Lizzie.board != board || Lizzie.leelaz != target
+                || !target.isCurrentLiveEngineIncarnation(incarnation)) {
+              throw new IllegalStateException("Stopped game foreground context changed before restore");
+            }
+          };
+      handback.acquireReservation();
+      handback.beginLifecycleCompletionClaim();
+      handback.runAfterCompletionRelease(() -> completeEngineGameTransactionRetirement(transaction));
+      handback.runUntilStable();
+      handback.confirmFinalBoardSynchronization(
+          handback::close,
+          detail -> {
+            try {
+              target.runIfCurrentEngineIncarnation(incarnation, () -> target.isLoaded = false);
+              transaction.terminalFailure =
+                  appendEngineGameFailure(transaction.terminalFailure, new IllegalStateException(detail));
+            } finally {
+              handback.close();
+            }
+          });
+    } catch (RuntimeException | Error failure) {
+      transaction.terminalFailure = appendEngineGameFailure(transaction.terminalFailure, failure);
+      target.runIfCurrentEngineIncarnation(incarnation, () -> target.isLoaded = false);
+      try {
+        if (synchronization != null) synchronization.close();
+      } finally {
+        completeEngineGameTransactionRetirement(transaction);
+      }
+    }
   }
 
   private static void completeEngineGameTransactionRetirement(EngineGameOwnerTransaction transaction) {

--- a/src/main/java/featurecat/lizzie/analysis/Leelaz.java
+++ b/src/main/java/featurecat/lizzie/analysis/Leelaz.java
@@ -4788,6 +4788,25 @@ public class Leelaz {
       // Analyze-style genmove streams ACK with an empty numbered "=" and finish on unnumbered "play".
       return;
     }
+    if (moveResponseHandler != null
+        && moveResponseHandler.isAnalyzeStream()
+        && line.startsWith("=")
+        && parseResponseCommandId(line) != NO_RESPONSE_COMMAND_ID
+        && gtpResponsePayload(line).isEmpty()) {
+      // A numbered empty ACK opens the stream, even after its game has stopped.
+      isCommandLine = false;
+      return;
+    }
+    String analyzeTerminal = null;
+    if (moveResponseHandler != null && moveResponseHandler.acceptsUnnumberedAnalyzePlay(line)) {
+      String[] terminalParts = line.trim().split("\\s+");
+      if (terminalParts.length == 2
+          && (terminalParts[1].equalsIgnoreCase("pass")
+              || terminalParts[1].equalsIgnoreCase("resign")
+              || Board.asCoordinates(terminalParts[1]).isPresent())) {
+        analyzeTerminal = terminalParts[1];
+      }
+    }
     EngineManager.EngineGameMoveResponseContext moveResponseContext =
         moveResponseHandler == null ? null : moveResponseHandler.context;
     long startupPrimaryGenerationAtParse =
@@ -4795,13 +4814,18 @@ public class Leelaz {
     EngineManager.EngineGameMoveResponseLease responseLease =
         EngineManager.claimEngineGameMoveResponse(moveResponseContext);
     if (responseLease == null) {
-      // A numbered response from a retired transaction still owns its exact pending handler.
-      // Drain that handler so its WRITE_CLAIMED carrier cannot block a successor, but perform no
-      // board, UI, or engine-game side effects.
+      // Retired responses retain their exact pending handler but have no game side effects.
       if (moveResponseHandler != null
           && parseResponseCommandId(line) != NO_RESPONSE_COMMAND_ID) {
         processCommandResponseLine(line, sourceEngineIncarnation);
         isCommandLine = false;
+      } else if (analyzeTerminal != null) {
+        int pendingId = pendingResponseCommandIdFor(moveResponseHandler);
+        if (pendingId != NO_RESPONSE_COMMAND_ID) {
+          processCommandResponseLine(
+              "=" + pendingId + " " + analyzeTerminal, sourceEngineIncarnation);
+          isCommandLine = false;
+        }
       } else if (moveResponseHandler != null
           && moveResponseHandler.awaitingPassingCoordinate
           && !line.startsWith("info")) {
@@ -4945,15 +4969,6 @@ public class Leelaz {
               : line.trim().split(" ");
       // currentCmdNum = Integer.parseInt(params[0].substring(1).trim());
       if (params.length <= 1) {
-        if (moveResponseHandler != null
-            && moveResponseHandler.isAnalyzeStream()
-            && line.startsWith("=")
-            && parseResponseCommandId(line) != NO_RESPONSE_COMMAND_ID) {
-          // kata-genmove_analyze / lz-genmove_analyze ACK. Keep the numbered carrier in flight
-          // until the later unnumbered play/resign/pass terminal.
-          isCommandLine = false;
-          return;
-        }
         if (parseResponseCommandId(line) != NO_RESPONSE_COMMAND_ID) {
           processCommandResponseLine(line, sourceEngineIncarnation);
           afterEngineGameResponseSettledForTest();
@@ -11330,9 +11345,10 @@ public class Leelaz {
     final boolean[] sent = new boolean[1];
     boolean ownerCurrent =
         admission.runIfCurrentBoardSyncPrimary(
-            () ->
-                sent[0] =
-                    sendExactSnapshotRestoreCommandAdmitted(command, onResponse, onSendFailure, admission));
+            () -> withExactSnapshotRestoreAdmission(
+                admission,
+                () -> sent[0] =
+                    sendExactSnapshotRestoreCommandAdmitted(command, onResponse, onSendFailure, admission)));
     return ownerCurrent && sent[0];
   }
 
@@ -11779,7 +11795,8 @@ public class Leelaz {
               EngineManager.claimTransactionlessAnalysisWrite(
                   this,
                   outputBinding,
-                  outputBinding == null ? null : outputBinding.analysisOutputRecoveryToken);
+                  outputBinding == null ? null : outputBinding.analysisOutputRecoveryToken,
+                  queuedCommand.restoreAdmission == null ? null : queuedCommand.restoreAdmission.ownerIdentity);
           if (transactionlessAnalysisWrite == null) {
             throw new AnalysisOutputAdmissionFailure(
                 "analysis/state output is blocked by an unrelated game or recovery owner");
@@ -18349,6 +18366,7 @@ public class Leelaz {
     private final RestartBootstrapReceipt restartBootstrapReceipt;
     private final ReaderStreamBinding readBoardGmaResponseBinding;
     private final Object expectedLeela0110StateToken;
+    private final ExactSnapshotRestoreAdmission restoreAdmission = exactSnapshotRestoreAdmissionContext.get();
     private boolean foregroundRestoreCommand;
     private RuntimeException cancellationFailure;
     private boolean outputWriteStarted;

--- a/src/main/java/featurecat/lizzie/gui/LizzieFrame.java
+++ b/src/main/java/featurecat/lizzie/gui/LizzieFrame.java
@@ -12390,11 +12390,34 @@ public class LizzieFrame extends JFrame {
     }
   }
 
+  private Leelaz.EngineModeReservation engineGameDialogReservation;
+
+  boolean reserveEngineGameDialog() {
+    if (engineGameDialogReservation != null) return true;
+    Leelaz engine = Lizzie.leelaz;
+    if (engine == null) return true;
+    engineGameDialogReservation = engine.beginEngineModeReservation();
+    if (engineGameDialogReservation != null) return true;
+    showForegroundEngineModeReservationConflict();
+    return false;
+  }
+
+  void releaseEngineGameDialog() {
+    Leelaz.EngineModeReservation reservation = engineGameDialogReservation;
+    engineGameDialogReservation = null;
+    if (reservation != null) reservation.close();
+  }
+
   public void startEngineGameDialog() {
     if (deferUntilHumanSlExit(this::startEngineGameDialog)) {
       return;
     }
-    runWithForegroundEngineModeReservation(this::startEngineGameDialogReserved);
+    if (!reserveEngineGameDialog()) return;
+    try {
+      startEngineGameDialogReserved();
+    } finally {
+      releaseEngineGameDialog();
+    }
   }
 
   protected void startEngineGameDialogReserved() {

--- a/src/main/java/featurecat/lizzie/gui/NewEngineGameDialog.java
+++ b/src/main/java/featurecat/lizzie/gui/NewEngineGameDialog.java
@@ -1014,6 +1014,7 @@ public class NewEngineGameDialog extends JDialog {
   }
 
   public void apply() {
+    if (!Lizzie.frame.reserveEngineGameDialog()) return;
     try {
       // validate data
       if (Lizzie.config.chkEngineSgfStart) {
@@ -1135,6 +1136,9 @@ public class NewEngineGameDialog extends JDialog {
       EngineGameBatchSpec spec =
           EngineGameBatchSpecFactory.from(
               EngineGameBatchSpecCapture.fromToolbar(LizzieFrame.toolbar, Utils.getEngineData()));
+      // The exact game owner must acquire its own lifecycle before its worker emits genmove.
+      // Keeping the modal dialog's EDT reservation until playing() would reject that first move.
+      Lizzie.frame.releaseEngineGameDialog();
       Acceptance acceptance =
           Lizzie.engineGame.accept(
               spec,
@@ -1150,6 +1154,10 @@ public class NewEngineGameDialog extends JDialog {
                   pendingEngineGameStart = false;
                   cancelled = true;
                   okButton.setEnabled(true);
+                  if (!Lizzie.frame.reserveEngineGameDialog()) {
+                    setVisible(false);
+                    return;
+                  }
                   if (!(failure instanceof StartFailure.CancelledByUser)) {
                     Utils.showMsg(
                         Lizzie.resourceBundle.getString("EngineManager.engineGameStartFailed"),
@@ -1161,6 +1169,7 @@ public class NewEngineGameDialog extends JDialog {
         pendingEngineGameStart = false;
         cancelled = true;
         okButton.setEnabled(true);
+        if (!Lizzie.frame.reserveEngineGameDialog()) setVisible(false);
       }
 
     } catch (ParseException e) {

--- a/src/test/java/featurecat/lizzie/analysis/EngineManagerEngineGameStateMachineTest.java
+++ b/src/test/java/featurecat/lizzie/analysis/EngineManagerEngineGameStateMachineTest.java
@@ -45,6 +45,8 @@ import javax.swing.SwingUtilities;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 class EngineManagerEngineGameStateMachineTest {
   private EngineManager previousManager;
@@ -1051,6 +1053,113 @@ class EngineManagerEngineGameStateMachineTest {
     assertEquals(1, Lizzie.board.getHistory().getMoveNumber());
     assertTrue(EngineManager.isCurrentEngineGameTransaction(transaction));
     assertEquals(EngineManager.EngineGamePhase.ACTIVE, transaction.phase());
+  }
+
+  @Test
+  void retiredAnalyzeTerminalAfterInitialAckDrainsWithoutLateMoveOrForce() throws Exception {
+    WatchdogEngineManager manager = installManager(new WatchdogEngineManager(allEngines()));
+    black.isKatago = true;
+    EngineManager.EngineGameOwnerTransaction transaction =
+        activeTransaction(manager, EngineGamePlans.harness(0, 1, true), black, 0);
+    assertTrue(black.genmoveForPk("B", transaction));
+    int commandId = firstCommandId(black.commandText());
+    black.parseEngineGameLineForTest("=" + commandId);
+
+    manager.clearEngineGame();
+    assertNull(EngineManager.beginEngineGameTransaction(manager, gameInfo(), null, true));
+    black.parseEngineGameLineForTest("play D4");
+
+    assertEquals(0, Lizzie.board.getHistory().getMoveNumber());
+    assertEquals(EngineManager.EngineGamePhase.CANCELLED, transaction.phase());
+    assertEquals(0, transaction.openPhysicalRequestsForTest());
+    assertEquals(0, transaction.operationsInFlightForTest());
+    manager.runWatchdog();
+    assertEquals(0, black.forceQuitAttempts.get());
+    assertTrue(black.isStarted());
+    assertTrue(black.isLoaded());
+    assertNotNull(EngineManager.beginEngineGameTransaction(manager, gameInfo(), null, true));
+  }
+
+  @Test
+  void retiredAnalyzeInitialAckKeepsSuccessorBlockedUntilTerminal() throws Exception {
+    WatchdogEngineManager manager = installManager(new WatchdogEngineManager(allEngines()));
+    black.isKatago = true;
+    EngineManager.EngineGameOwnerTransaction transaction =
+        activeTransaction(manager, EngineGamePlans.harness(0, 1, true), black, 0);
+    assertTrue(black.genmoveForPk("B", transaction));
+    int commandId = firstCommandId(black.commandText());
+    manager.clearEngineGame();
+
+    black.parseEngineGameLineForTest("=" + commandId);
+    assertEquals(1, transaction.openPhysicalRequestsForTest());
+    assertNull(EngineManager.beginEngineGameTransaction(manager, gameInfo(), null, true));
+    black.parseEngineGameLineForTest(kataAnalysisInfo());
+    black.parseEngineGameLineForTest("play");
+    black.parseEngineGameLineForTest("play not-a-coordinate");
+    assertEquals(1, transaction.openPhysicalRequestsForTest());
+    black.parseEngineGameLineForTest("play pass");
+
+    assertEquals(0, Lizzie.board.getHistory().getMoveNumber());
+    assertEquals(EngineManager.EngineGamePhase.CANCELLED, transaction.phase());
+    assertEquals(0, transaction.openPhysicalRequestsForTest());
+    assertEquals(0, transaction.operationsInFlightForTest());
+    manager.runWatchdog();
+    assertEquals(0, black.forceQuitAttempts.get());
+    assertTrue(black.isStarted());
+    assertTrue(black.isLoaded());
+    assertNotNull(EngineManager.beginEngineGameTransaction(manager, gameInfo(), null, true));
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {false, true})
+  void manualStopRestoresPositionBeforeSuccessfulOrFailedForegroundFence(boolean failFence)
+      throws Exception {
+    WatchdogEngineManager manager = installManager(new WatchdogEngineManager(allEngines()));
+    Field wrnControl = Menu.class.getDeclaredField("chkWRN");
+    wrnControl.setAccessible(true);
+    wrnControl.set(LizzieFrame.menu, new featurecat.lizzie.gui.JFontCheckBox());
+    LizzieFrame.menu.txtWRN = new featurecat.lizzie.gui.JFontTextField();
+    black.isKatago = true;
+    AtomicBoolean engineHasLateStone = new AtomicBoolean();
+    AtomicBoolean engineBlackToPlay = new AtomicBoolean(true);
+    AtomicBoolean restoring = new AtomicBoolean();
+    ExactSnapshotRestoreProtocolFixture.Transport protocol =
+        ExactSnapshotRestoreProtocolFixture.install(
+            black,
+            command -> {
+              if (command.startsWith("kata-genmove_analyze")) return null;
+              if (command.equals("clear_board") || command.startsWith("boardsize ")) {
+                engineHasLateStone.set(false);
+                engineBlackToPlay.set(true);
+                restoring.set(true);
+              }
+              if (command.equals("name") && restoring.get()) return null;
+              return ExactSnapshotRestoreProtocolFixture.Response.success();
+            });
+    EngineManager.EngineGameOwnerTransaction transaction =
+        activeTransaction(manager, EngineGamePlans.harness(0, 1, true), black, 0);
+    assertTrue(black.genmoveForPk("B", transaction));
+    manager.stopEngineGame(0, true);
+    engineHasLateStone.set(true);
+    engineBlackToPlay.set(false);
+    black.parseEngineGameLineForTest("play D4");
+    assertNotNull(manager.retirementWorker);
+    manager.retirementWorker.join(2_000L);
+    assertFalse(manager.retirementWorker.isAlive());
+
+    assertEquals(0, Lizzie.board.getHistory().getMoveNumber());
+    assertFalse(engineHasLateStone.get(), "foreground engine must not retain the late D4 stone");
+    assertEquals(Lizzie.board.getHistory().isBlacksTurn(), engineBlackToPlay.get());
+    assertFalse(black.isPondering());
+    assertNull(EngineManager.beginEngineGameTransaction(manager, gameInfo(), null, true));
+    assertNull(black.beginExclusiveGtpLifecycleReservation());
+    List<String> commands = protocol.rawCommands();
+    int fenceId = firstCommandId(commands.get(commands.size() - 1));
+    black.processCommandResponseLineForTest((failFence ? "?" : "=") + fenceId);
+    assertEquals(!failFence, black.isLoaded());
+    assertTrue(black.isStarted());
+    assertFalse(black.isPondering());
+    assertNotNull(EngineManager.beginEngineGameTransaction(manager, gameInfo(), null, true));
   }
 
   @Test
@@ -4858,6 +4967,13 @@ class EngineManagerEngineGameStateMachineTest {
   private static final class WatchdogEngineManager extends ImmediateUiEngineManager {
     private final AtomicReference<Runnable> pendingWatchdog = new AtomicReference<>();
     private volatile RuntimeException graceFailure;
+    private volatile Thread retirementWorker;
+
+    @Override
+    protected Thread createEngineGameRetirementContinuationWorker(Runnable task, String name) {
+      retirementWorker = super.createEngineGameRetirementContinuationWorker(task, name);
+      return retirementWorker;
+    }
 
     private WatchdogEngineManager(List<Leelaz> engines) {
       super(engines);

--- a/src/test/java/featurecat/lizzie/analysis/EngineManagerInitialStartupSynchronizationTest.java
+++ b/src/test/java/featurecat/lizzie/analysis/EngineManagerInitialStartupSynchronizationTest.java
@@ -2261,7 +2261,7 @@ class EngineManagerInitialStartupSynchronizationTest {
           assertEquals("EXACT_RETIRED", previous.analysisOutputRouteForTest());
           unexpectedLease =
               EngineManager.claimTransactionlessAnalysisWrite(
-                  previous, failedBinding, failedRecoveryToken);
+                  previous, failedBinding, failedRecoveryToken, null);
           assertNull(
               unexpectedLease,
               "a failed recovery capability must reject ordinary ownership after barrier clear");

--- a/src/test/java/featurecat/lizzie/gui/EngineGameDialogReservationTest.java
+++ b/src/test/java/featurecat/lizzie/gui/EngineGameDialogReservationTest.java
@@ -1,0 +1,52 @@
+package featurecat.lizzie.gui;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import featurecat.lizzie.Lizzie;
+import featurecat.lizzie.analysis.Leelaz;
+import java.lang.reflect.Field;
+import java.util.concurrent.FutureTask;
+import java.util.concurrent.TimeUnit;
+import javax.swing.SwingUtilities;
+import org.junit.jupiter.api.Test;
+
+class EngineGameDialogReservationTest {
+  @Test
+  void dialogHandsExclusiveEngineToWorkerAndCanReserveAgainAfterFailedStart() throws Exception {
+    Leelaz previous = Lizzie.leelaz;
+    Field unsafeField = sun.misc.Unsafe.class.getDeclaredField("theUnsafe");
+    unsafeField.setAccessible(true);
+    LizzieFrame frame =
+        (LizzieFrame) ((sun.misc.Unsafe) unsafeField.get(null)).allocateInstance(LizzieFrame.class);
+    Leelaz engine = new Leelaz("");
+    try {
+      Lizzie.leelaz = engine;
+      SwingUtilities.invokeAndWait(() -> assertTrue(frame.reserveEngineGameDialog()));
+      assertFalse(workerCanReserve(engine), "editing dialog excludes another engine owner");
+      SwingUtilities.invokeAndWait(frame::releaseEngineGameDialog);
+      assertTrue(workerCanReserve(engine), "submitted game can own its first worker operation");
+      SwingUtilities.invokeAndWait(() -> assertTrue(frame.reserveEngineGameDialog()));
+      assertFalse(workerCanReserve(engine), "failed-start dialog resumes exclusion for retry");
+      SwingUtilities.invokeAndWait(frame::releaseEngineGameDialog);
+      assertTrue(workerCanReserve(engine));
+    } finally {
+      SwingUtilities.invokeAndWait(frame::releaseEngineGameDialog);
+      Lizzie.leelaz = previous;
+    }
+  }
+
+  private static boolean workerCanReserve(Leelaz engine) throws Exception {
+    FutureTask<Boolean> result =
+        new FutureTask<>(
+            () -> {
+              Leelaz.EngineModeReservation reservation = engine.beginEngineModeReservation();
+              if (reservation == null) return false;
+              reservation.close();
+              return true;
+            });
+    Thread worker = new Thread(result, "game-dialog-reservation-consumer");
+    worker.setDaemon(true);
+    worker.start();
+    return result.get(2, TimeUnit.SECONDS);
+  }
+}


### PR DESCRIPTION
## Summary

- Correctly retire streaming genmove responses across game termination: retain the request after an empty numbered ACK, and consume the exact late unnumbered play terminal without appending a client move.
- Restore the foreground engine's position before releasing handback admission, preserving exact request ownership and the existing missing-terminal watchdog.
- Release the game dialog's reservation before handing startup to the new-game lifecycle; reacquire it for retryable startup failures.
- Add focused regression coverage and update the lifecycle contract.

## Type Of Change

- [x] Bug fix

## Testing

- [x] Focused protocol, watchdog, handback, and dialog-reservation regressions
- [x] Shaded JAR build and Failsafe integration tests
- [x] Line-ending policy check
- [x] Independent Standards and Spec reviews: no blocking findings
- [x] Windows native acceptance on commit 48c83f63f67ac39942e179eed638dd86b3f05980

Native acceptance verified:
- Stopping an in-flight request consumed late `play K7` within the grace period.
- Client history remained at 48 moves, with no late move appended.
- All 48 history moves matched the acknowledged native restore sequence.
- Foreground analysis resumed normally.
- A subsequent game using the same configuration continued automatic play.
- Both engine processes retained their original PIDs throughout acceptance.

Full-suite result: 3820 tests, 2 failures, 0 errors, 9 skipped.
The two previously recorded, out-of-scope GUI failures remain:
- KomiHoldSessionTest.realWindowControlHideStopsProductionLifecycleSession
- WholeGameAnalysisDialogLayoutTest.localizedProgressAndControlsRemainVisibleAtCommonDpiScales

The complete suite is not claimed green.

## Notes

- This is an independent lifecycle repair from the rules-dialog protection associated with #421.
- Native late pass/resign/error and missing-terminal force were not deliberately manufactured during desktop acceptance; automated fixtures cover those protocol and watchdog boundaries.
- Review the transition from response retirement to confirmed foreground restoration, and the dialog-to-startup reservation handoff.
