### PR TITLE
fix(logging): preserve exported log record boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable maintenance updates to this fork are documented here.
 
 ## Unreleased
 
+- Preserved diagnostic log record boundaries and stack-trace whitespace during export without weakening privacy redaction (#431).
 - Preserved complete custom match rules, distinguished official rule presets, clarified unverified participation, and enabled match-rule inspection from independent-board shortcuts (#422).
 - Run custom local KataGo `benchmark` commands as slot-owned, cancellable tasks with streamed output and exit-code results (#423).
 - Prevented KataGo rules dialogs from interrupting engine games while their participants remain occupied (#421).

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -98,6 +98,8 @@ chmod +x start-linux64.sh
 
 如果程序能够正常启动，请打开 **帮助 → 诊断与日志 → 导出诊断包**，并将生成的 ZIP 附加到 Issue 中。诊断包会经过现有隐私脱敏处理。如果程序无法启动，请提供 `logs/app.log`，以及存在时的 `logs/crash.log`。
 
+ZIP 中的 `logs/lizzie/app.log` 和 `logs/lizzie/crash.log` 使用 LF 行尾，保留日志事件分隔、空行和未被脱敏替换的堆栈缩进。
+
 相关入口：
 
 - [安装指南](INSTALL.md)

--- a/src/main/java/featurecat/lizzie/analysis/SyncDiagnosticsExportSanitizer.java
+++ b/src/main/java/featurecat/lizzie/analysis/SyncDiagnosticsExportSanitizer.java
@@ -65,8 +65,10 @@ public final class SyncDiagnosticsExportSanitizer {
   }
 
   public String text(String value) {
+    // Text whitespace belongs to the payload; only identifiers are trimmed by normalize.
     // Redact Windows paths before credential canonicalization can collapse JSON/UNC separators.
-    String safe = redactEmbeddedWindowsAbsolutePaths(normalize(value, "none"));
+    String safe =
+        redactEmbeddedWindowsAbsolutePaths(value == null || value.isEmpty() ? "none" : value);
     safe = credentials.sanitize(safe);
     safe = credentials.sanitize(unescapeDiagnosticSeparators(safe));
     safe = SGF_PAYLOAD.matcher(safe).replaceAll("<redacted-sgf>");

--- a/src/main/java/featurecat/lizzie/logging/DiagnosticBundleExporter.java
+++ b/src/main/java/featurecat/lizzie/logging/DiagnosticBundleExporter.java
@@ -1523,8 +1523,12 @@ public final class DiagnosticBundleExporter {
         && !hasTraceSession(raw, requiredSession)) {
       return record.truncated();
     }
-    byte[] sanitized = sanitizer.sanitize(raw).getBytes(StandardCharsets.UTF_8);
-    records.add(sanitized);
+    String sanitized = sanitizer.sanitizeText(raw);
+    // Fail-closed redaction can consume the terminator; restore it before byte accounting.
+    if (!sanitized.endsWith("\n")) {
+      sanitized += "\n";
+    }
+    records.add(sanitized.getBytes(StandardCharsets.UTF_8));
     return record.truncated();
   }
 

--- a/src/test/java/featurecat/lizzie/analysis/SyncDiagnosticsExportSanitizerTest.java
+++ b/src/test/java/featurecat/lizzie/analysis/SyncDiagnosticsExportSanitizerTest.java
@@ -17,10 +17,21 @@ class SyncDiagnosticsExportSanitizerTest {
         "yike session=(live-room#1), next=unite-board#1.",
         sanitizer.text(
             "yike session=(live-room:private-room_42), next=unite-board:board-7."));
+    assertEquals("live-room#1", sanitizer.sessionAlias(" \tlive-room:private-room_42\r\n"));
     assertEquals(2, sanitizer.aliases().size());
     assertEquals(
         List.of("live-room#1", "unite-board#1"),
         List.copyOf(sanitizer.aliases().values()));
+  }
+
+  @Test
+  void preservesTextWhitespaceWhileRedactingCredentials() {
+    SyncDiagnosticsExportSanitizer sanitizer = new SyncDiagnosticsExportSanitizer();
+
+    assertEquals(" \t\r\n\n", sanitizer.text(" \t\r\n\n"));
+    assertEquals(
+        "\tpassword=<redacted> \r\n\n",
+        sanitizer.text("\tpassword=CANARY_TEXT_WHITESPACE \r\n\n"));
   }
 
   @Test

--- a/src/test/java/featurecat/lizzie/logging/DiagnosticBundleExporterTest.java
+++ b/src/test/java/featurecat/lizzie/logging/DiagnosticBundleExporterTest.java
@@ -1197,6 +1197,75 @@ class DiagnosticBundleExporterTest {
   }
 
   @Test
+  void exportedLogsPreserveRecordBoundariesAndStackTraceWhitespace() throws Exception {
+    LoggingRuntime runtime = start();
+    runtime.awaitIdle();
+    runtime.shutdown();
+    String timestamp = LocalDateTime.now().minusSeconds(1).format(LOG_TIMESTAMP);
+    Files.writeString(
+        tempDir.resolve("logs/app.log"),
+        timestamp
+            + " INFO  [lizzie.app] first password=CANARY_LOG_BOUNDARY\r\n\r\n"
+            + timestamp
+            + " INFO  [lizzie.app] second\r\n",
+        StandardCharsets.UTF_8);
+    Files.writeString(
+        tempDir.resolve("logs/crash.log"),
+        timestamp
+            + " ERROR [lizzie.crash] java.lang.IllegalStateException: failed\n"
+            + "\tat Example.run(Example.java:1)\n\n"
+            + timestamp
+            + " ERROR [lizzie.crash] next failure",
+        StandardCharsets.UTF_8);
+
+    Map<String, String> entries = unzipTextEntries(exportDefault(runtime));
+
+    assertEquals(
+        timestamp
+            + " INFO  [lizzie.app] first password=<redacted>\n\n"
+            + timestamp
+            + " INFO  [lizzie.app] second\n",
+        entries.get("logs/lizzie/app.log"));
+    assertEquals(
+        timestamp
+            + " ERROR [lizzie.crash] java.lang.IllegalStateException: failed\n"
+            + "\tat Example.run(Example.java:1)\n\n"
+            + timestamp
+            + " ERROR [lizzie.crash] next failure\n",
+        entries.get("logs/lizzie/crash.log"));
+  }
+
+  @Test
+  void redactedRecordTerminatorsSeparateEventsAndCountTowardsTheByteCap() throws Exception {
+    LoggingRuntime runtime = start();
+    runtime.awaitIdle();
+    runtime.shutdown();
+    String timestamp = LocalDateTime.now().minusSeconds(1).format(LOG_TIMESTAMP);
+    Files.writeString(
+        tempDir.resolve("logs/app.log"),
+        timestamp
+            + " INFO  [lizzie.app] password=\"CANARY_UNCLOSED_CREDENTIAL\n"
+            + "CANARY_CREDENTIAL_CONTINUATION\n"
+            + timestamp
+            + " INFO  [lizzie.app] 下一条\n",
+        StandardCharsets.UTF_8);
+    String nextRecord = timestamp + " INFO  [lizzie.app] 下一条\n";
+    String expected =
+        timestamp + " INFO  [lizzie.app] password=\"<redacted>\"\n" + nextRecord;
+
+    assertEquals(
+        expected, unzipTextEntries(exportDefault(runtime)).get("logs/lizzie/app.log"));
+
+    long cap = expected.getBytes(StandardCharsets.UTF_8).length - 1L;
+    Path cappedZip =
+        new DiagnosticBundleExporter(
+                DiagnosticBundleExporter.defaultOutputDirectory(tempDir),
+                new DiagnosticBundleLimits(24, cap, 24, 1024, 1024))
+            .export(request(runtime, EnumSet.noneOf(TraceScope.class)));
+    assertEquals(nextRecord, unzipTextEntries(cappedZip).get("logs/lizzie/app.log"));
+  }
+
+  @Test
   void malformedTimestampRecordAndContinuationsAreExcludedFailClosed() throws Exception {
     LoggingRuntime runtime = start();
     runtime.awaitIdle();


### PR DESCRIPTION
## Summary

- Preserve log-body whitespace during export while retaining identifier normalization and privacy redaction.
- Ensure each sanitized text log record ends with LF before UTF-8 byte-cap accounting, including records whose trailing content is consumed by credential redaction.
- Add ZIP-level regressions for event boundaries, stack indentation, blank lines, CRLF input, missing final newlines, credential redaction, and byte caps. Update the changelog and troubleshooting guide.

Previously, trimming each sanitized record removed its terminator and concatenated adjacent log events.

## Type Of Change

- [x] Bug fix
- [ ] Feature
- [ ] Packaging / release update
- [x] Docs / translation
- [ ] Refactor

## Testing

- [x] Tested locally
- [ ] Verified package contents if packaging changed — not applicable
- [ ] Verified Fox sync flow if related — not applicable
- [ ] Added screenshots if UI changed — not applicable
- [x] Updated README / docs if user-facing behavior changed
- [x] Noted affected platforms if the change is platform-specific — reported on Windows; shared Java export path also reproduced on Linux
- [x] Verified there is no unrelated formatting or line-ending churn
- [x] Ran `python3 scripts/check_line_endings.py`

Both new exporter regressions failed before their respective fixes and passed afterward. All 82 tests passed across `DiagnosticBundleExporterTest`, `SyncDiagnosticsExportSanitizerTest`, `PersistenceSanitizerTest`, `SyncDiagnosticsExporterTest`, `SyncDiagnosticsJsonTest`, `SyncDiagnosticsDialogTest`, and `ThreadSnapshotTest`.

A production ZIP smoke check on Linux confirmed separate app events and preserved multiline crash-log structure. A Windows shaded-JAR candidate built from `7b854125743eb6c62dac5a23394c660297fd0477` was launched with isolated configuration and used for manual GUI export. The resulting ZIP passed CRC checks; all 18 captured app records retained their order and LF boundaries, with observed Windows paths redacted and no truncation.

## Notes

The Windows source and exported `crash.log` were empty. Multiline stack and credential edge cases are covered by the automated regressions and Linux export evidence, not a separate Windows crash-log manual check.

Closes #431
