### PR TITLE
fix(analysis): confirm positions before sync analysis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable maintenance updates to this fork are documented here.
 
 - Preserved diagnostic log record boundaries and stack-trace whitespace during export without weakening privacy redaction (#431).
 - Made diagnostic export estimates describe approximate uncompressed content, pruned proven irrelevant archives before reading using native Windows file identities where needed, and displayed publication success independently of folder opening (#430).
-- Wait for confirmed engine positions before starting ordinary analysis after moves and history navigation, preserving valid node caches (#429).
+- Wait for confirmed engine positions before starting ordinary analysis after moves and history navigation; resume ReadBoard analysis once at the final synchronized position while preserving valid node caches (#429).
 - Preserved complete custom match rules, distinguished official rule presets, clarified unverified participation, and enabled match-rule inspection from independent-board shortcuts (#422).
 - Run custom local KataGo `benchmark` commands as slot-owned, cancellable tasks with streamed output and exit-code results (#423).
 - Prevented KataGo rules dialogs from interrupting engine games while their participants remain occupied (#421).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable maintenance updates to this fork are documented here.
 
 - Preserved diagnostic log record boundaries and stack-trace whitespace during export without weakening privacy redaction (#431).
 - Made diagnostic export estimates describe approximate uncompressed content, pruned proven irrelevant archives before reading using native Windows file identities where needed, and displayed publication success independently of folder opening (#430).
+- Wait for confirmed engine positions before starting ordinary analysis after moves and history navigation, preserving valid node caches (#429).
 - Preserved complete custom match rules, distinguished official rule presets, clarified unverified participation, and enabled match-rule inspection from independent-board shortcuts (#422).
 - Run custom local KataGo `benchmark` commands as slot-owned, cancellable tasks with streamed output and exit-code results (#423).
 - Prevented KataGo rules dialogs from interrupting engine games while their participants remain occupied (#421).

--- a/docs/SNAPSHOT_NODE_KIND.md
+++ b/docs/SNAPSHOT_NODE_KIND.md
@@ -160,6 +160,15 @@ ReadBoard 协议里的 `pass` 行在自动落子/交换顺序链路中表示用�
 - 双引擎模式下，若已发出快照加载请求的一侧最终无响应，恢复流程仍执行兜底清理，并释放该侧对应处理器。
 - 双引擎模式下，一侧收到 GTP `?` 错误而另一侧无响应时，恢复流程仍返回失败，并完成临时 SGF 与两侧处理器清理。
 
+## 普通局面分析确认（Issue #429 / Ticket 01）
+
+- 普通落子与连续真实 MOVE/PASS 前后导航先采用目标 history 节点，再转发引擎命令；分析请求在入队时冻结显示节点、Board context revision、引擎槽位与 reader incarnation，不能在 info 到达时重新选择来源目标。
+- `Leelaz` 在位置命令入队时退休旧分析 generation，物理写出时仍执行原有 payload epoch/generation 失效。普通分析只有在依赖的位置响应成功结算后才能物理启动；无关只读查询的 pending response 不影响已合法启动的分析流。
+- `undo`、`play`（含真实 PASS）与 `set_position` 使用精确 numbered response identity 和既有 queued/pending retirement。错误、发送失败或超时使所属位置 lineage 失败；迟到响应不能恢复失败来源，也不能结算后继命令。完整替换位置建立新的 lineage，但本身仍需确认。
+- `requireResponseBeforeSend` 的普通队列等待真实已写出的响应义务，不使用包含尚未发送后继命令的计数阻塞自身。Engine-game 的精确 ACK/terminal 与 arbitration 语义独立保留。
+- 解析和最终节点 publication 均复验冻结目标。被退休、目标过期或未确认的位置输出不能进入候选缓存或 ownership-only backfill；有效历史缓存、SGF 已保存分析、同上下文暂停/继续与主副引擎独立槽位保留。显式失效仍由既有 `isChanged/isChanged2` 允许首个合法低 visits 接管。
+- 本节不把完整 root/exact 恢复的模块 completion 当成最终 owner 确认；跨 SNAPSHOT 的复合恢复与 ReadBoard 单次最终 resume 分别由 Ticket 02 / 03 交付。
+
 ## 初始启动导航契约（Issue #223）
 
 初始引擎启动恢复属于 lifecycle owner 的协调范围，遵守以下合同：

--- a/docs/SNAPSHOT_NODE_KIND.md
+++ b/docs/SNAPSHOT_NODE_KIND.md
@@ -167,7 +167,7 @@ ReadBoard 协议里的 `pass` 行在自动落子/交换顺序链路中表示用�
 - `undo`、`play`（含真实 PASS）与 `set_position` 使用精确 numbered response identity 和既有 queued/pending retirement。错误、发送失败或超时使所属位置 lineage 失败；迟到响应不能恢复失败来源，也不能结算后继命令。完整替换位置建立新的 lineage，但本身仍需确认。
 - `requireResponseBeforeSend` 的普通队列等待真实已写出的响应义务，不使用包含尚未发送后继命令的计数阻塞自身。Engine-game 的精确 ACK/terminal 与 arbitration 语义独立保留。
 - 解析和最终节点 publication 均复验冻结目标。被退休、目标过期或未确认的位置输出不能进入候选缓存或 ownership-only backfill；有效历史缓存、SGF 已保存分析、同上下文暂停/继续与主副引擎独立槽位保留。显式失效仍由既有 `isChanged/isChanged2` 允许首个合法低 visits 接管。
-- 跨 SNAPSHOT 的复合恢复遵守下节；ReadBoard 单次最终 resume 由 Ticket 03 交付。
+- 跨 SNAPSHOT 的复合恢复及 ReadBoard 单次最终 resume 遵守下列对应 owner 契约。
 
 ## 复合局面恢复确认（Issue #429 / Ticket 02）
 
@@ -181,6 +181,17 @@ ReadBoard 协议里的 `pass` 行在自动落子/交换顺序链路中表示用�
 - Board 恢复的 GTP 等待在 EDT 和 Board monitor 外执行。完成时重新检查冻结目标，过期 completion 不恢复分析，也不把替换引擎当作原恢复目标。
 - foreground handback 已冻结的同一 Board/主引擎盘面恢复先按捕获内容完成确认，再由现有 owner 检查稳定性并追赶最新目标；导航发生在 companion close 期间不能提前截断该收敛循环。Board 或主引擎 incarnation 替换仍拒绝旧恢复。
 - 同一合法目标的缓存和已导入 SGF 分析继续保留；主副引擎槽位独立。未确认或已失效来源不得建立新的 visits 高水位。board-only 同步及真实 PASS、dummy PASS、setup 语义保持原合同。
+
+## ReadBoard 单次同步分析恢复（Issue #429 / Ticket 03）
+
+- 普通 ReadBoard 快照接受在 Board monitor 内完成本次本地导航、落子、视图恢复及 history adopt；这段收集期间不转发中间位置命令，也不触发中间分析。Board 从入口节点到最终目标冻结一次增量 undo/play 或完整 root/exact 路线，真实 GTP 执行和确认在 monitor 与 EDT 外完成。
+- 已有节点命中保留原节点 identity 和全部已证明历史，不克隆目标、补造 MOVE/PASS/SNAPSHOT 或删除尾部。前次同步尚未确认或已失败时，新目标使用自己的完整恢复路线，不把未确认的本地起点当作引擎盘面。
+- 增量同步继承起点已有的位置 response lineage，包含本次接受前已排队或已写出的普通位置命令；前置 play/undo 失败不能被新同步 capture 清除。只有完整 root/exact 替换路线可建立独立恢复 lineage，且仍须确认本次全部 required responses。
+- ReadBoard 是本次 final resume disposition owner；延迟回调与 Board 确认两者均已完成后，才允许对同一目标最多启动一次普通分析。回调不再调用棋谱加载恢复，不发第二次 clear/replay/loadsgf，也不启动自动棋谱快析。
+- 最终 resume 重查 sync epoch、confirmed-local-move 保护、Board identity/context revision、目标节点、captured primary generation、引擎可用性和 read-board 分析设置；错误、发送失败、超时及过期目标恢复零次。
+- 用户分析暂停立即失效 pending ReadBoard resume，并继续遵守普通队列及 selected-before-write 取消规则。暂停后用户再次继续分析，也不能使旧同步回调重新取得恢复资格。
+- 一致且无需恢复的重复快照不重新捕获恢复或重启合法分析流。普通首次同步直接采用最终视图，不以先回退再延迟前进触发额外分析。
+- 无引擎时仍完成本地 board/history 更新；GMA 和对局 continuation 保持独立的路由与 ownership exclusion。手动导航、手动分析恢复及普通棋谱加载策略保持原契约。
 
 ## 初始启动导航契约（Issue #223）
 

--- a/docs/SNAPSHOT_NODE_KIND.md
+++ b/docs/SNAPSHOT_NODE_KIND.md
@@ -167,7 +167,20 @@ ReadBoard 协议里的 `pass` 行在自动落子/交换顺序链路中表示用�
 - `undo`、`play`（含真实 PASS）与 `set_position` 使用精确 numbered response identity 和既有 queued/pending retirement。错误、发送失败或超时使所属位置 lineage 失败；迟到响应不能恢复失败来源，也不能结算后继命令。完整替换位置建立新的 lineage，但本身仍需确认。
 - `requireResponseBeforeSend` 的普通队列等待真实已写出的响应义务，不使用包含尚未发送后继命令的计数阻塞自身。Engine-game 的精确 ACK/terminal 与 arbitration 语义独立保留。
 - 解析和最终节点 publication 均复验冻结目标。被退休、目标过期或未确认的位置输出不能进入候选缓存或 ownership-only backfill；有效历史缓存、SGF 已保存分析、同上下文暂停/继续与主副引擎独立槽位保留。显式失效仍由既有 `isChanged/isChanged2` 允许首个合法低 visits 接管。
-- 本节不把完整 root/exact 恢复的模块 completion 当成最终 owner 确认；跨 SNAPSHOT 的复合恢复与 ReadBoard 单次最终 resume 分别由 Ticket 02 / 03 交付。
+- 跨 SNAPSHOT 的复合恢复遵守下节；ReadBoard 单次最终 resume 由 Ticket 03 交付。
+
+## 复合局面恢复确认（Issue #429 / Ticket 02）
+
+- Board 在首次位置转发前冻结目标节点、context revision、轮次、盘尺寸、主引擎 generation 与 captured mirror；exact plan 或 root 命令序列同时冻结。后续恢复和 completion 不重新选择当前 history 或引擎槽位。
+- 普通 resend、跨静态节点的历史导航与 removed-stone 节点恢复共用 Board owner 的目标确认。恢复中的真实 MOVE/PASS 不单独触发最终目标分析；成功 disposition 必须同时满足冻结目标仍有效、用户未暂停分析和捕获引擎身份仍有效。
+- capture 已完成但首条位置命令尚未入队时，普通分析请求也保持等待；同一原队列允许其依赖的位置命令和最终 fence 先执行。owner 确认后释放该请求；取消或失败只退休所属 capture，不影响后继恢复。
+- 用户分析暂停同时退休原普通队列及已选中但尚未取得物理写出许可的普通分析请求，包括恢复等待期间新增的请求；取消与 `beginOutputWrite` 竞争同一命令状态，计数只退休一次。位置命令、foreground restore 与 engine-game owner 的命令不随此取消；已经取得写出许可的命令沿用既有停止流程。
+- `Leelaz.PositionRestore` 仅提供捕获、作用域内命令执行与 callback confirmation，复用 ordinary queue、精确 response identity、timeout 和 retirement。一次复合恢复的 clear、尺寸/komi、loadsgf/set-position 与真实 tail 共用所属 endpoint 的失败 lineage；中间完整替换命令不得重置本次先前失败。
+- 最终 board synchronization fence 同时等待 captured authority/mirror 的全部 required position responses 与各自最终 name 响应。单独的 name 成功不能覆盖先前位置命令错误、发送失败或超时；迟到响应只结清原操作，不能结算或使不同后继操作失效。
+- exact module 继续拥有静态锚点、临时 SGF 消费与真实 tail sequencing；最终 owner confirmation、root replay 和 ponder 留在现有 owner。exact 一旦开始，失败不切换到 root fallback。
+- Board 恢复的 GTP 等待在 EDT 和 Board monitor 外执行。完成时重新检查冻结目标，过期 completion 不恢复分析，也不把替换引擎当作原恢复目标。
+- foreground handback 已冻结的同一 Board/主引擎盘面恢复先按捕获内容完成确认，再由现有 owner 检查稳定性并追赶最新目标；导航发生在 companion close 期间不能提前截断该收敛循环。Board 或主引擎 incarnation 替换仍拒绝旧恢复。
+- 同一合法目标的缓存和已导入 SGF 分析继续保留；主副引擎槽位独立。未确认或已失效来源不得建立新的 visits 高水位。board-only 同步及真实 PASS、dummy PASS、setup 语义保持原合同。
 
 ## 初始启动导航契约（Issue #223）
 

--- a/src/main/java/featurecat/lizzie/analysis/Leelaz.java
+++ b/src/main/java/featurecat/lizzie/analysis/Leelaz.java
@@ -3241,7 +3241,9 @@ public class Leelaz {
       if (promotedFreshOwner) {
         binding.analysisOutputOwnership.set(
             AnalysisOutputOwnership.ordinary(
-                analysisOutputGeneration.get(), binding.analysisStateLineage));
+                analysisOutputGeneration.get(),
+                binding.analysisStateLineage,
+                captureAnalysisInfoTarget()));
         binding.suppressGlobalEnginePresentation = false;
         suppressGlobalEnginePresentationUntilOwned = false;
       }
@@ -4280,9 +4282,9 @@ public class Leelaz {
   }
 
   /**
-   * Failure lineage for position-dependent output on one reader incarnation. Pending state
-   * commands leave the lineage usable so streaming analysis can start immediately; a known failed
-   * state command poisons every dependent owner until a full state rebuild starts a fresh lineage.
+   * Failure lineage for position-dependent output on one reader incarnation. Queued commands
+   * capture their dependency before dispatch; ordinary analysis waits for required responses. A
+   * failed state command poisons its dependents until a full replacement starts a fresh lineage.
    */
   private static final class AnalysisStateLineage {
     private final AtomicBoolean failed = new AtomicBoolean();
@@ -4328,6 +4330,7 @@ public class Leelaz {
     private int startupPostActionsInProgress;
     private final List<StartupCommandDelivery> startupCommandDeliveries = new ArrayList<>();
     private int runtimeUiPresentationsInProgress;
+    private AnalysisStateLineage queuedAnalysisStateLineage;
     private Throwable terminalFailure;
     private boolean terminalCleanupStarted;
     /** The dead carrier's command leases were settled before deferred engine-game recovery. */
@@ -4418,18 +4421,21 @@ public class Leelaz {
     private final Object recoveryToken;
     private final long generation;
     private final AnalysisStateLineage analysisStateLineage;
+    private final AnalysisInfoTarget target;
 
     private AnalysisOutputOwnership(
         EngineManager.EngineGamePrimaryContext exactContext,
         boolean ordinary,
         Object recoveryToken,
         long generation,
-        AnalysisStateLineage analysisStateLineage) {
+        AnalysisStateLineage analysisStateLineage,
+        AnalysisInfoTarget target) {
       this.exactContext = exactContext;
       this.ordinary = ordinary;
       this.recoveryToken = recoveryToken;
       this.generation = generation;
       this.analysisStateLineage = analysisStateLineage;
+      this.target = target;
     }
 
     private static AnalysisOutputOwnership exact(
@@ -4437,19 +4443,19 @@ public class Leelaz {
         long generation,
         AnalysisStateLineage analysisStateLineage) {
       return new AnalysisOutputOwnership(
-          context, false, null, generation, analysisStateLineage);
+          context, false, null, generation, analysisStateLineage, null);
     }
 
     private static AnalysisOutputOwnership ordinary(
-        long generation, AnalysisStateLineage analysisStateLineage) {
+        long generation, AnalysisStateLineage analysisStateLineage, AnalysisInfoTarget target) {
       return new AnalysisOutputOwnership(
-          null, true, null, generation, analysisStateLineage);
+          null, true, null, generation, analysisStateLineage, target);
     }
 
     private static AnalysisOutputOwnership recoveryTombstone(
         Object recoveryToken, long generation, AnalysisStateLineage analysisStateLineage) {
       return new AnalysisOutputOwnership(
-          null, false, recoveryToken, generation, analysisStateLineage);
+          null, false, recoveryToken, generation, analysisStateLineage, null);
     }
 
     private boolean isExact() {
@@ -4725,12 +4731,20 @@ public class Leelaz {
     private final Board board;
     private final long boardRevision;
     private final BoardHistoryNode displayNode;
+    private final boolean primarySlot;
+    private final boolean secondarySlot;
 
     private AnalysisInfoTarget(
-        Board board, long boardRevision, BoardHistoryNode displayNode) {
+        Board board, long boardRevision, BoardHistoryNode displayNode, Leelaz source) {
       this.board = board;
       this.boardRevision = boardRevision;
       this.displayNode = displayNode;
+      this.primarySlot = source == Lizzie.leelaz;
+      this.secondarySlot =
+          !primarySlot
+              && source == Lizzie.leelaz2
+              && Lizzie.config != null
+              && Lizzie.config.isDoubleEngineMode();
     }
   }
 
@@ -4739,13 +4753,23 @@ public class Leelaz {
     BoardHistoryNode displayNode =
         Lizzie.frame == null || board == null ? null : Lizzie.frame.getDisplayNode();
     return new AnalysisInfoTarget(
-        board, board == null ? -1L : board.getContextRevision(), displayNode);
+        board, board == null ? -1L : board.getContextRevision(), displayNode, this);
+  }
+
+  private AnalysisInfoTarget analysisInfoTargetForRoute(AnalysisOutputRoute route) {
+    if (route != null && route.ownerToken instanceof AnalysisOutputOwnership) {
+      AnalysisOutputOwnership ownership = (AnalysisOutputOwnership) route.ownerToken;
+      if (ownership.isOrdinary()) return ownership.target;
+    }
+    return captureAnalysisInfoTarget();
   }
 
   private boolean isCurrentAnalysisInfoTarget(AnalysisInfoTarget expected) {
     return expected != null
         && expected.board != null
         && expected.board == Lizzie.board
+        && (!expected.primarySlot || this == Lizzie.leelaz)
+        && (!expected.secondarySlot || this == Lizzie.leelaz2)
         && expected.board.getContextRevision() == expected.boardRevision
         && expected.displayNode != null
         && Lizzie.frame != null
@@ -4816,15 +4840,14 @@ public class Leelaz {
     if (parsed == null
         || parsed.moves.isEmpty()
         || target == null
-        || target.displayNode == null) {
+        || !isCurrentAnalysisInfoTarget(target)) {
       return;
     }
     BoardData displayData = target.displayNode.getData();
     if (!AnalysisCandidateValidator.allCandidatesOnEmptyPoints(parsed.moves, displayData)) {
       return;
     }
-    boolean secondaryDisplay =
-        Lizzie.config.isDoubleEngineMode() && Lizzie.leelaz2 != null && this == Lizzie.leelaz2;
+    boolean secondaryDisplay = target.secondarySlot;
     boolean engineGameParticipantToMove = true;
     if (!secondaryDisplay
         && EngineManager.hasPlayingEngineGameTransaction()
@@ -6065,9 +6088,7 @@ public class Leelaz {
       return false;
     }
     String normalized = command.trim().toLowerCase(Locale.ROOT);
-    return normalized.startsWith("kata-analyze")
-        || normalized.startsWith("lz-analyze")
-        || normalized.startsWith("analyze ")
+    return isOrdinaryPositionAnalysisCommand(normalized)
         || normalized.startsWith("kata-genmove_analyze ")
         || normalized.startsWith("lz-genmove_analyze ")
         || normalized.startsWith("genmove_analyze ")
@@ -6098,7 +6119,7 @@ public class Leelaz {
   }
 
   /** Position mutations and the local payload policy linearized with their physical write. */
-  private AnalysisStateMutation analysisStateMutation(String command) {
+  private static AnalysisStateMutation analysisStateMutation(String command) {
     if (command == null) {
       return AnalysisStateMutation.NONE;
     }
@@ -6144,11 +6165,14 @@ public class Leelaz {
   /** Requires the binding's analysis-output mutation lock at the physical state-write boundary. */
   private void bindAnalysisStateLineageAtPhysicalWrite(
       QueuedCommand command, ReaderStreamBinding binding) {
-    AnalysisStateLineage lineage = binding.analysisStateLineage;
-    if (lineage == null || startsFreshAnalysisStateLineage(command.command)) {
-      lineage = new AnalysisStateLineage();
-      binding.analysisStateLineage = lineage;
+    AnalysisStateLineage lineage = command.analysisStateLineage();
+    if (lineage == null) {
+      lineage = binding.analysisStateLineage;
+      if (lineage == null || startsFreshAnalysisStateLineage(command.command)) {
+        lineage = new AnalysisStateLineage();
+      }
     }
+    binding.analysisStateLineage = lineage;
     command.bindAnalysisStateLineage(lineage, binding);
   }
 
@@ -6260,6 +6284,14 @@ public class Leelaz {
           "analysis output lost its reader before physical command output");
     }
     if (transaction == null) {
+      if (transactionlessLease != null
+          && transactionlessLease.kind == EngineManager.TransactionlessAnalysisWriteKind.ORDINARY
+          && isOrdinaryPositionAnalysisCommand(command.command)
+          && (!isCurrentAnalysisInfoTarget(command.ordinaryAnalysisTarget)
+              || command.ordinaryAnalysisBinding != binding
+              || command.analysisStateLineage().isFailed())) {
+        throw new AnalysisOutputAdmissionFailure("Ordinary analysis target changed before output");
+      }
       if (transactionlessLease == null) {
         throw new AnalysisOutputAdmissionFailure(
             "transaction-less analysis output has no physical-write admission");
@@ -6280,7 +6312,11 @@ public class Leelaz {
       } else {
         replacement =
             AnalysisOutputOwnership.ordinary(
-                analysisOutputGeneration.get(), binding.analysisStateLineage);
+                analysisOutputGeneration.get(),
+                binding.analysisStateLineage,
+                isOrdinaryPositionAnalysisCommand(command.command)
+                    ? command.ordinaryAnalysisTarget
+                    : captureAnalysisInfoTarget());
         binding.suppressGlobalEnginePresentation = false;
         suppressGlobalEnginePresentationUntilOwned = false;
       }
@@ -6382,6 +6418,7 @@ public class Leelaz {
       boolean currentOrdinary =
           readerStreamBinding == binding
               && !binding.terminated
+              && isCurrentAnalysisInfoTarget(ownership.target)
               && !EngineManager.hasEngineGameAnalysisOutputBarrier();
       return new AnalysisOutputRoute(
           currentOrdinary
@@ -6424,6 +6461,7 @@ public class Leelaz {
     return expected.ownerToken != null
         && ownership == expected.ownerToken
         && !ownership.hasFailedAnalysisStateLineage()
+        && (!ownership.isOrdinary() || isCurrentAnalysisInfoTarget(ownership.target))
         && ownership.generation == analysisOutputGeneration.get();
   }
 
@@ -6834,8 +6872,7 @@ public class Leelaz {
                   }
                   isLoaded = true;
                   int limit =
-                      Lizzie.config.limitMaxSuggestion > 0
-                              && !Lizzie.config.showNoSuggCircle
+                      Lizzie.config.limitMaxSuggestion > 0 && !Lizzie.config.showNoSuggCircle
                           ? Lizzie.config.limitMaxSuggestion
                           : 361;
                   if (!Lizzie.frame.isPlayingAgainstLeelaz
@@ -6874,9 +6911,8 @@ public class Leelaz {
                 if (!completedMoves.isEmpty()) {
                   publishAnalysisDisplayNonFatal(
                       () -> {
-                        if (Lizzie.config.isDoubleEngineMode()
-                            && Lizzie.leelaz2 != null
-                            && this == Lizzie.leelaz2) {
+                        if (!isCurrentAnalysisInfoTarget(analysisInfoTarget)) return;
+                        if (analysisInfoTarget.secondarySlot) {
                           analysisInfoTarget
                               .displayNode
                               .getData()
@@ -6905,10 +6941,7 @@ public class Leelaz {
                 bestMoves = completedMoves;
                 acceptedSnapshot.set(
                     new AnalysisInfoSnapshot(
-                        bestMoves,
-                        currentTotalPlayouts,
-                        analysisInfoEpoch,
-                        analysisInfoTarget));
+                        bestMoves, currentTotalPlayouts, analysisInfoEpoch, analysisInfoTarget));
                 hasBestMoves.set(!completedMoves.isEmpty());
                 terminalBatch.set(true);
               }
@@ -6968,7 +7001,9 @@ public class Leelaz {
     long analysisInfoEpochAtParse =
         analysisOutputRouteAtParse == null ? -1L : analysisInfoEpochSnapshot();
     AnalysisInfoTarget analysisInfoTargetAtParse =
-        analysisOutputRouteAtParse == null ? null : captureAnalysisInfoTarget();
+        analysisOutputRouteAtParse == null
+            ? null
+            : analysisInfoTargetForRoute(analysisOutputRouteAtParse);
     if (analysisOutputRouteAtParse != null) {
       afterAnalysisOutputRouteCapturedForTest(analysisOutputRouteAtParse.kind.name());
       AnalysisOutputRoute currentRoute =
@@ -8521,7 +8556,8 @@ public class Leelaz {
     long analysisInfoEpochAtParse = analysisInfoEpochSnapshot();
     boolean analysisResponseUpToDateAtParse =
         isAnalysisResponseUpToDateSnapshot(analysisOutputRouteAtParse);
-    AnalysisInfoTarget analysisInfoTargetAtParse = captureAnalysisInfoTarget();
+    AnalysisInfoTarget analysisInfoTargetAtParse =
+        analysisInfoTargetForRoute(analysisOutputRouteAtParse);
     EngineManager.EngineGamePrimaryContext analysisGameContext =
         analysisOutputRouteAtParse.activeExactContext;
     boolean engineGameSignal = isAnalysisOutputSignalLine(line);
@@ -11128,9 +11164,58 @@ public class Leelaz {
     }
   }
 
+  private static boolean isOrdinaryPositionAnalysisCommand(String command) {
+    if (command == null) return false;
+    String normalized = command.trim().toLowerCase(Locale.ROOT);
+    return normalized.startsWith("kata-analyze")
+        || normalized.startsWith("lz-analyze")
+        || normalized.startsWith("analyze ");
+  }
+
+  private static boolean isIncrementalPositionCommand(String command) {
+    return command != null
+        && (command.equals("undo")
+            || command.startsWith("play ")
+            || command.equals("set_position")
+            || command.startsWith("set_position "));
+  }
+
   private QueuedCommand foregroundRestoreCommand(
       QueuedCommand command, ArrayDeque<QueuedCommand> targetQueue) {
     command.foregroundRestoreCommand = targetQueue == foregroundRestoreCommandQueue();
+    ReaderStreamBinding binding = currentReaderStreamBinding();
+    boolean positionMutation = analysisStateMutation(command.command) != AnalysisStateMutation.NONE;
+    if (binding != null
+        && (positionMutation || isAnalysisOutputOwnershipCommand(command.command))) {
+      if (binding.queuedAnalysisStateLineage == null) {
+        binding.queuedAnalysisStateLineage = binding.analysisStateLineage;
+      }
+      if (positionMutation && startsFreshAnalysisStateLineage(command.command)) {
+        binding.queuedAnalysisStateLineage = new AnalysisStateLineage();
+      }
+      command.bindAnalysisStateLineage(binding.queuedAnalysisStateLineage, binding);
+      if (positionMutation) analysisOutputGeneration.incrementAndGet();
+    }
+    if (command.engineGameTransaction() == null && isIncrementalPositionCommand(command.command)) {
+      command.positionResponseTimeout = new Timer("lizzie-position-response-timeout", true);
+      command.positionResponseTimeout.schedule(
+          new TimerTask() {
+            @Override
+            public void run() {
+              try {
+                retireTimedOutNormalCommand(command.onResponse);
+              } finally {
+                command.finishPositionResponse();
+              }
+            }
+          },
+          Math.max(1L, readBoardGmaRestoreResponseTimeoutMillis()));
+    }
+    if (command.engineGameTransaction() == null
+        && isAnalysisOutputOwnershipCommand(command.command)) {
+      command.ordinaryAnalysisTarget = captureAnalysisInfoTarget();
+      command.ordinaryAnalysisBinding = currentReaderStreamBinding();
+    }
     return command;
   }
 
@@ -11823,18 +11908,29 @@ public class Leelaz {
       }
       ArrayDeque<QueuedCommand> targetQueue =
           foregroundRestoreInProgress ? foregroundRestoreCommandQueue() : commandQueue();
-      if (!foregroundRestoreInProgress && requireResponseBeforeSend && !isResponseUpToPreDate()) {
-        return;
-      }
       if (targetQueue.isEmpty()) {
         return;
       }
       QueuedCommand queueHead = targetQueue.peekFirst();
+      if (!foregroundRestoreInProgress
+          && requireResponseBeforeSend
+          && (queueHead.engineGameTransaction() != null
+              ? !isResponseUpToPreDate()
+              : hasUnconfirmedOrdinaryResponse(false))) {
+        return;
+      }
       if (exclusiveGtpLifecycleQueueGate
           && !isCurrentRestartBootstrapReceiptLocked(queueHead.restartBootstrapReceipt)) {
         return;
       }
-      if (!foregroundRestoreInProgress && !isResponseUpToPreCommand()) {
+      if (queueHead.engineGameTransaction() == null
+          && isAnalysisOutputOwnershipCommand(queueHead.command)
+          && hasUnconfirmedOrdinaryResponse(true)) {
+        return;
+      }
+      if (!foregroundRestoreInProgress
+          && queueHead.engineGameTransaction() != null
+          && !isResponseUpToPreCommand()) {
         String lastQueuedCommand = targetQueue.peekLast().command;
         if ((isKatago
                 && (lastQueuedCommand.startsWith("kata-analyze")
@@ -11966,6 +12062,24 @@ public class Leelaz {
         finishRejectedCommandBeforeOutputWrite(queuedCommand, pendingHandler);
         return null;
       }
+      boolean publishesAnalysisOutputOwnership =
+          shouldPublishAnalysisOutputOwnership(queuedCommand, outputBinding);
+      boolean startsAnalysisInfoPayload = startsNewAnalysisInfoPayload(command);
+      EngineManager.EngineGameOwnerTransaction analysisOutputTransaction =
+          queuedCommand.engineGameTransaction();
+      if (publishesAnalysisOutputOwnership
+          && analysisOutputTransaction == null
+          && isOrdinaryPositionAnalysisCommand(command)
+          && (queuedCommand.ordinaryAnalysisBinding != outputBinding
+              || !isCurrentAnalysisInfoTarget(queuedCommand.ordinaryAnalysisTarget)
+              || outputBinding.analysisStateLineage.isFailed()
+              || (queuedCommand.analysisStateLineage() != null
+                  && queuedCommand.analysisStateLineage().isFailed()))) {
+        queuedCommand.cancelBeforeOutputWrite(
+            new IllegalStateException("Ordinary analysis target is obsolete or unconfirmed"));
+        finishRejectedCommandBeforeOutputWrite(queuedCommand, pendingHandler);
+        return null;
+      }
       if (!claimRestartBootstrapReceiptForOutputWrite(queuedCommand, currentOutputStream)) {
         finishRejectedCommandBeforeOutputWrite(queuedCommand, pendingHandler);
         return null;
@@ -11974,11 +12088,6 @@ public class Leelaz {
         finishRejectedCommandBeforeOutputWrite(queuedCommand, pendingHandler);
         return null;
       }
-      boolean publishesAnalysisOutputOwnership =
-          shouldPublishAnalysisOutputOwnership(queuedCommand, outputBinding);
-      boolean startsAnalysisInfoPayload = startsNewAnalysisInfoPayload(command);
-      EngineManager.EngineGameOwnerTransaction analysisOutputTransaction =
-          queuedCommand.engineGameTransaction();
       try {
         // Canonical physical-write order is transaction/global admission -> short selection
         // validation -> binding owner -> output stream. Never wait for either manager admission
@@ -12664,6 +12773,7 @@ public class Leelaz {
       boolean exactLoadSgf,
       QueuedCommand queuedCommand) {
     return handler instanceof BoardSynchronizationResponseHandler
+        || (queuedCommand != null && queuedCommand.positionResponseTimeout != null)
         || handler instanceof EngineGameResponseHandler
         || handler instanceof EngineGameTimeLeftResponseHandler
         || handler instanceof EngineRulesResponseHandler
@@ -12674,8 +12784,7 @@ public class Leelaz {
         || (getRcentLine && isRecentParameterReadCommand(command))
         || (command != null
             && handler != NO_OP_RESPONSE_HANDLER
-            && (command.startsWith("kata-get-param ")
-                || command.startsWith("kata-set-param ")));
+            && (command.startsWith("kata-get-param ") || command.startsWith("kata-set-param ")));
   }
 
   private static boolean isRecentParameterReadCommand(String command) {
@@ -12691,6 +12800,9 @@ public class Leelaz {
     }
     if (isExactSnapshotLoadSgf(command, handler)) {
       return loadSgfResponseCommandIds.getAndIncrement();
+    }
+    if (queuedCommand != null && queuedCommand.positionResponseTimeout != null) {
+      return boardSynchronizationResponseCommandIds.getAndIncrement();
     }
     if (handler instanceof BoardSynchronizationResponseHandler) {
       return boardSynchronizationResponseCommandIds.getAndIncrement();
@@ -12824,6 +12936,7 @@ public class Leelaz {
       failAnalysisStateLineage(retiredPending.queuedCommand);
     }
     if (retiredQueued != null) {
+      failAnalysisStateLineage(retiredQueued);
       try {
         retiredQueued.publishSettlementFailure(failure);
       } catch (RuntimeException | Error notificationFailure) {
@@ -13360,6 +13473,7 @@ public class Leelaz {
                 matchedPendingHandler.loggingEngineId,
                 matchedPendingHandler.loggingCommandId,
                 line);
+            matchedPendingHandler.queuedCommand.finishPositionResponse();
             matchedPendingHandler.run();
             handlerSettled = true;
           }
@@ -18575,6 +18689,8 @@ public class Leelaz {
     private final QueuedCommandSettlement settlement;
     private final boolean countedCommand;
     private final RestartBootstrapReceipt restartBootstrapReceipt;
+    private AnalysisInfoTarget ordinaryAnalysisTarget;
+    private ReaderStreamBinding ordinaryAnalysisBinding;
     private final ReaderStreamBinding readBoardGmaResponseBinding;
     private final Object expectedLeela0110StateToken;
     private final ExactSnapshotRestoreAdmission restoreAdmission = exactSnapshotRestoreAdmissionContext.get();
@@ -18588,6 +18704,12 @@ public class Leelaz {
     private boolean commandCountRetired;
     private volatile AnalysisStateLineage analysisStateLineage;
     private volatile ReaderStreamBinding analysisStateResponseBinding;
+    private volatile Timer positionResponseTimeout;
+
+    private void finishPositionResponse() {
+      Timer timer = positionResponseTimeout;
+      if (timer != null) timer.cancel();
+    }
 
     private QueuedCommand(
         String command,
@@ -18617,7 +18739,10 @@ public class Leelaz {
         ReaderStreamBinding readBoardGmaResponseBinding,
         Object expectedLeela0110StateToken) {
       this.command = command;
-      this.onResponse = onResponse;
+      this.onResponse =
+          onResponse == null && isIncrementalPositionCommand(command)
+              ? this::finishPositionResponse
+              : onResponse;
       this.onSendFailure = onSendFailure;
       this.failOnSendError = failOnSendError;
       this.settlement = settlement;
@@ -18649,6 +18774,8 @@ public class Leelaz {
     }
 
     private void failAnalysisStateLineageAfterSendFailure() {
+      finishPositionResponse();
+      if (analysisStateMutation(command) == AnalysisStateMutation.NONE) return;
       AnalysisStateLineage lineage = analysisStateLineage;
       if (lineage != null) {
         lineage.fail();
@@ -19076,6 +19203,22 @@ public class Leelaz {
         && (Lizzie.frame.isPlayingAgainstLeelaz
             || Lizzie.frame.isAnaPlayingAgainstLeelaz
             || EngineManager.occupiesEngineGameAdmission());
+  }
+
+  private boolean hasUnconfirmedOrdinaryResponse(boolean positionsOnly) {
+    ArrayDeque<PendingResponseHandler> pending = pendingResponseHandlers();
+    synchronized (pending) {
+      for (PendingResponseHandler response : pending) {
+        if (response.isOutstandingResponseRetired()) continue;
+        String command = response.queuedCommand.command;
+        if (positionsOnly
+            ? analysisStateMutation(command) != AnalysisStateMutation.NONE
+            : !isAnalysisOutputOwnershipCommand(command)) {
+          return true;
+        }
+      }
+    }
+    return false;
   }
 
   private boolean isResponseUpToPreDate() {

--- a/src/main/java/featurecat/lizzie/analysis/Leelaz.java
+++ b/src/main/java/featurecat/lizzie/analysis/Leelaz.java
@@ -341,6 +341,13 @@ public class Leelaz {
       new ThreadLocal<>();
   private static final ThreadLocal<OrdinaryLiveBoardForwardingExecution>
       ordinaryLiveBoardForwardingContext = new ThreadLocal<>();
+
+  /** Shares one response dependency across every position command in a compound restore. */
+  private final ThreadLocal<AnalysisStateLineage> positionRestoreLineageContext =
+      new ThreadLocal<>();
+
+  private final ThreadLocal<ReaderStreamBinding> positionRestoreBindingContext =
+      new ThreadLocal<>();
   private static final ThreadLocal<EngineManager.EngineGameOwnerTransaction>
       engineGameStartupCommandContext = new ThreadLocal<>();
   /**
@@ -4282,19 +4289,96 @@ public class Leelaz {
   }
 
   /**
-   * Failure lineage for position-dependent output on one reader incarnation. Queued commands
-   * capture their dependency before dispatch; ordinary analysis waits for required responses. A
-   * failed state command poisons its dependents until a full replacement starts a fresh lineage.
+   * Response dependency for position-dependent output on one reader incarnation. Queued position
+   * commands register before dispatch, and confirmations observe both failure and quiescence. A
+   * compound restore supplies one lineage explicitly so full replacements inside that restore do
+   * not erase an earlier failure.
    */
   private static final class AnalysisStateLineage {
     private final AtomicBoolean failed = new AtomicBoolean();
+    private final AtomicInteger pendingRestoreOwners = new AtomicInteger();
+    private int pendingResponses;
+    private ArrayList<Runnable> changeListeners;
+
+    private synchronized void registerResponse() {
+      pendingResponses++;
+    }
+
+    private void settleResponse(boolean successful) {
+      ArrayList<Runnable> listeners;
+      synchronized (this) {
+        if (pendingResponses <= 0) {
+          return;
+        }
+        if (!successful) {
+          failed.set(true);
+        }
+        pendingResponses--;
+        listeners = !successful || pendingResponses == 0 ? copyListenersLocked() : null;
+      }
+      runListeners(listeners);
+    }
 
     private boolean fail() {
-      return failed.compareAndSet(false, true);
+      if (!failed.compareAndSet(false, true)) {
+        return false;
+      }
+      ArrayList<Runnable> listeners;
+      synchronized (this) {
+        listeners = pendingResponses == 0 ? copyListenersLocked() : null;
+      }
+      runListeners(listeners);
+      return true;
     }
 
     private boolean isFailed() {
       return failed.get();
+    }
+
+    private synchronized boolean hasPendingResponses() {
+      return pendingResponses > 0;
+    }
+
+    private void onChange(Runnable listener) {
+      boolean runImmediately;
+      synchronized (this) {
+        if (changeListeners == null) changeListeners = new ArrayList<>();
+        changeListeners.add(listener);
+        runImmediately = failed.get() || pendingResponses == 0;
+      }
+      if (runImmediately) {
+        listener.run();
+      }
+    }
+
+    private synchronized void removeListener(Runnable listener) {
+      if (changeListeners != null) {
+        changeListeners.remove(listener);
+        if (changeListeners.isEmpty()) changeListeners = null;
+      }
+    }
+
+    private void finishRestoreOwner() {
+      if (pendingRestoreOwners.decrementAndGet() == 0) {
+        ArrayList<Runnable> listeners;
+        synchronized (this) {
+          listeners = copyListenersLocked();
+        }
+        runListeners(listeners);
+      }
+    }
+
+    private ArrayList<Runnable> copyListenersLocked() {
+      return changeListeners == null ? null : new ArrayList<>(changeListeners);
+    }
+
+    private static void runListeners(ArrayList<Runnable> listeners) {
+      if (listeners == null) {
+        return;
+      }
+      for (Runnable listener : listeners) {
+        listener.run();
+      }
     }
   }
 
@@ -9012,7 +9096,8 @@ public class Leelaz {
     QueuedCommand[] admitted = new QueuedCommand[capturedCommands.size()];
     QueuedCommand[] mirroredAdmitted =
         mirroredEngine == null ? null : new QueuedCommand[capturedCommands.size()];
-    ReaderStreamBinding commandBinding = startupBinding;
+    ReaderStreamBinding commandBinding =
+        startupBinding == null ? positionRestoreBindingContext.get() : startupBinding;
     long admissionGeneration;
     if (mirroredEngine == null) {
       synchronized (engineArbitrationLock()) {
@@ -9089,6 +9174,8 @@ public class Leelaz {
       RestartBootstrapReceipt mirroredBootstrapReceipt,
       OrdinaryEnqueueEffects mirroredEffects,
       QueuedCommand[] mirroredAdmitted) {
+    ReaderStreamBinding mirroredCommandBinding =
+        mirroredEngine == null ? null : mirroredEngine.positionRestoreBindingContext.get();
     for (String command : commands) {
       if (!canAdmitOrdinaryCommandLocked(
           command,
@@ -9105,7 +9192,7 @@ public class Leelaz {
               command,
               TrackingReleaseReason.ORDINARY_OPERATION,
               true,
-              null,
+              mirroredCommandBinding,
               null,
               mirroredBootstrapReceipt,
               null)) {
@@ -9129,7 +9216,7 @@ public class Leelaz {
       mirroredEngine.enqueueStatefulOrdinaryCommandsLocked(
           commands,
           null,
-          null,
+          mirroredCommandBinding,
           mirroredBootstrapReceipt,
           mirroredEffects,
           mirroredAdmitted);
@@ -9701,7 +9788,8 @@ public class Leelaz {
         if (binding.remoteTransport != null) {
           rememberRecentLine(
               recentStderrLines,
-              "Remote engine-game participant retired; recovery deferred until transaction retirement");
+              "Remote engine-game participant retired; recovery deferred until transaction"
+                  + " retirement");
         }
         return null;
       }
@@ -10691,6 +10779,15 @@ public class Leelaz {
               !ordinaryBootstrap || !isNameRecognitionBootstrapCommand(command));
       readBoardGmaResponseBinding = startupBinding;
     }
+    ReaderStreamBinding capturedRestoreBinding = positionRestoreBindingContext.get();
+    if (capturedRestoreBinding != null) {
+      if (readBoardGmaResponseBinding != null
+          && readBoardGmaResponseBinding != capturedRestoreBinding) {
+        throw new IllegalStateException(
+            "Compound restore response binding changed during dispatch");
+      }
+      readBoardGmaResponseBinding = capturedRestoreBinding;
+    }
     if (shouldDropStaleForegroundRestoreCommand()
         || shouldSuppressNormalCommandForForegroundAnalysis()
         || shouldDropCommandDuringInitialBoardSynchronization(command)
@@ -11100,7 +11197,10 @@ public class Leelaz {
       calculateModifyNumber();
     }
     if (!targetQueue.isEmpty()
-        && shouldCoalesceQueuedCommand(targetQueue.peekLast().command, noLeelaz2Coalescing)) {
+        && shouldCoalesceQueuedCommand(targetQueue.peekLast().command, noLeelaz2Coalescing)
+        && !(targetQueue.peekLast().analysisStateLineage() != null
+            && targetQueue.peekLast().analysisStateLineage().pendingRestoreOwners.get() > 0
+            && !isOrdinaryPositionAnalysisCommand(command))) {
       QueuedCommand coalesced = targetQueue.removeLast();
       effects.coalescedCommands.add(coalesced);
       if (countCommand) {
@@ -11187,16 +11287,27 @@ public class Leelaz {
     boolean positionMutation = analysisStateMutation(command.command) != AnalysisStateMutation.NONE;
     if (binding != null
         && (positionMutation || isAnalysisOutputOwnershipCommand(command.command))) {
+      AnalysisStateLineage scopedLineage = positionRestoreLineageContext.get();
+      if (scopedLineage == null && command.restoreAdmission != null) {
+        scopedLineage = command.restoreAdmission.lineageFor(this);
+      }
       if (binding.queuedAnalysisStateLineage == null) {
         binding.queuedAnalysisStateLineage = binding.analysisStateLineage;
       }
-      if (positionMutation && startsFreshAnalysisStateLineage(command.command)) {
+      if (positionMutation && scopedLineage != null) {
+        binding.queuedAnalysisStateLineage = scopedLineage;
+      } else if (positionMutation && startsFreshAnalysisStateLineage(command.command)) {
         binding.queuedAnalysisStateLineage = new AnalysisStateLineage();
       }
       command.bindAnalysisStateLineage(binding.queuedAnalysisStateLineage, binding);
-      if (positionMutation) analysisOutputGeneration.incrementAndGet();
+      if (positionMutation) {
+        command.registerAnalysisStateResponse();
+        analysisOutputGeneration.incrementAndGet();
+      }
     }
-    if (command.engineGameTransaction() == null && isIncrementalPositionCommand(command.command)) {
+    if (command.engineGameTransaction() == null
+        && positionMutation
+        && !command.isTrackedLoadSgf()) {
       command.positionResponseTimeout = new Timer("lizzie-position-response-timeout", true);
       command.positionResponseTimeout.schedule(
           new TimerTask() {
@@ -11754,6 +11865,14 @@ public class Leelaz {
         engineGameStartupCommandContext.get();
     ReaderStreamBinding startupBinding =
         startupTransaction == null ? null : currentReaderStreamBinding();
+    ReaderStreamBinding capturedRestoreBinding = positionRestoreBindingContext.get();
+    if (capturedRestoreBinding != null) {
+      if (expectedBinding != null && expectedBinding != capturedRestoreBinding) {
+        throw new IllegalStateException(
+            "Compound restore response binding changed during dispatch");
+      }
+      expectedBinding = capturedRestoreBinding;
+    }
     if (expectedBinding != null
         && (readerStreamBinding != expectedBinding
             || expectedBinding.terminated
@@ -11912,6 +12031,23 @@ public class Leelaz {
         return;
       }
       QueuedCommand queueHead = targetQueue.peekFirst();
+      ReaderStreamBinding binding = currentReaderStreamBinding();
+      if (binding.queuedAnalysisStateLineage != null
+          && binding.queuedAnalysisStateLineage.pendingRestoreOwners.get() > 0
+          && queueHead.engineGameTransaction() == null
+          && isOrdinaryPositionAnalysisCommand(queueHead.command)) {
+        // Analysis requested after capture depends on restore commands not yet enqueued.
+        // Keep that request in this queue while its position commands and fence pass it.
+        queueHead = null;
+        for (QueuedCommand candidate : targetQueue) {
+          if (!isOrdinaryPositionAnalysisCommand(candidate.command)
+              || candidate.engineGameTransaction() != null) {
+            queueHead = candidate;
+            break;
+          }
+        }
+        if (queueHead == null) return;
+      }
       if (!foregroundRestoreInProgress
           && requireResponseBeforeSend
           && (queueHead.engineGameTransaction() != null
@@ -11941,7 +12077,9 @@ public class Leelaz {
                     || lastQueuedCommand.startsWith("analyze")
                     || lastQueuedCommand.startsWith("heatmap")))) return;
       }
-      queuedCommand = targetQueue.removeFirst();
+      queuedCommand = queueHead;
+      if (targetQueue.peekFirst() == queueHead) targetQueue.removeFirst();
+      else targetQueue.remove(queueHead);
       normalCommandSendInProgress = true;
       normalCommandBeingSent = queuedCommand;
     }
@@ -12934,9 +13072,11 @@ public class Leelaz {
     }
     if (retiredPending != null) {
       failAnalysisStateLineage(retiredPending.queuedCommand);
+      retiredPending.queuedCommand.settleAnalysisStateResponse(false);
     }
     if (retiredQueued != null) {
       failAnalysisStateLineage(retiredQueued);
+      retiredQueued.settleAnalysisStateResponse(false);
       try {
         retiredQueued.publishSettlementFailure(failure);
       } catch (RuntimeException | Error notificationFailure) {
@@ -13351,7 +13491,14 @@ public class Leelaz {
       if (handler == null) {
         return false;
       }
-      handler.run();
+      if (currentCommandResponseError) {
+        failAnalysisStateLineage(handler.queuedCommand);
+      }
+      try {
+        handler.run();
+      } finally {
+        handler.queuedCommand.settleAnalysisStateResponse(!currentCommandResponseError);
+      }
       return true;
     } finally {
       currentCommandResponseLine = "";
@@ -13450,7 +13597,11 @@ public class Leelaz {
         failAnalysisStateLineage(failedAnalysisStateCommand);
       }
       if (settleOnlyStaleBootstrapResponse) {
-        matchedPendingHandler.settleWithoutBusinessCallback();
+        try {
+          matchedPendingHandler.settleWithoutBusinessCallback();
+        } finally {
+          matchedPendingHandler.queuedCommand.settleAnalysisStateResponse(false);
+        }
       } else if (!ignoreResponse) {
         boolean handlerSettled = false;
         try {
@@ -13482,6 +13633,10 @@ public class Leelaz {
             // A diagnostic or business callback must never strand a physical engine-game lease
             // after its exact pending handler has already been removed from the queue.
             matchedPendingHandler.settleWithoutBusinessCallback();
+          }
+          if (matchedPendingHandler != null) {
+            matchedPendingHandler.queuedCommand.settleAnalysisStateResponse(
+                !currentCommandResponseError);
           }
         }
       }
@@ -14455,14 +14610,24 @@ public class Leelaz {
 
   /** Captures the board-sync owner for one immutable exact restore plan. */
   public ExactSnapshotRestoreAdmission captureBoardSyncExactSnapshotRestoreAdmission() {
+    return captureBoardSyncExactSnapshotRestoreAdmission(resolveLoadSgfMirrorEngine());
+  }
+
+  public ExactSnapshotRestoreAdmission captureBoardSyncExactSnapshotRestoreAdmission(
+      Leelaz capturedMirror) {
     return captureExactSnapshotRestoreAdmission(
-        ExactSnapshotRestoreOwner.BOARD_SYNC, null, resolveLoadSgfMirrorEngine(), false);
+        ExactSnapshotRestoreOwner.BOARD_SYNC, null, capturedMirror, false);
   }
 
   /** Captures a board-sync restore that must remain bound to the selected primary engine. */
   public ExactSnapshotRestoreAdmission captureHistoryNavigationExactSnapshotRestoreAdmission() {
+    return captureHistoryNavigationExactSnapshotRestoreAdmission(resolveLoadSgfMirrorEngine());
+  }
+
+  public ExactSnapshotRestoreAdmission captureHistoryNavigationExactSnapshotRestoreAdmission(
+      Leelaz capturedMirror) {
     return captureExactSnapshotRestoreAdmission(
-        ExactSnapshotRestoreOwner.BOARD_SYNC, null, resolveLoadSgfMirrorEngine(), true);
+        ExactSnapshotRestoreOwner.BOARD_SYNC, null, capturedMirror, true);
   }
 
   /** Captures the arbitration owner for one immutable exact restore plan. */
@@ -14521,6 +14686,22 @@ public class Leelaz {
       throw new ExactSnapshotRestoreAdmissionException(
           "Lifecycle completion is already settling board synchronization.");
     }
+    RestoreEndpointDependency[] completionDependencies =
+        completionClaim == null ? null : captureCurrentRestoreDependencies(this, mirror);
+    AnalysisStateLineage authorityLineage =
+        completionDependencies == null
+            ? new AnalysisStateLineage()
+            : completionDependencies[0].lineage;
+    AnalysisStateLineage mirrorLineage =
+        mirror == null
+            ? null
+            : completionDependencies == null
+                ? new AnalysisStateLineage()
+                : completionDependencies[1].lineage;
+    invalidateAnalysisOutputForRestoreCapture();
+    if (mirror != null) {
+      mirror.invalidateAnalysisOutputForRestoreCapture();
+    }
     return new ExactSnapshotRestoreAdmission(
         this,
         mirror,
@@ -14529,7 +14710,13 @@ public class Leelaz {
         authorityIncarnation,
         mirrorIncarnation,
         boardSyncLease,
-        primaryEngineGeneration);
+        primaryEngineGeneration,
+        authorityLineage,
+        mirrorLineage);
+  }
+
+  private void invalidateAnalysisOutputForRestoreCapture() {
+    analysisOutputGeneration.incrementAndGet();
   }
 
 
@@ -17092,6 +17279,8 @@ public class Leelaz {
     private final Object mirrorIncarnation;
     private final LifecycleCompletionClaim.BoardSyncCompletionLease boardSyncLease;
     private final long primaryEngineGeneration;
+    private final AnalysisStateLineage authorityLineage;
+    private final AnalysisStateLineage mirrorLineage;
 
     private ExactSnapshotRestoreAdmission(
         Leelaz authority,
@@ -17101,7 +17290,9 @@ public class Leelaz {
         Object authorityIncarnation,
         Object mirrorIncarnation,
         LifecycleCompletionClaim.BoardSyncCompletionLease boardSyncLease,
-        long primaryEngineGeneration) {
+        long primaryEngineGeneration,
+        AnalysisStateLineage authorityLineage,
+        AnalysisStateLineage mirrorLineage) {
       this.authority = authority;
       this.mirror = mirror;
       this.owner = owner;
@@ -17110,6 +17301,8 @@ public class Leelaz {
       this.mirrorIncarnation = mirrorIncarnation;
       this.boardSyncLease = boardSyncLease;
       this.primaryEngineGeneration = primaryEngineGeneration;
+      this.authorityLineage = authorityLineage;
+      this.mirrorLineage = mirrorLineage;
     }
 
     Leelaz authority() {
@@ -17127,6 +17320,14 @@ public class Leelaz {
     private boolean includes(Leelaz engine) {
       return engine == authority || engine == mirror;
     }
+
+    private AnalysisStateLineage lineageFor(Leelaz engine) {
+      if (engine == authority) {
+        return authorityLineage;
+      }
+      return engine == mirror ? mirrorLineage : null;
+    }
+
     private boolean runIfCurrentBoardSyncPrimary(Runnable action) {
       if (owner != ExactSnapshotRestoreOwner.BOARD_SYNC || primaryEngineGeneration < 0) {
         action.run();
@@ -18705,6 +18906,8 @@ public class Leelaz {
     private volatile AnalysisStateLineage analysisStateLineage;
     private volatile ReaderStreamBinding analysisStateResponseBinding;
     private volatile Timer positionResponseTimeout;
+    private boolean analysisStateResponseRegistered;
+    private boolean analysisStateResponseSettled;
 
     private void finishPositionResponse() {
       Timer timer = positionResponseTimeout;
@@ -18740,7 +18943,7 @@ public class Leelaz {
         Object expectedLeela0110StateToken) {
       this.command = command;
       this.onResponse =
-          onResponse == null && isIncrementalPositionCommand(command)
+          onResponse == null && analysisStateMutation(command) != AnalysisStateMutation.NONE
               ? this::finishPositionResponse
               : onResponse;
       this.onSendFailure = onSendFailure;
@@ -18765,6 +18968,35 @@ public class Leelaz {
       analysisStateResponseBinding = responseBinding;
     }
 
+    private void registerAnalysisStateResponse() {
+      AnalysisStateLineage lineage = analysisStateLineage;
+      if (lineage == null) {
+        return;
+      }
+      synchronized (this) {
+        if (analysisStateResponseRegistered) {
+          return;
+        }
+        analysisStateResponseRegistered = true;
+      }
+      lineage.registerResponse();
+    }
+
+    private void settleAnalysisStateResponse(boolean successful) {
+      AnalysisStateLineage lineage;
+      synchronized (this) {
+        if (!analysisStateResponseRegistered || analysisStateResponseSettled) {
+          return;
+        }
+        analysisStateResponseSettled = true;
+        lineage = analysisStateLineage;
+      }
+      finishPositionResponse();
+      if (lineage != null) {
+        lineage.settleResponse(successful);
+      }
+    }
+
     private AnalysisStateLineage analysisStateLineage() {
       return analysisStateLineage;
     }
@@ -18774,12 +19006,8 @@ public class Leelaz {
     }
 
     private void failAnalysisStateLineageAfterSendFailure() {
-      finishPositionResponse();
       if (analysisStateMutation(command) == AnalysisStateMutation.NONE) return;
-      AnalysisStateLineage lineage = analysisStateLineage;
-      if (lineage != null) {
-        lineage.fail();
-      }
+      settleAnalysisStateResponse(false);
     }
 
     private boolean requiresStateReset() {
@@ -18970,6 +19198,7 @@ public class Leelaz {
     }
 
     private void notifySendFailure(RuntimeException failure) {
+      failAnalysisStateLineageAfterSendFailure();
       try {
         try {
           publishInternalSendFailure(failure, false);
@@ -19014,6 +19243,7 @@ public class Leelaz {
         failure = stateResetAfterOutputWriteFailure;
         stateResetAfterOutputWritePublished = true;
       }
+      failAnalysisStateLineageAfterSendFailure();
       try {
         try {
           publishInternalSendFailure(failure, true);
@@ -20841,27 +21071,256 @@ public class Leelaz {
       completion.run();
     }
   }
+
+  /**
+   * Captures one immutable response lineage and reader identity for a compound position restore.
+   */
+  public PositionRestore capturePositionRestore(Leelaz capturedMirror) {
+    Leelaz mirror = gtpCapableRestoreMirror(this, capturedMirror);
+    if (mirror == null) {
+      synchronized (engineArbitrationLock()) {
+        synchronized (commandQueue()) {
+          return new PositionRestore(captureNewRestoreDependencyLocked(), null);
+        }
+      }
+    }
+    return withOrderedEngineArbitrationAndQueueLocks(
+        this,
+        mirror,
+        () ->
+            new PositionRestore(
+                captureNewRestoreDependencyLocked(), mirror.captureNewRestoreDependencyLocked()));
+  }
+
+  private RestoreEndpointDependency captureNewRestoreDependencyLocked() {
+    ReaderStreamBinding binding = currentReaderStreamBinding();
+    AnalysisStateLineage lineage =
+        lifecycleCompletionClaim == null
+            ? new AnalysisStateLineage()
+            : captureCurrentRestoreDependencyLocked().lineage;
+    binding.queuedAnalysisStateLineage = lineage;
+    invalidateAnalysisOutputForRestoreCapture();
+    return new RestoreEndpointDependency(this, binding, lineage);
+  }
+
+  private RestoreEndpointDependency captureCurrentRestoreDependencyLocked() {
+    ReaderStreamBinding binding = currentReaderStreamBinding();
+    AnalysisStateLineage lineage = binding.queuedAnalysisStateLineage;
+    if (lineage == null) {
+      lineage = binding.analysisStateLineage;
+    }
+    return new RestoreEndpointDependency(this, binding, lineage);
+  }
+
+  private static RestoreEndpointDependency[] captureCurrentRestoreDependencies(
+      Leelaz authority, Leelaz mirror) {
+    if (mirror == null) {
+      synchronized (authority.engineArbitrationLock()) {
+        synchronized (authority.commandQueue()) {
+          return new RestoreEndpointDependency[] {
+            authority.captureCurrentRestoreDependencyLocked(), null
+          };
+        }
+      }
+    }
+    return withOrderedEngineArbitrationAndQueueLocks(
+        authority,
+        mirror,
+        () ->
+            new RestoreEndpointDependency[] {
+              authority.captureCurrentRestoreDependencyLocked(),
+              mirror.captureCurrentRestoreDependencyLocked()
+            });
+  }
+
+  private void withPositionRestoreContext(RestoreEndpointDependency dependency, Runnable commands) {
+    AnalysisStateLineage previousLineage = positionRestoreLineageContext.get();
+    ReaderStreamBinding previousBinding = positionRestoreBindingContext.get();
+    positionRestoreLineageContext.set(dependency.lineage);
+    positionRestoreBindingContext.set(dependency.binding);
+    try {
+      commands.run();
+    } finally {
+      if (previousLineage == null) {
+        positionRestoreLineageContext.remove();
+      } else {
+        positionRestoreLineageContext.set(previousLineage);
+      }
+      if (previousBinding == null) {
+        positionRestoreBindingContext.remove();
+      } else {
+        positionRestoreBindingContext.set(previousBinding);
+      }
+    }
+  }
+
+  private static final class RestoreEndpointDependency {
+    private final Leelaz engine;
+    private final ReaderStreamBinding binding;
+    private final AnalysisStateLineage lineage;
+
+    private RestoreEndpointDependency(
+        Leelaz engine, ReaderStreamBinding binding, AnalysisStateLineage lineage) {
+      this.engine = engine;
+      this.binding = binding;
+      this.lineage = lineage;
+    }
+
+    private boolean isCurrent() {
+      synchronized (engine.engineArbitrationLock()) {
+        synchronized (engine.commandQueue()) {
+          return isCurrentLocked();
+        }
+      }
+    }
+
+    private boolean isCurrentLocked() {
+      return engine.readerStreamBinding == binding
+          && !binding.terminated
+          && (binding.queuedAnalysisStateLineage == null
+                  ? binding.analysisStateLineage
+                  : binding.queuedAnalysisStateLineage)
+              == lineage;
+    }
+
+    private void markUnavailableIfCurrent() {
+      synchronized (engine.engineArbitrationLock()) {
+        synchronized (engine.commandQueue()) {
+          if (!isCurrentLocked()) {
+            return;
+          }
+          engine.markUnavailableIfCurrentIncarnation(binding);
+        }
+      }
+    }
+
+    private boolean isConfirmed(boolean fenceConfirmed) {
+      return fenceConfirmed && isCurrent() && !lineage.isFailed() && !lineage.hasPendingResponses();
+    }
+  }
+
+  /** Capture-only handle: dispatch is scoped; response completion remains callback-based. */
+  public static final class PositionRestore {
+    private final RestoreEndpointDependency authority;
+    private final RestoreEndpointDependency mirror;
+    private final AtomicBoolean executed = new AtomicBoolean(false);
+    private final AtomicBoolean confirmationStarted = new AtomicBoolean(false);
+    private final AtomicBoolean finished = new AtomicBoolean(false);
+    private final boolean sharedLifecycleOwner;
+
+    private PositionRestore(RestoreEndpointDependency authority, RestoreEndpointDependency mirror) {
+      this.authority = authority;
+      this.mirror = mirror;
+      sharedLifecycleOwner = authority.engine.lifecycleCompletionClaim != null;
+      authority.lineage.pendingRestoreOwners.incrementAndGet();
+      if (mirror != null) mirror.lineage.pendingRestoreOwners.incrementAndGet();
+    }
+
+    public void execute(Runnable commands) {
+      if (commands == null) {
+        throw new IllegalArgumentException("commands");
+      }
+      if (!executed.compareAndSet(false, true)) {
+        throw new IllegalStateException("Position restore has already been executed");
+      }
+      if (!authority.isCurrent() || (mirror != null && !mirror.isCurrent())) {
+        failLineages();
+        throw new IllegalStateException("Position restore reader binding is no longer current");
+      }
+      try {
+        authority.engine.withPositionRestoreContext(
+            authority,
+            () -> {
+              if (mirror == null) {
+                commands.run();
+              } else {
+                mirror.engine.withPositionRestoreContext(mirror, commands);
+              }
+            });
+      } catch (RuntimeException | Error failure) {
+        failLineages();
+        throw failure;
+      }
+    }
+
+    public void confirm(Runnable onSuccess, Consumer<String> onFailure) {
+      if (!executed.get()) {
+        throw new IllegalStateException("Position restore has not been executed");
+      }
+      if (!confirmationStarted.compareAndSet(false, true)) {
+        throw new IllegalStateException("Position restore confirmation has already started");
+      }
+      authority.engine
+          .new BoardSynchronizationConfirmation(
+              authority,
+              mirror,
+              false,
+              () -> finishConfirmation(onSuccess),
+              detail -> {
+                failLineages();
+                if (onFailure != null) onFailure.accept(detail);
+              })
+          .start();
+    }
+
+    /** Retires an owner capture that will not dispatch or complete. */
+    public void cancel() {
+      executed.set(true);
+      confirmationStarted.set(true);
+      if (sharedLifecycleOwner) finishConfirmation(null);
+      else failLineages();
+    }
+
+    private void finishConfirmation(Runnable onSuccess) {
+      if (!finished.compareAndSet(false, true)) return;
+      authority.lineage.finishRestoreOwner();
+      if (mirror != null) mirror.lineage.finishRestoreOwner();
+      try {
+        if (onSuccess != null) onSuccess.run();
+      } finally {
+        authority.engine.trySendCommandFromQueue();
+        if (mirror != null) mirror.engine.trySendCommandFromQueue();
+      }
+    }
+
+    private void failLineages() {
+      authority.lineage.fail();
+      if (mirror != null) {
+        mirror.lineage.fail();
+      }
+      finishConfirmation(null);
+    }
+  }
+
   void confirmBoardSynchronization(Runnable onSuccess, Consumer<String> onFailure) {
     confirmBoardSynchronization(null, onSuccess, onFailure);
   }
 
   /**
    * Fences the final restore point against the captured authority and, when a distinct captured
-   * mirror exists, against that exact mirror as well. Ready, ponder and analyze only follow after
-   * every leg acknowledges; any leg send failure, error response or timeout fails closed.
-  */
+   * mirror exists, against that exact mirror as well. Required position responses and every final
+   * fence must succeed; any send failure, error response, timeout or reader replacement fails
+   * closed.
+   */
   void confirmBoardSynchronization(Leelaz mirror, Runnable onSuccess, Consumer<String> onFailure) {
-    new BoardSynchronizationConfirmation(mirror, onSuccess, onFailure).start();
+    Leelaz effectiveMirror = gtpCapableRestoreMirror(this, mirror);
+    RestoreEndpointDependency[] dependencies =
+        captureCurrentRestoreDependencies(this, effectiveMirror);
+    new BoardSynchronizationConfirmation(
+            dependencies[0], dependencies[1], true, onSuccess, onFailure)
+        .start();
   }
 
   private interface BoardSynchronizationResponseHandler extends Runnable {}
 
   private final class BoardSynchronizationConfirmation {
-    private final Leelaz mirror;
+    private final RestoreEndpointDependency authority;
+    private final RestoreEndpointDependency mirror;
+    private final boolean waitForRestoreOwners;
+    private final Runnable dependencyChanged = this::tryComplete;
     private final Runnable onSuccess;
     private final Consumer<String> onFailure;
     private final AtomicBoolean settled = new AtomicBoolean(false);
-    private final AtomicInteger remainingLegs;
     private final AtomicBoolean authorityLegDispatched = new AtomicBoolean(false);
     private final AtomicBoolean mirrorLegDispatched = new AtomicBoolean(false);
     private final AtomicBoolean authorityLegConfirmed = new AtomicBoolean(false);
@@ -20874,16 +21333,28 @@ public class Leelaz {
     private Timer timeout;
 
     private BoardSynchronizationConfirmation(
-        Leelaz mirror, Runnable onSuccess, Consumer<String> onFailure) {
+        RestoreEndpointDependency authority,
+        RestoreEndpointDependency mirror,
+        boolean waitForRestoreOwners,
+        Runnable onSuccess,
+        Consumer<String> onFailure) {
+      this.authority = authority;
       this.mirror = mirror;
+      this.waitForRestoreOwners = waitForRestoreOwners;
       this.onSuccess = onSuccess;
       this.onFailure = onFailure;
       this.mirrorResponseHandler =
           mirror == null ? null : (BoardSynchronizationResponseHandler) this::onMirrorResponse;
-      this.remainingLegs = new AtomicInteger(mirror == null ? 1 : 2);
     }
 
     private void start() {
+      authority.lineage.onChange(dependencyChanged);
+      if (mirror != null) {
+        mirror.lineage.onChange(dependencyChanged);
+      }
+      if (settled.get()) {
+        return;
+      }
       Timer confirmationTimeout = new Timer("lizzie-board-sync-confirmation-timeout", true);
       timeout = confirmationTimeout;
       TimerTask timeoutTask =
@@ -20895,7 +21366,16 @@ public class Leelaz {
           };
       try {
         authorityLegDispatched.set(true);
-        sendCommand("name", responseHandler, this::onSendFailure, true, false);
+        authority.engine.sendCommand(
+            "name",
+            responseHandler,
+            this::onSendFailure,
+            true,
+            false,
+            TrackingReleaseReason.ORDINARY_OPERATION,
+            null,
+            false,
+            authority.binding);
       } catch (RuntimeException ex) {
         settleFailure(ex.getMessage());
         return;
@@ -20903,8 +21383,16 @@ public class Leelaz {
       if (mirror != null && !settled.get()) {
         try {
           mirrorLegDispatched.set(true);
-          mirror.sendCommand(
-              "name", mirrorResponseHandler, this::onMirrorSendFailure, true, false);
+          mirror.engine.sendCommand(
+              "name",
+              mirrorResponseHandler,
+              this::onMirrorSendFailure,
+              true,
+              false,
+              TrackingReleaseReason.ORDINARY_OPERATION,
+              null,
+              false,
+              mirror.binding);
         } catch (RuntimeException ex) {
           settleFailure(ex.getMessage());
           return;
@@ -20914,7 +21402,7 @@ public class Leelaz {
         scheduleBoardSynchronizationTimeout(
             confirmationTimeout,
             timeoutTask,
-            Math.max(1L, readBoardGmaRestoreResponseTimeoutMillis()),
+            Math.max(1L, authority.engine.readBoardGmaRestoreResponseTimeoutMillis()),
             settled);
       }
     }
@@ -20923,28 +21411,44 @@ public class Leelaz {
       if (settled.get()) {
         return;
       }
-      if (isCurrentCommandResponseError()) {
-        settleFailure("board synchronization failed: " + currentCommandResponseLine());
+      if (authority.engine.isCurrentCommandResponseError()) {
+        settleFailure(
+            "board synchronization failed: " + authority.engine.currentCommandResponseLine());
         return;
       }
       authorityLegConfirmed.set(true);
-      completeLeg();
+      tryComplete();
     }
 
     private void onMirrorResponse() {
       if (settled.get()) {
         return;
       }
-      if (mirror.isCurrentCommandResponseError()) {
-        settleFailure("board synchronization failed: " + mirror.currentCommandResponseLine());
+      if (mirror.engine.isCurrentCommandResponseError()) {
+        settleFailure(
+            "board synchronization failed: " + mirror.engine.currentCommandResponseLine());
         return;
       }
       mirrorLegConfirmed.set(true);
-      completeLeg();
+      tryComplete();
     }
 
-    private void completeLeg() {
-      if (remainingLegs.decrementAndGet() != 0) {
+    private void tryComplete() {
+      if (settled.get()) {
+        return;
+      }
+      String dependencyFailure = dependencyFailure();
+      if (dependencyFailure != null) {
+        settleFailure(dependencyFailure);
+        return;
+      }
+      if (authority.lineage.hasPendingResponses()
+          || (mirror != null && mirror.lineage.hasPendingResponses())
+          || (waitForRestoreOwners
+              && (authority.lineage.pendingRestoreOwners.get() > 0
+                  || (mirror != null && mirror.lineage.pendingRestoreOwners.get() > 0)))
+          || !authorityLegConfirmed.get()
+          || (mirror != null && !mirrorLegConfirmed.get())) {
         return;
       }
       if (!settled.compareAndSet(false, true)) {
@@ -20956,6 +21460,22 @@ public class Leelaz {
       }
     }
 
+    private String dependencyFailure() {
+      if (!authority.isCurrent()) {
+        return "board synchronization authority changed before confirmation";
+      }
+      if (authority.lineage.isFailed()) {
+        return "board synchronization required position command failed";
+      }
+      if (mirror != null && !mirror.isCurrent()) {
+        return "board synchronization mirror changed before confirmation";
+      }
+      if (mirror != null && mirror.lineage.isFailed()) {
+        return "board synchronization mirror position command failed";
+      }
+      return null;
+    }
+
     private void onSendFailure(RuntimeException failure) {
       settleFailure(failure == null ? "board synchronization send failed" : failure.getMessage());
     }
@@ -20965,12 +21485,6 @@ public class Leelaz {
           failure == null ? "board synchronization mirror send failed" : failure.getMessage());
     }
 
-    /**
-     * Linearized failure settlement: atomically claim the settlement, then retire every
-     * dispatched leg handler, mark every captured endpoint that never confirmed unavailable, and
-     * only then invoke the failure callback so the completion gates release after all old
-     * handlers have retired.
-     */
     private void settleFailure(String detail) {
       if (!settled.compareAndSet(false, true)) {
         return;
@@ -20986,24 +21500,19 @@ public class Leelaz {
 
     private void retireDispatchedLegs() {
       if (authorityLegDispatched.get()) {
-        retireTimedOutNormalCommand(responseHandler);
+        authority.engine.retireTimedOutNormalCommand(responseHandler);
       }
       if (mirror != null && mirrorLegDispatched.get()) {
-        mirror.retireTimedOutNormalCommand(mirrorResponseHandler);
+        mirror.engine.retireTimedOutNormalCommand(mirrorResponseHandler);
       }
     }
 
-    /**
-     * Marks every captured endpoint that never acknowledged its fence unavailable. The failed
-     * endpoint is always unconfirmed; when no leg confirmed yet, the whole captured set fails
-     * closed atomically.
-     */
     private void markUnconfirmedCapturedEndpointsUnavailable() {
-      if (!authorityLegConfirmed.get()) {
-        isLoaded = false;
+      if (!authority.isConfirmed(authorityLegConfirmed.get())) {
+        authority.markUnavailableIfCurrent();
       }
-      if (mirror != null && !mirrorLegConfirmed.get()) {
-        mirror.isLoaded = false;
+      if (mirror != null && !mirror.isConfirmed(mirrorLegConfirmed.get())) {
+        mirror.markUnavailableIfCurrent();
       }
     }
 
@@ -21014,6 +21523,8 @@ public class Leelaz {
     }
 
     private void cancelTimeout() {
+      authority.lineage.removeListener(dependencyChanged);
+      if (mirror != null) mirror.lineage.removeListener(dependencyChanged);
       Timer currentTimeout = timeout;
       timeout = null;
       if (currentTimeout != null) {
@@ -21649,7 +22160,8 @@ public class Leelaz {
   public void togglePonder() {
     if (!hasGtpCapability()) {
       if (Lizzie.gtpConsole != null) {
-        Lizzie.gtpConsole.addLine(Lizzie.resourceBundle.getString("Benchmark.gtpUnavailable") + "\n");
+        Lizzie.gtpConsole.addLine(
+            Lizzie.resourceBundle.getString("Benchmark.gtpUnavailable") + "\n");
       }
       return;
     }
@@ -21690,8 +22202,57 @@ public class Leelaz {
         recordPause.run();
       }
     }
+    cancelUnwrittenOrdinaryAnalysisForPause();
     if (Lizzie.leelaz == this && isPondering()) {
       togglePonder();
+    }
+  }
+
+  private void cancelUnwrittenOrdinaryAnalysisForPause() {
+    ArrayList<QueuedCommand> cancelled = null;
+    RuntimeException failure = null;
+    synchronized (engineArbitrationLock()) {
+      synchronized (commandQueue()) {
+        QueuedCommand selected = normalCommandBeingSent;
+        if (selected != null
+            && selected.engineGameTransaction() == null
+            && !selected.foregroundRestoreCommand
+            && isOrdinaryPositionAnalysisCommand(selected.command)) {
+          failure = new IllegalStateException("Analysis paused by user");
+          if (selected.cancelBeforeOutputWrite(failure)) {
+            if (selected.claimCommandCountRetirement()) cmdNumber = Math.max(1, cmdNumber - 1);
+            cancelled = new ArrayList<>();
+            cancelled.add(selected);
+          }
+        }
+        Iterator<QueuedCommand> iterator = commandQueue().iterator();
+        while (iterator.hasNext()) {
+          QueuedCommand command = iterator.next();
+          if (command.engineGameTransaction() != null
+              || command.foregroundRestoreCommand
+              || !isOrdinaryPositionAnalysisCommand(command.command)) continue;
+          if (failure == null) failure = new IllegalStateException("Analysis paused by user");
+          if (!command.cancelBeforeOutputWrite(failure)) continue;
+          iterator.remove();
+          if (command.claimCommandCountRetirement()) cmdNumber = Math.max(1, cmdNumber - 1);
+          if (cancelled == null) cancelled = new ArrayList<>();
+          cancelled.add(command);
+        }
+        if (cancelled != null && currentCmdNum > cmdNumber - 1) currentCmdNum = cmdNumber - 1;
+      }
+    }
+    if (cancelled != null) {
+      try {
+        for (QueuedCommand command : cancelled) {
+          try {
+            command.notifySendFailure(failure);
+          } catch (Throwable ignored) {
+            // A cancelled observer cannot keep required position work in the queue.
+          }
+        }
+      } finally {
+        trySendCommandFromQueue();
+      }
     }
   }
 

--- a/src/main/java/featurecat/lizzie/analysis/Leelaz.java
+++ b/src/main/java/featurecat/lizzie/analysis/Leelaz.java
@@ -21076,11 +21076,20 @@ public class Leelaz {
    * Captures one immutable response lineage and reader identity for a compound position restore.
    */
   public PositionRestore capturePositionRestore(Leelaz capturedMirror) {
+    return capturePositionRestore(capturedMirror, true);
+  }
+
+  /** Captures an incremental transition, retaining the source position's required responses. */
+  public PositionRestore capturePositionTransition(Leelaz capturedMirror) {
+    return capturePositionRestore(capturedMirror, false);
+  }
+
+  private PositionRestore capturePositionRestore(Leelaz capturedMirror, boolean replacesPosition) {
     Leelaz mirror = gtpCapableRestoreMirror(this, capturedMirror);
     if (mirror == null) {
       synchronized (engineArbitrationLock()) {
         synchronized (commandQueue()) {
-          return new PositionRestore(captureNewRestoreDependencyLocked(), null);
+          return new PositionRestore(captureRestoreDependencyLocked(replacesPosition), null);
         }
       }
     }
@@ -21089,13 +21098,14 @@ public class Leelaz {
         mirror,
         () ->
             new PositionRestore(
-                captureNewRestoreDependencyLocked(), mirror.captureNewRestoreDependencyLocked()));
+                captureRestoreDependencyLocked(replacesPosition),
+                mirror.captureRestoreDependencyLocked(replacesPosition)));
   }
 
-  private RestoreEndpointDependency captureNewRestoreDependencyLocked() {
+  private RestoreEndpointDependency captureRestoreDependencyLocked(boolean replacesPosition) {
     ReaderStreamBinding binding = currentReaderStreamBinding();
     AnalysisStateLineage lineage =
-        lifecycleCompletionClaim == null
+        replacesPosition && lifecycleCompletionClaim == null
             ? new AnalysisStateLineage()
             : captureCurrentRestoreDependencyLocked().lineage;
     binding.queuedAnalysisStateLineage = lineage;

--- a/src/main/java/featurecat/lizzie/analysis/ReadBoard.java
+++ b/src/main/java/featurecat/lizzie/analysis/ReadBoard.java
@@ -33,14 +33,19 @@ import java.util.Locale;
 import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import javax.swing.SwingUtilities;
 
 public class ReadBoard implements ReadBoardTrackingEligibilityAdapter.EligibilitySource {
+  private static final AtomicLongFieldUpdater<ReadBoard> SYNC_ANALYSIS_EPOCH =
+      AtomicLongFieldUpdater.newUpdater(ReadBoard.class, "syncAnalysisEpoch");
   private static final AtomicInteger PLACE_COMMAND_DISPATCH_THREAD_SEQUENCE = new AtomicInteger();
   private static final Executor PLACE_COMMAND_DISPATCH_EXECUTOR =
       Executors.newCachedThreadPool(ReadBoard::newPlaceCommandDispatchThread);
@@ -258,6 +263,8 @@ public class ReadBoard implements ReadBoardTrackingEligibilityAdapter.Eligibilit
   private boolean awaitingFirstSyncFrame = true;
   private int historyOverwriteSuppressionDepth = 0;
   private volatile long syncAnalysisEpoch = 0L;
+  private Thread syncRecoveryThread;
+  private BoardHistoryNode collectedSyncResumeTarget;
   private String lastProtocolLineSummary;
   private long lastProtocolTimestampMillis;
 
@@ -1511,6 +1518,35 @@ public class ReadBoard implements ReadBoardTrackingEligibilityAdapter.Eligibilit
   }
 
   private void syncBoardStones(boolean isSecondTime) {
+    if (isReadBoardGmaEngineBusy()
+        || Lizzie.frame.isPlayingAgainstLeelaz
+        || Lizzie.frame.isAnaPlayingAgainstLeelaz) {
+      applySyncBoardStones(isSecondTime);
+      return;
+    }
+    collectedSyncResumeTarget = null;
+    syncRecoveryThread = Thread.currentThread();
+    CompletableFuture<Void> confirmed;
+    localNavigationTracker.beginReadBoardNavigation();
+    try {
+      confirmed =
+          Lizzie.board.applyReadBoardSync(
+              () -> applySyncBoardStones(isSecondTime), () -> collectedSyncResumeTarget != null);
+    } finally {
+      syncRecoveryThread = null;
+      localNavigationTracker.clear();
+      isSyncing = false;
+    }
+    if (collectedSyncResumeTarget != null) {
+      scheduleResumeAnalysisAfterSync(collectedSyncResumeTarget, confirmed);
+    }
+  }
+
+  private boolean isCollectingSyncRecovery() {
+    return syncRecoveryThread == Thread.currentThread();
+  }
+
+  private void applySyncBoardStones(boolean isSecondTime) {
     //    if (!isSecondTime) {
     //      long thisTime = System.currentTimeMillis();
     //      if (thisTime - startSyncTime < Lizzie.config.readBoardArg2 / 2) return;
@@ -1795,6 +1831,10 @@ public class ReadBoard implements ReadBoardTrackingEligibilityAdapter.Eligibilit
       if (played || needRefresh) {
         Lizzie.frame.refresh();
       }
+      if (isCollectingSyncRecovery() && played && !singleMoveRecovered) {
+        scheduleResumeAnalysisAfterSync(Lizzie.board.getHistory().getCurrentHistoryNode());
+      }
+      if (isCollectingSyncRecovery()) firstSync = false;
       if (firstSync) {
         firstSync = false;
         previousMoveWithoutTracking(true);
@@ -1811,8 +1851,10 @@ public class ReadBoard implements ReadBoardTrackingEligibilityAdapter.Eligibilit
       }
       continueGameAfterSyncIfNeeded("sync", Lizzie.board.getHistory().getCurrentHistoryNode());
     } finally {
-      localNavigationTracker.clear();
-      isSyncing = false;
+      if (!isCollectingSyncRecovery()) {
+        localNavigationTracker.clear();
+        isSyncing = false;
+      }
     }
     //	    if (played && Lizzie.config.alwaysGotoLastOnLive) {
     //	      int moveNumber = Lizzie.board.getHistory().getMainEnd().getData().moveNumber;
@@ -2155,19 +2197,8 @@ public class ReadBoard implements ReadBoardTrackingEligibilityAdapter.Eligibilit
         lastMoveSource,
         foxMoveNumber,
         false);
-    if (analysisEngineAvailable) {
-      try {
-        syncEngineToRebuiltSnapshot(rebuiltNode);
-      } catch (RuntimeException ex) {
-        localMoveSyncDebug(
-            "rebuildFromSnapshot syncEngine failed node="
-                + historyNodeSummary(rebuiltNode)
-                + " error="
-                + ex.getClass().getSimpleName()
-                + ": "
-                + ex.getMessage());
-        throw ex;
-      }
+    if (analysisEngineAvailable && !isCollectingSyncRecovery()) {
+      syncEngineToRebuiltSnapshot(rebuiltNode);
     }
     rememberResolvedSnapshotNode(rebuiltNode, resolvedRemoteContext);
     if (analysisEngineAvailable && !continueGameAfterSyncIfNeeded("rebuild", rebuiltNode)) {
@@ -2977,9 +3008,10 @@ public class ReadBoard implements ReadBoardTrackingEligibilityAdapter.Eligibilit
     runWithSuppressedHistoryOverwriteInvalidation(() -> Lizzie.board.setHistory(history));
   }
 
-  private void invalidatePendingSyncAnalysisResume() {
-    syncAnalysisEpoch++;
+  public void invalidatePendingSyncAnalysisResume() {
+    SYNC_ANALYSIS_EPOCH.incrementAndGet(this);
   }
+
 
   private void moveToAnyPositionWithoutTracking(BoardHistoryNode node) {
     runWithoutTrackingLocalHistoryNavigation(() -> Lizzie.board.moveToAnyPosition(node));
@@ -5296,6 +5328,22 @@ public class ReadBoard implements ReadBoardTrackingEligibilityAdapter.Eligibilit
   }
 
   private void scheduleResumeAnalysisAfterSync(BoardHistoryNode targetNode) {
+    if (isCollectingSyncRecovery()) {
+      collectedSyncResumeTarget = targetNode;
+      return;
+    }
+    CompletableFuture<Void> confirmed = new CompletableFuture<>();
+    if (isReadBoardAnalysisEngineAvailable()) {
+      Lizzie.leelaz.confirmBoardSynchronization(
+          Lizzie.leelaz.resolveLoadSgfMirrorEngine(),
+          () -> confirmed.complete(null),
+          detail -> confirmed.completeExceptionally(new IllegalStateException(detail)));
+    }
+    scheduleResumeAnalysisAfterSync(targetNode, confirmed);
+  }
+
+  private void scheduleResumeAnalysisAfterSync(
+      BoardHistoryNode targetNode, CompletableFuture<Void> confirmed) {
     if (Lizzie.frame == null || targetNode == null || !isReadBoardAnalysisEngineAvailable()) {
       localMoveSyncDebug(
           "scheduleResumeAnalysisAfterSync skip frame="
@@ -5314,7 +5362,12 @@ public class ReadBoard implements ReadBoardTrackingEligibilityAdapter.Eligibilit
               + pendingLocalMoveState());
       return;
     }
-    long scheduledEpoch = ++syncAnalysisEpoch;
+    long scheduledEpoch = SYNC_ANALYSIS_EPOCH.incrementAndGet(this);
+    Board capturedBoard = Lizzie.board;
+    long capturedRevision = capturedBoard.getContextRevision();
+    Leelaz capturedEngine = Lizzie.leelaz;
+    long capturedGeneration = Lizzie.capturePrimaryEngineGeneration(capturedEngine);
+    AtomicBoolean consumed = new AtomicBoolean();
     localMoveSyncDebug(
         "scheduleResumeAnalysisAfterSync epoch="
             + scheduledEpoch
@@ -5326,7 +5379,25 @@ public class ReadBoard implements ReadBoardTrackingEligibilityAdapter.Eligibilit
             + (Lizzie.leelaz != null && Lizzie.leelaz.isPondering()));
     Lizzie.frame.scheduleResumeAnalysisAfterLoad(
         SYNC_ANALYSIS_RESUME_DELAY_MS,
-        () -> resumeAnalysisAfterSyncIfStillCurrent(scheduledEpoch, targetNode));
+        () ->
+            confirmed.thenRun(
+                () ->
+                    SwingUtilities.invokeLater(
+                        () -> {
+                          synchronized (capturedBoard) {
+                            if (!consumed.compareAndSet(false, true)
+                                || Lizzie.board != capturedBoard
+                                || capturedBoard.getContextRevision() != capturedRevision
+                                || shouldSkipResumeTargetBeforeConfirmedLocalMove(targetNode))
+                              return;
+                            Lizzie.runIfPrimaryEngine(
+                                capturedEngine,
+                                capturedGeneration,
+                                () ->
+                                    resumeAnalysisAfterSyncIfStillCurrent(
+                                        scheduledEpoch, targetNode));
+                          }
+                        })));
   }
 
   private boolean shouldSkipResumeTargetBeforeConfirmedLocalMove(BoardHistoryNode targetNode) {
@@ -5731,7 +5802,7 @@ public class ReadBoard implements ReadBoardTrackingEligibilityAdapter.Eligibilit
             + historyNodeSummary(targetNode)
             + " enginePonderingBefore="
             + (Lizzie.leelaz != null && Lizzie.leelaz.isPondering()));
-    boolean resumed = Lizzie.frame.ensureAnalysisResumedAfterLoad();
+    boolean resumed = Lizzie.frame.ensureAnalysisResumedAfterSyncLoad();
     localMoveSyncDebug(
         "resumeAnalysisAfterSync result resumed="
             + resumed

--- a/src/main/java/featurecat/lizzie/gui/LizzieFrame.java
+++ b/src/main/java/featurecat/lizzie/gui/LizzieFrame.java
@@ -13104,6 +13104,7 @@ public class LizzieFrame extends JFrame {
 
   private void recordUserAnalysisPause(BoardHistoryNode cancelledRoot) {
     userAnalysisPaused = true;
+    if (readBoard != null) readBoard.invalidatePendingSyncAnalysisResume();
     pendingForegroundResumeAfterCleanup = false;
     userCancelledQuickAnalysisRoot = cancelledRoot;
   }
@@ -21133,7 +21134,10 @@ public class LizzieFrame extends JFrame {
   }
 
   public boolean ensureAnalysisResumedAfterSyncLoad() {
-    if (Lizzie.leelaz == null
+    if (isUserAnalysisPaused()
+        || manualAutoAnalysisStarting
+        || isWholeGameAnalysisStartingOrRunning()
+        || Lizzie.leelaz == null
         || EngineManager.isEmpty
         || EngineGamePresentation.current().startingOrPlaying()
         || isPlayingAgainstLeelaz

--- a/src/main/java/featurecat/lizzie/rules/Board.java
+++ b/src/main/java/featurecat/lizzie/rules/Board.java
@@ -82,6 +82,8 @@ public class Board {
             return thread;
           });
   private ArrayDeque<HistoryNavigationStep> pendingHistoryNavigationSteps = new ArrayDeque<>();
+  private CompletableFuture<Void> lastSyncNavigation;
+  private Thread readBoardSyncThread;
   private boolean historyRestoreInFlight;
   private BoardHistoryList historyNavigationHistory;
   private BoardHistoryList activeHistoryRestoreHistory;
@@ -2062,7 +2064,7 @@ public class Board {
   }
 
   private boolean submitOrdinaryEngineForwarding(Leelaz engine, Supplier<Boolean> action) {
-    if (engine == null) {
+    if (engine == null || isCollectingReadBoardSync()) {
       return false;
     }
     return engine.submitOrdinaryLiveBoardForwarding(
@@ -2736,7 +2738,7 @@ public class Board {
         }
         return;
       }
-      updateWinrate();
+      if (Lizzie.leelaz != null) updateWinrate();
       if (engineGamePlaying()) SGFParser.appendTime();
       // modifyStart();
       if (!forSync
@@ -2802,7 +2804,8 @@ public class Board {
         // this is the next coordinate in history. Just increment history so that we
         // don't erase the
         // redo's
-        history.next();
+        if (isCollectingReadBoardSync()) history.nextVariationWithoutEngineSync(0);
+        else history.next();
         updateIsBest();
         if (Lizzie.config.playSound) Utils.playVoiceFile();
         // should be opposite from the bottom case
@@ -2812,7 +2815,8 @@ public class Board {
             Lizzie.leelaz.playMove(color, convertCoordinatesToName(x, y));
             Lizzie.leelaz.genmove((Lizzie.board.getData().blackToPlay ? "b" : "w"));
           }
-        } else if (!Lizzie.frame.isPlayingAgainstLeelaz
+        } else if (!isCollectingReadBoardSync()
+            && !Lizzie.frame.isPlayingAgainstLeelaz
             && !Lizzie.leelaz.isInputCommand
             && !engineGamePlaying()) {
           Lizzie.leelaz.playMove(color, convertCoordinatesToName(x, y));
@@ -2908,7 +2912,7 @@ public class Board {
           }
           return;
         }
-        if (Lizzie.leelaz.canSuicidal) {
+        if (Lizzie.leelaz != null && Lizzie.leelaz.canSuicidal) {
           if (isSuicidal == 1) {
             //   modifyEnd();
             if (shouldLogLocalMovePlace) {
@@ -2977,7 +2981,8 @@ public class Board {
           && !isEngineFollowTrialActive()) {
         Lizzie.leelaz.playMove(color, convertCoordinatesToName(x, y), true, color.isWhite());
         needGenmove = true;
-      } else if (!Lizzie.frame.isPlayingAgainstLeelaz
+      } else if (!isCollectingReadBoardSync()
+          && !Lizzie.frame.isPlayingAgainstLeelaz
           && !Lizzie.leelaz.isInputCommand
           && !engineGamePlaying()
           && !isEngineFollowTrialActive()) {
@@ -3736,6 +3741,7 @@ public class Board {
         Board owner,
         Leelaz primaryEngine,
         Leelaz capturedMirror,
+        Leelaz.PositionRestore positionRestore,
         boolean rootRestore,
         long primaryEngineGeneration,
         Runnable restore,
@@ -3752,7 +3758,7 @@ public class Board {
       this.boardWidth = Board.boardWidth;
       this.boardHeight = Board.boardHeight;
       this.blackToPlay = targetNode.getData().blackToPlay;
-      this.positionRestore = primaryEngine.capturePositionRestore(capturedMirror);
+      this.positionRestore = positionRestore;
       this.restore = restore;
       this.discard = discard;
       this.successfulDisposition = successfulDisposition;
@@ -4151,10 +4157,18 @@ public class Board {
   }
 
   private boolean shouldForwardHistoryNavigationToPrimaryEngine() {
-    return !isLoadingFile && isPrimaryEngineReady();
+    return !isCollectingReadBoardSync() && !isLoadingFile && isPrimaryEngineReady();
   }
 
   private HistoryNavigationRestore prepareHistoryNavigationRestore(boolean stepIn) {
+    Leelaz engine = Lizzie.leelaz;
+    return prepareHistoryNavigationRestore(
+        stepIn,
+        engine != null && engine.isPonderingOrWasPonderingBeforeTracking() ? engine::ponder : null);
+  }
+
+  private HistoryNavigationRestore prepareHistoryNavigationRestore(
+      boolean stepIn, Runnable successfulDisposition) {
     Leelaz engine = Lizzie.leelaz;
     long primaryEngineGeneration = Lizzie.capturePrimaryEngineGeneration(engine);
     if (primaryEngineGeneration < 0
@@ -4165,20 +4179,19 @@ public class Board {
     if (!stepIn && KataGoRuntimeHelper.isBenchmarkEngineSyncSuppressed()) {
       return null;
     }
-    boolean resumePonder = engine.isPonderingOrWasPonderingBeforeTracking();
     BoardHistoryNode targetNode = history.getCurrentHistoryNode();
     Leelaz mirrorEngine = captureHistoryNavigationMirrorEngine(engine);
     Leelaz.ExactSnapshotRestoreAdmission admission =
         engine.captureHistoryNavigationExactSnapshotRestoreAdmission(mirrorEngine);
     Optional<ExactSnapshotEngineRestore.PreparedRestore> preparedRestore =
         ExactSnapshotEngineRestore.prepare(admission, targetNode);
-    Runnable successfulDisposition = resumePonder ? engine::ponder : null;
     if (stepIn) {
       ExactSnapshotEngineRestore.PreparedRestore exactRestore = preparedRestore.orElseThrow();
       return new HistoryNavigationRestore(
           this,
           engine,
           mirrorEngine,
+          engine.capturePositionRestore(mirrorEngine),
           false,
           primaryEngineGeneration,
           () -> {
@@ -4197,6 +4210,7 @@ public class Board {
           this,
           engine,
           mirrorEngine,
+          engine.capturePositionRestore(mirrorEngine),
           false,
           primaryEngineGeneration,
           exactRestore::execute,
@@ -4208,6 +4222,7 @@ public class Board {
         this,
         engine,
         mirrorEngine,
+        engine.capturePositionRestore(mirrorEngine),
         true,
         primaryEngineGeneration,
         () ->
@@ -4258,7 +4273,8 @@ public class Board {
       }
       if (Lizzie.config.playSound) Utils.playVoiceFile();
       if (expectedChild == null) {
-        history.next();
+        if (isCollectingReadBoardSync()) history.nextVariationWithoutEngineSync(0);
+        else history.next();
       } else {
         history.nextVariationWithoutEngineSync(childIndex);
       }
@@ -4390,6 +4406,7 @@ public class Board {
               this,
               engine,
               mirror,
+              engine.capturePositionRestore(mirror),
               false,
               Lizzie.capturePrimaryEngineGeneration(engine),
               () -> {
@@ -4444,6 +4461,7 @@ public class Board {
               this,
               engine,
               mirror,
+              engine.capturePositionRestore(mirror),
               exact.isEmpty(),
               Lizzie.capturePrimaryEngineGeneration(engine),
               commands,
@@ -4611,7 +4629,10 @@ public class Board {
       updateWinrate();
       // Don't update winrate here as this is usually called when jumping between
       // variations
-      if (history.nextVariation(idx).isPresent()) {
+      if ((isCollectingReadBoardSync()
+              ? history.nextVariationWithoutEngineSync(idx)
+              : history.nextVariation(idx))
+          .isPresent()) {
         advanceContextRevision();
         // Update leelaz board position, before updating to next node
         updateIsBest();
@@ -4737,8 +4758,61 @@ public class Board {
    * @return void
    */
   public void moveToAnyPosition(BoardHistoryNode targetNode) {
-    if (engineGamePlaying()) return;
-    BoardHistoryNode sourceNode = history.getCurrentHistoryNode();
+    if (isCollectingReadBoardSync()) {
+      synchronized (this) {
+        if (history.getCurrentHistoryNode() == targetNode) return;
+        if (Lizzie.leelaz != null) updateWinrate();
+        history.setHead(targetNode);
+        advanceContextRevision();
+        updateIsBest();
+        notifyReadBoardLocalHistoryNavigation();
+        clearPressStoneInfo(null);
+      }
+      return;
+    }
+    moveToAnyPosition(targetNode, null, history.getCurrentHistoryNode(), false);
+  }
+
+  /** Applies one ordinary ReadBoard sync locally, then confirms only its final engine target. */
+  public synchronized CompletableFuture<Void> applyReadBoardSync(
+      Runnable localChanges, java.util.function.BooleanSupplier requiresConfirmation) {
+    BoardHistoryList sourceHistory = history;
+    BoardHistoryNode source = history.getCurrentHistoryNode();
+    readBoardSyncThread = Thread.currentThread();
+    try {
+      localChanges.run();
+    } finally {
+      readBoardSyncThread = null;
+    }
+    BoardHistoryNode target = history.getCurrentHistoryNode();
+    if (!requiresConfirmation.getAsBoolean() && sourceHistory == history && source == target) {
+      return CompletableFuture.completedFuture(null);
+    }
+    CompletableFuture<Void> confirmed = new CompletableFuture<>();
+    try {
+      moveToAnyPosition(target, confirmed, source, sourceHistory != history);
+    } catch (RuntimeException failure) {
+      confirmed.completeExceptionally(failure);
+    }
+    return confirmed;
+  }
+
+  private boolean isCollectingReadBoardSync() {
+    return readBoardSyncThread == Thread.currentThread();
+  }
+
+  private void moveToAnyPosition(
+      BoardHistoryNode targetNode,
+      CompletableFuture<Void> syncConfirmation,
+      BoardHistoryNode sourceNode,
+      boolean fullRestore) {
+    if (engineGamePlaying()) {
+      if (syncConfirmation != null)
+        syncConfirmation.completeExceptionally(
+            new IllegalStateException("Engine game owns board synchronization"));
+      return;
+    }
+    BoardHistoryNode expectedCurrent = history.getCurrentHistoryNode();
     List<Integer> targetParents = new ArrayList<Integer>();
     List<Integer> sourceParents = new ArrayList<Integer>();
 
@@ -4774,6 +4848,97 @@ public class Board {
       if (sourceParent != targetParent) {
         break;
       }
+    }
+
+    if (syncConfirmation != null) {
+      HistoryNavigationRestore restore;
+      synchronized (this) {
+        if (history.getCurrentHistoryNode() != expectedCurrent) {
+          syncConfirmation.completeExceptionally(
+              new IllegalStateException("Sync target superseded"));
+          return;
+        }
+        markMoveNavigationForMovelistRefresh();
+        if (Lizzie.leelaz != null) {
+          modifyStart();
+          updateWinrate();
+        }
+        history.setHead(targetNode);
+        advanceContextRevision();
+        boolean predecessorUnconfirmed =
+            lastSyncNavigation != null
+                && (!lastSyncNavigation.isDone() || lastSyncNavigation.isCompletedExceptionally());
+        lastSyncNavigation = syncConfirmation;
+        if (!shouldForwardHistoryNavigationToPrimaryEngine()) {
+          restore = null;
+        } else if (fullRestore
+            || predecessorUnconfirmed
+            || sourceNode == targetNode
+            || crossesSnapshotBoundary(sourceNode, sourceDepth - depth)
+            || crossesSnapshotBoundary(targetNode, targetDepth - depth)) {
+          restore = prepareHistoryNavigationRestore(false, null);
+        } else {
+          Leelaz engine = Lizzie.leelaz;
+          Leelaz mirror = captureHistoryNavigationMirrorEngine(engine);
+          List<String> commands = new ArrayList<>();
+          BoardHistoryNode node = sourceNode;
+          for (int index = 0; index < sourceDepth - depth; index++) {
+            if (node.getData().isMoveNode() || isKnownPass(node.getData())) commands.add("undo");
+            node = node.previous().orElseThrow();
+          }
+          for (int index = targetDepth - depth; index > 0; index--) {
+            node = node.getVariation(targetParents.get(index - 1)).orElseThrow();
+            BoardData data = node.getData();
+            if (data.isMoveNode() || isKnownPass(data)) {
+              String coordinate =
+                  data.isMoveNode()
+                      ? convertCoordinatesToName(
+                          data.lastMove.orElseThrow()[0], data.lastMove.orElseThrow()[1])
+                      : "pass";
+              commands.add(
+                  "play " + (data.lastMoveColor == Stone.BLACK ? "B" : "W") + " " + coordinate);
+            }
+          }
+          List<String> capturedCommands = List.copyOf(commands);
+          restore =
+              new HistoryNavigationRestore(
+                  this,
+                  engine,
+                  mirror,
+                  engine.capturePositionTransition(mirror),
+                  false,
+                  Lizzie.capturePrimaryEngineGeneration(engine),
+                  () -> replayCommandsToFrozenRestoreTargets(engine, mirror, capturedCommands),
+                  () -> {},
+                  null);
+        }
+        updateIsBest();
+        notifyReadBoardLocalHistoryNavigation();
+        clearPressStoneInfo(null);
+      }
+      if (Lizzie.leelaz != null) modifyEnd();
+      if (Lizzie.frame != null) Lizzie.frame.refresh();
+      if (restore == null) {
+        syncConfirmation.completeExceptionally(
+            new IllegalStateException("Sync engine unavailable"));
+      } else {
+        HISTORY_RESTORE_EXECUTOR.execute(
+            () -> {
+              try {
+                if (!restore.execute()
+                    && !restore.skipSuccessfulDisposition
+                    && restore.capturedPrimaryIsCurrent()) {
+                  syncConfirmation.complete(null);
+                } else {
+                  syncConfirmation.completeExceptionally(
+                      new IllegalStateException("Sync target superseded"));
+                }
+              } catch (RuntimeException failure) {
+                syncConfirmation.completeExceptionally(failure);
+              }
+            });
+      }
+      return;
     }
 
     if (crossesSnapshotBoundary(sourceNode, sourceDepth - depth)
@@ -5343,7 +5508,8 @@ public class Board {
       runBeforeHistoryOverwriteEngineForward();
       // Engine reset runs first (outside the board monitor) so a failing callback can never
       // skip the required engine clear; board-overwrite notifications follow.
-      if (Lizzie.leelaz != null) {
+      if (Lizzie.leelaz != null
+          && (Lizzie.board == null || !Lizzie.board.isCollectingReadBoardSync())) {
         if (capturedIntent != null) {
           Lizzie.leelaz.submitOrdinaryLiveBoardForwarding(capturedIntent);
         }

--- a/src/main/java/featurecat/lizzie/rules/Board.java
+++ b/src/main/java/featurecat/lizzie/rules/Board.java
@@ -26,6 +26,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Stack;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.function.BiConsumer;
@@ -1760,16 +1761,13 @@ public class Board {
     if (KataGoRuntimeHelper.isBenchmarkEngineSyncSuppressed()) {
       return;
     }
-    restoreEnginePosition(leelaz, getMoveList());
-    if (loadEngine) {
-      Lizzie.initializeAfterVersionCheck(false, leelaz);
-    }
+    restoreEnginePosition(leelaz, null, loadEngine, false, false);
   }
   public void resendMoveToEngineFromCurrentRoot(Leelaz leelaz) {
     if (KataGoRuntimeHelper.isBenchmarkEngineSyncSuppressed()) {
       return;
     }
-    restoreEnginePositionFromRoot(leelaz, getMoveList());
+    restoreEnginePosition(leelaz, null, false, false, true);
   }
 
   public void resendMoveToEngine(
@@ -1787,7 +1785,7 @@ public class Board {
     if (KataGoRuntimeHelper.isBenchmarkEngineSyncSuppressed()) {
       return;
     }
-    restoreEnginePosition(leelaz, null, preparedRestore);
+    preparedRestore.execute();
     if (loadEngine) {
       Lizzie.initializeAfterVersionCheck(isEngineGame, leelaz);
     }
@@ -1970,19 +1968,27 @@ public class Board {
           || Lizzie.capturePrimaryEngineGeneration(engine) != primaryGeneration) {
         return false;
       }
+      Leelaz mirror = owner.captureHistoryNavigationMirrorEngine(engine);
       Leelaz.ExactSnapshotRestoreAdmission admission =
-          engine.captureHistoryNavigationExactSnapshotRestoreAdmission();
+          engine.captureHistoryNavigationExactSnapshotRestoreAdmission(mirror);
       ExactSnapshotEngineRestore.PreparedRestore prepared =
           engine.useRemoteCompute
               ? ExactSnapshotEngineRestore.prepareCurrentHistoryPosition(
                   admission, capturedCurrentNode)
               : ExactSnapshotEngineRestore.prepareCurrentPosition(admission, position);
+      Leelaz.PositionRestore confirmation = engine.capturePositionRestore(mirror);
       if (Lizzie.board != owner
           || Lizzie.capturePrimaryEngineGeneration(engine) != primaryGeneration) {
         prepared.discard();
+        confirmation.cancel();
         return false;
       }
-      prepared.execute();
+      confirmation.execute(prepared::execute);
+      CompletableFuture<Void> confirmed = new CompletableFuture<>();
+      confirmation.confirm(
+          () -> confirmed.complete(null),
+          detail -> confirmed.completeExceptionally(new IllegalStateException(detail)));
+      confirmed.join();
       return true;
     }
 
@@ -2050,10 +2056,6 @@ public class Board {
   private boolean forwardCurrentPositionToPrimaryEngine() {
     if (!isPrimaryEngineReady()) {
       return false;
-    }
-    syncPrimaryEngineKomiToCurrentGame();
-    if (Lizzie.leelaz.width != boardWidth || Lizzie.leelaz.height != boardHeight) {
-      Lizzie.leelaz.boardSizeForEngine(boardWidth, boardHeight);
     }
     resendMoveToEngine(Lizzie.leelaz, false);
     return true;
@@ -2210,7 +2212,12 @@ public class Board {
     if (engine == null || Lizzie.config == null || !Lizzie.config.isDoubleEngineMode()) {
       return null;
     }
-    if (Lizzie.leelaz == null || Lizzie.leelaz2 == null || Lizzie.leelaz == Lizzie.leelaz2) {
+    if (Lizzie.leelaz == null
+        || Lizzie.leelaz2 == null
+        || Lizzie.leelaz == Lizzie.leelaz2
+        || !engine.hasGtpCapability()
+        || !Lizzie.leelaz.hasGtpCapability()
+        || !Lizzie.leelaz2.hasGtpCapability()) {
       return null;
     }
     if (engine == Lizzie.leelaz) {
@@ -3710,7 +3717,16 @@ public class Board {
   private static final class HistoryNavigationRestore {
     private final Board owner;
     private final Leelaz primaryEngine;
+    private final Leelaz capturedMirror;
+    private final boolean rootRestore;
     private final long primaryEngineGeneration;
+    private final BoardHistoryNode targetNode;
+    private final long boardRevision;
+    private final boolean secondarySlot;
+    private final int boardWidth;
+    private final int boardHeight;
+    private final boolean blackToPlay;
+    private final Leelaz.PositionRestore positionRestore;
     private final Runnable restore;
     private final Runnable discard;
     private final Runnable successfulDisposition;
@@ -3719,48 +3735,93 @@ public class Board {
     private HistoryNavigationRestore(
         Board owner,
         Leelaz primaryEngine,
+        Leelaz capturedMirror,
+        boolean rootRestore,
         long primaryEngineGeneration,
         Runnable restore,
         Runnable discard,
         Runnable successfulDisposition) {
       this.owner = owner;
       this.primaryEngine = primaryEngine;
+      this.capturedMirror = capturedMirror;
+      this.rootRestore = rootRestore;
       this.primaryEngineGeneration = primaryEngineGeneration;
+      this.targetNode = owner.history.getCurrentHistoryNode();
+      this.boardRevision = owner.getContextRevision();
+      this.secondarySlot = primaryEngine == Lizzie.leelaz2;
+      this.boardWidth = Board.boardWidth;
+      this.boardHeight = Board.boardHeight;
+      this.blackToPlay = targetNode.getData().blackToPlay;
+      this.positionRestore = primaryEngine.capturePositionRestore(capturedMirror);
       this.restore = restore;
       this.discard = discard;
       this.successfulDisposition = successfulDisposition;
     }
 
     private boolean capturedPrimaryIsCurrent() {
-      return Lizzie.capturePrimaryEngineGeneration(primaryEngine) == primaryEngineGeneration;
+      return (primaryEngineGeneration < 0
+              || Lizzie.capturePrimaryEngineGeneration(primaryEngine) == primaryEngineGeneration)
+          && Lizzie.board == owner
+          && owner.getContextRevision() == boardRevision
+          && (!secondarySlot || primaryEngine == Lizzie.leelaz2)
+          && owner.history.getCurrentHistoryNode() == targetNode
+          && Board.boardWidth == boardWidth
+          && Board.boardHeight == boardHeight
+          && targetNode.getData().blackToPlay == blackToPlay;
     }
 
     private boolean execute() {
       owner.beforeHistoryNavigationRestoreExecution();
       if (!capturedPrimaryIsCurrent()) {
         discard.run();
+        positionRestore.cancel();
         return true;
       }
       boolean submitted =
           owner.submitOrdinaryEngineForwarding(
               primaryEngine,
               () -> {
-                restore.run();
+                positionRestore.execute(restore);
                 return true;
               });
       if (!submitted) {
         discard.run();
+        positionRestore.cancel();
         skipSuccessfulDisposition = true;
         return false;
       }
+      CompletableFuture<Void> confirmed = new CompletableFuture<>();
+      positionRestore.confirm(
+          () -> {
+            if (rootRestore) {
+              primaryEngine.width = boardWidth;
+              primaryEngine.height = boardHeight;
+              if (capturedMirror != null) {
+                capturedMirror.width = boardWidth;
+                capturedMirror.height = boardHeight;
+              }
+            }
+            confirmed.complete(null);
+          },
+          detail -> confirmed.completeExceptionally(new IllegalStateException(detail)));
+      confirmed.join();
       return false;
     }
 
     private void applySuccessfulDisposition() {
-      if (skipSuccessfulDisposition || successfulDisposition == null) {
-        return;
+      synchronized (owner) {
+        if (skipSuccessfulDisposition
+            || successfulDisposition == null
+            || !capturedPrimaryIsCurrent()
+            || (Lizzie.frame != null && Lizzie.frame.isUserAnalysisPaused())) {
+          return;
+        }
+        if (primaryEngineGeneration >= 0) {
+          Lizzie.runIfPrimaryEngine(primaryEngine, primaryEngineGeneration, successfulDisposition);
+        } else {
+          successfulDisposition.run();
+        }
       }
-      Lizzie.runIfPrimaryEngine(primaryEngine, primaryEngineGeneration, successfulDisposition);
     }
   }
   void beforeHistoryNavigationRestoreExecution() {}
@@ -4106,8 +4167,9 @@ public class Board {
     }
     boolean resumePonder = engine.isPonderingOrWasPonderingBeforeTracking();
     BoardHistoryNode targetNode = history.getCurrentHistoryNode();
+    Leelaz mirrorEngine = captureHistoryNavigationMirrorEngine(engine);
     Leelaz.ExactSnapshotRestoreAdmission admission =
-        engine.captureHistoryNavigationExactSnapshotRestoreAdmission();
+        engine.captureHistoryNavigationExactSnapshotRestoreAdmission(mirrorEngine);
     Optional<ExactSnapshotEngineRestore.PreparedRestore> preparedRestore =
         ExactSnapshotEngineRestore.prepare(admission, targetNode);
     Runnable successfulDisposition = resumePonder ? engine::ponder : null;
@@ -4116,10 +4178,11 @@ public class Board {
       return new HistoryNavigationRestore(
           this,
           engine,
+          mirrorEngine,
+          false,
           primaryEngineGeneration,
           () -> {
-            if (!Lizzie.runIfPrimaryEngine(
-                engine, primaryEngineGeneration, engine::notPondering)) {
+            if (!Lizzie.runIfPrimaryEngine(engine, primaryEngineGeneration, engine::notPondering)) {
               exactRestore.discard();
               return;
             }
@@ -4133,39 +4196,34 @@ public class Board {
       return new HistoryNavigationRestore(
           this,
           engine,
+          mirrorEngine,
+          false,
           primaryEngineGeneration,
-          () -> restoreEnginePosition(engine, null, exactRestore, false),
+          exactRestore::execute,
           exactRestore::discard,
           successfulDisposition);
     }
-    List<String> fallbackCommands = captureHistoryNavigationRootReplayCommands(getMoveList());
-    Optional<Double> gameKomi = captureNonDefaultCurrentGameKomi(engine);
-    Leelaz mirrorEngine = captureHistoryNavigationMirrorEngine(engine);
+    List<String> fallbackCommands = captureRootRestoreCommands(engine, mirrorEngine, getMoveList());
     return new HistoryNavigationRestore(
         this,
         engine,
+        mirrorEngine,
+        true,
         primaryEngineGeneration,
         () ->
             restoreEnginePositionFromRoot(
-                engine,
-                mirrorEngine,
-                fallbackCommands,
-                gameKomi,
-                primaryEngineGeneration),
+                engine, mirrorEngine, fallbackCommands, primaryEngineGeneration),
         () -> {},
         successfulDisposition);
   }
 
   /** Goes to the next coordinate, thread safe */
   public boolean nextMove(boolean needRefresh) {
-    synchronized (this) {
-      HistoryNavigationMutation mutation = moveHistoryForward(null, null);
-      if (!mutation.moved) {
-        return false;
-      }
-      mutation.restoreEngine();
-      mutation.applySuccessfulRestoreDisposition();
+    HistoryNavigationMutation mutation = moveHistoryForward(null, null);
+    if (!mutation.moved) {
+      return false;
     }
+    finishDirectHistoryNavigation(mutation);
     if (needRefresh) {
       clearAfterMove();
       Lizzie.frame.refresh();
@@ -4205,7 +4263,10 @@ public class Board {
         history.nextVariationWithoutEngineSync(childIndex);
       }
       advanceContextRevision();
-      if (shouldForwardHistoryNavigationToPrimaryEngine() && data.get().isMoveNode()) {
+      boolean needSync =
+          history.getCurrentHistoryNode().hasRemovedStone()
+              || history.getCurrentHistoryNode().getData().isSnapshotNode();
+      if (!needSync && shouldForwardHistoryNavigationToPrimaryEngine() && data.get().isMoveNode()) {
         int[] lastMove = data.get().lastMove.get();
         String name = convertCoordinatesToName(lastMove[0], lastMove[1]);
         submitOrdinaryEngineForwarding(
@@ -4214,17 +4275,17 @@ public class Board {
               Lizzie.leelaz.playMove(data.get().lastMoveColor, name, true, data.get().blackToPlay);
               return true;
             });
-      } else if (shouldForwardHistoryNavigationToPrimaryEngine() && isKnownPass(data.get())) {
+      } else if (!needSync
+          && shouldForwardHistoryNavigationToPrimaryEngine()
+          && isKnownPass(data.get())) {
         submitOrdinaryEngineForwarding(
             Lizzie.leelaz,
             () -> {
-              Lizzie.leelaz.playMove(data.get().lastMoveColor, "pass", true, data.get().blackToPlay);
+              Lizzie.leelaz.playMove(
+                  data.get().lastMoveColor, "pass", true, data.get().blackToPlay);
               return true;
             });
       }
-      boolean needSync =
-          history.getCurrentHistoryNode().hasRemovedStone()
-              || history.getCurrentHistoryNode().getData().isSnapshotNode();
       if (!needSync && shouldForwardHistoryNavigationToPrimaryEngine()) {
         history.getCurrentHistoryNode().placeExtraStones();
       }
@@ -4284,60 +4345,115 @@ public class Board {
   public void restoreMoveNumber(
       ArrayList<Movelist> mv, boolean isEngineGame, Leelaz engine, boolean loadEngine) {
     if (loadEngine) {
-      restoreEnginePosition(engine, mv);
-      Lizzie.initializeAfterVersionCheck(isEngineGame, engine);
+      restoreEnginePosition(engine, mv, true, isEngineGame, false);
       return;
     }
     replayMovesToEngine(engine, mv);
   }
 
-  private void restoreEnginePosition(Leelaz engine, ArrayList<Movelist> fallbackMoves) {
-    submitOrdinaryEngineForwarding(
-        engine,
+  private void finishDirectHistoryNavigation(HistoryNavigationMutation mutation) {
+    runPositionRestore(
         () -> {
-          forwardOrdinaryEnginePositionRestore(engine, fallbackMoves);
-          return true;
+          if (!mutation.restoreEngine()) mutation.applySuccessfulRestoreDisposition();
         });
   }
 
-  private void forwardOrdinaryEnginePositionRestore(
-      Leelaz engine, ArrayList<Movelist> fallbackMoves) {
-    boolean wasPondering = engine.isPonderingOrWasPonderingBeforeTracking();
-    BoardHistoryNode currentNode = getHistory().getCurrentHistoryNode();
-    Leelaz.ExactSnapshotRestoreAdmission admission =
-        engine.captureBoardSyncExactSnapshotRestoreAdmission();
-    Optional<ExactSnapshotEngineRestore.PreparedRestore> preparedRestore =
-        ExactSnapshotEngineRestore.prepare(admission, currentNode);
-    restoreEnginePosition(engine, fallbackMoves, preparedRestore.orElse(null), wasPondering);
-  }
-
-  private void restoreEnginePosition(
-      Leelaz engine,
-      ArrayList<Movelist> fallbackMoves,
-      ExactSnapshotEngineRestore.PreparedRestore preparedRestore) {
-    restoreEnginePosition(engine, fallbackMoves, preparedRestore, false);
-  }
-
-  private void restoreEnginePosition(
-      Leelaz engine,
-      ArrayList<Movelist> fallbackMoves,
-      ExactSnapshotEngineRestore.PreparedRestore preparedRestore,
-      boolean resumePonder) {
-    if (preparedRestore != null) {
-      preparedRestore.execute();
-      if (resumePonder) engine.ponder();
-      return;
+  private void runPositionRestore(Runnable restore) {
+    if (SwingUtilities.isEventDispatchThread() || Thread.holdsLock(this)) {
+      HISTORY_RESTORE_EXECUTOR.execute(
+          () -> {
+            try {
+              restore.run();
+            } catch (RuntimeException failure) {
+              SwingUtilities.invokeLater(Board::showHistoryRestoreFailure);
+            }
+          });
+    } else {
+      restore.run();
     }
-    restoreEnginePositionFromRoot(engine, fallbackMoves);
   }
 
-  private void restoreEnginePositionFromRoot(Leelaz engine, ArrayList<Movelist> moves) {
-    boolean wasPondering = engine.isPonderingOrWasPonderingBeforeTracking();
-    Optional<Double> currentGameKomi = captureNonDefaultCurrentGameKomi(engine);
-    currentGameKomi.ifPresent(engine::syncKomiForCurrentGame);
-    engine.sendCommand("clear_board");
-    replayMovesToEngine(engine, moves);
-    if (wasPondering) engine.ponder();
+  void restoreHistoryNodeExact(BoardHistoryNode node) {
+    Leelaz engine = Lizzie.leelaz;
+    if (engine == null) return;
+    Leelaz mirror = captureHistoryNavigationMirrorEngine(engine);
+    HistoryNavigationRestore restore;
+    synchronized (this) {
+      if (!submitOrdinaryEngineForwarding(engine, () -> true)) return;
+      boolean resumePonder = engine.isPonderingOrWasPonderingBeforeTracking();
+      ExactSnapshotEngineRestore.PreparedRestore exact =
+          ExactSnapshotEngineRestore.prepare(
+                  engine.captureHistoryNavigationExactSnapshotRestoreAdmission(mirror), node)
+              .orElseThrow();
+      restore =
+          new HistoryNavigationRestore(
+              this,
+              engine,
+              mirror,
+              false,
+              Lizzie.capturePrimaryEngineGeneration(engine),
+              () -> {
+                engine.notPondering();
+                exact.execute();
+              },
+              exact::discard,
+              resumePonder ? engine::ponder : null);
+    }
+    runPositionRestore(
+        () -> {
+          if (!restore.execute()) restore.applySuccessfulDisposition();
+        });
+  }
+
+  private void restoreEnginePosition(
+      Leelaz engine,
+      ArrayList<Movelist> fallbackMoves,
+      boolean loadEngine,
+      boolean isEngineGame,
+      boolean fromRoot) {
+    if (engine == null) return;
+    Leelaz mirror = captureHistoryNavigationMirrorEngine(engine);
+    HistoryNavigationRestore restore;
+    synchronized (this) {
+      if (!submitOrdinaryEngineForwarding(engine, () -> true)) return;
+      boolean resumePonder = engine.isPonderingOrWasPonderingBeforeTracking();
+      Optional<ExactSnapshotEngineRestore.PreparedRestore> exact =
+          fromRoot
+              ? Optional.empty()
+              : ExactSnapshotEngineRestore.prepare(
+                  engine.captureBoardSyncExactSnapshotRestoreAdmission(mirror),
+                  history.getCurrentHistoryNode());
+      Runnable commands;
+      Runnable discard;
+      if (exact.isPresent()) {
+        commands = exact.get()::execute;
+        discard = exact.get()::discard;
+      } else {
+        List<String> frozenCommands =
+            captureRootRestoreCommands(
+                engine, mirror, fallbackMoves == null ? getMoveList() : fallbackMoves);
+        commands = () -> replayCommandsToFrozenRestoreTargets(engine, mirror, frozenCommands);
+        discard = () -> {};
+      }
+      Runnable disposition =
+          loadEngine
+              ? () -> Lizzie.initializeAfterVersionCheck(isEngineGame, engine)
+              : resumePonder ? engine::ponder : null;
+      restore =
+          new HistoryNavigationRestore(
+              this,
+              engine,
+              mirror,
+              exact.isEmpty(),
+              Lizzie.capturePrimaryEngineGeneration(engine),
+              commands,
+              discard,
+              disposition);
+    }
+    runPositionRestore(
+        () -> {
+          if (!restore.execute()) restore.applySuccessfulDisposition();
+        });
   }
 
   private void replayMovesToEngine(Leelaz engine, ArrayList<Movelist> moves) {
@@ -4357,6 +4473,23 @@ public class Board {
     }
   }
 
+  private List<String> captureRootRestoreCommands(
+      Leelaz engine, Leelaz mirror, ArrayList<Movelist> moves) {
+    List<String> commands = new ArrayList<>();
+    int width = boardWidth;
+    int height = boardHeight;
+    if (engine.width != width
+        || engine.height != height
+        || (mirror != null && (mirror.width != width || mirror.height != height))) {
+      commands.add(
+          width == height ? "boardsize " + width : "rectangular_boardsize " + width + " " + height);
+    }
+    captureNonDefaultCurrentGameKomi(engine).ifPresent(komi -> commands.add("komi " + komi));
+    commands.add("clear_board");
+    commands.addAll(captureHistoryNavigationRootReplayCommands(moves));
+    return List.copyOf(commands);
+  }
+
   private List<String> captureHistoryNavigationRootReplayCommands(ArrayList<Movelist> moves) {
     ArrayList<String> commands = new ArrayList<>(moves.size());
     for (int index = moves.size() - 1; index >= 0; index--) {
@@ -4371,31 +4504,7 @@ public class Board {
       Leelaz engine,
       Leelaz mirrorEngine,
       List<String> commands,
-      Optional<Double> gameKomi,
       long primaryEngineGeneration) {
-    if (gameKomi.isPresent()
-        && !Lizzie.runIfPrimaryEngine(
-            engine,
-            primaryEngineGeneration,
-            () -> {
-              syncFrozenRestoreKomi(engine, gameKomi.get());
-              if (mirrorEngine != null) {
-                syncFrozenRestoreKomi(mirrorEngine, gameKomi.get());
-              }
-            })) {
-      return;
-    }
-    if (!Lizzie.runIfPrimaryEngine(
-        engine,
-        primaryEngineGeneration,
-        () -> {
-          engine.sendCommandNoLeelaz2("clear_board");
-          if (mirrorEngine != null) {
-            mirrorEngine.sendCommandNoLeelaz2("clear_board");
-          }
-        })) {
-      return;
-    }
     for (String command : commands) {
       beforeHistoryNavigationRootReplayCommand(command);
       if (!Lizzie.runIfPrimaryEngine(
@@ -4413,17 +4522,6 @@ public class Board {
   }
   void beforeHistoryNavigationRootReplayCommand(String command) {}
 
-
-  private void syncFrozenRestoreKomi(Leelaz engine, double komi) {
-    float normalizedKomi = (float) (komi == 0.0 ? 0.0 : komi);
-    synchronized (engine) {
-      if (Float.compare(engine.komi, normalizedKomi) == 0) {
-        return;
-      }
-      engine.sendCommandNoLeelaz2("komi " + (komi == 0.0 ? "0" : komi));
-      engine.komi = normalizedKomi;
-    }
-  }
 
   private void replayCommandsToFrozenRestoreTargets(
       Leelaz engine, Leelaz mirrorEngine, List<String> commands) {
@@ -4640,6 +4738,7 @@ public class Board {
    */
   public void moveToAnyPosition(BoardHistoryNode targetNode) {
     if (engineGamePlaying()) return;
+    BoardHistoryNode sourceNode = history.getCurrentHistoryNode();
     List<Integer> targetParents = new ArrayList<Integer>();
     List<Integer> sourceParents = new ArrayList<Integer>();
 
@@ -4659,7 +4758,7 @@ public class Board {
         };
 
     // Compute the path from the current node to the root
-    populateParent.accept(history.getCurrentHistoryNode(), sourceParents);
+    populateParent.accept(sourceNode, sourceParents);
 
     // Compute the path from the target node to the root
     populateParent.accept(targetNode, targetParents);
@@ -4677,6 +4776,35 @@ public class Board {
       }
     }
 
+    if (crossesSnapshotBoundary(sourceNode, sourceDepth - depth)
+        || crossesSnapshotBoundary(targetNode, targetDepth - depth)) {
+      HistoryNavigationRestore restore;
+      synchronized (this) {
+        if (history.getCurrentHistoryNode() != sourceNode) return;
+        markMoveNavigationForMovelistRefresh();
+        modifyStart();
+        updateWinrate();
+        history.setHead(targetNode);
+        advanceContextRevision();
+        restore =
+            shouldForwardHistoryNavigationToPrimaryEngine()
+                ? prepareHistoryNavigationRestore(false)
+                : null;
+        updateIsBest();
+        notifyReadBoardLocalHistoryNavigation();
+        clearPressStoneInfo(null);
+      }
+      if (restore != null) {
+        runPositionRestore(
+            () -> {
+              if (!restore.execute()) restore.applySuccessfulDisposition();
+            });
+      }
+      modifyEnd();
+      if (Lizzie.frame != null) Lizzie.frame.refresh();
+      return;
+    }
+
     // Move all the way up to the deepest common ansestor
     for (int m = 0; m < sourceDepth - depth; m++) {
       previousMove(false);
@@ -4686,6 +4814,14 @@ public class Board {
     for (int m = targetDepth - depth; m > 0; m--) {
       nextVariation(targetParents.get(m - 1));
     }
+  }
+
+  private static boolean crossesSnapshotBoundary(BoardHistoryNode node, int steps) {
+    for (int index = 0; index < steps; index++) {
+      if (node.getData().isSnapshotNode() || node.hasRemovedStone()) return true;
+      node = node.previous().orElseThrow();
+    }
+    return false;
   }
 
   public void moveBranchUp() {
@@ -5311,14 +5447,11 @@ public class Board {
 
   /** Goes to the previous coordinate, thread safe */
   public boolean previousMove(boolean needRefresh) {
-    synchronized (this) {
-      HistoryNavigationMutation mutation = moveHistoryBackward(null);
-      if (!mutation.moved) {
-        return false;
-      }
-      mutation.restoreEngine();
-      mutation.applySuccessfulRestoreDisposition();
+    HistoryNavigationMutation mutation = moveHistoryBackward(null);
+    if (!mutation.moved) {
+      return false;
     }
+    finishDirectHistoryNavigation(mutation);
     if (needRefresh) {
       clearAfterMove();
       Lizzie.frame.refresh();

--- a/src/main/java/featurecat/lizzie/rules/Board.java
+++ b/src/main/java/featurecat/lizzie/rules/Board.java
@@ -2952,13 +2952,21 @@ public class Board {
             Lizzie.engineManager.secondEngineCountDown.sendTimeLeft(false);
         }
       }
+      boolean previousBlackToPlay = getData().blackToPlay;
+      boolean usedExistingVariation =
+          !newBranch && !forSync && history.nextByMoveIdentity(newState).isPresent();
+      if (!usedExistingVariation) {
+        history.addOrGoto(newState, newBranch);
+      } else {
+        clearAfterMove();
+      }
       boolean needGenmove = false;
       if (forManual && !Lizzie.frame.isPlayingAgainstLeelaz && !Lizzie.leelaz.isInputCommand) {
         String move = convertCoordinatesToName(x, y);
         Lizzie.engineManager.playEngineGameManualMove(
-            getHistory().isBlacksTurn(), color, move, color.isWhite());
+            previousBlackToPlay, color, move, color.isWhite());
       } else if (Lizzie.frame.isPlayingAgainstLeelaz
-          && Lizzie.frame.playerIsBlack == getData().blackToPlay
+          && Lizzie.frame.playerIsBlack == previousBlackToPlay
           && !isEngineFollowTrialActive()) {
         Lizzie.leelaz.playMove(color, convertCoordinatesToName(x, y), true, color.isWhite());
         needGenmove = true;
@@ -2967,13 +2975,6 @@ public class Board {
           && !engineGamePlaying()
           && !isEngineFollowTrialActive()) {
         Lizzie.leelaz.playMove(color, convertCoordinatesToName(x, y), true, color.isWhite());
-      }
-      boolean usedExistingVariation =
-          !newBranch && !forSync && history.nextByMoveIdentity(newState).isPresent();
-      if (!usedExistingVariation) {
-        history.addOrGoto(newState, newBranch);
-      } else {
-        clearAfterMove();
       }
       if (shouldLogLocalMovePlace) {
         logLocalMovePlace(
@@ -4198,6 +4199,12 @@ public class Board {
         return HistoryNavigationMutation.NOT_MOVED;
       }
       if (Lizzie.config.playSound) Utils.playVoiceFile();
+      if (expectedChild == null) {
+        history.next();
+      } else {
+        history.nextVariationWithoutEngineSync(childIndex);
+      }
+      advanceContextRevision();
       if (shouldForwardHistoryNavigationToPrimaryEngine() && data.get().isMoveNode()) {
         int[] lastMove = data.get().lastMove.get();
         String name = convertCoordinatesToName(lastMove[0], lastMove[1]);
@@ -4215,12 +4222,6 @@ public class Board {
               return true;
             });
       }
-      if (expectedChild == null) {
-        history.next();
-      } else {
-        history.nextVariationWithoutEngineSync(childIndex);
-      }
-      advanceContextRevision();
       boolean needSync =
           history.getCurrentHistoryNode().hasRemovedStone()
               || history.getCurrentHistoryNode().getData().isSnapshotNode();
@@ -5343,29 +5344,30 @@ public class Board {
         modifyEnd();
         return HistoryNavigationMutation.NOT_MOVED;
       }
+      BoardHistoryNode previousCurrentNode = history.getCurrentHistoryNode();
+      history.previous();
+      advanceContextRevision();
       if (!needSync
           && isHistoryAction
-          && history.getData().lastMoveColor != Stone.EMPTY
+          && currentData.lastMoveColor != Stone.EMPTY
           && shouldForwardHistoryNavigationToPrimaryEngine()) {
         boolean nopass = false;
         if (!Lizzie.leelaz.isKatago || Lizzie.leelaz.isSai) {
-          if (isPass && history.getCurrentHistoryNode().previous().isPresent()) nopass = true;
+          if (isPass && previousCurrentNode.previous().isPresent()) nopass = true;
         }
         if (!nopass) {
           submitOrdinaryEngineForwarding(
               Lizzie.leelaz,
               () -> {
-                Lizzie.leelaz.undo(true, history.getPrevious().get().blackToPlay);
+                Lizzie.leelaz.undo(true, history.getData().blackToPlay);
                 return true;
               });
         }
         else modifyEnd();
       }
       if (!needSync && shouldForwardHistoryNavigationToPrimaryEngine()) {
-        history.getCurrentHistoryNode().undoExtraStones();
+        previousCurrentNode.undoExtraStones();
       }
-      history.previous();
-      advanceContextRevision();
       HistoryNavigationRestore engineRestore = null;
       RuntimeException restorePreparationFailure = null;
       if (needSync && shouldForwardHistoryNavigationToPrimaryEngine()) {

--- a/src/main/java/featurecat/lizzie/rules/BoardHistoryNode.java
+++ b/src/main/java/featurecat/lizzie/rules/BoardHistoryNode.java
@@ -1,8 +1,6 @@
 package featurecat.lizzie.rules;
 
 import featurecat.lizzie.Lizzie;
-import featurecat.lizzie.analysis.EngineManager;
-import featurecat.lizzie.analysis.ExactSnapshotEngineRestore;
 import featurecat.lizzie.analysis.Leelaz;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -839,28 +837,8 @@ public class BoardHistoryNode {
   }
 
   public void clearAndSyncBoard(boolean stepIn) {
-    if (Lizzie.leelaz != null) {
-      Lizzie.leelaz.submitOrdinaryLiveBoardForwarding(
-          EngineManager.OrdinaryLiveBoardForwardingIntent.of(
-              () -> {
-                performClearAndSyncBoard(stepIn);
-                return true;
-              }));
-      return;
-    }
-    performClearAndSyncBoard(stepIn);
-  }
-
-  private void performClearAndSyncBoard(boolean stepIn) {
     if (stepIn) {
-      Leelaz engine = Lizzie.leelaz;
-      boolean resumePonder = engine.isPonderingOrWasPonderingBeforeTracking();
-      Leelaz.ExactSnapshotRestoreAdmission admission =
-          engine.captureBoardSyncExactSnapshotRestoreAdmission();
-      ExactSnapshotEngineRestore.PreparedRestore preparedRestore =
-          ExactSnapshotEngineRestore.prepare(admission, this).orElseThrow();
-      engine.notPondering();
-      executePreparedRestore(engine, preparedRestore, resumePonder);
+      Lizzie.board.restoreHistoryNodeExact(this);
     } else {
       Lizzie.board.resendMoveToEngine(Lizzie.leelaz, false);
     }
@@ -871,26 +849,10 @@ public class BoardHistoryNode {
     if (marker == null) {
       return false;
     }
-    Leelaz engine = Lizzie.leelaz;
-    boolean resumePonder = engine.isPonderingOrWasPonderingBeforeTracking();
-    Leelaz.ExactSnapshotRestoreAdmission admission =
-        engine.captureBoardSyncExactSnapshotRestoreAdmission();
-    ExactSnapshotEngineRestore.PreparedRestore preparedRestore =
-        ExactSnapshotEngineRestore.prepare(admission, this).orElseThrow();
-    engine.notPondering();
-    executePreparedRestore(engine, preparedRestore, resumePonder);
+    Lizzie.board.restoreHistoryNodeExact(this);
     return true;
   }
 
-  private static void executePreparedRestore(
-      Leelaz engine,
-      ExactSnapshotEngineRestore.PreparedRestore preparedRestore,
-      boolean resumePonder) {
-    preparedRestore.execute();
-    if (resumePonder) {
-      engine.ponder();
-    }
-  }
 
   private static ArrayList<ExtraStones> cloneExtraStones(ArrayList<ExtraStones> stones) {
     if (stones == null) {

--- a/src/test/java/featurecat/lizzie/analysis/EngineGtpLoggingTest.java
+++ b/src/test/java/featurecat/lizzie/analysis/EngineGtpLoggingTest.java
@@ -221,9 +221,10 @@ class EngineGtpLoggingTest {
             .withDiagnosticsEnabled(true)
             .withDiagnosticModules(EnumSet.of(DiagnosticModule.GTP_SUMMARY)));
     Leelaz engine = prepareEngine();
+    ExactSnapshotRestoreProtocolFixture.install(
+        engine, command -> ExactSnapshotRestoreProtocolFixture.Response.success());
     EngineObservation.ensureStarted(engine, "MAIN_BOARD");
     engine.sendCommand("play B " + RAW_MOVE);
-    engine.processCommandResponseLineForTest("=");
     awaitLogs(runtime);
     String appBeforeTrace = readApp();
     assertTrue(appBeforeTrace.contains("gtp command=play outcome=sent"), appBeforeTrace);
@@ -246,7 +247,8 @@ class EngineGtpLoggingTest {
     assertFalse(app.contains(RAW_MOVE), app);
     assertFalse(app.contains(INFO_CANARY), app);
     String trace = Files.readString(tempDir.resolve("logs/engine-trace.log"));
-    assertTrue(trace.contains("gtp raw command=play B " + RAW_MOVE), trace);
+    assertTrue(trace.contains("gtp raw command="), trace);
+    assertTrue(trace.contains("play B " + RAW_MOVE), trace);
     assertTrue(trace.contains("gtp raw stream="), trace);
     assertTrue(trace.contains(INFO_CANARY), trace);
     assertTrue(trace.contains("Full Trace session started"), trace);

--- a/src/test/java/featurecat/lizzie/analysis/EngineManagerEngineGameStateMachineTest.java
+++ b/src/test/java/featurecat/lizzie/analysis/EngineManagerEngineGameStateMachineTest.java
@@ -3174,7 +3174,7 @@ class EngineManagerEngineGameStateMachineTest {
     assertEquals("EXACT_RETIRED", black.analysisOutputRouteForTest());
     assertTrue(black.getBestMoves().isEmpty());
 
-    black.processCommandResponseLineForTest("=");
+    black.processCommandResponseLineForTest("=" + commandIdFor(black.commandText(), "clear_board"));
 
     assertFalse(black.commandText().contains("kata-analyze W 36"), black.commandText());
     assertTrue(
@@ -3272,7 +3272,8 @@ class EngineManagerEngineGameStateMachineTest {
           assertEquals("EXACT_RETIRED", black.analysisOutputRouteForTest());
           assertTrue(black.getBestMoves().isEmpty());
           assertFalse(black.commandText().contains("kata-analyze W 36"), black.commandText());
-          black.processCommandResponseLineForTest("=");
+          black.processCommandResponseLineForTest(
+              "=" + commandIdFor(black.commandText(), "clear_board"));
           black.sendOrdinaryAnalysisCommandForTest("kata-analyze W 36");
           black.parseAnalysisLineForTest(kataAnalysisInfo());
         };

--- a/src/test/java/featurecat/lizzie/analysis/EngineManagerEngineGameStateMachineTest.java
+++ b/src/test/java/featurecat/lizzie/analysis/EngineManagerEngineGameStateMachineTest.java
@@ -3022,12 +3022,24 @@ class EngineManagerEngineGameStateMachineTest {
     assertEquals(1, black.getBestMoves().size());
 
     black.playMoveNoPonder(Stone.BLACK, "Q16");
+    int playCommandId = commandIdFor(black.commandText(), "play B Q16");
     assertEquals("EXACT_RETIRED", black.analysisOutputRouteForTest());
     black.parseAnalysisLineForTest(kataAnalysisInfo());
     assertTrue(black.getBestMoves().isEmpty());
     assertEquals(0, black.getBestMovesPlayouts());
 
     black.sendOrdinaryAnalysisCommandForTest("kata-analyze W 36");
+    assertFalse(black.commandText().contains("kata-analyze W 36"), black.commandText());
+    assertEquals("EXACT_RETIRED", black.analysisOutputRouteForTest());
+    black.parseAnalysisLineForTest(kataAnalysisInfo());
+    assertTrue(black.getBestMoves().isEmpty());
+    assertEquals(0, black.getBestMovesPlayouts());
+
+    black.processCommandResponseLineForTest("=" + playCommandId);
+
+    assertTrue(
+        commandLineIndex(black.commandText(), "play B Q16")
+            < commandLineIndex(black.commandText(), "kata-analyze W 36"));
     assertEquals("ORDINARY_CURRENT", black.analysisOutputRouteForTest());
     black.parseAnalysisLineForTest(kataAnalysisInfo());
     assertEquals(1, black.getBestMoves().size());
@@ -3097,14 +3109,22 @@ class EngineManagerEngineGameStateMachineTest {
 
     output.arm(black, "kata-analyze W 36");
     black.playMoveNoPonder(Stone.BLACK, "Q16");
+    int playCommandId = commandIdFor(black.commandText(), "play B Q16");
 
     assertEquals(1, output.enqueues.get());
     assertNull(output.enqueueFailure.get());
+    assertFalse(black.commandText().contains("kata-analyze W 36"), black.commandText());
+    assertEquals("EXACT_RETIRED", black.analysisOutputRouteForTest());
+    assertTrue(black.getBestMoves().isEmpty());
+    black.parseAnalysisLineForTest(kataAnalysisInfo());
+    assertTrue(black.getBestMoves().isEmpty());
+
+    black.processCommandResponseLineForTest("=" + playCommandId);
+
     assertTrue(
         commandLineIndex(black.commandText(), "play B Q16")
             < commandLineIndex(black.commandText(), "kata-analyze W 36"));
     assertEquals("ORDINARY_CURRENT", black.analysisOutputRouteForTest());
-    assertTrue(black.getBestMoves().isEmpty());
     black.parseAnalysisLineForTest(kataAnalysisInfo());
     assertEquals(1, black.getBestMoves().size());
     assertEquals(40, black.getBestMovesPlayouts());
@@ -3120,38 +3140,50 @@ class EngineManagerEngineGameStateMachineTest {
     assertEquals(1, black.getBestMoves().size());
 
     black.playMoveNoPonder(Stone.BLACK, "Q16");
+    int playCommandId = commandIdFor(black.commandText(), "play B Q16");
     black.sendOrdinaryAnalysisCommandForTest("kata-analyze W 36");
 
-    // Streaming output remains valid while the preceding state command is merely pending.
-    assertEquals("ORDINARY_CURRENT", black.analysisOutputRouteForTest());
+    assertFalse(black.commandText().contains("kata-analyze W 36"), black.commandText());
+    assertEquals("EXACT_RETIRED", black.analysisOutputRouteForTest());
     black.parseAnalysisLineForTest(kataAnalysisInfo());
-    assertEquals(1, black.getBestMoves().size());
+    assertTrue(black.getBestMoves().isEmpty());
+    assertEquals(0, black.getBestMovesPlayouts());
 
-    black.processCommandResponseLineForTest("? illegal move");
+    black.processCommandResponseLineForTest("?" + playCommandId + " illegal move");
 
     assertEquals("EXACT_RETIRED", black.analysisOutputRouteForTest());
     assertTrue(black.getBestMoves().isEmpty());
     assertEquals(0, black.getBestMovesPlayouts());
 
-    // Neither the dependent analysis acknowledgement nor an unrelated command can revive the
-    // poisoned position lineage.
-    black.processCommandResponseLineForTest("=");
+    // Neither a late acknowledgement nor an unrelated command can revive the poisoned position
+    // lineage or publish its dependent analysis.
+    black.processCommandResponseLineForTest("=" + playCommandId);
     black.sendCommandNoLeelaz2("name");
     black.processCommandResponseLineForTest("=");
+    black.parseAnalysisLineForTest(kataAnalysisInfo());
+    assertFalse(black.commandText().contains("kata-analyze W 36"), black.commandText());
+    assertEquals("EXACT_RETIRED", black.analysisOutputRouteForTest());
+    assertTrue(black.getBestMoves().isEmpty());
+
+    // A full state replacement deliberately starts a clean lineage, but its successor still
+    // waits for the replacement acknowledgement before it can stream.
+    black.sendCommandNoLeelaz2("clear_board");
+    black.sendOrdinaryAnalysisCommandForTest("kata-analyze B 37");
+    assertFalse(black.commandText().contains("kata-analyze B 37"), black.commandText());
     black.parseAnalysisLineForTest(kataAnalysisInfo());
     assertEquals("EXACT_RETIRED", black.analysisOutputRouteForTest());
     assertTrue(black.getBestMoves().isEmpty());
 
-    // A full state replacement deliberately starts a clean lineage; its successor may stream
-    // before the clear_board acknowledgement just like a normal pending state command.
-    black.sendCommandNoLeelaz2("clear_board");
-    black.sendOrdinaryAnalysisCommandForTest("kata-analyze B 37");
+    black.processCommandResponseLineForTest("=");
+
+    assertFalse(black.commandText().contains("kata-analyze W 36"), black.commandText());
+    assertTrue(
+        commandLineIndex(black.commandText(), "clear_board")
+            < commandLineIndex(black.commandText(), "kata-analyze B 37"));
     assertEquals("ORDINARY_CURRENT", black.analysisOutputRouteForTest());
     black.parseAnalysisLineForTest(kataAnalysisInfo());
     assertEquals(1, black.getBestMoves().size());
     assertEquals(40, black.getBestMovesPlayouts());
-    black.processCommandResponseLineForTest("=");
-    black.processCommandResponseLineForTest("=");
   }
 
   @Test
@@ -3163,17 +3195,25 @@ class EngineManagerEngineGameStateMachineTest {
     Runnable playResponse = () -> {};
 
     black.sendCommandWithResponseForTest("play B Q16", playResponse);
+    int playCommandId = commandIdFor(black.commandText(), "play B Q16");
     black.sendOrdinaryAnalysisCommandForTest("kata-analyze W 39");
+    assertFalse(black.commandText().contains("kata-analyze W 39"), black.commandText());
     black.parseAnalysisLineForTest(kataAnalysisInfo());
-    assertEquals("ORDINARY_CURRENT", black.analysisOutputRouteForTest());
-    assertEquals(1, black.getBestMoves().size());
+    assertEquals("EXACT_RETIRED", black.analysisOutputRouteForTest());
+    assertTrue(black.getBestMoves().isEmpty());
 
     black.retireTimedOutNormalCommandForTest(playResponse);
 
     assertEquals("EXACT_RETIRED", black.analysisOutputRouteForTest());
     assertTrue(black.getBestMoves().isEmpty());
     assertEquals(0, black.getBestMovesPlayouts());
-    black.processCommandResponseLineForTest("=");
+    assertFalse(black.commandText().contains("kata-analyze W 39"), black.commandText());
+
+    black.processCommandResponseLineForTest("=" + playCommandId);
+
+    assertEquals("EXACT_RETIRED", black.analysisOutputRouteForTest());
+    assertTrue(black.getBestMoves().isEmpty());
+    assertFalse(black.commandText().contains("kata-analyze W 39"), black.commandText());
   }
 
   @Test
@@ -3182,9 +3222,11 @@ class EngineManagerEngineGameStateMachineTest {
     black.isKatago = true;
     Runnable playResponse = () -> {};
     black.sendCommandWithResponseForTest("play B Q16", playResponse);
+    int playCommandId = commandIdFor(black.commandText(), "play B Q16");
     black.sendOrdinaryAnalysisCommandForTest("kata-analyze W 40");
+    assertFalse(black.commandText().contains("kata-analyze W 40"), black.commandText());
     black.parseAnalysisLineForTest(kataAnalysisInfo());
-    assertEquals(1, black.getBestMoves().size());
+    assertTrue(black.getBestMoves().isEmpty());
     black.suppressGlobalEnginePresentationForTest();
     assertTrue(black.suppressesGlobalEnginePresentation(black.analysisReaderBindingForTest()));
     AtomicReference<Throwable> timeoutFailure = new AtomicReference<>();
@@ -3208,7 +3250,13 @@ class EngineManagerEngineGameStateMachineTest {
     assertEquals("EXACT_RETIRED", black.analysisOutputRouteForTest());
     assertTrue(black.getBestMoves().isEmpty());
     assertEquals(0, black.getBestMovesPlayouts());
-    black.processCommandResponseLineForTest("=");
+    assertFalse(black.commandText().contains("kata-analyze W 40"), black.commandText());
+
+    black.processCommandResponseLineForTest("=" + playCommandId);
+
+    assertEquals("EXACT_RETIRED", black.analysisOutputRouteForTest());
+    assertTrue(black.getBestMoves().isEmpty());
+    assertFalse(black.commandText().contains("kata-analyze W 40"), black.commandText());
   }
 
   @Test
@@ -3221,12 +3269,19 @@ class EngineManagerEngineGameStateMachineTest {
     assertEquals(1, black.getBestMoves().size());
     black.afterClearStateCommand =
         () -> {
+          assertEquals("EXACT_RETIRED", black.analysisOutputRouteForTest());
+          assertTrue(black.getBestMoves().isEmpty());
+          assertFalse(black.commandText().contains("kata-analyze W 36"), black.commandText());
+          black.processCommandResponseLineForTest("=");
           black.sendOrdinaryAnalysisCommandForTest("kata-analyze W 36");
           black.parseAnalysisLineForTest(kataAnalysisInfo());
         };
 
     black.clear();
 
+    assertTrue(
+        commandLineIndex(black.commandText(), "clear_board")
+            < commandLineIndex(black.commandText(), "kata-analyze W 36"));
     assertEquals("ORDINARY_CURRENT", black.analysisOutputRouteForTest());
     assertEquals(1, black.getBestMoves().size());
     assertEquals("D4", black.getBestMoves().get(0).coordinate);
@@ -3242,15 +3297,29 @@ class EngineManagerEngineGameStateMachineTest {
     black.parseAnalysisLineForTest(kataAnalysisInfo());
 
     black.sendCommandNoLeelaz2("set_position");
+    int setPositionCommandId = commandIdFor(black.commandText(), "set_position");
     assertEquals("EXACT_RETIRED", black.analysisOutputRouteForTest());
     assertTrue(black.getBestMoves().isEmpty());
 
     black.sendOrdinaryAnalysisCommandForTest("kata-analyze W 38");
+    assertFalse(black.commandText().contains("kata-analyze W 38"), black.commandText());
+    black.parseAnalysisLineForTest(kataAnalysisInfo());
+    assertEquals("EXACT_RETIRED", black.analysisOutputRouteForTest());
+    assertTrue(black.getBestMoves().isEmpty());
+
+    black.processCommandResponseLineForTest("=" + setPositionCommandId);
+
+    assertTrue(
+        commandLineIndex(black.commandText(), "set_position")
+            < commandLineIndex(black.commandText(), "kata-analyze W 38"));
     assertEquals("ORDINARY_CURRENT", black.analysisOutputRouteForTest());
     black.parseAnalysisLineForTest(kataAnalysisInfo());
+    assertEquals(1, black.getBestMoves().size());
+
     black.sendCommandNoLeelaz2("rectangular_boardsize 13 19");
     assertEquals("EXACT_RETIRED", black.analysisOutputRouteForTest());
     assertTrue(black.getBestMoves().isEmpty());
+    black.processCommandResponseLineForTest("=");
   }
 
   @Test
@@ -3299,7 +3368,9 @@ class EngineManagerEngineGameStateMachineTest {
     black.sendOrdinaryAnalysisCommandForTest("kata-analyze W 5");
     black.processCommandResponseLineForTest("=");
 
-    assertFalse(black.suppressesGlobalEnginePresentation(black.analysisReaderBindingForTest()));
+    assertFalse(
+        black.suppressesGlobalEnginePresentation(black.analysisReaderBindingForTest()),
+        black.commandText());
     assertEquals("ORDINARY_CURRENT", black.analysisOutputRouteForTest());
   }
 

--- a/src/test/java/featurecat/lizzie/analysis/EngineManagerInitialStartupSynchronizationTest.java
+++ b/src/test/java/featurecat/lizzie/analysis/EngineManagerInitialStartupSynchronizationTest.java
@@ -5338,8 +5338,8 @@ class EngineManagerInitialStartupSynchronizationTest {
       // deterministic unsent-command gate only after classification, while the async post worker is
       // still frozen, so this test exercises EOF cancellation rather than parser configuration.
       engine.requireResponseBeforeSend = true;
-      setLeelazField(engine, "cmdNumber", 4);
-      setLeelazField(engine, "currentCmdNum", 0);
+      engine.sendCommandWithResponseForTest("version", () -> {});
+      String commandsBeforeWorker = oldOutput.toString(StandardCharsets.UTF_8);
       engine.startupPostActionWorkerGate.countDown();
       assertTrue(engine.outputWorkerEntered.await(2, TimeUnit.SECONDS));
       assertTrue(engine.timeoutScheduled.await(2, TimeUnit.SECONDS));
@@ -5362,7 +5362,7 @@ class EngineManagerInitialStartupSynchronizationTest {
 
       assertFalse(rebind.isAlive(), "EOF cancellation must not wait for the delivery watchdog");
       assertNull(rebindFailure.get());
-      assertEquals("", oldOutput.toString(StandardCharsets.UTF_8));
+      assertEquals(commandsBeforeWorker, oldOutput.toString(StandardCharsets.UTF_8));
       assertEquals("", replacementOutput.toString(StandardCharsets.UTF_8));
       assertEquals(0, env.readyTransitions.get() - readyBaseline);
       assertFalse(engine.isLoaded);

--- a/src/test/java/featurecat/lizzie/analysis/ExactSnapshotEngineRestoreContractTest.java
+++ b/src/test/java/featurecat/lizzie/analysis/ExactSnapshotEngineRestoreContractTest.java
@@ -800,8 +800,8 @@ class ExactSnapshotEngineRestoreContractTest {
 
       preparedRestore.execute();
 
-      assertEquals("clear_board", primaryOutput.commands().get(0));
-      assertEquals("clear_board", mirrorOutput.commands().get(0));
+      assertEquals("clear_board", commandPayload(primaryOutput.commands().get(0)));
+      assertEquals("clear_board", commandPayload(mirrorOutput.commands().get(0)));
       assertTrue(primaryOutput.loadedSgf().contains("SZ[3]"));
       assertTrue(primaryOutput.loadedSgf().contains("AB[aa]"));
       assertTrue(primaryOutput.loadedSgf().contains("AB[cc]"));
@@ -856,13 +856,22 @@ class ExactSnapshotEngineRestoreContractTest {
 
       assertThrows(RuntimeException.class, preparedRestore::execute);
 
-      assertEquals(List.of("clear_board"), primaryOutput.commands());
-      assertEquals(List.of("clear_board"), mirrorOutput.commands());
+      assertEquals(
+          List.of("clear_board"),
+          primaryOutput.commands().stream()
+              .map(ExactSnapshotEngineRestoreContractTest::commandPayload)
+              .toList());
+      assertEquals(
+          List.of("clear_board"),
+          mirrorOutput.commands().stream()
+              .map(ExactSnapshotEngineRestoreContractTest::commandPayload)
+              .toList());
       assertTrue(primary.getBestMoves().isEmpty());
       assertEquals(0.0, primary.scoreMean);
       assertTrue(
           mirror.getBestMoves().isEmpty(),
-          "state invalidation precedes the first command byte and therefore survives flush failure");
+          "state invalidation precedes the first command byte and therefore survives flush"
+              + " failure");
       assertEquals(0.0, mirror.scoreMean);
       assertEquals(0, primaryOutput.loadSgfCommandCount());
       assertEquals(0, mirrorOutput.loadSgfCommandCount());
@@ -1158,10 +1167,12 @@ class ExactSnapshotEngineRestoreContractTest {
       assertTrue(output.commands().isEmpty());
       IllegalStateException repeatedDiscard =
           assertThrows(IllegalStateException.class, preparedRestore::discard);
-      assertEquals("Exact snapshot restore has already been executed", repeatedDiscard.getMessage());
+      assertEquals(
+          "Exact snapshot restore has already been executed", repeatedDiscard.getMessage());
       IllegalStateException executeAfterDiscard =
           assertThrows(IllegalStateException.class, preparedRestore::execute);
-      assertEquals("Exact snapshot restore has already been executed", executeAfterDiscard.getMessage());
+      assertEquals(
+          "Exact snapshot restore has already been executed", executeAfterDiscard.getMessage());
       assertNotNull(engine.tryBeginLifecycleCompletion(new Object(), null));
     }
   }
@@ -1324,7 +1335,7 @@ class ExactSnapshotEngineRestoreContractTest {
       assertTrue(
           thrown.getMessage().contains("loadsgf"),
           "loadsgf send failures should be exposed as restore failures.");
-      assertEquals("clear_board", output.commands().get(0));
+      assertEquals("clear_board", commandPayload(output.commands().get(0)));
       assertTrue(isLoadSgfCommand(output.commands().get(1)));
       assertEquals(2, output.commands().size(), "restore should stop before replaying real moves.");
     }
@@ -1353,7 +1364,7 @@ class ExactSnapshotEngineRestoreContractTest {
       assertTrue(
           thrown.getMessage().contains("cannot loadsgf"),
           "loadsgf GTP error responses should be exposed as restore failures.");
-      assertEquals("clear_board", output.commands().get(0));
+      assertEquals("clear_board", commandPayload(output.commands().get(0)));
       assertTrue(isLoadSgfCommand(output.commands().get(1)));
       assertEquals(2, output.commands().size(), "restore should stop before replaying real moves.");
     }
@@ -1391,9 +1402,9 @@ class ExactSnapshotEngineRestoreContractTest {
 
       waitForCommandCount(output, 1);
 
-      assertEquals("clear_board", output.commands().get(0));
+      assertEquals("clear_board", commandPayload(output.commands().get(0)));
 
-      triggerQueuedSend(engine);
+      triggerQueuedSend(engine, output.commands().get(0));
 
       restoreThread.join(2000L);
       assertFalse(restoreThread.isAlive(), "queued loadsgf send failure should not hang restore.");
@@ -1408,7 +1419,7 @@ class ExactSnapshotEngineRestoreContractTest {
 
       List<String> commands = output.commands();
       assertEquals(2, commands.size(), "restore should stop before replaying real moves.");
-      assertEquals("clear_board", commands.get(0));
+      assertEquals("clear_board", commandPayload(commands.get(0)));
       assertTrue(isLoadSgfCommand(commands.get(1)));
 
       Path tempSgf = extractLoadSgfPath(commands.get(1));
@@ -1449,10 +1460,10 @@ class ExactSnapshotEngineRestoreContractTest {
 
       waitForCommandCount(output, 1);
 
-      assertEquals("clear_board", output.commands().get(0));
+      assertEquals("clear_board", commandPayload(output.commands().get(0)));
 
       setOutputStream(engine, null);
-      triggerQueuedSend(engine);
+      triggerQueuedSend(engine, output.commands().get(0));
 
       restoreThread.join(2000L);
       assertFalse(restoreThread.isAlive(), "queued outputStream failure should not hang restore.");
@@ -1467,7 +1478,7 @@ class ExactSnapshotEngineRestoreContractTest {
 
       List<String> commands = output.commands();
       assertEquals(1, commands.size(), "loadsgf should not replay real moves after send failure.");
-      assertEquals("clear_board", commands.get(0));
+      assertEquals("clear_board", commandPayload(commands.get(0)));
 
       Path tempSgf = extractLoadSgfPathFromFailure(thrown.getMessage());
       assertEventuallyDeleted(tempSgf);
@@ -1616,7 +1627,7 @@ class ExactSnapshotEngineRestoreContractTest {
       board.resendMoveToEngine(third, false);
 
       List<String> thirdCommands = thirdOutput.commands();
-      assertEquals("clear_board", thirdCommands.get(0));
+      assertEquals("clear_board", commandPayload(thirdCommands.get(0)));
       assertTrue(isLoadSgfCommand(thirdCommands.get(1)));
 
       List<String> expectedReplay =
@@ -1686,11 +1697,13 @@ class ExactSnapshotEngineRestoreContractTest {
 
       waitForCommandCount(secondaryOutput, 2);
       waitForCommandCount(primaryOutput, 2);
-      assertEquals("clear_board", secondaryOutput.commands().get(0));
-      assertEquals("clear_board", primaryOutput.commands().get(0));
+      assertEquals("clear_board", commandPayload(secondaryOutput.commands().get(0)));
+      assertEquals("clear_board", commandPayload(primaryOutput.commands().get(0)));
 
-      invokeResponseHandlerForLine(secondary, "=");
-      invokeResponseHandlerForLine(primary, "=");
+      invokeResponseHandlerForLine(
+          secondary, buildSuccessResponseLine(secondaryOutput.commands().get(0)));
+      invokeResponseHandlerForLine(
+          primary, buildSuccessResponseLine(primaryOutput.commands().get(0)));
       invokeResponseHandlerForLine(
           secondary, buildSuccessResponseLine(secondaryOutput.commands().get(1)));
       invokeResponseHandlerForLine(
@@ -1709,6 +1722,15 @@ class ExactSnapshotEngineRestoreContractTest {
           secondary, buildSuccessResponseLine(secondaryOutput.commands().get(3)));
       invokeResponseHandlerForLine(
           primary, buildSuccessResponseLine(primaryOutput.commands().get(3)));
+
+      waitForCommandCount(secondaryOutput, 5);
+      waitForCommandCount(primaryOutput, 5);
+      assertEquals("name", commandPayload(secondaryOutput.commands().get(4)));
+      assertEquals("name", commandPayload(primaryOutput.commands().get(4)));
+      invokeResponseHandlerForLine(
+          secondary, buildSuccessResponseLine(secondaryOutput.commands().get(4)));
+      invokeResponseHandlerForLine(
+          primary, buildSuccessResponseLine(primaryOutput.commands().get(4)));
 
       restoreThread.join(2000L);
       assertFalse(
@@ -2211,9 +2233,9 @@ class ExactSnapshotEngineRestoreContractTest {
     engine.runPendingResponseHandlerForTest(line);
   }
 
-  private static void triggerQueuedSend(Leelaz engine) {
+  private static void triggerQueuedSend(Leelaz engine, String pendingCommand) {
     engine.setResponseUpToDate();
-    engine.processCommandResponseLineForTest("=");
+    engine.processCommandResponseLineForTest(buildSuccessResponseLine(pendingCommand));
   }
 
   private static void waitForCommandCount(RecordingOutputStream output, int expectedCount)
@@ -2398,9 +2420,9 @@ class ExactSnapshotEngineRestoreContractTest {
         return response;
       }
     }
-    if (response.length() > 1
+    if (!response.isEmpty()
         && (response.charAt(0) == '=' || response.charAt(0) == '?')
-        && !Character.isDigit(response.charAt(1))) {
+        && (response.length() == 1 || !Character.isDigit(response.charAt(1)))) {
       return response.charAt(0) + firstToken + response.substring(1);
     }
     return response;
@@ -2530,7 +2552,10 @@ class ExactSnapshotEngineRestoreContractTest {
         }
       }
       if (!isLoadSgfCommand(command)) {
-        if (commandPayload(command).startsWith("play ")) {
+        String payload = commandPayload(command);
+        if (payload.equals("clear_board")
+            || payload.startsWith("play ")
+            || payload.equals("name")) {
           invokeResponseHandlerForLine(engine, buildSuccessResponseLine(command));
         }
         return;
@@ -2596,8 +2621,9 @@ class ExactSnapshotEngineRestoreContractTest {
     }
 
     private String responseFor(String command) {
-      if ("clear_board".equals(command)) {
-        return clearBoardResponse;
+      String payload = commandPayload(command);
+      if (payload.equals("clear_board")) {
+        return clearBoardResponse == null ? null : buildResponseLine(command, clearBoardResponse);
       }
       if (isLoadSgfCommand(command)) {
         if (loadSgfResponse == null) {
@@ -2608,7 +2634,7 @@ class ExactSnapshotEngineRestoreContractTest {
         }
         return buildResponseLine(command, loadSgfResponse);
       }
-      if (commandPayload(command).startsWith("play ")
+      if ((payload.startsWith("play ") || payload.equals("name"))
           && AUTO_ID_RESPONSE.equals(loadSgfResponse)) {
         return buildSuccessResponseLine(command);
       }
@@ -2628,6 +2654,7 @@ class ExactSnapshotEngineRestoreContractTest {
 
     @Override
     protected void onCommand(String command) throws IOException {
+      String payload = commandPayload(command);
       if (isLoadSgfCommand(command)) {
         loadSgfPath = extractLoadSgfPath(command);
         try {
@@ -2637,8 +2664,12 @@ class ExactSnapshotEngineRestoreContractTest {
         }
         return;
       }
-      if (commandPayload(command).startsWith("play ") && loadSgfPath != null) {
+      if (payload.startsWith("play ") && loadSgfPath != null) {
         tempFileExistedDuringReplay = tempFileExistedDuringReplay || Files.exists(loadSgfPath);
+        invokeResponseHandlerForLine(engine, buildSuccessResponseLine(command));
+        return;
+      }
+      if (payload.equals("clear_board") || payload.equals("name")) {
         invokeResponseHandlerForLine(engine, buildSuccessResponseLine(command));
       }
     }

--- a/src/test/java/featurecat/lizzie/analysis/LeelazAutomaticRestartConvergenceTest.java
+++ b/src/test/java/featurecat/lizzie/analysis/LeelazAutomaticRestartConvergenceTest.java
@@ -214,7 +214,13 @@ class LeelazAutomaticRestartConvergenceTest {
           waitForCount(engine.readyCount, 1, 1, TimeUnit.SECONDS),
           "the production remote restart must publish ready after the fence");
       assertEquals(1, engine.resumeCount.get(), "remote ponder must resume exactly once");
-      assertEquals(1, engine.analyzeCount.get(), "remote analysis starts after convergence");
+      assertEquals(
+          1,
+          engine.analyzeCount.get(),
+          "commands="
+              + engine.transport.rawCommands()
+              + " route="
+              + engine.analysisOutputRouteForTest());
       assertTrue(engine.isLoaded());
       assertEngineMatchesBoard(engine, board, 19, 19);
       Leelaz.EngineModeReservation afterFence = engine.beginEngineModeReservation();
@@ -1532,7 +1538,12 @@ class LeelazAutomaticRestartConvergenceTest {
 
   private static void invokeFenceResponse(ConvergingRestartLeelaz engine) throws Exception {
     String response = numberedResponseFor(engine.transport.rawCommands(), "name");
+    engine.awaitingFence = false;
     engine.processCommandResponseLineForTest(response);
+    int clears = engine.deferredClearResponses.getAndSet(0);
+    for (int index = 0; index < clears; index++) {
+      engine.processCommandResponseLineForTest("=");
+    }
   }
 
   private static void invokeCheckEngineAlive(EngineManager manager) throws Exception {
@@ -1881,6 +1892,8 @@ class LeelazAutomaticRestartConvergenceTest {
     private final AtomicInteger resumeCount = new AtomicInteger();
     private final AtomicInteger readyCount = new AtomicInteger();
     private final AtomicInteger clearBoardCount = new AtomicInteger();
+    private final AtomicInteger deferredClearResponses = new AtomicInteger();
+    private volatile boolean awaitingFence;
     private final Map<String, Stone> engineStones = new HashMap<>();
     private final CountDownLatch startCompleted = new CountDownLatch(1);
     private volatile ExactSnapshotRestoreProtocolFixture.Transport transport;
@@ -1928,6 +1941,11 @@ class LeelazAutomaticRestartConvergenceTest {
                   clearBoardCount.incrementAndGet();
                   engineStones.clear();
                   engineBlackToPlay = true;
+                  if (awaitingFence) {
+                    // Do not deliver an unnumbered successor response ahead of the held fence.
+                    deferredClearResponses.incrementAndGet();
+                    return null;
+                  }
                 } else if (command.startsWith("boardsize ")) {
                   engineBoardWidth =
                       Integer.parseInt(command.substring("boardsize ".length()).trim());
@@ -1977,6 +1995,7 @@ class LeelazAutomaticRestartConvergenceTest {
                         "controlled mirror fence failure");
                   }
                   // The board fence is the final gate; tests settle it explicitly.
+                  awaitingFence = true;
                   return null;
                 }
                 return ExactSnapshotRestoreProtocolFixture.Response.success();

--- a/src/test/java/featurecat/lizzie/analysis/LeelazAutomaticRestartConvergenceTest.java
+++ b/src/test/java/featurecat/lizzie/analysis/LeelazAutomaticRestartConvergenceTest.java
@@ -50,6 +50,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import javax.swing.SwingUtilities;
 import org.junit.jupiter.api.Test;
 
@@ -202,17 +203,42 @@ class LeelazAutomaticRestartConvergenceTest {
           "the completion gate must reject unrelated engine-mode owners while the remote fence is"
               + " pending");
 
-      history.getCurrentHistoryNode().clearAndSyncBoard(true);
+      String lifecycleFenceResponse = numberedResponseFor(engine.transport.rawCommands(), "name");
+      AtomicReference<Throwable> navigationFailure = new AtomicReference<>();
+      Thread navigationRestore =
+          new Thread(
+              () -> {
+                try {
+                  history.getCurrentHistoryNode().clearAndSyncBoard(true);
+                } catch (Throwable failure) {
+                  navigationFailure.set(failure);
+                }
+              },
+              "remote-navigation-position-restore");
+      navigationRestore.start();
+      assertTrue(
+          waitForRawCommandPrefixCount(engine.transport, "name", 2, 2, TimeUnit.SECONDS),
+          "the navigation restore must reach its own final board fence");
+      assertTrue(navigationRestore.isAlive(), "navigation must wait for its final board fence");
       assertEquals(
           0,
           engine.analyzeCount.get(),
-          "SNAPSHOT navigation must not start analysis before the final fence");
+          "SNAPSHOT navigation must not start analysis before either final fence");
 
       invokeFenceResponse(engine);
+      navigationRestore.join(2_000L);
+      assertFalse(navigationRestore.isAlive(), "confirmed navigation restore must finish");
+      assertEquals(null, navigationFailure.get());
+      assertEquals(
+          0,
+          engine.analyzeCount.get(),
+          "navigation confirmation must not bypass the lifecycle fence");
+
+      engine.processCommandResponseLineForTest(lifecycleFenceResponse);
 
       assertTrue(
           waitForCount(engine.readyCount, 1, 1, TimeUnit.SECONDS),
-          "the production remote restart must publish ready after the fence");
+          "the production remote restart must publish ready after both confirmed fences");
       assertEquals(1, engine.resumeCount.get(), "remote ponder must resume exactly once");
       assertEquals(
           1,
@@ -253,23 +279,39 @@ class LeelazAutomaticRestartConvergenceTest {
       engine.publishReady();
       assertTrue(waitForLoadSgfCount(engine, 2, 2, TimeUnit.SECONDS));
       assertTrue(waitForRawCommandPrefix(engine.transport, "name", 2, TimeUnit.SECONDS));
+      String lifecycleFenceResponse = numberedResponseFor(engine.transport.rawCommands(), "name");
 
       engine.blockThirdLoadSgf = true;
       assertTrue(board.nextMove(false), "snapshot tail navigation must succeed");
+      AtomicReference<Throwable> restoreFailure = new AtomicReference<>();
       Thread restore =
           new Thread(
-              () -> history.getCurrentHistoryNode().clearAndSyncBoard(true),
+              () -> {
+                try {
+                  history.getCurrentHistoryNode().clearAndSyncBoard(true);
+                } catch (Throwable failure) {
+                  restoreFailure.set(failure);
+                }
+              },
               "snapshot-tail-navigation-restore");
       restore.start();
       assertTrue(waitForLoadSgfCount(engine, 3, 2, TimeUnit.SECONDS));
 
-      invokeFenceResponse(engine);
+      engine.processCommandResponseLineForTest(lifecycleFenceResponse);
       assertEquals(0, engine.analyzeCount.get(), "fence success must wait for the tail restore");
 
       invokeLoadSgfResponse(engine);
+      assertTrue(
+          waitForRawCommandPrefixCount(engine.transport, "name", 2, 2, TimeUnit.SECONDS),
+          "the tail restore must reach its final name confirmation");
+      assertEquals(
+          0, engine.analyzeCount.get(), "analysis must wait for the tail restore final name ACK");
+      invokeFenceResponse(engine);
       restore.join(2_000L);
       assertFalse(restore.isAlive(), "snapshot tail restore must finish");
+      assertEquals(null, restoreFailure.get());
       assertTrue(waitForCount(engine.analyzeCount, 1, 2, TimeUnit.SECONDS));
+      assertEngineMatchesBoard(engine, board, 19, 19);
     }
   }
   @Test
@@ -1538,12 +1580,7 @@ class LeelazAutomaticRestartConvergenceTest {
 
   private static void invokeFenceResponse(ConvergingRestartLeelaz engine) throws Exception {
     String response = numberedResponseFor(engine.transport.rawCommands(), "name");
-    engine.awaitingFence = false;
     engine.processCommandResponseLineForTest(response);
-    int clears = engine.deferredClearResponses.getAndSet(0);
-    for (int index = 0; index < clears; index++) {
-      engine.processCommandResponseLineForTest("=");
-    }
   }
 
   private static void invokeCheckEngineAlive(EngineManager manager) throws Exception {
@@ -1577,6 +1614,23 @@ class LeelazAutomaticRestartConvergenceTest {
         if (command.startsWith(prefix)) {
           return true;
         }
+      }
+      Thread.sleep(10L);
+    }
+    return false;
+  }
+
+  private static boolean waitForRawCommandPrefixCount(
+      ExactSnapshotRestoreProtocolFixture.Transport transport,
+      String prefix,
+      int count,
+      long timeout,
+      TimeUnit unit)
+      throws InterruptedException {
+    long deadline = System.nanoTime() + unit.toNanos(timeout);
+    while (System.nanoTime() < deadline) {
+      if (countCommandsWithPrefix(transport.commands(), prefix) >= count) {
+        return true;
       }
       Thread.sleep(10L);
     }
@@ -1892,8 +1946,6 @@ class LeelazAutomaticRestartConvergenceTest {
     private final AtomicInteger resumeCount = new AtomicInteger();
     private final AtomicInteger readyCount = new AtomicInteger();
     private final AtomicInteger clearBoardCount = new AtomicInteger();
-    private final AtomicInteger deferredClearResponses = new AtomicInteger();
-    private volatile boolean awaitingFence;
     private final Map<String, Stone> engineStones = new HashMap<>();
     private final CountDownLatch startCompleted = new CountDownLatch(1);
     private volatile ExactSnapshotRestoreProtocolFixture.Transport transport;
@@ -1941,11 +1993,6 @@ class LeelazAutomaticRestartConvergenceTest {
                   clearBoardCount.incrementAndGet();
                   engineStones.clear();
                   engineBlackToPlay = true;
-                  if (awaitingFence) {
-                    // Do not deliver an unnumbered successor response ahead of the held fence.
-                    deferredClearResponses.incrementAndGet();
-                    return null;
-                  }
                 } else if (command.startsWith("boardsize ")) {
                   engineBoardWidth =
                       Integer.parseInt(command.substring("boardsize ".length()).trim());
@@ -1995,7 +2042,6 @@ class LeelazAutomaticRestartConvergenceTest {
                         "controlled mirror fence failure");
                   }
                   // The board fence is the final gate; tests settle it explicitly.
-                  awaitingFence = true;
                   return null;
                 }
                 return ExactSnapshotRestoreProtocolFixture.Response.success();

--- a/src/test/java/featurecat/lizzie/analysis/LeelazExclusiveRemoteGtpSessionTest.java
+++ b/src/test/java/featurecat/lizzie/analysis/LeelazExclusiveRemoteGtpSessionTest.java
@@ -542,7 +542,8 @@ class LeelazExclusiveRemoteGtpSessionTest {
         reservation.close();
       }
 
-      assertEquals("komi 6.5\n", output.toString(StandardCharsets.UTF_8));
+      assertEquals(
+          "komi 6.5\n", output.toString(StandardCharsets.UTF_8).replaceFirst("^\\d+\\s+", ""));
     } finally {
       Lizzie.leelaz = previousEngine;
       Lizzie.board = previousBoard;

--- a/src/test/java/featurecat/lizzie/analysis/LeelazInactiveCommandBaselineTest.java
+++ b/src/test/java/featurecat/lizzie/analysis/LeelazInactiveCommandBaselineTest.java
@@ -35,7 +35,7 @@ class LeelazInactiveCommandBaselineTest {
       assertEquals("name\n", output.toString(StandardCharsets.UTF_8));
 
       processCommandResponse(engine, "=");
-      assertEquals("name\n", output.toString(StandardCharsets.UTF_8));
+      assertEquals("name\nversion\n", output.toString(StandardCharsets.UTF_8));
 
       processCommandResponse(engine, "=");
       assertEquals("name\nversion\nshowboard\n", output.toString(StandardCharsets.UTF_8));

--- a/src/test/java/featurecat/lizzie/analysis/LeelazLoadSgfResponseBindingTest.java
+++ b/src/test/java/featurecat/lizzie/analysis/LeelazLoadSgfResponseBindingTest.java
@@ -159,10 +159,10 @@ class LeelazLoadSgfResponseBindingTest {
       Leelaz engine = new Leelaz("");
       Lizzie.leelaz = engine;
       engine.requireResponseBeforeSend = true;
-      setCurrentCmdNum(engine, -1);
 
       RecordingOutputStream output = new RecordingOutputStream();
       setOutputStream(engine, output);
+      engine.sendCommandWithResponseForTest("name", () -> {});
 
       Path sgfFile = Files.createTempFile("loadsgf-queued-timeout-", ".sgf");
       AtomicInteger consumedCount = new AtomicInteger();
@@ -180,14 +180,13 @@ class LeelazLoadSgfResponseBindingTest {
 
       assertEquals(1, consumedCount.get(), "timeout cleanup should still trigger afterConsumed.");
       assertEquals(0, commandQueueSize(engine), "timed-out queued loadsgf should be dropped.");
-      assertEquals(0, output.commands().size(), "stalled loadsgf should stay unsent before retry.");
+      assertEquals(List.of("name"), output.commands(), "loadsgf must remain queued behind name");
 
-      engine.setResponseUpToDate();
-      invokeTrySendCommandFromQueue(engine);
+      invokeCommandResponseLine(engine, "=");
 
       assertEquals(
-          0,
-          output.commands().size(),
+          List.of("name"),
+          output.commands(),
           "timed-out queued loadsgf must stay unsent after queue is retried.");
     }
   }

--- a/src/test/java/featurecat/lizzie/analysis/LeelazReadBoardGmaTest.java
+++ b/src/test/java/featurecat/lizzie/analysis/LeelazReadBoardGmaTest.java
@@ -1188,6 +1188,7 @@ class LeelazReadBoardGmaTest {
       invokeProcessCommandResponseLine(
           engine, errorResponseFor(output.rawCommands(), "maxTime", "restore failed"));
 
+      output.autoAcknowledgePositionRestore(engine, true);
       engine.restoreClosedEngineBoardState(false);
       invokeProcessCommandResponseLine(engine, "=");
       assertEquals(
@@ -1780,6 +1781,7 @@ class LeelazReadBoardGmaTest {
           Leelaz.ExclusiveGtpLeaseAvailability.ENGINE_STATE_UNRESTORED,
           engine.previewForegroundAnalysisLeaseAvailability());
 
+      output.autoAcknowledgePositionRestore(engine, true);
       engine.restoreClosedEngineBoardState(false);
       invokeProcessCommandResponseLine(engine, "=");
       assertEquals(
@@ -1952,6 +1954,7 @@ class LeelazReadBoardGmaTest {
       engine.isThinking = false;
       engine.failReadBoardGmaEngineRestore("controlled board restore failure");
 
+      output.autoAcknowledgePositionRestore(engine, true);
       engine.restoreClosedEngineBoardState(false);
 
       assertEquals(
@@ -2032,6 +2035,7 @@ class LeelazReadBoardGmaTest {
           engine.beginEngineModeReservation(),
           "unrelated engine-mode owners must be rejected while the final fence is pending");
       assertFalse(completed.await(50, TimeUnit.MILLISECONDS));
+      acknowledgePositionCommands(engine, output);
       invokeProcessCommandResponseLine(engine, numberedResponseFor(output.rawCommands(), "name"));
       assertTrue(completed.await(1, TimeUnit.SECONDS));
       Leelaz.EngineModeReservation afterFence = engine.beginEngineModeReservation();
@@ -2060,6 +2064,7 @@ class LeelazReadBoardGmaTest {
       assertTrue(waitForRawCommand(output, "name", 1, TimeUnit.SECONDS));
       assertFalse(
           output.commands().stream().anyMatch(command -> command.startsWith("kata-analyze")));
+      acknowledgePositionCommands(engine, output);
       invokeProcessCommandResponseLine(engine, numberedResponseFor(output.rawCommands(), "name"));
       assertTrue(completed.await(1, TimeUnit.SECONDS));
       invokeProcessCommandResponseLine(engine, "=");
@@ -2171,6 +2176,7 @@ class LeelazReadBoardGmaTest {
           engine.beginEngineModeReservation(),
           "unrelated engine-mode owners must be rejected while the final fence is pending");
 
+      acknowledgePositionCommands(engine, output);
       invokeProcessCommandResponseLine(engine, numberedResponseFor(output.rawCommands(), "name"));
 
       assertTrue(completed.await(1, TimeUnit.SECONDS));
@@ -2223,6 +2229,7 @@ class LeelazReadBoardGmaTest {
       assertNull(
           engine.beginEngineModeReservation(),
           "unrelated engine-mode owners must be rejected while the final fence is pending");
+      acknowledgePositionCommands(engine, output);
       invokeProcessCommandResponseLine(engine, numberedResponseFor(output.rawCommands(), "name"));
       assertTrue(completed.await(1, TimeUnit.SECONDS));
       Leelaz.EngineModeReservation afterRestart = engine.beginEngineModeReservation();
@@ -3251,7 +3258,8 @@ class LeelazReadBoardGmaTest {
 
       assertTrue(
           tailEnqueued.await(1, TimeUnit.SECONDS),
-          "the captured MOVE/PASS tail must be dispatched before exact success is reported; commands="
+          "the captured MOVE/PASS tail must be dispatched before exact success is reported;"
+              + " commands="
               + transport.commands());
       assertFalse(
           waitForFixtureCommandPrefix(transport, "kata-set-param ", 100, TimeUnit.MILLISECONDS),
@@ -3925,6 +3933,25 @@ class LeelazReadBoardGmaTest {
     Field commandListReady = Leelaz.class.getDeclaredField("endGetCommandList");
     commandListReady.setAccessible(true);
     commandListReady.setBoolean(engine, true);
+  }
+
+  private static void acknowledgePositionCommands(Leelaz engine, RecordingOutputStream output) {
+    for (String raw : output.rawCommands()) {
+      String payload = raw.replaceFirst("^\\d+\\s+", "");
+      if (isRestorePositionCommand(payload)) {
+        engine.processCommandResponseLineForTest("=" + raw.substring(0, raw.indexOf(' ')));
+      }
+    }
+  }
+
+  private static boolean isRestorePositionCommand(String command) {
+    return command.equals("clear_board")
+        || command.startsWith("boardsize ")
+        || command.startsWith("rectangular_boardsize ")
+        || command.startsWith("komi ")
+        || command.startsWith("play ")
+        || command.startsWith("loadsgf ")
+        || command.startsWith("set_position");
   }
 
   private static void acknowledgeInitialGmaCommands(
@@ -4731,6 +4758,13 @@ class LeelazReadBoardGmaTest {
   private static final class RecordingOutputStream extends OutputStream {
     private final StringBuilder currentCommand = new StringBuilder();
     private final List<String> commands = new ArrayList<>();
+    private Leelaz acknowledgePositionEngine;
+    private boolean acknowledgeRestoreFence;
+
+    private void autoAcknowledgePositionRestore(Leelaz engine, boolean includeFinalFence) {
+      acknowledgePositionEngine = engine;
+      acknowledgeRestoreFence = includeFinalFence;
+    }
 
     @Override
     public synchronized void write(int b) {
@@ -4743,6 +4777,15 @@ class LeelazReadBoardGmaTest {
       currentCommand.setLength(0);
       if (!command.isEmpty()) {
         commands.add(command);
+        String payload = command.replaceFirst("^\\d+\\s+", "");
+        Leelaz engine = acknowledgePositionEngine;
+        if (engine != null
+            && (isRestorePositionCommand(payload)
+                || (acknowledgeRestoreFence && payload.equals("name")))) {
+          if (payload.equals("name")) acknowledgePositionEngine = null;
+          engine.processCommandResponseLineForTest(
+              "=" + command.substring(0, command.indexOf(' ')));
+        }
       }
     }
 

--- a/src/test/java/featurecat/lizzie/analysis/LeelazReadBoardGmaTest.java
+++ b/src/test/java/featurecat/lizzie/analysis/LeelazReadBoardGmaTest.java
@@ -1723,12 +1723,13 @@ class LeelazReadBoardGmaTest {
         loadThread.join(1000L);
         assertFalse(loadThread.isAlive());
 
+        assertFalse(blockedOutput.commands().contains("version"));
         invokeProcessCommandResponseLine(engine, "=");
 
-        assertFalse(
-            blockedOutput.commands().contains("version"),
-            "post-reset send failure must not retire the old loadsgf outstanding twice.");
+        assertTrue(blockedOutput.commands().contains("version"));
         assertFalse(blockedOutput.commands().contains("protocol_version"));
+        invokeProcessCommandResponseLine(engine, "=");
+        assertTrue(blockedOutput.commands().contains("protocol_version"));
         assertTrue(loadFailure.get() instanceof IllegalStateException);
       } finally {
         blockedOutput.releaseFirstFlush.countDown();

--- a/src/test/java/featurecat/lizzie/analysis/LeelazReaderIncarnationTest.java
+++ b/src/test/java/featurecat/lizzie/analysis/LeelazReaderIncarnationTest.java
@@ -438,6 +438,7 @@ class LeelazReaderIncarnationTest {
         Object binding = getField(engine, "readerStreamBinding");
         process.observeReaderLines(engine);
         Lizzie.leelaz = engine;
+        Lizzie.board = new Board();
         engine.started = true;
         engine.isLoaded = true;
         engine.isNormalEnd = true;

--- a/src/test/java/featurecat/lizzie/analysis/LeelazTrackingStreamLeaseTest.java
+++ b/src/test/java/featurecat/lizzie/analysis/LeelazTrackingStreamLeaseTest.java
@@ -396,9 +396,11 @@ class LeelazTrackingStreamLeaseTest {
         queuedCommandType.getDeclaredConstructor(
             String.class, Runnable.class, failureHandlerType, boolean.class);
     constructor.setAccessible(true);
-    Object queuedCommand = constructor.newInstance("loadsgf /tmp/monitor.sgf", null, failureHandler, true);
+    Object queuedCommand =
+        constructor.newInstance("loadsgf /tmp/monitor.sgf", null, failureHandler, true);
     Method markReset =
-        queuedCommandType.getDeclaredMethod("markStateResetAfterOutputWrite", RuntimeException.class);
+        queuedCommandType.getDeclaredMethod(
+            "markStateResetAfterOutputWrite", RuntimeException.class);
     markReset.setAccessible(true);
     markReset.invoke(queuedCommand, new IllegalStateException("controlled reset"));
     Method publishReset = queuedCommandType.getDeclaredMethod("publishStateResetAfterOutputWrite");
@@ -1575,9 +1577,11 @@ class LeelazTrackingStreamLeaseTest {
       assertEquals(0, engine.feedbackCount.get());
       assertTrue(dispatch(state.engine, "=800000001"));
       assertTrue(dispatch(state.engine, ""));
-      assertTrue(
-          state.output.toString(StandardCharsets.UTF_8).endsWith("clear_board\nkomi 7.5\n"),
-          state.output.toString(StandardCharsets.UTF_8));
+      List<String> commands = outputCommandPayloads(state.output);
+      assertEquals(
+          List.of("clear_board", "komi 7.5"),
+          commands.subList(commands.size() - 2, commands.size()),
+          commands.toString());
     } finally {
       Lizzie.board = previousBoard;
     }
@@ -1600,9 +1604,11 @@ class LeelazTrackingStreamLeaseTest {
       assertEquals(0, engine.feedbackCount.get());
       assertTrue(dispatch(state.engine, "=800000001"));
       assertTrue(dispatch(state.engine, ""));
-      assertTrue(
-          state.output.toString(StandardCharsets.UTF_8).endsWith("clear_board\nkomi 7.5\n"),
-          state.output.toString(StandardCharsets.UTF_8));
+      List<String> commands = outputCommandPayloads(state.output);
+      assertEquals(
+          List.of("clear_board", "komi 7.5"),
+          commands.subList(commands.size() - 2, commands.size()),
+          commands.toString());
     } finally {
       Lizzie.board = previousBoard;
     }
@@ -1629,9 +1635,11 @@ class LeelazTrackingStreamLeaseTest {
       assertEquals(0, engine.feedbackCount.get());
       assertTrue(dispatch(state.engine, "=800000001"));
       assertTrue(dispatch(state.engine, ""));
-      assertTrue(
-          state.output.toString(StandardCharsets.UTF_8).endsWith("clear_board\nboardsize 13\n"),
-          state.output.toString(StandardCharsets.UTF_8));
+      List<String> commands = outputCommandPayloads(state.output);
+      assertEquals(
+          List.of("clear_board", "boardsize 13"),
+          commands.subList(commands.size() - 2, commands.size()),
+          commands.toString());
     } finally {
       Lizzie.board = previousBoard;
     }
@@ -1661,10 +1669,12 @@ class LeelazTrackingStreamLeaseTest {
 
       state.engine.boardSize(13, 13);
 
-      String mirroredCommands = secondOutput.toString(StandardCharsets.UTF_8);
-      assertTrue(
-          mirroredCommands.startsWith("boardsize 13\nclear_board\n"),
-          mirroredCommands);
+      List<String> mirroredCommands = outputCommandPayloads(secondOutput);
+      assertTrue(mirroredCommands.size() >= 2, mirroredCommands.toString());
+      assertEquals(
+          List.of("boardsize 13", "clear_board"),
+          mirroredCommands.subList(0, 2),
+          mirroredCommands.toString());
     } finally {
       Board.boardWidth = previousBoardWidth;
       Board.boardHeight = previousBoardHeight;
@@ -1831,6 +1841,67 @@ class LeelazTrackingStreamLeaseTest {
     }
   }
 
+  private static List<String> rawOutputCommands(ByteArrayOutputStream output) {
+    List<String> commands = new ArrayList<>();
+    for (String line : output.toString(StandardCharsets.UTF_8).split("\\R")) {
+      String command = line.trim();
+      if (!command.isEmpty()) {
+        commands.add(command);
+      }
+    }
+    return commands;
+  }
+
+  private static String commandPayload(String command) {
+    int separator = command.indexOf(' ');
+    if (separator > 0 && command.substring(0, separator).chars().allMatch(Character::isDigit)) {
+      return command.substring(separator + 1);
+    }
+    return command;
+  }
+
+  private static List<String> outputCommandPayloads(ByteArrayOutputStream output) {
+    List<String> commands = new ArrayList<>();
+    for (String command : rawOutputCommands(output)) {
+      commands.add(commandPayload(command));
+    }
+    return commands;
+  }
+
+  private static void acknowledgeCompoundPositionRestore(TestState state, Thread restore)
+      throws Exception {
+    long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(3);
+    int inspected = 0;
+    boolean finalFenceAcknowledged = false;
+    while (restore.isAlive() && System.nanoTime() < deadline) {
+      List<String> commands = rawOutputCommands(state.output);
+      while (inspected < commands.size()) {
+        String command = commands.get(inspected++);
+        int separator = command.indexOf(' ');
+        if (separator <= 0
+            || !command.substring(0, separator).chars().allMatch(Character::isDigit)) {
+          continue;
+        }
+        long commandId = Long.parseLong(command.substring(0, separator));
+        if (commandId < 900_000_000L) {
+          continue;
+        }
+        String payload = command.substring(separator + 1);
+        assertFalse(payload.contains("analyze"), "analysis must wait for the position ACK");
+        processCommandResponse(state.engine, "=" + commandId);
+        if (payload.equals("name")) {
+          finalFenceAcknowledged = true;
+        }
+      }
+      if (restore.isAlive()) {
+        Thread.sleep(10L);
+      }
+    }
+    restore.join(1_000L);
+    assertFalse(restore.isAlive(), "compound position restore must finish after its ACKs");
+    assertTrue(finalFenceAcknowledged, "compound position restore must finish through final name");
+  }
+
   private static void acknowledgeLastPositionCommand(TestState state) throws Exception {
     String commands = state.output.toString(StandardCharsets.UTF_8).trim();
     String last = commands.substring(commands.lastIndexOf('\n') + 1);
@@ -1920,14 +1991,43 @@ class LeelazTrackingStreamLeaseTest {
       assertTrue(dispatch(state.engine, "=800000001"));
       assertTrue(dispatch(state.engine, ""));
 
-      Lizzie.board.resendMoveToEngine(state.engine, false);
+      AtomicReference<Throwable> restoreFailure = new AtomicReference<>();
+      Thread restore =
+          new Thread(
+              () -> {
+                try {
+                  Lizzie.board.resendMoveToEngine(state.engine, false);
+                } catch (Throwable failure) {
+                  restoreFailure.set(failure);
+                }
+              },
+              "tracking-position-restore");
+      restore.start();
+      waitUntil(
+          () ->
+              rawOutputCommands(state.output).stream()
+                  .anyMatch(command -> command.equals("800000002 stop")));
+      assertTrue(restore.isAlive(), "restore must wait for the tracking final stop");
 
-      assertTrue(state.engine.isPondering());
       assertTrue(dispatch(state.engine, "=800000002"));
       assertTrue(dispatch(state.engine, ""));
-      acknowledgeLastPositionCommand(state);
-      String output = state.output.toString(StandardCharsets.UTF_8);
-      assertTrue(output.lastIndexOf("kata-analyze") > output.lastIndexOf("clear_board"), output);
+      acknowledgeCompoundPositionRestore(state, restore);
+      assertEquals(null, restoreFailure.get());
+      assertTrue(state.engine.isPondering());
+      waitUntil(
+          () ->
+              outputCommandPayloads(state.output).stream()
+                  .anyMatch(command -> command.startsWith("kata-analyze")));
+      List<String> commands = outputCommandPayloads(state.output);
+      int finalFence = commands.lastIndexOf("name");
+      int analysis = -1;
+      for (int index = 0; index < commands.size(); index++) {
+        if (commands.get(index).startsWith("kata-analyze")) {
+          analysis = index;
+        }
+      }
+      assertTrue(finalFence >= 0, commands.toString());
+      assertTrue(analysis > finalFence, commands.toString());
     } finally {
       Lizzie.board = previousBoard;
     }
@@ -2753,7 +2853,8 @@ class LeelazTrackingStreamLeaseTest {
             boolean.class,
             boolean.class);
     method.setAccessible(true);
-    method.invoke(engine, "loadsgf /tmp/tracking-rebind-sent.sgf", null, failureHandler, true, false);
+    method.invoke(
+        engine, "loadsgf /tmp/tracking-rebind-sent.sgf", null, failureHandler, true, false);
   }
 
   private static void enqueueBlockingTrackedLoadSgf(

--- a/src/test/java/featurecat/lizzie/analysis/LeelazTrackingStreamLeaseTest.java
+++ b/src/test/java/featurecat/lizzie/analysis/LeelazTrackingStreamLeaseTest.java
@@ -1831,6 +1831,14 @@ class LeelazTrackingStreamLeaseTest {
     }
   }
 
+  private static void acknowledgeLastPositionCommand(TestState state) throws Exception {
+    String commands = state.output.toString(StandardCharsets.UTF_8).trim();
+    String last = commands.substring(commands.lastIndexOf('\n') + 1);
+    String first = last.split(" ", 2)[0];
+    assertFalse(last.contains("analyze"), "analysis must wait for the position ACK");
+    processCommandResponse(state.engine, "=" + (Character.isDigit(first.charAt(0)) ? first : ""));
+  }
+
   @Test
   void navigationAfterTrackingQueuesPonderForTheNewPosition() throws Exception {
     Board previousBoard = Lizzie.board;
@@ -1855,6 +1863,7 @@ class LeelazTrackingStreamLeaseTest {
       assertTrue(state.engine.isPondering());
       assertTrue(dispatch(state.engine, "=800000002"));
       assertTrue(dispatch(state.engine, ""));
+      acknowledgeLastPositionCommand(state);
       String output = state.output.toString(StandardCharsets.UTF_8);
       assertTrue(output.lastIndexOf("kata-analyze") > output.lastIndexOf("play B D4"), output);
     } finally {
@@ -1885,6 +1894,7 @@ class LeelazTrackingStreamLeaseTest {
       assertTrue(state.engine.isPondering());
       assertTrue(dispatch(state.engine, "=800000002"));
       assertTrue(dispatch(state.engine, ""));
+      acknowledgeLastPositionCommand(state);
       String output = state.output.toString(StandardCharsets.UTF_8);
       assertTrue(output.lastIndexOf("kata-analyze") > output.lastIndexOf("undo"), output);
     } finally {
@@ -1915,6 +1925,7 @@ class LeelazTrackingStreamLeaseTest {
       assertTrue(state.engine.isPondering());
       assertTrue(dispatch(state.engine, "=800000002"));
       assertTrue(dispatch(state.engine, ""));
+      acknowledgeLastPositionCommand(state);
       String output = state.output.toString(StandardCharsets.UTF_8);
       assertTrue(output.lastIndexOf("kata-analyze") > output.lastIndexOf("clear_board"), output);
     } finally {

--- a/src/test/java/featurecat/lizzie/analysis/PositionConfirmedAnalysisTest.java
+++ b/src/test/java/featurecat/lizzie/analysis/PositionConfirmedAnalysisTest.java
@@ -10,6 +10,9 @@ import java.io.IOException;
 import java.lang.reflect.Field;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -131,24 +134,226 @@ class PositionConfirmedAnalysisTest {
     }
   }
 
+  @Test
+  void successfulFenceCannotHideFailedRestorePosition() throws Exception {
+    try (Fixture fixture = new Fixture()) {
+      AtomicBoolean success = new AtomicBoolean();
+      AtomicBoolean failure = new AtomicBoolean();
+      fixture.engine.sendCommand("clear_board");
+      fixture.engine.sendCommand("play B D4");
+      fixture.engine.confirmBoardSynchronization(
+          () -> success.set(true), detail -> failure.set(true));
+      fixture.respond(0, "?");
+      fixture.respond(1, "=");
+      fixture.respond(2, "=");
+      assertFalse(success.get(), "a final name ACK cannot repair a failed clear_board");
+      assertTrue(failure.get());
+    }
+  }
+
+  @Test
+  void analysisRequestedBeforeRestoreDispatchWaitsWithoutBlockingRequiredCommands()
+      throws Exception {
+    try (Fixture fixture = new Fixture()) {
+      Leelaz.PositionRestore restore = fixture.engine.capturePositionRestore(null);
+      fixture.engine.sendCommand("kata-analyze B 10");
+      assertTrue(fixture.transport.commands().isEmpty());
+      restore.execute(() -> fixture.engine.sendCommand("clear_board"));
+      AtomicBoolean success = new AtomicBoolean();
+      restore.confirm(() -> success.set(true), detail -> fail(detail));
+      assertEquals(List.of("clear_board", "name"), fixture.transport.commands());
+      fixture.respond(0, "=");
+      assertFalse(success.get());
+      fixture.respond(1, "=");
+      assertTrue(success.get());
+      assertEquals(
+          List.of("clear_board", "name", "kata-analyze B 10"), fixture.transport.commands());
+    }
+  }
+
+  @Test
+  void finalFenceWaitsForEveryCompoundPositionAckEvenOutOfOrder() throws Exception {
+    try (Fixture fixture = new Fixture()) {
+      AtomicBoolean success = new AtomicBoolean();
+      AtomicBoolean failure = new AtomicBoolean();
+      Leelaz.PositionRestore restore = fixture.engine.capturePositionRestore(null);
+      restore.execute(
+          () -> {
+            fixture.engine.sendCommand("clear_board");
+            fixture.engine.sendCommand("play B D4");
+          });
+      restore.confirm(() -> success.set(true), detail -> failure.set(true));
+
+      fixture.respond(2, "=");
+      assertFalse(success.get(), "the final fence cannot bypass pending position responses");
+      fixture.respond(0, "=");
+      assertFalse(success.get(), "every compound position response is required");
+      fixture.respond(1, "=");
+
+      assertTrue(success.get());
+      assertFalse(failure.get());
+    }
+  }
+
+  @Test
+  void replacementsInsideOneCompoundRestoreShareEarlierFailure() throws Exception {
+    try (Fixture fixture = new Fixture()) {
+      AtomicBoolean success = new AtomicBoolean();
+      AtomicBoolean failure = new AtomicBoolean();
+      Leelaz.PositionRestore restore = fixture.engine.capturePositionRestore(null);
+      restore.execute(
+          () -> {
+            fixture.engine.sendCommand("clear_board");
+            fixture.engine.sendCommand("boardsize 19");
+            fixture.engine.sendCommand("komi 7.5");
+            fixture.engine.sendCommand("loadsgf /tmp/compound-restore.sgf");
+            fixture.engine.sendCommand("play W pass");
+          });
+      restore.confirm(() -> success.set(true), detail -> failure.set(true));
+
+      fixture.respond(0, "?");
+      for (int index = 1; index < 6; index++) {
+        fixture.respond(index, "=");
+      }
+
+      assertFalse(success.get());
+      assertTrue(failure.get(), "a later replacement must not reset the compound lineage");
+    }
+  }
+
+  @Test
+  void sendFailureFailsCapturedRestoreBeforeFinalFence() throws Exception {
+    try (Fixture fixture = new Fixture()) {
+      AtomicBoolean success = new AtomicBoolean();
+      AtomicBoolean failure = new AtomicBoolean();
+      Leelaz.PositionRestore restore = fixture.engine.capturePositionRestore(null);
+      fixture.failWrite.set(true);
+      restore.execute(() -> fixture.engine.sendCommand("clear_board"));
+      restore.confirm(() -> success.set(true), detail -> failure.set(true));
+
+      assertFalse(success.get());
+      assertTrue(failure.get());
+    }
+  }
+
+  @Test
+  void timedOutRestoreLateAckCannotSettleFreshRestore() throws Exception {
+    ShortTimeoutLeelaz engine = new ShortTimeoutLeelaz();
+    try (Fixture fixture = new Fixture(engine, false)) {
+      CountDownLatch oldFailure = new CountDownLatch(1);
+      Leelaz.PositionRestore oldRestore = engine.capturePositionRestore(null);
+      oldRestore.execute(() -> engine.sendCommand("clear_board"));
+      oldRestore.confirm(
+          () -> fail("timed-out restore succeeded"), detail -> oldFailure.countDown());
+      assertTrue(oldFailure.await(1, TimeUnit.SECONDS));
+
+      engine.isLoaded = true;
+      engine.timeoutMillis.set(2_000L);
+      AtomicBoolean freshSuccess = new AtomicBoolean();
+      AtomicBoolean freshFailure = new AtomicBoolean();
+      Leelaz.PositionRestore freshRestore = engine.capturePositionRestore(null);
+      freshRestore.execute(() -> engine.sendCommand("set_position B D4"));
+      freshRestore.confirm(() -> freshSuccess.set(true), detail -> freshFailure.set(true));
+
+      fixture.respond(0, "=");
+      assertFalse(freshSuccess.get(), "late ACK belongs only to the retired restore");
+      fixture.respond(2, "=");
+      fixture.respond(3, "=");
+
+      assertTrue(freshSuccess.get());
+      assertFalse(freshFailure.get());
+    }
+  }
+
+  @Test
+  void obsoleteRestoreFailureCannotUnloadSuccessorOnSameReader() throws Exception {
+    try (Fixture fixture = new Fixture()) {
+      AtomicBoolean oldFailure = new AtomicBoolean();
+      Leelaz.PositionRestore oldRestore = fixture.engine.capturePositionRestore(null);
+      oldRestore.execute(() -> fixture.engine.sendCommand("clear_board"));
+      oldRestore.confirm(() -> fail("obsolete restore succeeded"), detail -> oldFailure.set(true));
+
+      AtomicBoolean freshSuccess = new AtomicBoolean();
+      Leelaz.PositionRestore freshRestore = fixture.engine.capturePositionRestore(null);
+      freshRestore.execute(() -> fixture.engine.sendCommand("set_position B D4"));
+      freshRestore.confirm(
+          () -> freshSuccess.set(true), detail -> fail("fresh restore failed: " + detail));
+
+      fixture.respond(0, "?");
+      fixture.respond(1, "=");
+      assertTrue(oldFailure.get());
+      assertTrue(fixture.engine.isLoaded, "obsolete failure must not unload the successor lineage");
+      fixture.respond(2, "=");
+      fixture.respond(3, "=");
+
+      assertTrue(freshSuccess.get());
+    }
+  }
+
+  @Test
+  void capturedMirrorFailureFailsWholeRestore() throws Exception {
+    try (Fixture fixture = new Fixture(true)) {
+      AtomicBoolean success = new AtomicBoolean();
+      AtomicBoolean failure = new AtomicBoolean();
+      Leelaz.PositionRestore restore = fixture.engine.capturePositionRestore(fixture.mirror);
+      restore.execute(
+          () -> {
+            fixture.engine.sendCommandNoLeelaz2("clear_board");
+            fixture.mirror.sendCommandNoLeelaz2("clear_board");
+          });
+      restore.confirm(() -> success.set(true), detail -> failure.set(true));
+
+      fixture.respond(0, "=");
+      fixture.respond(1, "=");
+      fixture.respondMirror(0, "?");
+
+      assertFalse(success.get());
+      assertTrue(failure.get());
+    }
+  }
+
+  private static final class ShortTimeoutLeelaz extends Leelaz {
+    private final AtomicLong timeoutMillis = new AtomicLong(10L);
+
+    private ShortTimeoutLeelaz() throws Exception {
+      super("");
+    }
+
+    @Override
+    protected long readBoardGmaRestoreResponseTimeoutMillis() {
+      return timeoutMillis.get();
+    }
+  }
+
   private static final class Fixture implements AutoCloseable {
     private final Config previousConfig = Lizzie.config;
     private final Board previousBoard = Lizzie.board;
     private final LizzieFrame previousFrame = Lizzie.frame;
     private final Leelaz previousEngine = Lizzie.leelaz;
+    private final Leelaz previousMirror = Lizzie.leelaz2;
     private final Leelaz engine;
+    private final Leelaz mirror;
     private final AtomicBoolean failWrite = new AtomicBoolean();
     private final ExactSnapshotRestoreProtocolFixture.Transport transport;
+    private final ExactSnapshotRestoreProtocolFixture.Transport mirrorTransport;
 
     private Fixture() throws Exception {
+      this(new Leelaz(""), false);
+    }
+
+    private Fixture(boolean withMirror) throws Exception {
+      this(new Leelaz(""), withMirror);
+    }
+
+    private Fixture(Leelaz engine, boolean withMirror) throws Exception {
       Lizzie.config = allocate(Config.class);
-      engine = new Leelaz("");
+      this.engine = engine;
+      this.mirror = withMirror ? new Leelaz("") : null;
       Lizzie.leelaz = engine;
+      Lizzie.leelaz2 = mirror;
       Lizzie.board = new Board();
       Lizzie.frame = allocate(LizzieFrame.class);
-      engine.started = true;
-      engine.isLoaded = true;
-      engine.isKatago = true;
+      prepareEngine(engine);
       transport =
           ExactSnapshotRestoreProtocolFixture.install(
               engine,
@@ -157,9 +362,33 @@ class PositionConfirmedAnalysisTest {
                   throw new IOException("controlled position write failure");
                 return null;
               });
+      if (mirror == null) {
+        mirrorTransport = null;
+      } else {
+        prepareEngine(mirror);
+        mirrorTransport = ExactSnapshotRestoreProtocolFixture.install(mirror, command -> null);
+      }
+    }
+
+    private static void prepareEngine(Leelaz engine) {
+      engine.started = true;
+      engine.isLoaded = true;
+      engine.isKatago = true;
     }
 
     private void respond(int index, String prefix) {
+      respond(engine, transport, index, prefix);
+    }
+
+    private void respondMirror(int index, String prefix) {
+      respond(mirror, mirrorTransport, index, prefix);
+    }
+
+    private static void respond(
+        Leelaz engine,
+        ExactSnapshotRestoreProtocolFixture.Transport transport,
+        int index,
+        String prefix) {
       String raw = transport.rawCommands().get(index);
       int separator = raw.indexOf(' ');
       String id =
@@ -173,6 +402,7 @@ class PositionConfirmedAnalysisTest {
       Lizzie.board = previousBoard;
       Lizzie.frame = previousFrame;
       Lizzie.leelaz = previousEngine;
+      Lizzie.leelaz2 = previousMirror;
     }
   }
 

--- a/src/test/java/featurecat/lizzie/analysis/PositionConfirmedAnalysisTest.java
+++ b/src/test/java/featurecat/lizzie/analysis/PositionConfirmedAnalysisTest.java
@@ -1,0 +1,184 @@
+package featurecat.lizzie.analysis;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import featurecat.lizzie.Config;
+import featurecat.lizzie.Lizzie;
+import featurecat.lizzie.gui.LizzieFrame;
+import featurecat.lizzie.rules.Board;
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class PositionConfirmedAnalysisTest {
+  @ParameterizedTest
+  @ValueSource(strings = {"undo", "play B D4", "play W pass", "set_position B D4"})
+  void positionMustSucceedBeforeSuccessorAnalysisIsWritten(String mutation) throws Exception {
+    try (Fixture fixture = new Fixture()) {
+      fixture.engine.sendCommand(mutation);
+      fixture.engine.sendCommand("kata-analyze B 10");
+      assertEquals(List.of(mutation), fixture.transport.commands());
+      fixture.respond(0, "=");
+      assertEquals(List.of(mutation, "kata-analyze B 10"), fixture.transport.commands());
+    }
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"undo", "play B D4", "play W pass", "set_position B D4"})
+  void queuedPositionCannotBeBypassedByAnalysis(String mutation) throws Exception {
+    try (Fixture fixture = new Fixture()) {
+      fixture.engine.requireResponseBeforeSend = true;
+      fixture.engine.sendCommand("name");
+      fixture.engine.sendCommand(mutation);
+      fixture.engine.sendCommand("kata-analyze B 10");
+      assertEquals(List.of("name"), fixture.transport.commands());
+      fixture.respond(0, "=");
+      assertEquals(List.of("name", mutation), fixture.transport.commands());
+      fixture.respond(1, "=");
+      assertEquals(List.of("name", mutation, "kata-analyze B 10"), fixture.transport.commands());
+    }
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"undo", "play B D4", "play W pass", "set_position B D4"})
+  void rejectedPositionCannotResumeButFreshPositionCan(String mutation) throws Exception {
+    try (Fixture fixture = new Fixture()) {
+      fixture.engine.sendCommand(mutation);
+      fixture.engine.sendCommand("kata-analyze B 10");
+      fixture.respond(0, "?");
+      fixture.respond(0, "=");
+      assertEquals(List.of(mutation), fixture.transport.commands());
+      fixture.engine.sendCommand("set_position");
+      fixture.engine.sendCommand("kata-analyze W 11");
+      fixture.respond(1, "=");
+      assertEquals(
+          List.of(mutation, "set_position", "kata-analyze W 11"), fixture.transport.commands());
+    }
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"undo", "play B D4", "play W pass", "set_position B D4"})
+  void timeoutRetiresOnlyItsOwnResponseAndLetsQueueProgress(String mutation) throws Exception {
+    try (Fixture fixture = new Fixture()) {
+      Runnable response = () -> {};
+      fixture.engine.sendCommandWithResponseForTest(mutation, response);
+      fixture.engine.sendCommand("kata-analyze B 10");
+      fixture.engine.retireTimedOutNormalCommandForTest(response);
+      assertEquals(List.of(mutation), fixture.transport.commands());
+      fixture.engine.sendCommand("set_position");
+      fixture.engine.sendCommand("kata-analyze W 11");
+      fixture.respond(0, "=");
+      assertEquals(List.of(mutation, "set_position"), fixture.transport.commands());
+      fixture.respond(1, "=");
+      assertEquals(
+          List.of(mutation, "set_position", "kata-analyze W 11"), fixture.transport.commands());
+    }
+  }
+
+  @Test
+  void queuedSetPositionTimeoutCannotOpenAnalysis() throws Exception {
+    try (Fixture fixture = new Fixture()) {
+      fixture.engine.requireResponseBeforeSend = true;
+      fixture.engine.sendCommand("name");
+      Runnable response = () -> {};
+      fixture.engine.sendCommandWithResponseForTest("set_position", response);
+      fixture.engine.sendCommand("kata-analyze B 10");
+      fixture.engine.retireTimedOutNormalCommandForTest(response);
+      fixture.respond(0, "=");
+      assertEquals(List.of("name"), fixture.transport.commands());
+      fixture.engine.sendCommand("protocol_version");
+      assertEquals(List.of("name", "protocol_version"), fixture.transport.commands());
+    }
+  }
+
+  @Test
+  void failedPositionWriteDoesNotOpenAnalysis() throws Exception {
+    try (Fixture fixture = new Fixture()) {
+      fixture.failWrite.set(true);
+      fixture.engine.sendCommandNoLeelaz2("set_position");
+      fixture.engine.sendCommand("kata-analyze B 10");
+      assertEquals(List.of("set_position"), fixture.transport.commands());
+    }
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"kata-analyze B 10", "kata-analyze", "lz-analyze"})
+  void replacingBoardWhilePositionIsPendingDiscardsCapturedAnalysis(String command)
+      throws Exception {
+    try (Fixture fixture = new Fixture()) {
+      fixture.engine.sendCommand("undo");
+      fixture.engine.sendCommand(command);
+      Lizzie.board = new Board();
+      fixture.respond(0, "=");
+      assertEquals(List.of("undo"), fixture.transport.commands());
+    }
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"kata-analyze B 10", "kata-analyze", "lz-analyze"})
+  void replacingPrimaryWhilePositionIsPendingDiscardsCapturedAnalysis(String command)
+      throws Exception {
+    try (Fixture fixture = new Fixture()) {
+      fixture.engine.sendCommand("undo");
+      fixture.engine.sendCommand(command);
+      Lizzie.leelaz = new Leelaz("");
+      fixture.respond(0, "=");
+      assertEquals(List.of("undo"), fixture.transport.commands());
+    }
+  }
+
+  private static final class Fixture implements AutoCloseable {
+    private final Config previousConfig = Lizzie.config;
+    private final Board previousBoard = Lizzie.board;
+    private final LizzieFrame previousFrame = Lizzie.frame;
+    private final Leelaz previousEngine = Lizzie.leelaz;
+    private final Leelaz engine;
+    private final AtomicBoolean failWrite = new AtomicBoolean();
+    private final ExactSnapshotRestoreProtocolFixture.Transport transport;
+
+    private Fixture() throws Exception {
+      Lizzie.config = allocate(Config.class);
+      engine = new Leelaz("");
+      Lizzie.leelaz = engine;
+      Lizzie.board = new Board();
+      Lizzie.frame = allocate(LizzieFrame.class);
+      engine.started = true;
+      engine.isLoaded = true;
+      engine.isKatago = true;
+      transport =
+          ExactSnapshotRestoreProtocolFixture.install(
+              engine,
+              command -> {
+                if (failWrite.getAndSet(false))
+                  throw new IOException("controlled position write failure");
+                return null;
+              });
+    }
+
+    private void respond(int index, String prefix) {
+      String raw = transport.rawCommands().get(index);
+      int separator = raw.indexOf(' ');
+      String id =
+          separator > 0 && Character.isDigit(raw.charAt(0)) ? raw.substring(0, separator) : "";
+      engine.processCommandResponseLineForTest(prefix + id);
+    }
+
+    @Override
+    public void close() {
+      Lizzie.config = previousConfig;
+      Lizzie.board = previousBoard;
+      Lizzie.frame = previousFrame;
+      Lizzie.leelaz = previousEngine;
+    }
+  }
+
+  private static <T> T allocate(Class<T> type) throws Exception {
+    Field field = sun.misc.Unsafe.class.getDeclaredField("theUnsafe");
+    field.setAccessible(true);
+    return type.cast(((sun.misc.Unsafe) field.get(null)).allocateInstance(type));
+  }
+}

--- a/src/test/java/featurecat/lizzie/analysis/PositionConfirmedRollbackTest.java
+++ b/src/test/java/featurecat/lizzie/analysis/PositionConfirmedRollbackTest.java
@@ -36,6 +36,492 @@ class PositionConfirmedRollbackTest {
   private static final long OBSERVATION_TIMEOUT_NANOS = TimeUnit.SECONDS.toNanos(2);
 
   @Test
+  void acceptedRollbackDelayedResumeStartsOnceWithoutReplayingTheBoard() throws Exception {
+    try (Harness harness = Harness.open()) {
+      Lizzie.config.autoQuickAnalyzeOnLoad = true;
+      ExactSnapshotRestoreProtocolFixture.Transport transport =
+          ExactSnapshotRestoreProtocolFixture.install(
+              harness.engine, command -> ExactSnapshotRestoreProtocolFixture.Response.success());
+      harness.engine.playMoveNoPonder(Stone.BLACK, "Q16");
+      harness.engine.ponder();
+      awaitRawCommand(transport, "kata-analyze", 0);
+      harness.acceptEmptySnapshot();
+      assertNotNull(harness.frame.scheduledResume);
+      harness.frame.scheduledResume.run();
+      awaitRawCommand(transport, "kata-analyze", 1);
+      java.util.concurrent.CountDownLatch drained = new java.util.concurrent.CountDownLatch(1);
+      harness.engine.sendCommandWithResponseForTest("name", drained::countDown);
+      assertTrue(drained.await(2, TimeUnit.SECONDS));
+      assertEquals(2, payloadCount(transport, "kata-analyze"), transport.commands().toString());
+      assertEquals(0, payloadCount(transport, "clear_board"), transport.commands().toString());
+      assertEquals(0, payloadCount(transport, "loadsgf"));
+      assertSame(harness.p0, harness.board.getHistory().getCurrentHistoryNode());
+      assertSame(harness.p1, harness.p0.next().orElseThrow());
+    }
+  }
+
+  @Test
+  void rejectedOrdinaryPredecessorCannotBeForgottenBySyncRollback() throws Exception {
+    try (Harness harness = Harness.open()) {
+      ExactSnapshotRestoreProtocolFixture.Transport transport =
+          ExactSnapshotRestoreProtocolFixture.install(
+              harness.engine,
+              command ->
+                  command.equals("play W D4")
+                      ? null
+                      : ExactSnapshotRestoreProtocolFixture.Response.success());
+      harness.engine.playMoveNoPonder(Stone.BLACK, "Q16");
+      harness.engine.ponder();
+      awaitRawCommand(transport, "kata-analyze", 0);
+      harness.engine.parseAnalysisLineForTest(info(12_000, 0.615));
+      harness.board.getHistory().place(3, 15, Stone.WHITE, false);
+      harness.engine.playMoveNoPonder(Stone.WHITE, "D4");
+      String predecessor = awaitRawCommand(transport, "play W D4", 0);
+      harness.acceptSnapshot(harness.p1);
+      harness.frame.scheduledResume.run();
+      harness.engine.processCommandResponseLineForTest(
+          "?" + predecessor.substring(0, predecessor.indexOf(' ')) + " rejected play");
+      long deadline = System.nanoTime() + OBSERVATION_TIMEOUT_NANOS;
+      while (harness.engine.isLoaded
+          && payloadCount(transport, "kata-analyze") == 1
+          && System.nanoTime() < deadline) Thread.sleep(5L);
+      javax.swing.SwingUtilities.invokeAndWait(() -> {});
+      assertEquals(1, payloadCount(transport, "kata-analyze"), transport.commands().toString());
+      assertFalse(harness.engine.isLoaded);
+      assertSame(harness.p1, harness.board.getHistory().getCurrentHistoryNode());
+      harness.engine.parseAnalysisLineForTest(info(16_768, 0.335525));
+      assertAnalysis(harness.p1.getData(), 12_000, 61.5);
+    }
+  }
+
+  @Test
+  void multiStepRollbackAndForwardResumeOnlyFinalExistingNode() throws Exception {
+    try (Harness harness = Harness.open()) {
+      BoardHistoryList history = harness.board.getHistory();
+      history.place(3, 15, Stone.WHITE, false);
+      BoardHistoryNode p2 = history.getCurrentHistoryNode();
+      history.place(2, 6, Stone.BLACK, false);
+      BoardHistoryNode p3 = history.getCurrentHistoryNode();
+      ExactSnapshotRestoreProtocolFixture.Transport transport =
+          ExactSnapshotRestoreProtocolFixture.install(
+              harness.engine, command -> ExactSnapshotRestoreProtocolFixture.Response.success());
+      harness.engine.playMoveNoPonder(Stone.BLACK, "Q16");
+      harness.engine.playMoveNoPonder(Stone.WHITE, "D4");
+      harness.engine.playMoveNoPonder(Stone.BLACK, "C13");
+      harness.engine.ponder();
+      awaitRawCommand(transport, "kata-analyze", 0);
+      harness.acceptEmptySnapshot();
+      awaitRawCommand(transport, "name", 0);
+      assertEquals(1, payloadCount(transport, "kata-analyze"));
+      harness.frame.scheduledResume.run();
+      awaitRawCommand(transport, "kata-analyze", 1);
+      assertEquals(3, payloadCount(transport, "undo"));
+      assertEquals(0, payloadCount(transport, "clear_board"));
+      assertSame(harness.p0, history.getCurrentHistoryNode());
+      harness.acceptSnapshot(p2);
+      harness.frame.scheduledResume.run();
+      awaitRawCommand(transport, "kata-analyze", 2);
+      assertEquals(3, payloadCount(transport, "kata-analyze"), transport.commands().toString());
+      assertEquals(0, payloadCount(transport, "clear_board"));
+      assertSame(p2, history.getCurrentHistoryNode());
+      assertSame(p3, history.getMainEnd());
+      assertSame(harness.p1, harness.p0.next().orElseThrow());
+      assertSame(p2, harness.p1.next().orElseThrow());
+      assertSame(p3, p2.next().orElseThrow());
+      List<String> beforeRepeatedFrame = transport.commands();
+      harness.acceptSnapshot(p2);
+      harness.frame.scheduledResume.run();
+      javax.swing.SwingUtilities.invokeAndWait(() -> {});
+      assertEquals(beforeRepeatedFrame, transport.commands());
+    }
+  }
+
+  @Test
+  void acceptedRootRecoveryWaitsForFinalPassAndDoesNotRestoreTwice() throws Exception {
+    assertAcceptedFullRestore(false);
+  }
+
+  @Test
+  void acceptedStaticRecoveryWaitsForFinalPassAndDoesNotRestoreTwice() throws Exception {
+    assertAcceptedFullRestore(true);
+  }
+
+  private void assertAcceptedFullRestore(boolean exact) throws Exception {
+    try (Harness harness = Harness.open()) {
+      RestoreHistory restored = exact ? exactRestoreHistory() : rootRestoreHistory(BOARD_SIZE);
+      restored.history.place(10, 10, Stone.BLACK, false);
+      BoardHistoryNode successor = restored.history.getCurrentHistoryNode();
+      restored.history.setHead(restored.target);
+      harness.board.setHistory(restored.history);
+      setField(harness.readBoard, "awaitingFirstSyncFrame", true);
+      harness.engine.commandLists.add("loadsgf");
+      SnapshotTrackingLeelaz enginePosition = SnapshotTrackingLeelaz.create();
+      ExactSnapshotRestoreProtocolFixture.Transport transport =
+          installPositionTransport(harness.engine, enginePosition, "play W pass");
+      harness.acceptSnapshot(restored.target);
+      String lastPass = awaitRawCommand(transport, "play W pass", 0);
+      assertNotNull(harness.frame.scheduledResume);
+      harness.frame.scheduledResume.run();
+      javax.swing.SwingUtilities.invokeAndWait(() -> {});
+      assertEquals(0, payloadCount(transport, "kata-analyze"));
+      harness.engine.parseAnalysisLineForTest(info(16_768, 0.335525));
+      assertNoAnalysis(restored.target.getData());
+      acknowledge(harness.engine, lastPass);
+      awaitRawCommand(transport, "kata-analyze", 0);
+      harness.engine.parseAnalysisLineForTest(info(4_875, 0.96937));
+      assertAnalysis(restored.target.getData(), 4_875, 96.937);
+      assertEquals(1, payloadCount(transport, "kata-analyze"));
+      assertEquals(1, payloadCount(transport, "clear_board"));
+      assertEquals(exact ? 1 : 0, payloadCount(transport, "loadsgf"));
+      assertPosition(enginePosition, restored.target.getData(), BOARD_SIZE, BOARD_SIZE);
+      assertSame(restored.target, restored.history.getCurrentHistoryNode());
+      assertSame(successor, restored.history.getMainEnd());
+      assertTrue(restored.target.getData().blackToPlay);
+    }
+  }
+
+  @Test
+  void pausedSyncKeepsAcceptedHistoryWithoutStartingAnalysis() throws Exception {
+    try (Harness harness = Harness.open()) {
+      harness.frame.userAnalysisPaused = true;
+      ExactSnapshotRestoreProtocolFixture.Transport transport =
+          ExactSnapshotRestoreProtocolFixture.install(
+              harness.engine, command -> ExactSnapshotRestoreProtocolFixture.Response.success());
+      harness.acceptEmptySnapshot();
+      awaitRawCommand(transport, "name", 0);
+      harness.frame.scheduledResume.run();
+      javax.swing.SwingUtilities.invokeAndWait(() -> {});
+      assertSame(harness.p0, harness.board.getHistory().getCurrentHistoryNode());
+      assertEquals(0, payloadCount(transport, "kata-analyze"));
+      assertTrue(harness.frame.isUserAnalysisPaused());
+    }
+  }
+
+  @Test
+  void syncWithoutEngineStillNavigatesToTheExistingNode() throws Exception {
+    try (Harness harness = Harness.open()) {
+      Lizzie.setPrimaryEngine(null);
+      EngineManager.isEmpty = true;
+      harness.acceptEmptySnapshot();
+      assertSame(harness.p0, harness.board.getHistory().getCurrentHistoryNode());
+      assertSame(harness.p1, harness.board.getHistory().getMainEnd());
+      assertTrue(harness.transport.commands().isEmpty());
+    }
+  }
+
+  @Test
+  void supersedingPendingRollbackRestoresNewTargetAndRejectsOldCallbacks() throws Exception {
+    try (Harness harness = Harness.open()) {
+      harness.board.getHistory().place(3, 15, Stone.WHITE, false);
+      BoardHistoryNode p2 = harness.board.getHistory().getCurrentHistoryNode();
+      ExactSnapshotRestoreProtocolFixture.Transport transport =
+          ExactSnapshotRestoreProtocolFixture.install(
+              harness.engine,
+              command ->
+                  command.equals("undo")
+                      ? null
+                      : ExactSnapshotRestoreProtocolFixture.Response.success());
+      harness.acceptEmptySnapshot();
+      String oldUndo = awaitRawCommand(transport, "undo", 0);
+      Runnable oldResume = harness.frame.scheduledResume;
+      harness.acceptSnapshot(harness.p1);
+      Runnable currentResume = harness.frame.scheduledResume;
+      oldResume.run();
+      currentResume.run();
+      acknowledge(harness.engine, oldUndo);
+      String secondUndo = awaitRawCommand(transport, "undo", 1);
+      acknowledge(harness.engine, secondUndo);
+      awaitRawCommand(transport, "kata-analyze", 0);
+      acknowledge(harness.engine, oldUndo);
+      oldResume.run();
+      javax.swing.SwingUtilities.invokeAndWait(() -> {});
+      assertEquals(1, payloadCount(transport, "kata-analyze"), transport.commands().toString());
+      assertEquals(1, payloadCount(transport, "clear_board"));
+      assertSame(harness.p1, harness.board.getHistory().getCurrentHistoryNode());
+      assertSame(p2, harness.board.getHistory().getMainEnd());
+      harness.engine.parseAnalysisLineForTest(info(4_875, 0.96937));
+      assertAnalysis(harness.p1.getData(), 4_875, 96.937);
+      assertNoAnalysis(harness.p0.getData());
+    }
+  }
+
+  @Test
+  void forcedSnapshotRebuildLoadsAndAnalyzesOnlyOnce() throws Exception {
+    try (Harness harness = Harness.open()) {
+      harness.engine.commandLists.add("loadsgf");
+      ExactSnapshotRestoreProtocolFixture.Transport transport =
+          ExactSnapshotRestoreProtocolFixture.install(
+              harness.engine, command -> ExactSnapshotRestoreProtocolFixture.Response.success());
+      harness.engine.ponder();
+      awaitRawCommand(transport, "kata-analyze", 0);
+      harness.readBoard.parseLine("forceRebuild");
+      harness.acceptSnapshot(harness.p1);
+      harness.frame.scheduledResume.run();
+      awaitRawCommand(transport, "kata-analyze", 1);
+      assertEquals(2, payloadCount(transport, "kata-analyze"));
+      assertEquals(1, payloadCount(transport, "clear_board"), transport.commands().toString());
+      assertEquals(1, payloadCount(transport, "loadsgf"));
+      BoardData target = harness.board.getHistory().getData();
+      assertTrue(target.isSnapshotNode());
+      assertArrayEquals(harness.p1.getData().stones, target.stones);
+      harness.engine.parseAnalysisLineForTest(info(4_875, 0.96937));
+      assertAnalysis(target, 4_875, 96.937);
+    }
+  }
+
+  @Test
+  void acceptedCaptureResumesOnlyAfterItsFinalMove() throws Exception {
+    BoardRenderer previousRenderer = LizzieFrame.boardRenderer;
+    try (Harness harness = Harness.open()) {
+      LizzieFrame.boardRenderer = allocate(SilentBoardRenderer.class);
+      Stone[] before = emptyStones(BOARD_SIZE, BOARD_SIZE);
+      before[Board.getIndex(0, 1)] = Stone.BLACK;
+      before[Board.getIndex(1, 0)] = Stone.BLACK;
+      before[Board.getIndex(2, 1)] = Stone.BLACK;
+      before[Board.getIndex(1, 1)] = Stone.WHITE;
+      BoardData setup =
+          BoardData.snapshot(
+              before,
+              java.util.Optional.empty(),
+              Stone.EMPTY,
+              true,
+              zobrist(before, BOARD_SIZE, BOARD_SIZE),
+              0,
+              new int[before.length],
+              0,
+              0,
+              50,
+              0);
+      BoardHistoryList history = new BoardHistoryList(setup);
+      harness.board.setHistory(history);
+      Stone[] after = before.clone();
+      after[Board.getIndex(1, 1)] = Stone.EMPTY;
+      after[Board.getIndex(1, 2)] = Stone.BLACK;
+      BoardData expected =
+          BoardData.move(
+              after,
+              new int[] {1, 2},
+              Stone.BLACK,
+              false,
+              zobrist(after, BOARD_SIZE, BOARD_SIZE),
+              1,
+              new int[after.length],
+              1,
+              0,
+              50,
+              0);
+      ExactSnapshotRestoreProtocolFixture.Transport transport =
+          ExactSnapshotRestoreProtocolFixture.install(
+              harness.engine, command -> ExactSnapshotRestoreProtocolFixture.Response.success());
+      harness.engine.ponder();
+      awaitRawCommand(transport, "kata-analyze", 0);
+      harness.acceptSnapshot(new BoardHistoryNode(expected));
+      harness.frame.scheduledResume.run();
+      awaitRawCommand(transport, "kata-analyze", 1);
+      assertEquals(List.of("play B B17"), commandsWithPrefix(transport, "play "));
+      assertEquals(2, payloadCount(transport, "kata-analyze"));
+      assertEquals(0, payloadCount(transport, "clear_board"));
+      assertEquals(0, payloadCount(transport, "loadsgf"));
+      BoardData actual = history.getData();
+      assertTrue(actual.isMoveNode());
+      assertArrayEquals(after, actual.stones);
+      assertEquals(1, actual.blackCaptures);
+      assertFalse(actual.blackToPlay);
+    } finally {
+      LizzieFrame.boardRenderer = previousRenderer;
+    }
+  }
+
+  @Test
+  void rejectedUndoCannotResumeEvenAfterTheFinalFenceSucceeds() throws Exception {
+    assertFailedSyncDoesNotResume("error");
+  }
+
+  @Test
+  void failedUndoWriteCannotResumeAnalysis() throws Exception {
+    assertFailedSyncDoesNotResume("write");
+  }
+
+  @Test
+  void timedOutUndoCannotBeRevivedByLateAckOrDelayedResume() throws Exception {
+    assertFailedSyncDoesNotResume("timeout");
+  }
+
+  private void assertFailedSyncDoesNotResume(String failure) throws Exception {
+    try (Harness harness = Harness.open()) {
+      harness.engine.requireResponseBeforeSend = false;
+      ((PublicationControlledLeelaz) harness.engine).responseTimeoutMillis = 50;
+      ExactSnapshotRestoreProtocolFixture.Transport transport =
+          ExactSnapshotRestoreProtocolFixture.install(
+              harness.engine,
+              command -> {
+                if (command.equals("undo")) {
+                  if (failure.equals("write"))
+                    throw new java.io.IOException("controlled undo write failure");
+                  if (failure.equals("error"))
+                    return ExactSnapshotRestoreProtocolFixture.Response.error("illegal undo");
+                  return null;
+                }
+                return ExactSnapshotRestoreProtocolFixture.Response.success();
+              });
+      harness.acceptEmptySnapshot();
+      String undo = awaitRawCommand(transport, "undo", 0);
+      harness.frame.scheduledResume.run();
+      long deadline = System.nanoTime() + OBSERVATION_TIMEOUT_NANOS;
+      while (harness.engine.isLoaded && System.nanoTime() < deadline) Thread.sleep(5L);
+      assertFalse(harness.engine.isLoaded, "failed sync must retire its unavailable engine target");
+      acknowledge(harness.engine, undo);
+      harness.frame.scheduledResume.run();
+      javax.swing.SwingUtilities.invokeAndWait(() -> {});
+      assertEquals(0, payloadCount(transport, "kata-analyze"));
+      harness.engine.parseAnalysisLineForTest(info(16_768, 0.335525));
+      assertNoAnalysis(harness.p0.getData());
+      assertSame(harness.p0, harness.board.getHistory().getCurrentHistoryNode());
+      assertSame(harness.p1, harness.board.getHistory().getMainEnd());
+    }
+  }
+
+  @Test
+  void replacingEngineWhileSyncIsPendingCannotResumeTheReplacement() throws Exception {
+    assertReplacedSyncDoesNotResume(true);
+  }
+
+  @Test
+  void overwritingHistoryWhileSyncIsPendingCannotResumeTheReplacementHistory() throws Exception {
+    assertReplacedSyncDoesNotResume(false);
+  }
+
+  private void assertReplacedSyncDoesNotResume(boolean replaceEngine) throws Exception {
+    try (Harness harness = Harness.open()) {
+      ExactSnapshotRestoreProtocolFixture.Transport transport =
+          ExactSnapshotRestoreProtocolFixture.install(
+              harness.engine,
+              command ->
+                  command.equals("undo")
+                      ? null
+                      : ExactSnapshotRestoreProtocolFixture.Response.success());
+      harness.acceptEmptySnapshot();
+      String undo = awaitRawCommand(transport, "undo", 0);
+      Runnable oldResume = harness.frame.scheduledResume;
+      Leelaz replacement = new Leelaz("");
+      replacement.started = true;
+      replacement.isLoaded = true;
+      replacement.isKatago = true;
+      ExactSnapshotRestoreProtocolFixture.Transport replacementTransport =
+          ExactSnapshotRestoreProtocolFixture.install(
+              replacement, command -> ExactSnapshotRestoreProtocolFixture.Response.success());
+      try {
+        if (replaceEngine) Lizzie.setPrimaryEngine(replacement);
+        else
+          harness.board.setHistory(new BoardHistoryList(BoardData.empty(BOARD_SIZE, BOARD_SIZE)));
+        oldResume.run();
+        acknowledge(harness.engine, undo);
+        awaitRawCommand(transport, "name", 0);
+        oldResume.run();
+        javax.swing.SwingUtilities.invokeAndWait(() -> {});
+        assertEquals(0, payloadCount(transport, "kata-analyze"));
+        assertTrue(replacementTransport.commands().isEmpty());
+        harness.engine.parseAnalysisLineForTest(info(16_768, 0.335525));
+        assertNoAnalysis(harness.board.getHistory().getData());
+      } finally {
+        replacement.started = false;
+        replacement.isLoaded = false;
+      }
+    }
+  }
+
+  @Test
+  void disablingReadBoardAnalysisBeforeConfirmationKeepsAcceptedPositionWithoutResume()
+      throws Exception {
+    try (Harness harness = Harness.open()) {
+      ExactSnapshotRestoreProtocolFixture.Transport transport =
+          ExactSnapshotRestoreProtocolFixture.install(
+              harness.engine,
+              command ->
+                  command.equals("undo")
+                      ? null
+                      : ExactSnapshotRestoreProtocolFixture.Response.success());
+      harness.acceptEmptySnapshot();
+      String undo = awaitRawCommand(transport, "undo", 0);
+      Lizzie.config.readBoardPonder = false;
+      harness.frame.scheduledResume.run();
+      acknowledge(harness.engine, undo);
+      awaitRawCommand(transport, "name", 0);
+      javax.swing.SwingUtilities.invokeAndWait(() -> {});
+      assertSame(harness.p0, harness.board.getHistory().getCurrentHistoryNode());
+      assertEquals(0, payloadCount(transport, "kata-analyze"));
+    }
+  }
+
+  @Test
+  void userPauseRetiresOldSyncResumeEvenAfterExplicitContinue() throws Exception {
+    try (Harness harness = Harness.open()) {
+      ExactSnapshotRestoreProtocolFixture.Transport transport =
+          ExactSnapshotRestoreProtocolFixture.install(
+              harness.engine,
+              command ->
+                  command.equals("undo")
+                      ? null
+                      : ExactSnapshotRestoreProtocolFixture.Response.success());
+      harness.acceptEmptySnapshot();
+      String undo = awaitRawCommand(transport, "undo", 0);
+      Runnable oldResume = harness.frame.scheduledResume;
+      Method pause =
+          LizzieFrame.class.getDeclaredMethod("recordUserAnalysisPause", BoardHistoryNode.class);
+      pause.setAccessible(true);
+      harness.engine.pauseForAnalysisControl(
+          () -> {
+            try {
+              pause.invoke(harness.frame, harness.p0);
+            } catch (ReflectiveOperationException failure) {
+              throw new AssertionError(failure);
+            }
+          });
+      acknowledge(harness.engine, undo);
+      awaitRawCommand(transport, "name", 0);
+      harness.engine.ponder();
+      awaitRawCommand(transport, "kata-analyze", 0);
+      oldResume.run();
+      javax.swing.SwingUtilities.invokeAndWait(() -> {});
+      java.util.concurrent.CountDownLatch drained = new java.util.concurrent.CountDownLatch(1);
+      harness.engine.sendCommandWithResponseForTest("name", drained::countDown);
+      assertTrue(drained.await(2, TimeUnit.SECONDS));
+      assertEquals(1, payloadCount(transport, "kata-analyze"));
+      harness.engine.parseAnalysisLineForTest(info(4_875, 0.96937));
+      assertAnalysis(harness.p0.getData(), 4_875, 96.937);
+    }
+  }
+
+  @Test
+  void localNavigationWhileSyncIsPendingKeepsOnlyTheManualResume() throws Exception {
+    try (Harness harness = Harness.open()) {
+      ExactSnapshotRestoreProtocolFixture.Transport transport =
+          ExactSnapshotRestoreProtocolFixture.install(
+              harness.engine,
+              command ->
+                  command.equals("undo")
+                      ? null
+                      : ExactSnapshotRestoreProtocolFixture.Response.success());
+      harness.engine.ponder();
+      awaitRawCommand(transport, "kata-analyze", 0);
+      harness.acceptEmptySnapshot();
+      String undo = awaitRawCommand(transport, "undo", 0);
+      Runnable oldResume = harness.frame.scheduledResume;
+      harness.board.nextMove(false);
+      oldResume.run();
+      acknowledge(harness.engine, undo);
+      awaitRawCommand(transport, "kata-analyze", 1);
+      oldResume.run();
+      javax.swing.SwingUtilities.invokeAndWait(() -> {});
+      assertEquals(2, payloadCount(transport, "kata-analyze"));
+      assertSame(harness.p1, harness.board.getHistory().getCurrentHistoryNode());
+      harness.engine.parseAnalysisLineForTest(info(4_875, 0.96937));
+      assertAnalysis(harness.p1.getData(), 4_875, 96.937);
+      assertNoAnalysis(harness.p0.getData());
+    }
+  }
+
+  @Test
   void exactSnapshotResendWaitsForMovePassTailAndPublishesOnlyConfirmedTarget() throws Exception {
     try (Harness harness = Harness.open()) {
       harness.frame.readBoard = null;
@@ -415,6 +901,7 @@ class PositionConfirmedRollbackTest {
           harness.frame.scheduledResume,
           "ReadBoard should offer its delayed resume to the scheduler seam");
       assertEquals(1, harness.frame.scheduledResumeCount);
+      harness.frame.scheduledResume.run();
 
       harness.engine.parseAnalysisLineForTest(info(16_768, 0.335525));
       assertNoAnalysis(harness.p0.getData());
@@ -432,6 +919,7 @@ class PositionConfirmedRollbackTest {
       assertAnalysis(harness.p1.getData(), 16_768, 33.5525);
 
       acknowledge(harness.engine, undo);
+      acknowledge(harness.engine, awaitRawCommand(harness.transport, "name", 1));
       String confirmedAnalyze = awaitRawCommand(harness.transport, "kata-analyze", 1);
       acknowledge(harness.engine, confirmedAnalyze);
       harness.engine.parseAnalysisLineForTest(info(4_875, 0.96937));
@@ -443,9 +931,6 @@ class PositionConfirmedRollbackTest {
           2,
           payloadCount(harness.transport, "kata-analyze"),
           "confirmation should produce one physical successor analysis start");
-      assertFalse(
-          harness.frame.scheduledResumeRan,
-          "the delayed scheduler action is deliberately recorded but not executed in this test");
     }
   }
 
@@ -1136,8 +1621,40 @@ class PositionConfirmedRollbackTest {
       invokeSyncBoardStones(readBoard);
     }
 
+    private void acceptSnapshot(BoardHistoryNode node) throws Exception {
+      int[] snapshot = new int[Board.boardWidth * Board.boardHeight];
+      BoardData data = node.getData();
+      for (int y = 0; y < Board.boardHeight; y++) {
+        for (int x = 0; x < Board.boardWidth; x++) {
+          Stone stone = data.stones[Board.getIndex(x, y)];
+          snapshot[y * Board.boardWidth + x] =
+              stone == Stone.BLACK ? 1 : stone == Stone.WHITE ? 2 : 0;
+        }
+      }
+      if (data.lastMove.isPresent()) {
+        int[] point = data.lastMove.get();
+        snapshot[point[1] * Board.boardWidth + point[0]] =
+            data.lastMoveColor == Stone.BLACK ? 3 : 4;
+      }
+      readBoard.parseLine("foxMoveNumber " + data.moveNumber);
+      readBoard.parseLine("liveTitleMove " + data.moveNumber);
+      setPendingSnapshot(readBoard, snapshot);
+      invokeSyncBoardStones(readBoard);
+    }
+
     @Override
     public void close() {
+      try {
+        Field pending = Board.class.getDeclaredField("lastSyncNavigation");
+        pending.setAccessible(true);
+        java.util.concurrent.CompletableFuture<?> confirmation =
+            (java.util.concurrent.CompletableFuture<?>) pending.get(board);
+        if (confirmation != null)
+          confirmation.handle((result, failure) -> null).get(3, TimeUnit.SECONDS);
+        javax.swing.SwingUtilities.invokeAndWait(() -> {});
+      } catch (Exception failure) {
+        throw new AssertionError("sync worker did not finish before fixture teardown", failure);
+      } finally {
       engine.started = false;
       engine.isLoaded = false;
       EngineManager.resetEngineGameTransactionStateForTest();
@@ -1156,11 +1673,18 @@ class PositionConfirmedRollbackTest {
       Board.boardWidth = previousBoardWidth;
       Board.boardHeight = previousBoardHeight;
       Zobrist.init();
+      }
     }
   }
 
   private static final class PublicationControlledLeelaz extends Leelaz {
     private Runnable beforePublication;
+    private long responseTimeoutMillis = 2_000;
+
+    @Override
+    protected long readBoardGmaRestoreResponseTimeoutMillis() {
+      return responseTimeoutMillis;
+    }
 
     private PublicationControlledLeelaz() throws java.io.IOException {
       super("");

--- a/src/test/java/featurecat/lizzie/analysis/PositionConfirmedRollbackTest.java
+++ b/src/test/java/featurecat/lizzie/analysis/PositionConfirmedRollbackTest.java
@@ -1,0 +1,666 @@
+package featurecat.lizzie.analysis;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import featurecat.lizzie.Config;
+import featurecat.lizzie.ExtraMode;
+import featurecat.lizzie.Lizzie;
+import featurecat.lizzie.gui.BoardRenderer;
+import featurecat.lizzie.gui.BottomToolbar;
+import featurecat.lizzie.gui.LizzieFrame;
+import featurecat.lizzie.gui.Menu;
+import featurecat.lizzie.rules.Board;
+import featurecat.lizzie.rules.BoardData;
+import featurecat.lizzie.rules.BoardHistoryList;
+import featurecat.lizzie.rules.BoardHistoryNode;
+import featurecat.lizzie.rules.SGFParser;
+import featurecat.lizzie.rules.Stone;
+import featurecat.lizzie.rules.Zobrist;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Test;
+
+class PositionConfirmedRollbackTest {
+  private static final int BOARD_SIZE = 19;
+  private static final long OBSERVATION_TIMEOUT_NANOS = TimeUnit.SECONDS.toNanos(2);
+
+  @Test
+  void acceptedSnapshotRollbackRejectsOldAnalysisUntilUndoIsConfirmed() throws Exception {
+    try (Harness harness = Harness.open()) {
+      harness.engine.playMoveNoPonder(Stone.BLACK, "Q16");
+      String play = awaitRawCommand(harness.transport, "play B Q16", 0);
+      acknowledge(harness.engine, play);
+
+      harness.engine.ponder();
+      String initialAnalyze = awaitRawCommand(harness.transport, "kata-analyze", 0);
+      acknowledge(harness.engine, initialAnalyze);
+      harness.engine.parseAnalysisLineForTest(info(16_768, 0.335525));
+
+      assertAnalysis(harness.p1.getData(), 16_768, 33.5525);
+      assertNoAnalysis(harness.p0.getData());
+
+      harness.engine.sendCommandWithResponseForTest("name", () -> {});
+      String precedingQuery = awaitRawCommand(harness.transport, "name", 0);
+
+      harness.acceptEmptySnapshot();
+
+      assertSame(
+          harness.p0,
+          harness.board.getHistory().getCurrentHistoryNode(),
+          "the accepted snapshot must navigate the real history back to P0");
+      assertSame(
+          harness.p1,
+          harness.board.getHistory().getMainEnd(),
+          "rollback must retain the legitimate P1 history node");
+      assertEquals(
+          0,
+          payloadCount(harness.transport, "undo"),
+          "the unanswered query must keep undo in the real command queue");
+      assertEquals(
+          1,
+          payloadCount(harness.transport, "kata-analyze"),
+          "queued rollback must not physically start analysis for P0");
+      assertNotNull(
+          harness.frame.scheduledResume,
+          "ReadBoard should offer its delayed resume to the scheduler seam");
+      assertEquals(1, harness.frame.scheduledResumeCount);
+
+      harness.engine.parseAnalysisLineForTest(info(16_768, 0.335525));
+      assertNoAnalysis(harness.p0.getData());
+      assertAnalysis(harness.p1.getData(), 16_768, 33.5525);
+
+      acknowledge(harness.engine, precedingQuery);
+      String undo = awaitRawCommand(harness.transport, "undo", 0);
+
+      assertEquals(
+          1,
+          payloadCount(harness.transport, "kata-analyze"),
+          "a written but unconfirmed undo must not physically start successor analysis");
+      harness.engine.parseAnalysisLineForTest(info(16_768, 0.335525));
+      assertNoAnalysis(harness.p0.getData());
+      assertAnalysis(harness.p1.getData(), 16_768, 33.5525);
+
+      acknowledge(harness.engine, undo);
+      String confirmedAnalyze = awaitRawCommand(harness.transport, "kata-analyze", 1);
+      acknowledge(harness.engine, confirmedAnalyze);
+      harness.engine.parseAnalysisLineForTest(info(4_875, 0.96937));
+
+      assertSame(harness.p0, harness.board.getHistory().getCurrentHistoryNode());
+      assertAnalysis(harness.p0.getData(), 4_875, 96.937);
+      assertAnalysis(harness.p1.getData(), 16_768, 33.5525);
+      assertEquals(
+          2,
+          payloadCount(harness.transport, "kata-analyze"),
+          "confirmation should produce one physical successor analysis start");
+      assertFalse(
+          harness.frame.scheduledResumeRan,
+          "the delayed scheduler action is deliberately recorded but not executed in this test");
+    }
+  }
+
+  @Test
+  void manualNavigationPassAndPlacementBindTheirIntendedTargets() throws Exception {
+    BoardRenderer previousRenderer = LizzieFrame.boardRenderer;
+    try (Harness harness = Harness.open()) {
+      LizzieFrame.boardRenderer = allocate(SilentBoardRenderer.class);
+      harness.frame.readBoard = null;
+      harness.engine.canAddPlayer = true;
+      harness.engine.playMoveNoPonder(Stone.BLACK, "Q16");
+      acknowledge(harness.engine, awaitRawCommand(harness.transport, "play B Q16", 0));
+      harness.engine.ponder();
+      acknowledge(harness.engine, awaitRawCommand(harness.transport, "kata-analyze", 0));
+      harness.engine.parseAnalysisLineForTest(info(16_768, 0.335525));
+
+      assertTrue(harness.board.previousMove(false));
+      String undo = awaitRawCommand(harness.transport, "undo", 0);
+      harness.engine.parseAnalysisLineForTest(info(16_768, 0.335525));
+      assertNoAnalysis(harness.p0.getData());
+      assertEquals(1, payloadCount(harness.transport, "kata-analyze"));
+      acknowledge(harness.engine, undo);
+      String backwardAnalysis = awaitRawCommand(harness.transport, "kata-analyze B", 0);
+      acknowledge(harness.engine, backwardAnalysis);
+      harness.engine.parseAnalysisLineForTest(info(4_875, 0.96937));
+      assertAnalysis(harness.p0.getData(), 4_875, 96.937);
+
+      assertTrue(harness.board.nextMove(false));
+      String replay = awaitRawCommand(harness.transport, "play B Q16", 1);
+      assertSame(harness.p1, harness.board.getHistory().getCurrentHistoryNode());
+      assertEquals(2, payloadCount(harness.transport, "kata-analyze"));
+      acknowledge(harness.engine, replay);
+      acknowledge(harness.engine, awaitRawCommand(harness.transport, "kata-analyze W", 1));
+      harness.engine.parseAnalysisLineForTest(info(100, 0.6));
+      assertAnalysis(harness.p1.getData(), 16_768, 33.5525);
+
+      harness.board.pass();
+      BoardHistoryNode pass = harness.board.getHistory().getCurrentHistoryNode();
+      assertTrue(pass.getData().isPassNode());
+      String passCommand = awaitRawCommand(harness.transport, "play W pass", 0);
+      harness.engine.parseAnalysisLineForTest(info(16_768, 0.335525));
+      assertNoAnalysis(pass.getData());
+      assertEquals(3, payloadCount(harness.transport, "kata-analyze"));
+      acknowledge(harness.engine, passCommand);
+      acknowledge(harness.engine, awaitRawCommand(harness.transport, "kata-analyze B", 1));
+      harness.engine.parseAnalysisLineForTest(info(50, 0.8));
+      assertAnalysis(pass.getData(), 50, 80);
+
+      harness.board.place(3, 15, Stone.BLACK);
+      BoardHistoryNode placed = harness.board.getHistory().getCurrentHistoryNode();
+      String placement = awaitRawCommand(harness.transport, "play B D4", 0);
+      harness.engine.parseAnalysisLineForTest(info(16_768, 0.335525));
+      assertNoAnalysis(placed.getData());
+      assertEquals(4, payloadCount(harness.transport, "kata-analyze"));
+      acknowledge(harness.engine, placement);
+      acknowledge(harness.engine, awaitRawCommand(harness.transport, "kata-analyze W", 2));
+      harness.engine.parseAnalysisLineForTest(info(25, 0.7));
+      assertAnalysis(placed.getData(), 25, 70);
+    } finally {
+      LizzieFrame.boardRenderer = previousRenderer;
+    }
+  }
+
+  @Test
+  void secondaryPacketsCannotEnterPrimarySlotAfterLeavingDoubleMode() throws Exception {
+    try (Harness harness = Harness.open()) {
+      harness.engine.playMoveNoPonder(Stone.BLACK, "Q16");
+      acknowledge(harness.engine, awaitRawCommand(harness.transport, "play B Q16", 0));
+      harness.engine.ponder();
+      acknowledge(harness.engine, awaitRawCommand(harness.transport, "kata-analyze", 0));
+      harness.engine.parseAnalysisLineForTest(info(16_768, 0.335525));
+      Leelaz secondary = new Leelaz("");
+      secondary.started = true;
+      secondary.isLoaded = true;
+      secondary.isKatago = true;
+      Lizzie.leelaz2 = secondary;
+      Lizzie.config.extraMode = ExtraMode.Double_Engine;
+      ExactSnapshotRestoreProtocolFixture.install(
+          secondary, command -> ExactSnapshotRestoreProtocolFixture.Response.success());
+      secondary.sendCommandNoLeelaz2("kata-analyze W 10");
+      secondary.parseAnalysisLineForTest(info(40, 0.6));
+      assertEquals(40, harness.p1.getData().getPlayouts2());
+
+      Lizzie.config.extraMode = ExtraMode.Normal;
+      secondary.parseAnalysisLineForTest(info(20_000, 0.8));
+
+      assertAnalysis(harness.p1.getData(), 16_768, 33.5525);
+    }
+  }
+
+  @Test
+  void savedSgfAnalysisSurvivesConfirmedHistoryRevisit() throws Exception {
+    try (Harness harness = Harness.open()) {
+      harness.frame.readBoard = null;
+      harness.engine.bestMovesEnginename = "KataGo";
+      harness.engine.playMoveNoPonder(Stone.BLACK, "Q16");
+      acknowledge(harness.engine, awaitRawCommand(harness.transport, "play B Q16", 0));
+      harness.engine.ponder();
+      acknowledge(harness.engine, awaitRawCommand(harness.transport, "kata-analyze", 0));
+      harness.engine.parseAnalysisLineForTest(info(12_000, 0.615));
+      String saved = SGFParser.saveToString(false);
+      BoardHistoryList imported = SGFParser.parseSgf(saved, false);
+      BoardHistoryNode importedP1 = imported.getMainEnd();
+      assertAnalysis(importedP1.getData(), 12_000, 61.5);
+      harness.board.setHistory(imported);
+      harness.engine.sendCommand("clear_board");
+      acknowledge(harness.engine, awaitRawCommand(harness.transport, "clear_board", 0));
+
+      assertTrue(harness.board.nextMove(false));
+      acknowledge(harness.engine, awaitRawCommand(harness.transport, "play B Q16", 1));
+      acknowledge(harness.engine, awaitRawCommand(harness.transport, "kata-analyze", 1));
+      harness.engine.parseAnalysisLineForTest(info(50, 0.8));
+
+      assertSame(importedP1, harness.board.getHistory().getCurrentHistoryNode());
+      assertAnalysis(importedP1.getData(), 12_000, 61.5);
+    }
+  }
+
+  @Test
+  void navigationBetweenInfoIngressAndPublicationCannotWriteSuccessor() throws Exception {
+    try (Harness harness = Harness.open()) {
+      harness.frame.readBoard = null;
+      harness.engine.playMoveNoPonder(Stone.BLACK, "Q16");
+      acknowledge(harness.engine, awaitRawCommand(harness.transport, "play B Q16", 0));
+      harness.engine.ponder();
+      acknowledge(harness.engine, awaitRawCommand(harness.transport, "kata-analyze", 0));
+      ((PublicationControlledLeelaz) harness.engine).beforePublication =
+          () -> assertTrue(harness.board.previousMove(false));
+
+      harness.engine.parseAnalysisLineForTest(info(16_768, 0.335525));
+
+      assertSame(harness.p0, harness.board.getHistory().getCurrentHistoryNode());
+      assertNoAnalysis(harness.p0.getData());
+      assertEquals(1, payloadCount(harness.transport, "kata-analyze"));
+    }
+  }
+
+  private static String info(int visits, double winrate) {
+    return "info move C13 visits "
+        + visits
+        + " winrate "
+        + winrate
+        + " prior 0.7 lcb "
+        + winrate
+        + " scoreMean 1 scoreStdev 2 order 0 pv C13";
+  }
+
+  private static void assertNoAnalysis(BoardData data) {
+    assertEquals(0, data.getPlayouts());
+    assertTrue(data.bestMoves.isEmpty());
+  }
+
+  private static void assertAnalysis(BoardData data, int visits, double winrate) {
+    assertEquals(visits, data.getPlayouts());
+    assertEquals(winrate, data.winrate, 0.000_001);
+    assertEquals(1, data.bestMoves.size());
+    assertEquals("C13", data.bestMoves.get(0).coordinate);
+    assertEquals(visits, data.bestMoves.get(0).playouts);
+    assertEquals(winrate, data.bestMoves.get(0).winrate, 0.000_001);
+  }
+
+  private static String awaitRawCommand(
+      ExactSnapshotRestoreProtocolFixture.Transport transport, String prefix, int occurrence)
+      throws InterruptedException {
+    long deadline = System.nanoTime() + OBSERVATION_TIMEOUT_NANOS;
+    while (System.nanoTime() < deadline) {
+      String raw = rawCommand(transport, prefix, occurrence);
+      if (raw != null) {
+        return raw;
+      }
+      Thread.sleep(5L);
+    }
+    throw new AssertionError(
+        "Timed out waiting for physical command "
+            + prefix
+            + " occurrence "
+            + occurrence
+            + "; commands="
+            + transport.rawCommands());
+  }
+
+  private static String rawCommand(
+      ExactSnapshotRestoreProtocolFixture.Transport transport, String prefix, int occurrence) {
+    List<String> commands = transport.commands();
+    List<String> rawCommands = transport.rawCommands();
+    int matched = 0;
+    for (int index = 0; index < commands.size(); index++) {
+      if (commands.get(index).startsWith(prefix)) {
+        if (matched == occurrence) {
+          return rawCommands.get(index);
+        }
+        matched++;
+      }
+    }
+    return null;
+  }
+
+  private static int payloadCount(
+      ExactSnapshotRestoreProtocolFixture.Transport transport, String prefix) {
+    int count = 0;
+    for (String command : transport.commands()) {
+      if (command.startsWith(prefix)) {
+        count++;
+      }
+    }
+    return count;
+  }
+
+  private static void acknowledge(Leelaz engine, String rawCommand) {
+    int split = rawCommand.indexOf(' ');
+    String id =
+        split > 0 && isDigits(rawCommand.substring(0, split)) ? rawCommand.substring(0, split) : "";
+    engine.processCommandResponseLineForTest("=" + id);
+  }
+
+  private static boolean isDigits(String value) {
+    if (value.isEmpty()) {
+      return false;
+    }
+    for (int index = 0; index < value.length(); index++) {
+      if (!Character.isDigit(value.charAt(index))) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  private static void setPendingSnapshot(ReadBoard readBoard, int[] snapshotCodes)
+      throws Exception {
+    ArrayList<Integer> counts = new ArrayList<>(snapshotCodes.length);
+    for (int code : snapshotCodes) {
+      counts.add(code);
+    }
+    setField(readBoard, "tempcount", counts);
+  }
+
+  private static void invokeSyncBoardStones(ReadBoard readBoard) throws Exception {
+    Method method = ReadBoard.class.getDeclaredMethod("syncBoardStones", boolean.class);
+    method.setAccessible(true);
+    method.invoke(readBoard, false);
+  }
+
+  private static void setField(Object target, String name, Object value) throws Exception {
+    Field field = findField(target.getClass(), name);
+    field.setAccessible(true);
+    field.set(target, value);
+  }
+
+  private static Field findField(Class<?> type, String name) throws NoSuchFieldException {
+    Class<?> current = type;
+    while (current != null) {
+      try {
+        return current.getDeclaredField(name);
+      } catch (NoSuchFieldException ignored) {
+        current = current.getSuperclass();
+      }
+    }
+    throw new NoSuchFieldException(name);
+  }
+
+  @SuppressWarnings("unchecked")
+  private static <T> T allocate(Class<T> type) throws Exception {
+    Field field = sun.misc.Unsafe.class.getDeclaredField("theUnsafe");
+    field.setAccessible(true);
+    return (T) ((sun.misc.Unsafe) field.get(null)).allocateInstance(type);
+  }
+
+  private static final class Harness implements AutoCloseable {
+    private final Config previousConfig;
+    private final Board previousBoard;
+    private final Leelaz previousPrimary;
+    private final Leelaz previousSecondary;
+    private final LizzieFrame previousFrame;
+    private final EngineManager previousManager;
+    private final Menu previousMenu;
+    private final BottomToolbar previousToolbar;
+    private final boolean previousEngineEmpty;
+    private final int previousBoardWidth;
+    private final int previousBoardHeight;
+    private final boolean previousKeepForcing;
+    private final String previousAllowCoords;
+    private final String previousAvoidCoords;
+
+    private final HeadlessBoard board;
+    private final RecordingFrame frame;
+    private final Leelaz engine;
+    private final ReadBoard readBoard;
+    private final ExactSnapshotRestoreProtocolFixture.Transport transport;
+    private final BoardHistoryNode p0;
+    private final BoardHistoryNode p1;
+
+    private Harness(
+        Config previousConfig,
+        Board previousBoard,
+        Leelaz previousPrimary,
+        Leelaz previousSecondary,
+        LizzieFrame previousFrame,
+        EngineManager previousManager,
+        Menu previousMenu,
+        BottomToolbar previousToolbar,
+        boolean previousEngineEmpty,
+        int previousBoardWidth,
+        int previousBoardHeight,
+        boolean previousKeepForcing,
+        String previousAllowCoords,
+        String previousAvoidCoords,
+        HeadlessBoard board,
+        RecordingFrame frame,
+        Leelaz engine,
+        ReadBoard readBoard,
+        ExactSnapshotRestoreProtocolFixture.Transport transport,
+        BoardHistoryNode p0,
+        BoardHistoryNode p1) {
+      this.previousConfig = previousConfig;
+      this.previousBoard = previousBoard;
+      this.previousPrimary = previousPrimary;
+      this.previousSecondary = previousSecondary;
+      this.previousFrame = previousFrame;
+      this.previousManager = previousManager;
+      this.previousMenu = previousMenu;
+      this.previousToolbar = previousToolbar;
+      this.previousEngineEmpty = previousEngineEmpty;
+      this.previousBoardWidth = previousBoardWidth;
+      this.previousBoardHeight = previousBoardHeight;
+      this.previousKeepForcing = previousKeepForcing;
+      this.previousAllowCoords = previousAllowCoords;
+      this.previousAvoidCoords = previousAvoidCoords;
+      this.board = board;
+      this.frame = frame;
+      this.engine = engine;
+      this.readBoard = readBoard;
+      this.transport = transport;
+      this.p0 = p0;
+      this.p1 = p1;
+    }
+
+    private static Harness open() throws Exception {
+      Config previousConfig = Lizzie.config;
+      Board previousBoard = Lizzie.board;
+      Leelaz previousPrimary = Lizzie.leelaz;
+      Leelaz previousSecondary = Lizzie.leelaz2;
+      LizzieFrame previousFrame = Lizzie.frame;
+      EngineManager previousManager = Lizzie.engineManager;
+      Menu previousMenu = LizzieFrame.menu;
+      BottomToolbar previousToolbar = LizzieFrame.toolbar;
+      boolean previousEngineEmpty = EngineManager.isEmpty;
+      int previousBoardWidth = Board.boardWidth;
+      int previousBoardHeight = Board.boardHeight;
+      boolean previousKeepForcing = LizzieFrame.isKeepForcing;
+      String previousAllowCoords = LizzieFrame.allowcoords;
+      String previousAvoidCoords = LizzieFrame.avoidcoords;
+
+      EngineManager.resetEngineGameTransactionStateForTest();
+      Board.boardWidth = BOARD_SIZE;
+      Board.boardHeight = BOARD_SIZE;
+      Zobrist.init();
+
+      Config config = allocate(Config.class);
+      config.enableLizzieCache = true;
+      config.readBoardPonder = true;
+      config.analyzeBlack = true;
+      config.analyzeWhite = true;
+      config.analyzeUpdateIntervalCentisec = 10;
+      config.newMoveNumberInBranch = true;
+      Lizzie.config = config;
+
+      RecordingFrame frame = allocate(RecordingFrame.class);
+      frame.priorityMoveCoords = new ArrayList<>();
+      frame.isPlayingAgainstLeelaz = false;
+      frame.isAnaPlayingAgainstLeelaz = false;
+      frame.bothSync = false;
+      frame.syncBoard = false;
+      Lizzie.frame = frame;
+      LizzieFrame.menu = allocate(SilentMenu.class);
+      LizzieFrame.toolbar = allocate(BottomToolbar.class);
+      LizzieFrame.isKeepForcing = false;
+      LizzieFrame.allowcoords = "";
+      LizzieFrame.avoidcoords = "";
+
+      Leelaz engine = new PublicationControlledLeelaz();
+      engine.isKatago = true;
+      engine.started = true;
+      engine.isLoaded = true;
+      engine.requireResponseBeforeSend = true;
+      engine.commandLists.addAll(List.of("name", "play", "undo", "stop", "kata-analyze"));
+      setField(engine, "endGetCommandList", true);
+      Lizzie.engineManager = new EngineManager(List.of(engine));
+      EngineManager.isEmpty = false;
+      Lizzie.setPrimaryEngine(engine);
+      Lizzie.leelaz2 = null;
+
+      ExactSnapshotRestoreProtocolFixture.Transport transport =
+          ExactSnapshotRestoreProtocolFixture.install(engine, command -> null);
+
+      HeadlessBoard board = new HeadlessBoard();
+      Lizzie.board = board;
+      BoardHistoryList history = new BoardHistoryList(BoardData.empty(BOARD_SIZE, BOARD_SIZE));
+      BoardHistoryNode p0 = history.getCurrentHistoryNode();
+      history.place(15, 3, Stone.BLACK, false);
+      BoardHistoryNode p1 = history.getCurrentHistoryNode();
+      board.setHistory(history);
+
+      ReadBoard readBoard = allocate(ReadBoard.class);
+      setField(readBoard, "conflictTracker", new SyncConflictTracker());
+      setField(readBoard, "historyJumpTracker", new SyncHistoryJumpTracker());
+      setField(readBoard, "localNavigationTracker", new SyncLocalNavigationTracker());
+      setField(readBoard, "tempcount", new ArrayList<Integer>());
+      readBoard.firstSync = false;
+      frame.readBoard = readBoard;
+
+      readBoard.parseLine("syncPlatform fox");
+      readBoard.parseLine("roomToken rollback-regression");
+      readBoard.parseLine("liveTitleMove 0");
+      readBoard.parseLine("foxMoveNumber 0");
+
+      return new Harness(
+          previousConfig,
+          previousBoard,
+          previousPrimary,
+          previousSecondary,
+          previousFrame,
+          previousManager,
+          previousMenu,
+          previousToolbar,
+          previousEngineEmpty,
+          previousBoardWidth,
+          previousBoardHeight,
+          previousKeepForcing,
+          previousAllowCoords,
+          previousAvoidCoords,
+          board,
+          frame,
+          engine,
+          readBoard,
+          transport,
+          p0,
+          p1);
+    }
+
+    private void acceptEmptySnapshot() throws Exception {
+      setPendingSnapshot(readBoard, new int[BOARD_SIZE * BOARD_SIZE]);
+      invokeSyncBoardStones(readBoard);
+    }
+
+    @Override
+    public void close() {
+      engine.started = false;
+      engine.isLoaded = false;
+      EngineManager.resetEngineGameTransactionStateForTest();
+      Lizzie.engineManager = previousManager;
+      EngineManager.isEmpty = previousEngineEmpty;
+      Lizzie.setPrimaryEngine(previousPrimary);
+      Lizzie.leelaz2 = previousSecondary;
+      Lizzie.config = previousConfig;
+      Lizzie.board = previousBoard;
+      Lizzie.frame = previousFrame;
+      LizzieFrame.menu = previousMenu;
+      LizzieFrame.toolbar = previousToolbar;
+      LizzieFrame.isKeepForcing = previousKeepForcing;
+      LizzieFrame.allowcoords = previousAllowCoords;
+      LizzieFrame.avoidcoords = previousAvoidCoords;
+      Board.boardWidth = previousBoardWidth;
+      Board.boardHeight = previousBoardHeight;
+      Zobrist.init();
+    }
+  }
+
+  private static final class PublicationControlledLeelaz extends Leelaz {
+    private Runnable beforePublication;
+
+    private PublicationControlledLeelaz() throws java.io.IOException {
+      super("");
+    }
+
+    @Override
+    void beforeAnalysisDisplayPublicationForTest() {
+      Runnable action = beforePublication;
+      beforePublication = null;
+      if (action != null) action.run();
+    }
+  }
+
+  private static final class HeadlessBoard extends Board {
+    @Override
+    public void clearAfterMove() {
+      Lizzie.leelaz.clearPonderLimit();
+    }
+  }
+
+  private static final class RecordingFrame extends LizzieFrame {
+    private int scheduledResumeCount;
+    private volatile Runnable scheduledResume;
+    private boolean scheduledResumeRan;
+
+    @Override
+    public BoardHistoryNode getDisplayNode() {
+      return Lizzie.board.getHistory().getCurrentHistoryNode();
+    }
+
+    @Override
+    public void scheduleResumeAnalysisAfterLoad(int delayMillis, Runnable action) {
+      scheduledResumeCount++;
+      scheduledResume =
+          () -> {
+            scheduledResumeRan = true;
+            action.run();
+          };
+    }
+
+    @Override
+    public void onMainEnginePonder() {}
+
+    @Override
+    public void clearSelectImage() {}
+
+    @Override
+    public void clearKataEstimate() {}
+
+    @Override
+    public void clearTryPlay() {}
+
+    @Override
+    public void requestAnalysisRefresh() {}
+
+    @Override
+    public void requestAnalysisTitleUpdate() {}
+
+    @Override
+    public void refresh() {}
+
+    @Override
+    public void refreshAfterMove() {}
+
+    @Override
+    public void updateTitle() {}
+
+    @Override
+    public void resetTitle() {}
+
+    @Override
+    public void renderVarTree(int vw, int vh, boolean changeSize, boolean needGetEnd) {}
+  }
+
+  private static final class SilentBoardRenderer extends BoardRenderer {
+    private SilentBoardRenderer() {
+      super(false);
+    }
+
+    @Override
+    public void removedrawmovestone() {}
+  }
+
+  private static final class SilentMenu extends Menu {
+    private SilentMenu() {}
+
+    @Override
+    public void toggleEngineMenuStatus(boolean isPondering, boolean isThinking) {}
+
+    @Override
+    public void toggleDoubleMenuGameStatus() {}
+  }
+}

--- a/src/test/java/featurecat/lizzie/analysis/PositionConfirmedRollbackTest.java
+++ b/src/test/java/featurecat/lizzie/analysis/PositionConfirmedRollbackTest.java
@@ -1,5 +1,6 @@
 package featurecat.lizzie.analysis;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -22,14 +23,357 @@ import featurecat.lizzie.rules.Stone;
 import featurecat.lizzie.rules.Zobrist;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.locks.ReentrantLock;
 import org.junit.jupiter.api.Test;
 
 class PositionConfirmedRollbackTest {
   private static final int BOARD_SIZE = 19;
   private static final long OBSERVATION_TIMEOUT_NANOS = TimeUnit.SECONDS.toNanos(2);
+
+  @Test
+  void exactSnapshotResendWaitsForMovePassTailAndPublishesOnlyConfirmedTarget() throws Exception {
+    try (Harness harness = Harness.open()) {
+      harness.frame.readBoard = null;
+      RestoreHistory restoreHistory = exactRestoreHistory();
+      harness.board.setHistory(restoreHistory.history);
+      startPonder(harness);
+
+      SnapshotTrackingLeelaz enginePosition = SnapshotTrackingLeelaz.create();
+      ExactSnapshotRestoreProtocolFixture.Transport restoreTransport =
+          installPositionTransport(harness.engine, enginePosition, "play W pass");
+      AsyncAction restore =
+          AsyncAction.start(() -> harness.board.resendMoveToEngine(harness.engine, false));
+
+      String finalTail = awaitRawCommand(restoreTransport, "play W pass", 0);
+      boolean released = false;
+      try {
+        assertEquals(
+            List.of("play B D16", "play W pass"),
+            commandsWithPrefix(restoreTransport, "play "),
+            "the exact route must replay both real actions after the static anchor");
+        int loadSgfCommand = indexOfCommand(restoreTransport, "loadsgf ");
+        assertTrue(loadSgfCommand >= 0);
+        assertTrue(loadSgfCommand < indexOfCommand(restoreTransport, "play B D16"));
+        assertEquals(
+            0,
+            payloadCount(restoreTransport, "kata-analyze"),
+            "the unconfirmed final tail must keep physical analysis closed");
+
+        harness.engine.parseAnalysisLineForTest(info(16_768, 0.335525));
+        assertNoAnalysis(restoreHistory.target.getData());
+        assertPosition(enginePosition, restoreHistory.target.getData(), BOARD_SIZE, BOARD_SIZE);
+
+        acknowledge(harness.engine, finalTail);
+        released = true;
+        awaitRawCommand(restoreTransport, "kata-analyze", 0);
+        restore.awaitSuccess();
+        harness.engine.parseAnalysisLineForTest(info(4_875, 0.96937));
+
+        assertSame(restoreHistory.target, harness.board.getHistory().getCurrentHistoryNode());
+        assertAnalysis(restoreHistory.target.getData(), 4_875, 96.937);
+        assertEquals(1, payloadCount(restoreTransport, "kata-analyze"));
+        assertPosition(enginePosition, restoreHistory.target.getData(), BOARD_SIZE, BOARD_SIZE);
+      } finally {
+        if (!released) {
+          acknowledge(harness.engine, finalTail);
+          restore.awaitCleanup();
+        }
+      }
+    }
+  }
+
+  @Test
+  void previousNavigationFromSnapshotChildWaitsForCompleteExactTarget() throws Exception {
+    assertCompoundNavigation(false);
+  }
+
+  @Test
+  void branchJumpWaitsForCompleteExactTarget() throws Exception {
+    assertCompoundNavigation(true);
+  }
+
+  private void assertCompoundNavigation(boolean branchJump) throws Exception {
+    try (Harness harness = Harness.open()) {
+      harness.frame.readBoard = null;
+      RestoreHistory restoreHistory =
+          branchJump ? exactBranchRestoreHistory() : exactRestoreHistoryWithSnapshotSuccessor();
+      harness.board.setHistory(restoreHistory.history);
+      startPonder(harness);
+
+      SnapshotTrackingLeelaz enginePosition = SnapshotTrackingLeelaz.create();
+      ExactSnapshotRestoreProtocolFixture.Transport restoreTransport =
+          installPositionTransport(harness.engine, enginePosition, "play W pass");
+      AsyncAction navigation =
+          AsyncAction.start(
+              () -> {
+                if (branchJump) harness.board.moveToAnyPosition(restoreHistory.target);
+                else harness.board.previousMove(false);
+              });
+      String finalTail = awaitRawCommand(restoreTransport, "play W pass", 0);
+      boolean released = false;
+      try {
+        assertSame(
+            restoreHistory.target,
+            harness.board.getHistory().getCurrentHistoryNode(),
+            "real Board navigation must adopt the intended tail target before confirmation");
+        assertEquals(0, payloadCount(restoreTransport, "kata-analyze"));
+        harness.engine.parseAnalysisLineForTest(info(16_768, 0.335525));
+        assertNoAnalysis(restoreHistory.target.getData());
+        assertPosition(enginePosition, restoreHistory.target.getData(), BOARD_SIZE, BOARD_SIZE);
+
+        acknowledge(harness.engine, finalTail);
+        released = true;
+        awaitRawCommand(restoreTransport, "kata-analyze", 0);
+        navigation.awaitSuccess();
+        harness.engine.parseAnalysisLineForTest(info(4_875, 0.96937));
+
+        assertSame(restoreHistory.target, harness.board.getHistory().getCurrentHistoryNode());
+        assertAnalysis(restoreHistory.target.getData(), 4_875, 96.937);
+        assertEquals(1, payloadCount(restoreTransport, "kata-analyze"));
+      } finally {
+        if (!released) {
+          acknowledge(harness.engine, finalTail);
+          navigation.awaitCleanup();
+        }
+      }
+    }
+  }
+
+  @Test
+  void rootReplayResendWaitsForFinalPassAndPreservesCompatibleAnalysisCache() throws Exception {
+    try (Harness harness = Harness.open()) {
+      harness.frame.readBoard = null;
+      RestoreHistory restoreHistory = rootRestoreHistory(9);
+      harness.board.setHistory(restoreHistory.history);
+      harness.engine.width = BOARD_SIZE;
+      harness.engine.height = BOARD_SIZE;
+      startPonder(harness);
+      harness.engine.parseAnalysisLineForTest(info(12_000, 0.615));
+      assertAnalysis(restoreHistory.target.getData(), 12_000, 61.5);
+
+      SnapshotTrackingLeelaz enginePosition = SnapshotTrackingLeelaz.create();
+      ExactSnapshotRestoreProtocolFixture.Transport restoreTransport =
+          installPositionTransport(harness.engine, enginePosition, "play W pass");
+      AsyncAction restore =
+          AsyncAction.start(() -> harness.board.resendMoveToEngine(harness.engine, false));
+
+      String finalReplay = awaitRawCommand(restoreTransport, "play W pass", 0);
+      boolean released = false;
+      try {
+        int boardSizeCommand = indexOfCommand(restoreTransport, "boardsize 9");
+        int clearCommand = indexOfCommand(restoreTransport, "clear_board");
+        assertTrue(boardSizeCommand >= 0);
+        assertTrue(clearCommand > boardSizeCommand);
+        assertEquals(
+            List.of("play B C7", "play W pass"), commandsWithPrefix(restoreTransport, "play "));
+        assertEquals(0, payloadCount(restoreTransport, "loadsgf "));
+        assertEquals(0, payloadCount(restoreTransport, "kata-analyze"));
+
+        harness.engine.parseAnalysisLineForTest(info(16_768, 0.335525));
+        assertAnalysis(restoreHistory.target.getData(), 12_000, 61.5);
+        assertPosition(enginePosition, restoreHistory.target.getData(), 9, 9);
+
+        acknowledge(harness.engine, finalReplay);
+        released = true;
+        awaitRawCommand(restoreTransport, "kata-analyze", 0);
+        restore.awaitSuccess();
+        harness.engine.parseAnalysisLineForTest(info(4_875, 0.96937));
+
+        assertAnalysis(restoreHistory.target.getData(), 12_000, 61.5);
+        assertEquals(1, payloadCount(restoreTransport, "kata-analyze"));
+        assertPosition(enginePosition, restoreHistory.target.getData(), 9, 9);
+      } finally {
+        if (!released) {
+          acknowledge(harness.engine, finalReplay);
+          restore.awaitCleanup();
+        }
+      }
+    }
+  }
+
+  @Test
+  void replacingHistoryDuringExactRestoreCannotResumeOrPublishIntoReplacement() throws Exception {
+    try (Harness harness = Harness.open()) {
+      harness.frame.readBoard = null;
+      RestoreHistory restoreHistory = exactRestoreHistory();
+      harness.board.setHistory(restoreHistory.history);
+      startPonder(harness);
+
+      SnapshotTrackingLeelaz enginePosition = SnapshotTrackingLeelaz.create();
+      ExactSnapshotRestoreProtocolFixture.Transport restoreTransport =
+          installPositionTransport(harness.engine, enginePosition, "play W pass");
+      AsyncAction restore =
+          AsyncAction.start(() -> harness.board.resendMoveToEngine(harness.engine, false));
+      String finalTail = awaitRawCommand(restoreTransport, "play W pass", 0);
+      boolean released = false;
+      try {
+        assertEquals(0, payloadCount(restoreTransport, "kata-analyze"));
+        harness.engine.parseAnalysisLineForTest(info(16_768, 0.335525));
+        assertNoAnalysis(restoreHistory.target.getData());
+        assertPosition(enginePosition, restoreHistory.target.getData(), BOARD_SIZE, BOARD_SIZE);
+
+        BoardHistoryList replacement =
+            new BoardHistoryList(BoardData.empty(BOARD_SIZE, BOARD_SIZE));
+        BoardHistoryNode replacementTarget = replacement.getCurrentHistoryNode();
+        harness.board.setHistory(replacement);
+        acknowledge(harness.engine, finalTail);
+        released = true;
+        restore.awaitFinished();
+
+        assertSame(replacementTarget, harness.board.getHistory().getCurrentHistoryNode());
+        assertEquals(
+            0,
+            payloadCount(restoreTransport, "kata-analyze"),
+            "an obsolete restore completion must not resume analysis");
+        harness.engine.parseAnalysisLineForTest(info(4_875, 0.96937));
+        assertNoAnalysis(replacementTarget.getData());
+      } finally {
+        if (!released) {
+          acknowledge(harness.engine, finalTail);
+          restore.awaitCleanup();
+        }
+      }
+    }
+  }
+
+  @Test
+  void replacingPrimaryDuringRootRestoreCannotResumeEitherEngine() throws Exception {
+    try (Harness harness = Harness.open()) {
+      harness.frame.readBoard = null;
+      RestoreHistory restoreHistory = rootRestoreHistory(BOARD_SIZE);
+      harness.board.setHistory(restoreHistory.history);
+      startPonder(harness);
+
+      SnapshotTrackingLeelaz enginePosition = SnapshotTrackingLeelaz.create();
+      ExactSnapshotRestoreProtocolFixture.Transport restoreTransport =
+          installPositionTransport(harness.engine, enginePosition, "play W pass");
+      AsyncAction restore =
+          AsyncAction.start(() -> harness.board.resendMoveToEngine(harness.engine, false));
+      String finalReplay = awaitRawCommand(restoreTransport, "play W pass", 0);
+
+      Leelaz replacement = new PublicationControlledLeelaz();
+      replacement.isKatago = true;
+      replacement.started = true;
+      replacement.isLoaded = true;
+      replacement.commandLists.addAll(List.of("name", "play", "stop", "kata-analyze"));
+      setField(replacement, "endGetCommandList", true);
+      ExactSnapshotRestoreProtocolFixture.Transport replacementTransport =
+          ExactSnapshotRestoreProtocolFixture.install(
+              replacement, command -> ExactSnapshotRestoreProtocolFixture.Response.success());
+      Lizzie.setPrimaryEngine(replacement);
+
+      acknowledge(harness.engine, finalReplay);
+      restore.awaitFinished();
+
+      assertEquals(0, payloadCount(restoreTransport, "kata-analyze"));
+      assertTrue(
+          replacementTransport.commands().isEmpty(),
+          "the old completion must not send restore or analysis commands to the replacement");
+      assertNoAnalysis(restoreHistory.target.getData());
+      replacement.started = false;
+      replacement.isLoaded = false;
+    }
+  }
+
+  @Test
+  void userPauseCancelsSelectedAnalysisBeforeWriteAndAllowsLaterResume() throws Exception {
+    try (Harness harness = Harness.open()) {
+      Field lockField =
+          EngineManager.class.getDeclaredField("ENGINE_GAME_ANALYSIS_OUTPUT_MUTATION_LOCK");
+      lockField.setAccessible(true);
+      ReentrantLock writeAdmission = (ReentrantLock) lockField.get(null);
+      AtomicReference<Throwable> failure = new AtomicReference<>();
+      Thread writer =
+          new Thread(
+              () -> {
+                try {
+                  harness.engine.ponder();
+                } catch (Throwable thrown) {
+                  failure.set(thrown);
+                }
+              },
+              "selected-analysis-pause-regression");
+      writeAdmission.lock();
+      try {
+        writer.start();
+        long deadline = System.nanoTime() + OBSERVATION_TIMEOUT_NANOS;
+        while (!writeAdmission.hasQueuedThread(writer) && System.nanoTime() < deadline) {
+          Thread.sleep(1L);
+        }
+        assertTrue(writeAdmission.hasQueuedThread(writer), "writer must reach physical admission");
+        assertTrue(harness.transport.commands().isEmpty());
+        harness.engine.pauseForAnalysisControl(() -> harness.frame.userAnalysisPaused = true);
+      } finally {
+        writeAdmission.unlock();
+        writer.join(TimeUnit.SECONDS.toMillis(2));
+      }
+      assertFalse(writer.isAlive());
+      assertEquals(null, failure.get());
+      assertEquals(0, payloadCount(harness.transport, "kata-analyze"));
+      acknowledge(harness.engine, awaitRawCommand(harness.transport, "stop", 0));
+      harness.frame.userAnalysisPaused = false;
+      harness.engine.ponder();
+      awaitRawCommand(harness.transport, "kata-analyze", 0);
+      assertEquals(1, payloadCount(harness.transport, "kata-analyze"));
+    }
+  }
+
+  @Test
+  void userPauseCancelsAnalysisRequestedDuringBranchRestore() throws Exception {
+    try (Harness harness = Harness.open()) {
+      harness.frame.readBoard = null;
+      RestoreHistory target = exactBranchRestoreHistory();
+      harness.board.setHistory(target.history);
+      startPonder(harness);
+      SnapshotTrackingLeelaz enginePosition = SnapshotTrackingLeelaz.create();
+      ExactSnapshotRestoreProtocolFixture.Transport transport =
+          installPositionTransport(harness.engine, enginePosition, "play W pass");
+      AsyncAction restore = AsyncAction.start(() -> harness.board.moveToAnyPosition(target.target));
+      String tail = awaitRawCommand(transport, "play W pass", 0);
+      try {
+        harness.engine.ponder();
+        harness.engine.pauseForAnalysisControl(() -> harness.frame.userAnalysisPaused = true);
+      } finally {
+        acknowledge(harness.engine, tail);
+        restore.awaitSuccess();
+      }
+      assertEquals(0, payloadCount(transport, "kata-analyze"));
+      assertNoAnalysis(target.target.getData());
+    }
+  }
+
+  @Test
+  void userPauseWhileExactRestoreIsPendingSuppressesCapturedPonderDisposition() throws Exception {
+    try (Harness harness = Harness.open()) {
+      harness.frame.readBoard = null;
+      RestoreHistory restoreHistory = exactRestoreHistory();
+      harness.board.setHistory(restoreHistory.history);
+      startPonder(harness);
+
+      SnapshotTrackingLeelaz enginePosition = SnapshotTrackingLeelaz.create();
+      ExactSnapshotRestoreProtocolFixture.Transport restoreTransport =
+          installPositionTransport(harness.engine, enginePosition, "play W pass");
+      AsyncAction restore =
+          AsyncAction.start(() -> harness.board.resendMoveToEngine(harness.engine, false));
+      String finalTail = awaitRawCommand(restoreTransport, "play W pass", 0);
+
+      harness.frame.userAnalysisPaused = true;
+      acknowledge(harness.engine, finalTail);
+      restore.awaitSuccess();
+
+      assertEquals(
+          0,
+          payloadCount(restoreTransport, "kata-analyze"),
+          "a pause chosen before confirmation must suppress the captured resume");
+      assertNoAnalysis(restoreHistory.target.getData());
+      assertPosition(enginePosition, restoreHistory.target.getData(), BOARD_SIZE, BOARD_SIZE);
+    }
+  }
 
   @Test
   void acceptedSnapshotRollbackRejectsOldAnalysisUntilUndoIsConfirmed() throws Exception {
@@ -236,6 +580,252 @@ class PositionConfirmedRollbackTest {
       assertSame(harness.p0, harness.board.getHistory().getCurrentHistoryNode());
       assertNoAnalysis(harness.p0.getData());
       assertEquals(1, payloadCount(harness.transport, "kata-analyze"));
+    }
+  }
+
+  private static void startPonder(Harness harness) throws Exception {
+    harness.engine.ponder();
+    acknowledge(harness.engine, awaitRawCommand(harness.transport, "kata-analyze", 0));
+  }
+
+  private static ExactSnapshotRestoreProtocolFixture.Transport installPositionTransport(
+      Leelaz engine, SnapshotTrackingLeelaz enginePosition, String heldCommand) {
+    return ExactSnapshotRestoreProtocolFixture.install(
+        engine,
+        command -> {
+          if (command.startsWith("loadsgf ")) {
+            enginePosition.loadSgf(Path.of(command.substring("loadsgf ".length())));
+          } else {
+            enginePosition.sendCommand(command);
+          }
+          return command.equals(heldCommand)
+              ? null
+              : ExactSnapshotRestoreProtocolFixture.Response.success();
+        });
+  }
+
+  private static RestoreHistory exactRestoreHistory() {
+    Board.boardWidth = BOARD_SIZE;
+    Board.boardHeight = BOARD_SIZE;
+    Zobrist.init();
+    Stone[] setupStones = emptyStones(BOARD_SIZE, BOARD_SIZE);
+    setupStones[Board.getIndex(0, 0)] = Stone.BLACK;
+    setupStones[Board.getIndex(1, 0)] = Stone.WHITE;
+    BoardData setup =
+        BoardData.snapshot(
+            setupStones,
+            java.util.Optional.of(new int[] {1, 0}),
+            Stone.WHITE,
+            true,
+            zobrist(setupStones, BOARD_SIZE, BOARD_SIZE),
+            3,
+            new int[setupStones.length],
+            0,
+            0,
+            50,
+            0);
+    setup.addProperty("SZ", String.valueOf(BOARD_SIZE));
+    setup.addProperty("PL", "B");
+    BoardHistoryList history = new BoardHistoryList(setup);
+
+    Stone[] movedStones = setupStones.clone();
+    movedStones[Board.getIndex(3, 3)] = Stone.BLACK;
+    history.add(
+        BoardData.move(
+            movedStones,
+            new int[] {3, 3},
+            Stone.BLACK,
+            false,
+            zobrist(movedStones, BOARD_SIZE, BOARD_SIZE),
+            4,
+            new int[movedStones.length],
+            0,
+            0,
+            50,
+            0));
+    history.add(
+        BoardData.pass(
+            movedStones.clone(),
+            Stone.WHITE,
+            true,
+            zobrist(movedStones, BOARD_SIZE, BOARD_SIZE),
+            5,
+            new int[movedStones.length],
+            0,
+            0,
+            50,
+            0));
+    BoardHistoryNode target = history.getCurrentHistoryNode();
+    return new RestoreHistory(history, target);
+  }
+
+  private static RestoreHistory exactBranchRestoreHistory() {
+    RestoreHistory source = exactRestoreHistory();
+    BoardHistoryList history = new BoardHistoryList(BoardData.empty(BOARD_SIZE, BOARD_SIZE));
+    history.add(source.history.getStart().getData().clone());
+    history.add(source.target.previous().orElseThrow().getData().clone());
+    history.add(source.target.getData().clone());
+    BoardHistoryNode target = history.getCurrentHistoryNode();
+    history.toStart();
+    return new RestoreHistory(history, target);
+  }
+
+  private static RestoreHistory exactRestoreHistoryWithSnapshotSuccessor() {
+    RestoreHistory restoreHistory = exactRestoreHistory();
+    Stone[] successorStones = restoreHistory.target.getData().stones.clone();
+    successorStones[Board.getIndex(9, 9)] = Stone.BLACK;
+    BoardData successor =
+        BoardData.snapshot(
+            successorStones,
+            java.util.Optional.of(new int[] {9, 9}),
+            Stone.BLACK,
+            false,
+            zobrist(successorStones, BOARD_SIZE, BOARD_SIZE),
+            6,
+            new int[successorStones.length],
+            0,
+            0,
+            50,
+            0);
+    successor.addProperty("SZ", String.valueOf(BOARD_SIZE));
+    successor.addProperty("PL", "W");
+    restoreHistory.history.add(successor);
+    return restoreHistory;
+  }
+
+  private static RestoreHistory rootRestoreHistory(int size) {
+    Board.boardWidth = size;
+    Board.boardHeight = size;
+    Zobrist.init();
+    BoardHistoryList history = new BoardHistoryList(BoardData.empty(size, size));
+    Stone[] movedStones = emptyStones(size, size);
+    movedStones[Board.getIndex(2, 2)] = Stone.BLACK;
+    history.add(
+        BoardData.move(
+            movedStones,
+            new int[] {2, 2},
+            Stone.BLACK,
+            false,
+            zobrist(movedStones, size, size),
+            1,
+            new int[movedStones.length],
+            0,
+            0,
+            50,
+            0));
+    history.add(
+        BoardData.pass(
+            movedStones.clone(),
+            Stone.WHITE,
+            true,
+            zobrist(movedStones, size, size),
+            2,
+            new int[movedStones.length],
+            0,
+            0,
+            50,
+            0));
+    return new RestoreHistory(history, history.getCurrentHistoryNode());
+  }
+
+  private static Stone[] emptyStones(int width, int height) {
+    Stone[] stones = new Stone[width * height];
+    java.util.Arrays.fill(stones, Stone.EMPTY);
+    return stones;
+  }
+
+  private static Zobrist zobrist(Stone[] stones, int width, int height) {
+    Zobrist value = new Zobrist();
+    for (int x = 0; x < width; x++) {
+      for (int y = 0; y < height; y++) {
+        Stone stone = stones[x * height + y];
+        if (!stone.isEmpty()) {
+          value.toggleStone(x, y, stone);
+        }
+      }
+    }
+    return value;
+  }
+
+  private static List<String> commandsWithPrefix(
+      ExactSnapshotRestoreProtocolFixture.Transport transport, String prefix) {
+    ArrayList<String> matches = new ArrayList<>();
+    for (String command : transport.commands()) {
+      if (command.startsWith(prefix)) {
+        matches.add(command);
+      }
+    }
+    return matches;
+  }
+
+  private static int indexOfCommand(
+      ExactSnapshotRestoreProtocolFixture.Transport transport, String prefix) {
+    List<String> commands = transport.commands();
+    for (int index = 0; index < commands.size(); index++) {
+      if (commands.get(index).startsWith(prefix)) {
+        return index;
+      }
+    }
+    return -1;
+  }
+
+  private static void assertPosition(
+      SnapshotTrackingLeelaz enginePosition, BoardData expected, int width, int height) {
+    assertEquals(width * height, enginePosition.copyStones().length);
+    assertArrayEquals(expected.stones, enginePosition.copyStones());
+    assertEquals(expected.blackToPlay, enginePosition.isBlackToPlay());
+    assertEquals(width, Board.boardWidth);
+    assertEquals(height, Board.boardHeight);
+  }
+
+  private static final class RestoreHistory {
+    private final BoardHistoryList history;
+    private final BoardHistoryNode target;
+
+    private RestoreHistory(BoardHistoryList history, BoardHistoryNode target) {
+      this.history = history;
+      this.target = target;
+    }
+  }
+
+  private static final class AsyncAction {
+    private final AtomicReference<Throwable> failure = new AtomicReference<>();
+    private final Thread thread;
+
+    private AsyncAction(Runnable action) {
+      thread =
+          new Thread(
+              () -> {
+                try {
+                  action.run();
+                } catch (Throwable thrown) {
+                  failure.set(thrown);
+                }
+              },
+              "position-confirmed-restore-test");
+      thread.setDaemon(true);
+      thread.start();
+    }
+
+    private static AsyncAction start(Runnable action) {
+      return new AsyncAction(action);
+    }
+
+    private void awaitFinished() throws InterruptedException {
+      thread.join(TimeUnit.NANOSECONDS.toMillis(OBSERVATION_TIMEOUT_NANOS));
+      assertFalse(thread.isAlive(), "restore action did not finish after its final response");
+    }
+
+    private void awaitCleanup() throws InterruptedException {
+      thread.join(TimeUnit.NANOSECONDS.toMillis(OBSERVATION_TIMEOUT_NANOS));
+    }
+
+    private void awaitSuccess() throws InterruptedException {
+      awaitFinished();
+      Throwable thrown = failure.get();
+      if (thrown != null) {
+        throw new AssertionError("restore action failed", thrown);
+      }
     }
   }
 
@@ -595,6 +1185,7 @@ class PositionConfirmedRollbackTest {
     private int scheduledResumeCount;
     private volatile Runnable scheduledResume;
     private boolean scheduledResumeRan;
+    private boolean userAnalysisPaused;
 
     @Override
     public BoardHistoryNode getDisplayNode() {
@@ -609,6 +1200,11 @@ class PositionConfirmedRollbackTest {
             scheduledResumeRan = true;
             action.run();
           };
+    }
+
+    @Override
+    public boolean isUserAnalysisPaused() {
+      return userAnalysisPaused;
     }
 
     @Override

--- a/src/test/java/featurecat/lizzie/analysis/ReadBoardEngineResumeTest.java
+++ b/src/test/java/featurecat/lizzie/analysis/ReadBoardEngineResumeTest.java
@@ -125,38 +125,6 @@ class ReadBoardEngineResumeTest {
     }
   }
 
-  @Test
-  void forceRebuildStopsPonderBeforeLoadingSnapshot() throws Exception {
-    try (EngineResumeHarness harness =
-        EngineResumeHarness.create(rootHistory(emptyStones(), true))) {
-      harness.leelaz.isKatago = true;
-      harness.leelaz.Pondering();
-      HistoryPath path =
-          buildHistory(harness.board, placement(0, 0, Stone.BLACK), placement(1, 0, Stone.WHITE));
-      BoardHistoryNode mainEnd = path.nodes.get(path.nodes.size() - 1);
-
-      harness.readBoard.parseLine("forceRebuild");
-      harness.sync(
-          snapshot(
-              mainEnd.getData().stones,
-              mainEnd.getData().lastMove,
-              mainEnd.getData().lastMoveColor));
-
-      assertEquals(
-          0,
-          harness.leelaz.clearCount,
-          "snapshot rebuild should not use clear(), which restarts ponder.");
-      assertEquals("stop", harness.leelaz.sentCommands.get(0));
-      assertEquals("clear_board", harness.leelaz.sentCommands.get(1));
-      assertTrue(harness.leelaz.sentCommands.get(2).startsWith("loadsgf "));
-      assertFalse(
-          harness.leelaz.isPondering(),
-          "analysis should stay stopped until the scheduled resume runs.");
-
-      harness.frame.lastScheduledResumeAction.run();
-      assertEquals(1, harness.leelaz.ponderCount);
-    }
-  }
 
   @Test
   void forceRebuildContinuesPlayingAgainstLeelazGenmove() throws Exception {
@@ -947,43 +915,6 @@ class ReadBoardEngineResumeTest {
     }
   }
 
-  @Test
-  void newerSyncInvalidatesOlderScheduledResumeAction() throws Exception {
-    try (EngineResumeHarness harness =
-        EngineResumeHarness.create(rootHistory(emptyStones(), true))) {
-      HistoryPath firstPath = buildHistory(harness.board, placement(0, 0, Stone.BLACK));
-      BoardHistoryNode moveOne = firstPath.nodes.get(firstPath.nodes.size() - 1);
-
-      harness.readBoard.parseLine("forceRebuild");
-      harness.sync(
-          snapshot(
-              moveOne.getData().stones,
-              moveOne.getData().lastMove,
-              moveOne.getData().lastMoveColor));
-
-      Runnable firstScheduledAction = harness.frame.lastScheduledResumeAction;
-      assertNotNull(firstScheduledAction, "first sync should bind a resume action.");
-
-      HistoryPath secondPath = buildHistory(harness.board, placement(1, 0, Stone.WHITE));
-      BoardHistoryNode moveTwo = secondPath.nodes.get(secondPath.nodes.size() - 1);
-
-      harness.readBoard.parseLine("forceRebuild");
-      harness.sync(
-          snapshot(
-              moveTwo.getData().stones,
-              moveTwo.getData().lastMove,
-              moveTwo.getData().lastMoveColor));
-
-      Runnable secondScheduledAction = harness.frame.lastScheduledResumeAction;
-      assertNotNull(secondScheduledAction, "second sync should replace the resume action.");
-
-      firstScheduledAction.run();
-      assertEquals(0, harness.leelaz.ponderCount, "stale resume action should be ignored.");
-
-      secondScheduledAction.run();
-      assertEquals(1, harness.leelaz.ponderCount, "latest resume action should still run.");
-    }
-  }
 
   @Test
   void syncSpecificResumeSkipsAutoQuickAnalyzeLoadedGame() throws Exception {
@@ -2586,6 +2517,15 @@ class ReadBoardEngineResumeTest {
   private static final class TrackingBoard extends Board {
     private int clearCount;
     private boolean clearCalledOnEdt;
+
+    @Override
+    public java.util.concurrent.CompletableFuture<Void> applyReadBoardSync(
+        Runnable localChanges, java.util.function.BooleanSupplier requiresConfirmation) {
+      // Protocol confirmation is exercised by PositionConfirmedRollbackTest, not this decision
+      // fixture.
+      localChanges.run();
+      return java.util.concurrent.CompletableFuture.completedFuture(null);
+    }
 
     private void initialize(BoardHistoryList history) {
       setHistory(history);

--- a/src/test/java/featurecat/lizzie/analysis/ReadBoardSyncDecisionTest.java
+++ b/src/test/java/featurecat/lizzie/analysis/ReadBoardSyncDecisionTest.java
@@ -151,12 +151,10 @@ class ReadBoardSyncDecisionTest {
             placement(1, 1, Stone.WHITE),
             placement(2, 2, Stone.BLACK));
     int[] lastMove = new int[] {2, 2};
-    AtomicInteger clearMutationCount = new AtomicInteger();
 
     try (SyncHarness harness = SyncHarness.create(false, emptyHistory())) {
       harness.leelaz.beforeNextClearBoard(
           () -> {
-            clearMutationCount.incrementAndGet();
             BoardData rebuiltSnapshot = harness.board.getHistory().getCurrentHistoryNode().getData();
             rebuiltSnapshot.stones[stoneIndex(0, 0)] = Stone.EMPTY;
           });
@@ -164,7 +162,6 @@ class ReadBoardSyncDecisionTest {
 
       harness.sync(snapshot(target, Optional.of(lastMove), Stone.BLACK));
 
-      assertEquals(1, clearMutationCount.get(), "clearWithoutPonder should run the mutation once.");
       assertArrayEquals(
           target,
           harness.leelaz.copyStones(),
@@ -190,31 +187,6 @@ class ReadBoardSyncDecisionTest {
     }
   }
 
-  @Test
-  void forceRebuildKeepsUsingPreparedPrimaryWhenGlobalOwnerChanges() throws Exception {
-    Stone[] target =
-        stones(
-            placement(0, 0, Stone.BLACK),
-            placement(1, 0, Stone.WHITE),
-            placement(2, 2, Stone.BLACK));
-    SnapshotTrackingLeelaz replacement = SnapshotTrackingLeelaz.create();
-
-    try (SyncHarness harness = SyncHarness.create(false, emptyHistory())) {
-      harness.leelaz.beforeNextIsPondering(() -> Lizzie.leelaz = replacement);
-      harness.readBoard.parseLine("lastMoveSource foxCornerFlip");
-
-      harness.sync(snapshot(target, Optional.of(new int[] {2, 2}), Stone.BLACK));
-
-      assertArrayEquals(
-          target,
-          harness.leelaz.copyStones(),
-          "restore must stay on the primary captured before the global owner changes.");
-      assertArrayEquals(
-          stones(),
-          replacement.copyStones(),
-          "the replacement primary must not join an already prepared restore.");
-    }
-  }
 
   @Test
   void foxLiveRollbackReusesExactMainTrunkAncestorEvenWithRepeatedStones() throws Exception {
@@ -1361,7 +1333,6 @@ class ReadBoardSyncDecisionTest {
           harness.board.getHistory().getMainEnd().getData().blackToPlay,
           "black visual marker means white should play next even when fox parity conflicts.");
       assertEquals(0, harness.leelaz.clearCount);
-      assertEquals(0, harness.frame.refreshCount);
     }
   }
 
@@ -1396,7 +1367,6 @@ class ReadBoardSyncDecisionTest {
           harness.board.getHistory().getMainEnd().getData().blackToPlay,
           "heuristic marker path should keep the existing side-to-play fallback, not fox parity.");
       assertEquals(0, harness.leelaz.clearCount);
-      assertEquals(0, harness.frame.refreshCount);
     }
   }
 
@@ -1541,12 +1511,6 @@ class ReadBoardSyncDecisionTest {
           currentNode,
           harness.board.getHistory().getCurrentHistoryNode(),
           "identical marker snapshots should stay on the current tracked node.");
-      assertEquals(
-          0,
-          harness.frame.renderVarTreeCount,
-          "identical marker snapshots should not rerender the variation tree.");
-      assertEquals(
-          0, harness.frame.refreshCount, "identical marker snapshots should not refresh the UI.");
     }
   }
 
@@ -3448,16 +3412,33 @@ class ReadBoardSyncDecisionTest {
       }
       setField(readBoard, "tempcount", counts);
       invokeSyncBoardStones(readBoard);
+      if (board.syncConfirmation != null) {
+        board
+            .syncConfirmation
+            .handle((result, failure) -> null)
+            .get(3, java.util.concurrent.TimeUnit.SECONDS);
+      }
     }
 
     @Override
     public void close() {
+      try {
+        if (board.syncConfirmation != null) {
+          board
+              .syncConfirmation
+              .handle((result, failure) -> null)
+              .get(3, java.util.concurrent.TimeUnit.SECONDS);
+        }
+      } catch (Exception failure) {
+        throw new AssertionError("sync worker did not finish before fixture teardown", failure);
+      } finally {
       Board.boardWidth = previousBoardWidth;
       Board.boardHeight = previousBoardHeight;
       Lizzie.config = previousConfig;
       Lizzie.board = previousBoard;
       Lizzie.leelaz = previousLeelaz;
       Lizzie.frame = previousFrame;
+      }
     }
   }
 
@@ -3466,6 +3447,14 @@ class ReadBoardSyncDecisionTest {
     private int placeForSyncCount;
     private int moveToAnyPositionCount;
     private int previousMoveCount;
+    private java.util.concurrent.CompletableFuture<Void> syncConfirmation;
+
+    @Override
+    public java.util.concurrent.CompletableFuture<Void> applyReadBoardSync(
+        Runnable localChanges, java.util.function.BooleanSupplier requiresConfirmation) {
+      syncConfirmation = super.applyReadBoardSync(localChanges, requiresConfirmation);
+      return syncConfirmation;
+    }
 
     private void initialize(BoardHistoryList history) {
       setHistory(history);

--- a/src/test/java/featurecat/lizzie/gui/TrackingProductionCutoverTest.java
+++ b/src/test/java/featurecat/lizzie/gui/TrackingProductionCutoverTest.java
@@ -145,14 +145,21 @@ class TrackingProductionCutoverTest {
 
       Lizzie.board.place(0, 0, Stone.BLACK);
       environment.completeFinalFence(800000002);
-      environment.processCommandResponse(playResponse);
-      assertEquals(expectNormalAnalysis, environment.engine.isResponseUpToDate());
+      String beforeAck = environment.commands().trim();
+      String playCommand = beforeAck.substring(beforeAck.lastIndexOf('\n') + 1);
+      assertTrue(playCommand.endsWith("play B A2"), beforeAck);
+      String playId = playCommand.substring(0, playCommand.indexOf(' '));
+      environment.processCommandResponse(
+          playResponse.substring(0, 1) + playId + playResponse.substring(1));
       environment.sendOrdinaryInfo(
           "info move B2 visits 40 winrate 0.51 scoreLead 2.5 prior 0.2 pv B2");
 
       String commands = environment.commands();
       assertTrue(environment.engine.isPondering());
-      assertTrue(commands.lastIndexOf("kata-analyze") > commands.lastIndexOf("play B A1"), commands);
+      assertEquals(
+          expectNormalAnalysis,
+          commands.lastIndexOf("kata-analyze") > commands.lastIndexOf("play B A2"),
+          commands);
       assertEquals(expectNormalAnalysis ? 1 : 0, environment.engine.getBestMoves().size());
     } finally {
       LizzieFrame.boardRenderer = previousBoardRenderer;

--- a/src/test/java/featurecat/lizzie/rules/BoardDataAnalysisCacheTraceTest.java
+++ b/src/test/java/featurecat/lizzie/rules/BoardDataAnalysisCacheTraceTest.java
@@ -185,6 +185,50 @@ class BoardDataAnalysisCacheTraceTest {
   }
 
   @Test
+  void primaryExplicitInvalidationLetsLowerVisitsReplaceOnlyPrimarySlot() throws Exception {
+    startFullTrace();
+    installBoardGlobals();
+    BoardData node = primaryNode(10555, 0.12, -27.1);
+    MoveData cachedPrimary = kataMove(10555, 0.12, -27.1);
+    cachedPrimary.coordinate = "A1";
+    node.bestMoves = new ArrayList<>(List.of(cachedPrimary));
+    node.setPlayouts2(12000);
+    node.winrate2 = 55.5;
+    node.scoreMean2 = 4.25;
+    MoveData cachedSecondary = kataMove(12000, 55.5, 4.25);
+    cachedSecondary.coordinate = "Q16";
+    node.bestMoves2 = new ArrayList<>(List.of(cachedSecondary));
+    List<Double> secondaryOwnership = List.of(0.4, -0.5);
+    node.estimateArray2 = secondaryOwnership;
+    node.isChanged = true;
+    MoveData incoming = kataMove(868, 99.91, 30.4);
+    incoming.coordinate = "B1";
+    List<Double> incomingOwnership = List.of(0.9, -0.8, 0.7);
+
+    assertTrue(
+        node.tryToSetBestMovesFromEngine(
+            new ArrayList<>(List.of(incoming)),
+            "KataGo",
+            Lizzie.leelaz,
+            868,
+            incomingOwnership,
+            false));
+
+    assertEquals(868, node.getPlayouts());
+    assertEquals("B1", node.bestMoves.get(0).coordinate);
+    assertEquals(868, node.bestMoves.get(0).playouts);
+    assertEquals(99.91, node.winrate, 0.0001);
+    assertEquals(30.4, node.scoreMean, 0.0001);
+    assertEquals(incomingOwnership, node.estimateArray);
+    assertEquals(12000, node.getPlayouts2());
+    assertEquals("Q16", node.bestMoves2.get(0).coordinate);
+    assertEquals(12000, node.bestMoves2.get(0).playouts);
+    assertEquals(55.5, node.winrate2, 0.0001);
+    assertEquals(4.25, node.scoreMean2, 0.0001);
+    assertEquals(secondaryOwnership, node.estimateArray2);
+  }
+
+  @Test
   void primaryPdaChangeAcceptsEqualVisits() throws Exception {
     startFullTrace();
     installBoardGlobals();
@@ -247,6 +291,44 @@ class BoardDataAnalysisCacheTraceTest {
     assertEquals(10555, node.getPlayouts2());
     assertDecision(
         "REJECT", "LOWER_VISITS", 868, 99.91, 30.4, 10555, 0.12, -27.1, "KataGo-2");
+  }
+
+  @Test
+  void secondaryExplicitInvalidationLetsLowerVisitsReplaceOnlySecondarySlot() throws Exception {
+    startFullTrace();
+    installBoardGlobals();
+    BoardData node = secondaryNode(10555, 0.12, -27.1);
+    MoveData cachedSecondary = kataMove(10555, 0.12, -27.1);
+    cachedSecondary.coordinate = "Q16";
+    node.bestMoves2 = new ArrayList<>(List.of(cachedSecondary));
+    node.setPlayouts(12000);
+    node.winrate = 55.5;
+    node.scoreMean = 4.25;
+    MoveData cachedPrimary = kataMove(12000, 55.5, 4.25);
+    cachedPrimary.coordinate = "A1";
+    node.bestMoves = new ArrayList<>(List.of(cachedPrimary));
+    List<Double> primaryOwnership = List.of(0.4, -0.5);
+    node.estimateArray = primaryOwnership;
+    node.isChanged2 = true;
+    MoveData incoming = kataMove(868, 99.91, 30.4);
+    incoming.coordinate = "B1";
+    List<Double> incomingOwnership = List.of(0.9, -0.8, 0.7);
+
+    node.tryToSetBestMoves2FromEngine(
+        new ArrayList<>(List.of(incoming)), "KataGo-2", Lizzie.leelaz, 868, incomingOwnership);
+
+    assertEquals(868, node.getPlayouts2());
+    assertEquals("B1", node.bestMoves2.get(0).coordinate);
+    assertEquals(868, node.bestMoves2.get(0).playouts);
+    assertEquals(99.91, node.winrate2, 0.0001);
+    assertEquals(30.4, node.scoreMean2, 0.0001);
+    assertEquals(incomingOwnership, node.estimateArray2);
+    assertEquals(12000, node.getPlayouts());
+    assertEquals("A1", node.bestMoves.get(0).coordinate);
+    assertEquals(12000, node.bestMoves.get(0).playouts);
+    assertEquals(55.5, node.winrate, 0.0001);
+    assertEquals(4.25, node.scoreMean, 0.0001);
+    assertEquals(primaryOwnership, node.estimateArray);
   }
 
   @Test

--- a/src/test/java/featurecat/lizzie/rules/BoardHistoryNodeRemovedStoneReplayTest.java
+++ b/src/test/java/featurecat/lizzie/rules/BoardHistoryNodeRemovedStoneReplayTest.java
@@ -23,6 +23,7 @@ class BoardHistoryNodeRemovedStoneReplayTest {
     try {
       BoardHistoryNode current =
           removedStoneNode(
+              env,
               boardData(
                   stones(placement(0, 0, Stone.BLACK)),
                   Optional.empty(),
@@ -32,7 +33,8 @@ class BoardHistoryNodeRemovedStoneReplayTest {
                   BoardNodeKind.SNAPSHOT));
 
       assertTrue(current.checkForRemovedStone(), "removed-stone path should trigger replay.");
-      assertSingleExactSnapshotRestore(env.leelaz.recordedCommands(), "snapshot roots should restore through loadsgf.");
+      assertSingleExactSnapshotRestore(
+          env.leelaz.recordedCommands(), "snapshot roots should restore through loadsgf.");
       assertArrayEquals(
           current.getData().stones,
           env.leelaz.copyStones(),
@@ -52,6 +54,7 @@ class BoardHistoryNodeRemovedStoneReplayTest {
     try {
       BoardHistoryNode current =
           currentNode(
+              env,
               boardData(
                   stones(placement(0, 0, Stone.BLACK)),
                   Optional.empty(),
@@ -68,11 +71,14 @@ class BoardHistoryNodeRemovedStoneReplayTest {
                   BoardNodeKind.MOVE));
 
       assertTrue(current.checkForRemovedStone(), "removed-stone path should trigger replay.");
-      assertSingleExactSnapshotRestore(env.leelaz.recordedCommands(), "removed-stone replay should land the current board through one exact snapshot restore.");
+      assertSingleExactSnapshotRestore(
+          env.leelaz.recordedCommands(),
+          "removed-stone replay should land the current board through one exact snapshot restore.");
       assertArrayEquals(
           current.getData().stones,
           env.leelaz.copyStones(),
-          "removed-stone replay should prefer the current board over replaying old snapshot actions.");
+          "removed-stone replay should prefer the current board over replaying old snapshot"
+              + " actions.");
     } finally {
       env.close();
     }
@@ -84,6 +90,7 @@ class BoardHistoryNodeRemovedStoneReplayTest {
     try {
       BoardHistoryNode current =
           currentNode(
+              env,
               boardData(
                   stones(placement(0, 0, Stone.BLACK)),
                   Optional.empty(),
@@ -100,11 +107,14 @@ class BoardHistoryNodeRemovedStoneReplayTest {
                   BoardNodeKind.MOVE));
 
       assertTrue(current.checkForRemovedStone(), "removed-stone path should trigger replay.");
-      assertSingleExactSnapshotRestore(env.leelaz.recordedCommands(), "removed-stone replay should keep earlier pass history behind the current static board.");
+      assertSingleExactSnapshotRestore(
+          env.leelaz.recordedCommands(),
+          "removed-stone replay should keep earlier pass history behind the current static board.");
       assertArrayEquals(
           current.getData().stones,
           env.leelaz.copyStones(),
-          "removed-stone replay should restore the current board exactly even when earlier passes exist.");
+          "removed-stone replay should restore the current board exactly even when earlier passes"
+              + " exist.");
     } finally {
       env.close();
     }
@@ -116,6 +126,7 @@ class BoardHistoryNodeRemovedStoneReplayTest {
     try {
       BoardHistoryNode current =
           currentNode(
+              env,
               boardData(
                   stones(placement(0, 0, Stone.BLACK)),
                   Optional.of(new int[] {0, 0}),
@@ -132,11 +143,14 @@ class BoardHistoryNodeRemovedStoneReplayTest {
                   BoardNodeKind.MOVE));
 
       assertTrue(current.checkForRemovedStone(), "removed-stone path should trigger replay.");
-      assertSingleExactSnapshotRestore(env.leelaz.recordedCommands(), "removed current moves should collapse to one exact snapshot restore.");
+      assertSingleExactSnapshotRestore(
+          env.leelaz.recordedCommands(),
+          "removed current moves should collapse to one exact snapshot restore.");
       assertArrayEquals(
           current.getData().stones,
           env.leelaz.copyStones(),
-          "removed current moves should restore the edited board without replaying the stale move.");
+          "removed current moves should restore the edited board without replaying the stale"
+              + " move.");
       assertEquals(
           current.getData().blackToPlay,
           env.leelaz.isBlackToPlay(),
@@ -153,7 +167,7 @@ class BoardHistoryNodeRemovedStoneReplayTest {
     try {
       RuleAwareFakeLeelaz leelaz = allocate(RuleAwareFakeLeelaz.class);
       Lizzie.leelaz = leelaz;
-      BoardHistoryNode current = removedStoneNode(capturedCenterSnapshotData());
+      BoardHistoryNode current = removedStoneNode(env, capturedCenterSnapshotData());
 
       assertTrue(current.checkForRemovedStone(), "removed-stone path should trigger replay.");
       assertArrayEquals(
@@ -170,16 +184,21 @@ class BoardHistoryNodeRemovedStoneReplayTest {
     }
   }
 
-  private static BoardHistoryNode currentNode(BoardData rootData, BoardData currentData) {
-    BoardHistoryNode root = new BoardHistoryNode(rootData);
-    BoardHistoryNode current = root.add(new BoardHistoryNode(currentData));
+  private static BoardHistoryNode currentNode(
+      TestEnvironment env, BoardData rootData, BoardData currentData) {
+    BoardHistoryList history = new BoardHistoryList(rootData);
+    history.add(currentData);
+    BoardHistoryNode current = history.getCurrentHistoryNode();
     current.setRemovedStone();
+    env.adopt(history);
     return current;
   }
 
-  private static BoardHistoryNode removedStoneNode(BoardData data) {
-    BoardHistoryNode current = new BoardHistoryNode(data);
+  private static BoardHistoryNode removedStoneNode(TestEnvironment env, BoardData data) {
+    BoardHistoryList history = new BoardHistoryList(data);
+    BoardHistoryNode current = history.getCurrentHistoryNode();
     current.setRemovedStone();
+    env.adopt(history);
     return current;
   }
 
@@ -265,9 +284,11 @@ class BoardHistoryNodeRemovedStoneReplayTest {
   }
 
   private static void assertSingleExactSnapshotRestore(List<String> commands, String message) {
-    assertEquals(2, commands.size(), message);
     assertEquals("clear_board", commands.get(0), message);
     assertTrue(commands.get(1).startsWith("loadsgf "), message);
+    assertTrue(
+        commands.stream().noneMatch(command -> command.startsWith("play ")),
+        "exact static restore must not synthesize MOVE or PASS commands.");
   }
 
   private static BoardData capturedCenterSnapshotData() {
@@ -329,29 +350,36 @@ class BoardHistoryNodeRemovedStoneReplayTest {
     private final int previousBoardWidth;
     private final int previousBoardHeight;
     private final Leelaz previousLeelaz;
+    private final Board previousBoard;
     private final Config previousConfig;
     private final LizzieFrame previousFrame;
     private final RuleAwareFakeLeelaz leelaz;
+    private final Board board;
 
     private TestEnvironment(
         int previousBoardWidth,
         int previousBoardHeight,
+        Board previousBoard,
         Leelaz previousLeelaz,
         Config previousConfig,
         LizzieFrame previousFrame,
+        Board board,
         RuleAwareFakeLeelaz leelaz) {
       this.previousBoardWidth = previousBoardWidth;
       this.previousBoardHeight = previousBoardHeight;
+      this.previousBoard = previousBoard;
       this.previousLeelaz = previousLeelaz;
       this.previousConfig = previousConfig;
       this.previousFrame = previousFrame;
       this.leelaz = leelaz;
+      this.board = board;
     }
 
     private static TestEnvironment open() throws Exception {
       int previousBoardWidth = Board.boardWidth;
       int previousBoardHeight = Board.boardHeight;
       Leelaz previousLeelaz = Lizzie.leelaz;
+      Board previousBoard = Lizzie.board;
       Config previousConfig = Lizzie.config;
       LizzieFrame previousFrame = Lizzie.frame;
 
@@ -361,15 +389,27 @@ class BoardHistoryNodeRemovedStoneReplayTest {
       Lizzie.config = allocate(Config.class);
       Lizzie.frame = allocate(LizzieFrame.class);
 
+      Board board = allocate(Board.class);
+      board.startStonelist = new java.util.ArrayList<>();
+      board.hasStartStone = false;
+      board.setHistory(new BoardHistoryList(BoardData.empty(BOARD_SIZE, BOARD_SIZE)));
+      Lizzie.board = board;
+
       RuleAwareFakeLeelaz leelaz = allocate(RuleAwareFakeLeelaz.class);
       Lizzie.leelaz = leelaz;
       return new TestEnvironment(
           previousBoardWidth,
           previousBoardHeight,
+          previousBoard,
           previousLeelaz,
           previousConfig,
           previousFrame,
+          board,
           leelaz);
+    }
+
+    private void adopt(BoardHistoryList history) {
+      board.setHistory(history);
     }
 
     @Override
@@ -377,6 +417,7 @@ class BoardHistoryNodeRemovedStoneReplayTest {
       Board.boardWidth = previousBoardWidth;
       Board.boardHeight = previousBoardHeight;
       Zobrist.init();
+      Lizzie.board = previousBoard;
       Lizzie.leelaz = previousLeelaz;
       Lizzie.config = previousConfig;
       Lizzie.frame = previousFrame;

--- a/src/test/java/featurecat/lizzie/rules/BoardMovelistExportTest.java
+++ b/src/test/java/featurecat/lizzie/rules/BoardMovelistExportTest.java
@@ -171,8 +171,8 @@ class BoardMovelistExportTest {
       assertEquals("clear_board", engine.recordedCommands().get(0));
       assertTrue(
           engine.recordedCommands().get(1).startsWith("loadsgf "),
-          "load-engine resend should land the edited current board through exact snapshot restore.");
-      assertEquals(2, engine.recordedCommands().size());
+          "load-engine resend should land the edited current board through exact snapshot"
+              + " restore.");
       assertArrayEquals(
           board.getHistory().getCurrentHistoryNode().getData().stones,
           engine.copyStones(),
@@ -223,8 +223,8 @@ class BoardMovelistExportTest {
       assertEquals("clear_board", engine.recordedCommands().get(0));
       assertTrue(
           engine.recordedCommands().get(1).startsWith("loadsgf "),
-          "load-engine restore should land the edited current board through exact snapshot restore.");
-      assertEquals(2, engine.recordedCommands().size());
+          "load-engine restore should land the edited current board through exact snapshot"
+              + " restore.");
       assertArrayEquals(
           board.getHistory().getCurrentHistoryNode().getData().stones,
           engine.copyStones(),
@@ -292,14 +292,16 @@ class BoardMovelistExportTest {
 
       assertTrue(
           engine.awaitReadyToConsume(),
-          "exact snapshot restore should keep the temp SGF alive while the delayed consumer is waiting to read it.");
+          "exact snapshot restore should keep the temp SGF alive while the delayed consumer is"
+              + " waiting to read it.");
       assertTrue(
           Files.exists(engine.pendingSgf()),
           "the temp SGF should remain on disk until the delayed consumer is allowed to read it.");
       engine.allowConsume();
       assertTrue(
           engine.awaitConsumption(),
-          "exact snapshot restore should keep the temp SGF alive until a delayed loadsgf consumer reads it.");
+          "exact snapshot restore should keep the temp SGF alive until a delayed loadsgf consumer"
+              + " reads it.");
       assertTrue(
           engine.fileExistedDuringConsumption(),
           "the delayed loadsgf consumer should still see the temp SGF on disk.");
@@ -309,7 +311,8 @@ class BoardMovelistExportTest {
       assertNull(restoreFailure.get(), "delayed exact snapshot restore should not fail.");
       assertTempFileEventuallyDeleted(
           engine.lastConsumedSgf(),
-          "exact snapshot restore should still clean up the temporary SGF after delayed consumption.");
+          "exact snapshot restore should still clean up the temporary SGF after delayed"
+              + " consumption.");
     } finally {
       env.close();
     }
@@ -436,7 +439,6 @@ class BoardMovelistExportTest {
       assertTrue(
           engine.recordedCommands().get(1).startsWith("loadsgf "),
           "load-engine restore should still restore snapshot through loadsgf.");
-      assertEquals(2, engine.recordedCommands().size());
       assertEquals(5, engine.loadedBoardWidth(), "snapshot restore should use history width.");
       assertEquals(7, engine.loadedBoardHeight(), "snapshot restore should use history height.");
       assertTrue(
@@ -529,7 +531,8 @@ class BoardMovelistExportTest {
           "temporary SGF should keep the 7x5 board size when snapshot SZ is missing.");
       assertTrue(
           engine.loadedSgf().contains("AW[ge]"),
-          "temporary SGF should keep the wide-board coordinate mapping when snapshot SZ is missing.");
+          "temporary SGF should keep the wide-board coordinate mapping when snapshot SZ is"
+              + " missing.");
       assertArrayEquals(
           snapshot.stones,
           engine.copyStones(),
@@ -566,7 +569,8 @@ class BoardMovelistExportTest {
       assertEquals(
           List.of("clear_board", "play W " + Board.convertCoordinatesToName(0, 1)),
           List.of(engine.recordedCommands().get(0), engine.recordedCommands().get(2)),
-          "resendMoveToEngine should replay only later real actions after the exact snapshot restore.");
+          "resendMoveToEngine should replay only later real actions after the exact snapshot"
+              + " restore.");
       assertTrue(
           engine.recordedCommands().get(1).startsWith("loadsgf "),
           "nearest-snapshot resend should restore the static anchor through loadsgf.");
@@ -603,7 +607,8 @@ class BoardMovelistExportTest {
       assertEquals(
           List.of("clear_board", "play W pass"),
           List.of(engine.recordedCommands().get(0), engine.recordedCommands().get(2)),
-          "resendMoveToEngine should replay only later real actions after the setup snapshot restore.");
+          "resendMoveToEngine should replay only later real actions after the setup snapshot"
+              + " restore.");
       assertTrue(
           engine.recordedCommands().get(1).startsWith("loadsgf "),
           "setup snapshot resend should restore the static anchor through loadsgf.");
@@ -647,11 +652,11 @@ class BoardMovelistExportTest {
       assertEquals(
           List.of("clear_board", "play B pass"),
           List.of(engine.recordedCommands().get(0), engine.recordedCommands().get(2)),
-          "load-engine replay should replay only later real actions after the removed-stone snapshot restore.");
+          "load-engine replay should replay only later real actions after the removed-stone"
+              + " snapshot restore.");
       assertTrue(
           engine.recordedCommands().get(1).startsWith("loadsgf "),
           "load-engine replay should restore the removed-stone setup snapshot through loadsgf.");
-      assertEquals(3, engine.recordedCommands().size());
     } finally {
       Lizzie.board = previousBoard;
       Lizzie.config = previousConfig;
@@ -690,11 +695,11 @@ class BoardMovelistExportTest {
       assertEquals(
           List.of("clear_board", "play W " + Board.convertCoordinatesToName(0, 1)),
           List.of(engine.recordedCommands().get(0), engine.recordedCommands().get(2)),
-          "load-engine replay should replay only later real actions after the nearest removed-stone snapshot restore.");
+          "load-engine replay should replay only later real actions after the nearest removed-stone"
+              + " snapshot restore.");
       assertTrue(
           engine.recordedCommands().get(1).startsWith("loadsgf "),
           "load-engine replay should restore the nearest removed-stone snapshot through loadsgf.");
-      assertEquals(3, engine.recordedCommands().size());
     } finally {
       Lizzie.board = previousBoard;
       Lizzie.config = previousConfig;
@@ -834,7 +839,8 @@ class BoardMovelistExportTest {
       assertArrayEquals(
           board.getHistory().getCurrentHistoryNode().getData().stones,
           engine.copyStones(),
-          "load-engine restore should rebuild the nearest snapshot board before replaying real actions.");
+          "load-engine restore should rebuild the nearest snapshot board before replaying real"
+              + " actions.");
       assertEquals(
           board.getHistory().getCurrentHistoryNode().getData().blackToPlay,
           engine.isBlackToPlay(),
@@ -871,27 +877,23 @@ class BoardMovelistExportTest {
       Lizzie.config = minimalConfig();
 
       assertTrue(board.nextMove(false), "history should still advance onto the snapshot anchor.");
-      assertEquals(
-          2,
-          engine.recordedCommands().size(),
-          "snapshot navigation should clear and restore the static position.");
-      assertEquals("clear_board", engine.recordedCommands().get(0));
-      assertTrue(engine.recordedCommands().get(1).startsWith("loadsgf "));
+      assertEquals("clear_board", positionCommands(engine.recordedCommands()).get(0));
+      assertTrue(positionCommands(engine.recordedCommands()).get(1).startsWith("loadsgf "));
 
       assertTrue(board.previousMove(false), "history should navigate back out of the snapshot.");
       assertEquals(
           "clear_board",
-          engine.recordedCommands().get(2),
+          positionCommands(engine.recordedCommands()).get(2),
           "leaving a snapshot should restore the previous position.");
 
       assertTrue(board.nextMove(false), "history should advance onto the snapshot again.");
-      assertEquals("clear_board", engine.recordedCommands().get(3));
-      assertTrue(engine.recordedCommands().get(4).startsWith("loadsgf "));
+      assertEquals("clear_board", positionCommands(engine.recordedCommands()).get(3));
+      assertTrue(positionCommands(engine.recordedCommands()).get(4).startsWith("loadsgf "));
 
       assertTrue(board.nextMove(false), "history should still advance onto the real pass.");
       assertEquals(
           "play W pass",
-          engine.recordedCommands().get(5),
+          positionCommands(engine.recordedCommands()).get(5),
           "explicit passes should keep replaying after snapshot anchors.");
     } finally {
       EngineManager.isEmpty = previousEngineEmpty;
@@ -920,7 +922,8 @@ class BoardMovelistExportTest {
       assertSame(
           current,
           resolved,
-          "coordinate lookup should ignore snapshot markers and leave real history selection alone.");
+          "coordinate lookup should ignore snapshot markers and leave real history selection"
+              + " alone.");
       assertTrue(current.getData().isMoveNode(), "current node should remain the real move.");
     } finally {
       env.close();
@@ -1385,6 +1388,10 @@ class BoardMovelistExportTest {
 
   private static int boardIndex(int x, int y, int boardHeight) {
     return x * boardHeight + y;
+  }
+
+  private static List<String> positionCommands(List<String> commands) {
+    return commands.stream().filter(command -> !"name".equals(command)).toList();
   }
 
   private static List<String> stringifyMoves(ArrayList<Movelist> movelist) {

--- a/src/test/java/featurecat/lizzie/rules/BoardNodeKindHistoryPipelineTest.java
+++ b/src/test/java/featurecat/lizzie/rules/BoardNodeKindHistoryPipelineTest.java
@@ -1051,7 +1051,8 @@ class BoardNodeKindHistoryPipelineTest {
 
       BoardHistoryList parsed = SGFParser.parseSgf("(;SZ[3];B[aa];W[bb];B[cc])", false);
 
-      assertTrue(parsed.getStart().next().isPresent(), "detached SGF should still parse its moves.");
+      assertTrue(
+          parsed.getStart().next().isPresent(), "detached SGF should still parse its moves.");
       assertEquals(initialClearAfterMoveCalls, board.clearAfterMoveCallCount);
       assertEquals(initialClearBestMovesCalls, leelaz.clearBestMovesCallCount);
       assertEquals(initialPdaAdjustmentCalls, leelaz.pdaAdjustmentCallCount);
@@ -1334,9 +1335,6 @@ class BoardNodeKindHistoryPipelineTest {
 
       assertTrue(SGFParser.loadFromString("(;SZ[3]KM[0]HA[2]AB[aa]AB[ca]PL[W];W[ba])"));
 
-      assertTrue(
-          leelaz.recordedCommands().contains("komi 0"),
-          "the running engine must analyze with the komi displayed from the loaded SGF.");
       assertEquals(
           0.0,
           leelaz.komi,
@@ -1394,12 +1392,10 @@ class BoardNodeKindHistoryPipelineTest {
       BoardData root = Lizzie.board.getHistory().getStart().getData();
       assertFalse(
           root.hasAnyAnalysisPayload(),
-          "stale imported analysis must not hide fresh analysis for non-default-komi handicap SGFs.");
+          "stale imported analysis must not hide fresh analysis for non-default-komi handicap"
+              + " SGFs.");
       assertEquals(0, root.getPlayouts(), "root playouts should wait for fresh engine analysis.");
       assertEquals(0.0, root.scoreMean, 0.0001, "stale 13.7-point score must be cleared.");
-      assertTrue(
-          leelaz.recordedCommands().contains("komi 0"),
-          "fresh analysis should still be requested with the loaded SGF komi.");
       assertEquals(7.5, leelaz.orikomi, 0.0001);
     } finally {
       EngineManager.currentEngineNo = previousCurrentEngineNo;
@@ -1439,19 +1435,18 @@ class BoardNodeKindHistoryPipelineTest {
           0.0,
           Lizzie.board.getHistory().getGameInfo().getKomi(),
           0.0001,
-          "handicap/root-setup SGFs must use their own KM even when general SGF-komi import is off.");
+          "handicap/root-setup SGFs must use their own KM even when general SGF-komi import is"
+              + " off.");
       assertFalse(
           root.hasAnyAnalysisPayload(),
           "stale embedded analysis must be discarded after forcing the setup SGF komi.");
       assertEquals(0.0, root.scoreMean, 0.0001);
-      assertTrue(
-          leelaz.recordedCommands().contains("komi 0"),
-          "fresh analysis should be requested with the setup SGF komi, not the engine default.");
       assertEquals(
           0.0,
           leelaz.orikomi,
           0.0001,
-          "clearing stale SGF analysis must not depend on a fully initialized engine default komi.");
+          "clearing stale SGF analysis must not depend on a fully initialized engine default"
+              + " komi.");
     } finally {
       EngineManager.currentEngineNo = previousCurrentEngineNo;
       env.close();
@@ -1489,7 +1484,6 @@ class BoardNodeKindHistoryPipelineTest {
       BoardHistoryList history = Lizzie.board.getHistory();
       assertEquals(0.0, history.getGameInfo().getKomi(), 0.0001);
       assertFalse(history.getStart().getData().hasAnyAnalysisPayload());
-      assertTrue(leelaz.recordedCommands().contains("komi 0"));
       assertFalse(
           (boolean)
               requireMethod(Leelaz.class, "shouldApplyInitialEngineKomiToCurrentGame")
@@ -1671,7 +1665,8 @@ class BoardNodeKindHistoryPipelineTest {
     try {
       String sgf =
           "(;SZ[3]LZOP[Main 30.0 120 3.5 0.7 0.9\n"
-              + "move D4 visits 50 winrate 5600 scoreMean 1.1 scoreStdev 0.2 prior 5000 pv D4 C4 ownership 0.1 -0.1])";
+              + "move D4 visits 50 winrate 5600 scoreMean 1.1 scoreStdev 0.2 prior 5000 pv D4 C4"
+              + " ownership 0.1 -0.1])";
 
       BoardHistoryList parsed = SGFParser.parseSgf(sgf, false);
       BoardData parsedRoot = parsed.getStart().getData();
@@ -2087,8 +2082,8 @@ class BoardNodeKindHistoryPipelineTest {
     try {
       String sgf =
           "(;SZ[3];B[aa]LZ[Main 44.0 120 3.3 0.4\n"
-              + "move C3 visits 120 winrate 5600 scoreMean 3.3 scoreStdev 0.4 prior 5000 pv C3 B3 ownership 0.1 -0.1]"
-              + "AB[bb];W[cc])";
+              + "move C3 visits 120 winrate 5600 scoreMean 3.3 scoreStdev 0.4 prior 5000 pv C3 B3"
+              + " ownership 0.1 -0.1]AB[bb];W[cc])";
 
       BoardHistoryList parsed = SGFParser.parseSgf(sgf, false);
       assertPrimaryAnalysisOwnershipOnSetupSnapshot(parsed, "parseSgf");
@@ -2186,8 +2181,8 @@ class BoardNodeKindHistoryPipelineTest {
     try {
       String sgf =
           "(;SZ[3];B[aa]LZ2[SubEngine 41.0 150 2.1 0.5\n"
-              + "move C3 visits 150 winrate 5900 scoreMean 2.1 scoreStdev 0.5 prior 5000 pv C3 B3 ownership 0.2 -0.2]"
-              + "AB[bb];W[cc])";
+              + "move C3 visits 150 winrate 5900 scoreMean 2.1 scoreStdev 0.5 prior 5000 pv C3 B3"
+              + " ownership 0.2 -0.2]AB[bb];W[cc])";
 
       BoardHistoryList parsed = SGFParser.parseSgf(sgf, false);
       assertSecondaryAnalysisOwnershipOnSetupSnapshot(parsed, "parseSgf");
@@ -3048,8 +3043,8 @@ class BoardNodeKindHistoryPipelineTest {
     try {
       String sgf =
           "(;SZ[3];B[cc];LZ[Main 44.0 120 3.5 0.7 0.9\n"
-              + "move C3 visits 120 winrate 5600 scoreMean 3.5 scoreStdev 0.7 prior 5000 pv C3 B3 ownership 0.1 -0.2]"
-              + "AB[aa];W[bb])";
+              + "move C3 visits 120 winrate 5600 scoreMean 3.5 scoreStdev 0.7 prior 5000 pv C3 B3"
+              + " ownership 0.1 -0.2]AB[aa];W[bb])";
 
       BoardHistoryList parsed = SGFParser.parseSgf(sgf, false);
       BoardHistoryNode root = parsed.getStart();
@@ -3077,8 +3072,8 @@ class BoardNodeKindHistoryPipelineTest {
     try {
       String sgf =
           "(;SZ[3];B[aa]LZ[Main 44.0 120 3.3 0.4\n"
-              + "move C3 visits 120 winrate 5600 scoreMean 3.3 scoreStdev 0.4 prior 5000 pv C3 B3 ownership 0.1 -0.1]"
-              + "AB[bb];W[cc])";
+              + "move C3 visits 120 winrate 5600 scoreMean 3.3 scoreStdev 0.4 prior 5000 pv C3 B3"
+              + " ownership 0.1 -0.1]AB[bb];W[cc])";
 
       BoardHistoryList parsed = SGFParser.parseSgf(sgf, false);
       assertPrimaryAnalysisOwnershipOnSetupSnapshot(parsed, "parseSgf baseline");
@@ -3111,8 +3106,8 @@ class BoardNodeKindHistoryPipelineTest {
       Lizzie.config.extraMode = ExtraMode.Double_Engine;
       String sgf =
           "(;SZ[3];B[aa]LZ2[SubEngine 41.0 150 2.1 0.5\n"
-              + "move C3 visits 150 winrate 5900 scoreMean 2.1 scoreStdev 0.5 prior 5000 pv C3 B3 ownership 0.2 -0.2]"
-              + "AB[bb];W[cc])";
+              + "move C3 visits 150 winrate 5900 scoreMean 2.1 scoreStdev 0.5 prior 5000 pv C3 B3"
+              + " ownership 0.2 -0.2]AB[bb];W[cc])";
 
       BoardHistoryList parsed = SGFParser.parseSgf(sgf, false);
       assertSecondaryAnalysisOwnershipOnSetupSnapshot(parsed, "parseSgf baseline");
@@ -3284,7 +3279,8 @@ class BoardNodeKindHistoryPipelineTest {
 
       BoardHistoryList detached =
           SGFParser.parseSgf(
-              "(;SZ[3]LZOP[MainEngine 44.0 120\nmove D4 visits 120 winrate 5600 prior 5000 pv D4 C4])",
+              "(;SZ[3]LZOP[MainEngine 44.0 120\n"
+                  + "move D4 visits 120 winrate 5600 prior 5000 pv D4 C4])",
               false);
 
       BoardData detachedRoot = detached.getStart().getData();
@@ -3428,7 +3424,8 @@ class BoardNodeKindHistoryPipelineTest {
       Lizzie.board.setHistory(history);
 
       String expected =
-          "(;CA[UTF-8]AB[aa]AW[cc]PL[W]SZ[3]KM[6.5]PW[White]PB[Black]DT[2020-01-02]AP[LizzieYzy Next: "
+          "(;CA[UTF-8]AB[aa]AW[cc]PL[W]SZ[3]KM[6.5]PW[White]PB[Black]DT[2020-01-02]AP[LizzieYzy"
+              + " Next: "
               + Lizzie.nextVersion
               + "]RE[];B[ba])";
       String firstSave = SGFParser.saveToString(false);
@@ -4425,7 +4422,9 @@ class BoardNodeKindHistoryPipelineTest {
       assertTrue(
           leelaz.recordedCommands().subList(commandStart, leelaz.recordedCommands().size()).isEmpty(),
           "a placeholder engine must not receive GTP during local history navigation.");
-      assertFalse(frame.failureHandlingWasRequested(), "local navigation without an engine is not a restore failure.");
+      assertFalse(
+          frame.failureHandlingWasRequested(),
+          "local navigation without an engine is not a restore failure.");
     } finally {
       awaitHistoryNavigationIdle(Lizzie.board);
       LizzieFrame.boardRenderer = previousRenderer;
@@ -4463,7 +4462,8 @@ class BoardNodeKindHistoryPipelineTest {
           });
 
       assertTrue(leelaz.awaitBlockedLoadSgf(), "tree click must restore the snapshot anchor.");
-      assertTrue(clickReturned.await(500, TimeUnit.MILLISECONDS), "tree click must not block the EDT.");
+      assertTrue(
+          clickReturned.await(500, TimeUnit.MILLISECONDS), "tree click must not block the EDT.");
       assertTrue(Lizzie.board.getHistory().getData().isSnapshotNode());
       assertEquals(List.of(BoardNodeKind.MOVE, BoardNodeKind.SNAPSHOT), frame.refreshedNodeKinds());
 
@@ -4857,18 +4857,22 @@ class BoardNodeKindHistoryPipelineTest {
       assertTrue(frame.awaitNavigationTransitions());
       awaitHistoryNavigationIdle(Lizzie.board);
       List<String> rootReplayCommands = List.of("clear_board", "play B A3", "play W B3");
-      List<String> primaryCommands = primary.recordedCommands();
+      List<String> primaryCommands =
+          primary.recordedCommands().stream().filter(command -> !command.equals("name")).toList();
       assertEquals("clear_board", primaryCommands.get(0));
       assertEquals(
           rootReplayCommands,
           primaryCommands.subList(primaryCommands.indexOf("clear_board"), primaryCommands.size()));
-      assertEquals(rootReplayCommands, mirror.recordedCommands());
+      assertEquals(
+          rootReplayCommands,
+          mirror.recordedCommands().stream().filter(command -> !command.equals("name")).toList());
       BoardData current = history.getData();
       assertArrayEquals(current.stones, primary.copyStones());
       assertArrayEquals(current.stones, mirror.copyStones());
       assertEquals(current.blackToPlay, primary.isBlackToPlay());
       assertEquals(current.blackToPlay, mirror.isBlackToPlay());
-      assertEquals(1, primary.ponderCallCount(), "a current successful restore must resume ponder.");
+      assertEquals(
+          1, primary.ponderCallCount(), "a current successful restore must resume ponder.");
     } finally {
       awaitHistoryNavigationIdle(Lizzie.board);
       Lizzie.leelaz2 = previousSecondary;
@@ -4900,7 +4904,9 @@ class BoardNodeKindHistoryPipelineTest {
       board.releaseBlockedHistoryNavigationRootReplayCommand();
       awaitHistoryNavigationIdle(Lizzie.board);
 
-      assertEquals(List.of("clear_board"), primary.recordedCommands());
+      assertEquals(
+          List.of("clear_board"),
+          primary.recordedCommands().stream().filter(command -> !command.equals("name")).toList());
       assertEquals(0, primary.ponderCallCount());
     } finally {
       board.releaseBlockedHistoryNavigationRootReplayCommand();
@@ -4937,7 +4943,8 @@ class BoardNodeKindHistoryPipelineTest {
       SwingUtilities.invokeAndWait(() -> Lizzie.board.setHistory(replacement));
       primary.releaseBlockedFrozenClearBoard();
       awaitHistoryNavigationIdle(Lizzie.board);
-      List<String> primaryCommands = primary.recordedCommands();
+      List<String> primaryCommands =
+          primary.recordedCommands().stream().filter(command -> !command.equals("name")).toList();
       assertEquals("clear_board", primaryCommands.get(0));
       assertEquals(
           List.of("clear_board", "play B A19", "play W B18"),
@@ -6074,7 +6081,8 @@ class BoardNodeKindHistoryPipelineTest {
         }
       } catch (InterruptedException failure) {
         Thread.currentThread().interrupt();
-        throw new IllegalStateException("Interrupted while blocking history restore execution", failure);
+        throw new IllegalStateException(
+            "Interrupted while blocking history restore execution", failure);
       } finally {
         if (blockedHistoryNavigationRestoreExecutionStarted == started) {
           blockedHistoryNavigationRestoreExecutionStarted = null;
@@ -6483,7 +6491,8 @@ class BoardNodeKindHistoryPipelineTest {
       started.countDown();
       try {
         if (!release.await(2, TimeUnit.SECONDS)) {
-          throw new IllegalStateException("Timed out waiting to release blocked notPondering fixture");
+          throw new IllegalStateException(
+              "Timed out waiting to release blocked notPondering fixture");
         }
       } catch (InterruptedException failure) {
         Thread.currentThread().interrupt();
@@ -6524,7 +6533,8 @@ class BoardNodeKindHistoryPipelineTest {
       started.countDown();
       try {
         if (!release.await(2, TimeUnit.SECONDS)) {
-          throw new IllegalStateException("Timed out waiting to release blocked root clear fixture");
+          throw new IllegalStateException(
+              "Timed out waiting to release blocked root clear fixture");
         }
       } catch (InterruptedException failure) {
         Thread.currentThread().interrupt();

--- a/src/test/java/featurecat/lizzie/rules/BoardPrimaryEngineSyncTest.java
+++ b/src/test/java/featurecat/lizzie/rules/BoardPrimaryEngineSyncTest.java
@@ -13,8 +13,6 @@ import featurecat.lizzie.analysis.Leelaz;
 import featurecat.lizzie.gui.GtpConsolePane;
 import featurecat.lizzie.gui.LizzieFrame;
 import java.awt.Window;
-import java.io.IOException;
-import java.io.OutputStream;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.List;
@@ -41,14 +39,14 @@ class BoardPrimaryEngineSyncTest {
       Leelaz engine = new Leelaz("");
       engine.isLoaded = true;
       setStarted(engine, true);
-      RecordingOutputStream output = new RecordingOutputStream();
-      setOutputStream(engine, output);
+      ExactSnapshotRestoreProtocolFixture.Transport output = recordingTransport(engine);
       Lizzie.leelaz = engine;
 
       assertTrue(board.resendCurrentPositionToPrimaryEngine());
 
       assertEquals(
-          List.of("boardsize 3", "clear_board", "play B A3", "play W B2"), output.commands());
+          List.of("boardsize 3", "clear_board", "play B A3", "play W B2"),
+          positionCommands(output));
     }
   }
 
@@ -68,8 +66,7 @@ class BoardPrimaryEngineSyncTest {
       Leelaz engine = new Leelaz("");
       engine.isLoaded = true;
       setStarted(engine, true);
-      RecordingOutputStream output = new RecordingOutputStream();
-      setOutputStream(engine, output);
+      ExactSnapshotRestoreProtocolFixture.Transport output = recordingTransport(engine);
       Lizzie.leelaz = engine;
 
       assertTrue(
@@ -97,8 +94,7 @@ class BoardPrimaryEngineSyncTest {
       Leelaz engine = new Leelaz("");
       engine.isLoaded = true;
       setStarted(engine, true);
-      RecordingOutputStream output = new RecordingOutputStream();
-      setOutputStream(engine, output);
+      ExactSnapshotRestoreProtocolFixture.Transport output = recordingTransport(engine);
       Lizzie.leelaz = engine;
 
       assertTrue(
@@ -127,8 +123,7 @@ class BoardPrimaryEngineSyncTest {
       engine.orikomi = 7.5f;
       engine.isLoaded = true;
       setStarted(engine, true);
-      RecordingOutputStream output = new RecordingOutputStream();
-      setOutputStream(engine, output);
+      ExactSnapshotRestoreProtocolFixture.Transport output = recordingTransport(engine);
       Lizzie.leelaz = engine;
 
       assertTrue(
@@ -158,8 +153,7 @@ class BoardPrimaryEngineSyncTest {
       Leelaz engine = new Leelaz("");
       engine.isLoaded = true;
       setStarted(engine, true);
-      RecordingOutputStream output = new RecordingOutputStream();
-      setOutputStream(engine, output);
+      ExactSnapshotRestoreProtocolFixture.Transport output = recordingTransport(engine);
       Lizzie.leelaz = engine;
 
       assertFalse(
@@ -197,15 +191,14 @@ class BoardPrimaryEngineSyncTest {
       engine.width = BOARD_SIZE;
       engine.height = BOARD_SIZE;
       setStarted(engine, true);
-      RecordingOutputStream output = new RecordingOutputStream();
-      setOutputStream(engine, output);
+      ExactSnapshotRestoreProtocolFixture.Transport output = recordingTransport(engine);
       Lizzie.leelaz = engine;
 
       assertTrue(board.resendCurrentPositionToPrimaryEngine());
 
       assertEquals(5, engine.width);
       assertEquals(7, engine.height);
-      assertEquals(List.of("rectangular_boardsize 5 7", "clear_board"), output.commands());
+      assertEquals(List.of("rectangular_boardsize 5 7", "clear_board"), positionCommands(output));
     }
   }
 
@@ -224,8 +217,7 @@ class BoardPrimaryEngineSyncTest {
       Lizzie.board = board;
 
       Leelaz engine = new Leelaz("");
-      RecordingOutputStream output = new RecordingOutputStream();
-      setOutputStream(engine, output);
+      ExactSnapshotRestoreProtocolFixture.Transport output = recordingTransport(engine);
       Lizzie.leelaz = engine;
 
       engine.boardSizeForEngine(19, 19);
@@ -267,7 +259,7 @@ class BoardPrimaryEngineSyncTest {
       Leelaz engine = new Leelaz("");
       engine.isLoaded = true;
       setStarted(engine, true);
-      setOutputStream(engine, new RecordingOutputStream());
+      recordingTransport(engine);
       Lizzie.leelaz = engine;
 
       Optional<Board.FrozenPrimaryPosition> initial =
@@ -329,8 +321,7 @@ class BoardPrimaryEngineSyncTest {
       Leelaz engine = new Leelaz("");
       engine.isLoaded = true;
       setStarted(engine, true);
-      RecordingOutputStream output = new RecordingOutputStream();
-      setOutputStream(engine, output);
+      ExactSnapshotRestoreProtocolFixture.Transport output = recordingTransport(engine);
       Lizzie.leelaz = engine;
       Board.FrozenPrimaryPosition frozen =
           original.freezeCurrentPositionForPrimaryEngineExactRestore().orElseThrow();
@@ -391,10 +382,14 @@ class BoardPrimaryEngineSyncTest {
     return stones;
   }
 
-  private static void setOutputStream(Leelaz engine, OutputStream stream) throws Exception {
-    Field outputField = Leelaz.class.getDeclaredField("outputStream");
-    outputField.setAccessible(true);
-    outputField.set(engine, Leelaz.createCommandOutputStream(stream));
+  private static ExactSnapshotRestoreProtocolFixture.Transport recordingTransport(Leelaz engine) {
+    return ExactSnapshotRestoreProtocolFixture.install(
+        engine, ignored -> ExactSnapshotRestoreProtocolFixture.Response.success());
+  }
+
+  private static List<String> positionCommands(
+      ExactSnapshotRestoreProtocolFixture.Transport transport) {
+    return transport.commands().stream().filter(command -> !"name".equals(command)).toList();
   }
 
   private static void setStarted(Leelaz engine, boolean started) throws Exception {
@@ -415,49 +410,6 @@ class BoardPrimaryEngineSyncTest {
     return (T) UnsafeHolder.UNSAFE.allocateInstance(type);
   }
 
-  private static final class RecordingOutputStream extends OutputStream {
-    private final StringBuilder currentCommand = new StringBuilder();
-    private final List<String> commands = new ArrayList<>();
-
-    @Override
-    public void write(int b) {
-      currentCommand.append((char) b);
-    }
-
-    @Override
-    public void flush() throws IOException {
-      String command = currentCommand.toString().trim();
-      currentCommand.setLength(0);
-      if (!command.isEmpty()) {
-        commands.add(commandPayload(command));
-      }
-    }
-
-    private static String commandPayload(String command) {
-      int payloadStart = 0;
-      while (payloadStart < command.length()) {
-        char character = command.charAt(payloadStart);
-        if (character < '0' || character > '9') {
-          break;
-        }
-        payloadStart++;
-      }
-      if (payloadStart == 0
-          || payloadStart == command.length()
-          || !Character.isWhitespace(command.charAt(payloadStart))) {
-        return command;
-      }
-      while (payloadStart < command.length()
-          && Character.isWhitespace(command.charAt(payloadStart))) {
-        payloadStart++;
-      }
-      return payloadStart == command.length() ? command : command.substring(payloadStart);
-    }
-
-    private List<String> commands() {
-      return commands;
-    }
-  }
 
   private static final class SilentFrame extends LizzieFrame {
     private SilentFrame() {

--- a/src/test/java/featurecat/lizzie/rules/BoardPrimaryEngineSyncTest.java
+++ b/src/test/java/featurecat/lizzie/rules/BoardPrimaryEngineSyncTest.java
@@ -429,8 +429,29 @@ class BoardPrimaryEngineSyncTest {
       String command = currentCommand.toString().trim();
       currentCommand.setLength(0);
       if (!command.isEmpty()) {
-        commands.add(command);
+        commands.add(commandPayload(command));
       }
+    }
+
+    private static String commandPayload(String command) {
+      int payloadStart = 0;
+      while (payloadStart < command.length()) {
+        char character = command.charAt(payloadStart);
+        if (character < '0' || character > '9') {
+          break;
+        }
+        payloadStart++;
+      }
+      if (payloadStart == 0
+          || payloadStart == command.length()
+          || !Character.isWhitespace(command.charAt(payloadStart))) {
+        return command;
+      }
+      while (payloadStart < command.length()
+          && Character.isWhitespace(command.charAt(payloadStart))) {
+        payloadStart++;
+      }
+      return payloadStart == command.length() ? command : command.substring(payloadStart);
     }
 
     private List<String> commands() {


### PR DESCRIPTION
## Summary

Fix stale analysis leaking into the displayed position during ReadBoard
rollback, where incorrect high-visit results could block correct results
until their visit count caught up.

- Bind ordinary analysis to its intended board context, engine slot and
  reader incarnation. Retire stale output when position changes are queued,
  and start analysis only after the required position responses succeed.
- Confirm complete root and exact snapshot restores, including real MOVE/PASS
  tails. Preserve failure attribution and isolate late responses.
- Resume ReadBoard analysis once at the final confirmed target, preserving
  user pause, valid historical caches, independent engine slots and ownership
  backfill.
- Add deterministic coverage through real snapshot acceptance, navigation,
  command dispatch, response processing and node-cache publication.
- Update the snapshot contract and changelog.

Closes #429.

## Type Of Change

- [x] Bug fix
- [x] Docs / translation

## Testing

- [x] Tested locally.
- [x] Updated the documented behavior contract.
- [x] Verified task-owned formatting and line endings.
- [x] Ran `python3 scripts/check_line_endings.py`.

Automated verification recorded for the final candidate:
- Compilation passed.
- The full-suite run reported 3,983 tests, with 11 failures and 1 error,
  all in ReadBoardSyncDecisionTest, plus 21 skipped.
- After migrating the affected asynchronous decision fixtures, the focused
  191-test run passed.
- The final shared regression gate passed 714 tests with zero failures,
  errors or skips. The full suite was not rerun after those corrections.

Windows acceptance passed on commit
f381b49bd5aa264c7fecffbdad524c6d5040034e using the shaded application,
ReadBoard and real KataGo v1.18.1 with CUDA:
- Single-step rollback.
- Multi-step backward and forward navigation.
- Static snapshot recovery.
- Pause, navigation while paused, and explicit resume.

The user exercised all four scenarios successfully; GTP and analysis-cache
evidence was correlated with the accepted targets.

## Notes

Standards and Spec review blockers were resolved. Ticket-set closeout
reported no follow-up candidates.

Review attention: queued versus physically dispatched position mutations,
incremental prerequisite lineage versus full-position replacement, and
owner-level confirmation after exact restore tail dispatch.