### PR TITLE
fix(sync): retire local confirmations on stop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable maintenance updates to this fork are documented here.
 
 ## Unreleased
 
+- Preserve local moves after stopping ReadBoard synchronization and retire obsolete placement confirmations and queued output (#432).
 - Preserved diagnostic log record boundaries and stack-trace whitespace during export without weakening privacy redaction (#431).
 - Made diagnostic export estimates describe approximate uncompressed content, pruned proven irrelevant archives before reading using native Windows file identities where needed, and displayed publication success independently of folder opening (#430).
 - Wait for confirmed engine positions before starting ordinary analysis after moves and history navigation; resume ReadBoard analysis once at the final synchronized position while preserving valid node caches (#429).

--- a/docs/SNAPSHOT_NODE_KIND.md
+++ b/docs/SNAPSHOT_NODE_KIND.md
@@ -208,6 +208,36 @@ ReadBoard 协议里的 `pass` 行在自动落子/交换顺序链路中表示用�
 - 任一初始或 catch-up restore 失败都 fail-closed：目标引擎置为 unavailable、不发送 ponder/analyze、释放 lifecycle reservation、结束 initial synchronization 状态、走既有引擎同步失败提示；不执行猜测性 root fallback。
 - `ExactSnapshotEngineRestore` 继续只负责单份 immutable exact plan；追赶最新棋盘的 lifecycle 收敛逻辑只属于 EngineManager 的 initial startup owner，不进入 exact module。
 
+## 连续同步与本地落子确认权限（Issue #432）
+
+- 本地落子的远端确认权限属于当前连接的 `ReadBoard`，仅在 helper 未退役、仍为窗口当前
+  helper、连续同步 `syncBoard` 开启且双向模式 `bothSync` 有效时成立。管道与 socket
+  保留各自传输可用性条件；帧处理标志 `isSyncing` 不表示连续同步权限。
+- `Board` 出站与本地落子抑制、`ReadBoard` 直接 placement admission、重试和最终失败
+  提交使用同一权限。停止后 helper 可以保持连接，本地 MOVE 按普通棋盘规则保留。
+- `stopsync` / `endsync` 退役 pending ACK identity，清除 confirmed protection 和失败
+  落子观察／抑制，并执行已有 placement UI cleanup。停止既不删除 pending MOVE，也不
+  声称远端已确认它；停止本身不创建 `MOVE/PASS/SNAPSHOT`。
+- pending 创建、ACK 结清、停止退役与最终失败提交由 ReadBoard 的短确认状态临界区串行化；
+  history 提交先取得既有 Board monitor，再进入确认临界区。确认临界区不等待引擎、
+  helper 输出或 EDT，也不取得 ReadBoard/GMA monitor。Board 负责纯 history 删除及 revision。
+  本地落子的 pending／失败抑制检查也在同一 Board monitor 内、history 变更之前执行。
+- 失败提交同时验证 helper、ACK generation、pending node、Board/history identity 和 mainEnd。
+  停止先退役时，旧 callback 不删谱、不建立失败抑制、不启动旧节点引擎恢复；有效失败先
+  提交时，该 history 决定保留，随后在临界区外按当前盘面与既有 primary generation fence
+  恢复引擎。GMA 仍由原 session/engine arbitration owner 决定恢复归属。
+- 出站 placement 捕获 pending identity；管道与 socket 均在实际输出锁取得后、开始写入前
+  复验。已开始的写入或 helper 已接受的物理点击不能撤回。阻塞输出不占用 EDT 或确认状态锁。
+- shutdown、helper replacement、外部换谱使旧 captured work 对当前棋盘失去权限。
+  `clear` 与同尺寸 `start` 是活动帧边界，仍保留 pending 供随后快照确认；尺寸变化沿用
+  既有 history/resume 失效规则。
+  `end` 才提交一帧；`endsync` 直接退役并丢弃未提交采样，不隐式提交缓冲快照。
+- `placeComplete` 只表示点击完成提示，匹配快照才是 ACK 证据。无编号的旧 wire failure
+  不能与新 pending 可靠关联，继续遵守活动同步既有失败策略；host callback identity 不等于
+  wire request ID。
+- 暂停时保留有效 `resumeState` / `lastResolvedSnapshotNode` 和 first-frame re-arming。
+  主动恢复后，远端快照仍按既有匹配／重建规则决定同步盘面；单次读盘不要求先开启连续同步。
+
 ## 同步决策规则
 
 同步主流程只允许四类结果：

--- a/src/main/java/featurecat/lizzie/analysis/ReadBoard.java
+++ b/src/main/java/featurecat/lizzie/analysis/ReadBoard.java
@@ -46,6 +46,9 @@ import javax.swing.SwingUtilities;
 public class ReadBoard implements ReadBoardTrackingEligibilityAdapter.EligibilitySource {
   private static final AtomicLongFieldUpdater<ReadBoard> SYNC_ANALYSIS_EPOCH =
       AtomicLongFieldUpdater.newUpdater(ReadBoard.class, "syncAnalysisEpoch");
+  // The application has one live board. Lock order: Board -> confirmation state.
+  // Never acquire Board/ReadBoard monitors, perform I/O, or hand off to the EDT under this lock.
+  private static final Object LOCAL_MOVE_CONFIRMATION_LOCK = new Object();
   private static final AtomicInteger PLACE_COMMAND_DISPATCH_THREAD_SEQUENCE = new AtomicInteger();
   private static final Executor PLACE_COMMAND_DISPATCH_EXECUTOR =
       Executors.newCachedThreadPool(ReadBoard::newPlaceCommandDispatchThread);
@@ -219,6 +222,9 @@ public class ReadBoard implements ReadBoardTrackingEligibilityAdapter.Eligibilit
   private Stone pendingLocalMoveColor = Stone.EMPTY;
   private String pendingLocalMoveBaselineKey = "";
   private long pendingLocalMoveAckGeneration = 0L;
+  private Board pendingLocalMoveBoard;
+  private BoardHistoryList pendingLocalMoveHistory;
+  private Executor placeCommandDispatcher;
   // Readboard placeComplete has no request id, so a late success from the previous command must
   // never be allowed to confirm the next pending move. Explicit failures still release the current
   // pending move; otherwise a missed click can wait forever with no follow-up snapshot.
@@ -756,7 +762,7 @@ public class ReadBoard implements ReadBoardTrackingEligibilityAdapter.Eligibilit
     if (line.startsWith("error")) {
       Lizzie.gtpConsole.addLineReadBoard(line + (usePipe ? "" : "\n"));
     }
-    if (line.startsWith("end")) {
+    if (line.trim().equals("end")) {
       boolean isYikePlatform =
           pendingRemoteContext != null
               && pendingRemoteContext.platform == SyncRemoteContext.SyncPlatform.YIKE;
@@ -795,7 +801,9 @@ public class ReadBoard implements ReadBoardTrackingEligibilityAdapter.Eligibilit
       publishCurrentReadBoardDiagnosticsSnapshot();
     }
     if (line.trim().equals("sync")) {
-      Lizzie.frame.syncBoard = true;
+      synchronized (LOCAL_MOVE_CONFIRMATION_LOCK) {
+        Lizzie.frame.syncBoard = true;
+      }
       if (isFailedLocalMoveAwaitingRemoteObservation()) {
         localMoveSyncDebug(
             "sync line resumes analysis while failed-place guard only blocks placement "
@@ -809,14 +817,19 @@ public class ReadBoard implements ReadBoardTrackingEligibilityAdapter.Eligibilit
       }
     }
     if (line.startsWith("both")) {
-      Lizzie.frame.bothSync = true;
+      synchronized (LOCAL_MOVE_CONFIRMATION_LOCK) {
+        Lizzie.frame.bothSync = true;
+      }
       if (Lizzie.frame.floatBoard != null && Lizzie.frame.floatBoard.isVisible())
         Lizzie.frame.floatBoard.setEditButton();
     }
     if (line.startsWith("noboth")) {
       clearReadBoardGmaAutoPlay("noboth");
       readBoardTurnTrusted = false;
-      Lizzie.frame.bothSync = false;
+      synchronized (LOCAL_MOVE_CONFIRMATION_LOCK) {
+        Lizzie.frame.bothSync = false;
+        clearPendingLocalMoveTracking();
+      }
       if (Lizzie.frame.floatBoard != null && Lizzie.frame.floatBoard.isVisible())
         Lizzie.frame.floatBoard.setEditButton();
     }
@@ -826,34 +839,34 @@ public class ReadBoard implements ReadBoardTrackingEligibilityAdapter.Eligibilit
       LizzieFrame.toolbar.isAutoPlay = false;
     }
     if (line.startsWith("endsync")) {
+      stopLocalMoveConfirmation();
       clearReadBoardGmaAutoPlay("endsync");
       noMsg = true;
-      resetActiveSyncStateForReadBoardControlLine();
       clearPendingRemoteContext();
       tempcount = new ArrayList<Integer>();
-      Lizzie.frame.syncBoard = false;
       if (Lizzie.frame.isAnaPlayingAgainstLeelaz) {
         Lizzie.frame.stopAiPlayingAndPolicy();
       }
       showInBoard = false;
       if (Lizzie.frame.floatBoard != null) {
-        Lizzie.frame.floatBoard.setVisible(false);
+        FloatBoard floatBoard = Lizzie.frame.floatBoard;
+        SwingUtilities.invokeLater(() -> floatBoard.setVisible(false));
       }
       publishCurrentReadBoardDiagnosticsSnapshot();
     }
     if (line.startsWith("stopsync")) {
+      stopLocalMoveConfirmation();
       clearReadBoardGmaAutoPlay("stopsync");
-      resetActiveSyncStateForReadBoardControlLine();
       clearPendingRemoteContext();
       tempcount = new ArrayList<Integer>();
-      Lizzie.frame.syncBoard = false;
       if (Lizzie.frame.isAnaPlayingAgainstLeelaz) {
         Lizzie.frame.stopAiPlayingAndPolicy();
       }
       Lizzie.leelaz.nameCmd();
       showInBoard = false;
       if (Lizzie.frame.floatBoard != null) {
-        Lizzie.frame.floatBoard.setVisible(false);
+        FloatBoard floatBoard = Lizzie.frame.floatBoard;
+        SwingUtilities.invokeLater(() -> floatBoard.setVisible(false));
       }
       publishCurrentReadBoardDiagnosticsSnapshot();
     }
@@ -1116,118 +1129,91 @@ public class ReadBoard implements ReadBoardTrackingEligibilityAdapter.Eligibilit
   }
 
   private boolean handlePendingLocalMovePlacementFailure(String reason) {
+    long generation;
+    BoardHistoryNode node;
+    synchronized (LOCAL_MOVE_CONFIRMATION_LOCK) {
+      generation = pendingLocalMoveAckGeneration;
+      node = pendingLocalMoveNode;
+    }
+    return handlePendingLocalMovePlacementFailure(reason, generation, node);
+  }
+
+  private boolean handlePendingLocalMovePlacementFailure(
+      String reason, long generation, BoardHistoryNode node) {
+    Board board = Lizzie.board;
+    if (board == null) {
+      return false;
+    }
+    Optional<BoardHistoryNode> rollbackNode;
+    Leelaz engine = Lizzie.leelaz;
+    long engineGeneration = Lizzie.capturePrimaryEngineGeneration(engine);
+    synchronized (board) {
+      synchronized (LOCAL_MOVE_CONFIRMATION_LOCK) {
+        if (!isCurrentLocalMoveConfirmation(generation, node)) {
+          return false;
+        }
+        clearConfirmedLocalMove();
+        rememberFailedLocalMoveSuppression();
+        rollbackNode = discardFailedLocalMoveFromMainEnd();
+        clearPendingLocalMoveTracking();
+        if (failedLocalMoveRecoveryActive) {
+          beginFailedLocalMoveObservationGuard();
+        }
+        rollbackNode.ifPresent(this::bindFailedLocalMoveSuppressionBaseline);
+      }
+    }
+    restoreFloatBoardAfterPlaceResult();
     if (ReadBoardObservation.diagnosticsEnabled()) {
       observe(() -> ReadBoardObservation.recordLocalMove("failed", reason));
     }
-    localMoveSyncDebug(
-        "pending local move placement failure reason="
-            + reason
-            + " before "
-            + pendingLocalMoveState());
-    restoreFloatBoardAfterPlaceResult();
-    if (isPendingLocalMoveAwaitingReadBoard()) {
-      clearConfirmedLocalMove();
-      rememberFailedLocalMoveSuppression();
-      Optional<BoardHistoryNode> rollbackNode = discardFailedLocalMoveFromMainEnd();
-      clearPendingLocalMoveTracking();
-      if (failedLocalMoveRecoveryActive) {
-        beginFailedLocalMoveObservationGuard();
+    if (rollbackNode.isPresent()
+        && Lizzie.board == board
+        && Lizzie.frame != null
+        && Lizzie.frame.readBoard == this
+        && Lizzie.capturePrimaryEngineGeneration(engine) == engineGeneration) {
+      BoardHistoryNode current = board.getHistory().getCurrentHistoryNode();
+      if (!deferReadBoardGmaEngineRestoreIfPending("placeFailed", current)) {
+        Optional<Board.FrozenPrimaryPosition> recovery =
+            board.freezeCurrentPositionForPrimaryEngineExactRestore();
+        if (recovery.isPresent()
+            && Lizzie.runIfPrimaryEngine(engine, engineGeneration, engine::notPondering)) {
+          recovery.get().execute();
+          if (recovery.get().matchesCurrentBoardAndPrimary()
+              && hasLocalMoveConfirmationAuthority()) {
+            continueGameAfterSyncIfNeeded("placeFailed", current);
+          }
+        }
       }
-      if (rollbackNode.isPresent()) {
-        bindFailedLocalMoveSuppressionBaseline(rollbackNode.get());
-        syncEngineToRebuiltSnapshot(rollbackNode.get());
-        localMoveSyncDebug(
-            "placement failed rolled back; resume analysis with placement guard baseline="
-                + historyNodeSummary(rollbackNode.get())
-                + " "
-                + pendingLocalMoveState());
-        continueGameAfterSyncIfNeeded("placeFailed", rollbackNode.get());
-      } else if (failedLocalMoveRecoveryActive) {
-        localMoveSyncDebug(
-            "placement failed keeps placement guard without rollback " + pendingLocalMoveState());
+      if (Lizzie.frame != null) {
+        Lizzie.frame.redrawTree = true;
+        Lizzie.frame.renderVarTree(0, 0, false, false);
+        Lizzie.frame.refresh();
       }
-    } else {
-      localMoveSyncDebug(
-          "pending local move placement failure ignored no pending reason="
-              + reason
-              + " "
-              + pendingLocalMoveState());
     }
-    localMoveSyncDebug(
-        "pending local move placement failure after reason="
-            + reason
-            + " "
-            + pendingLocalMoveState());
     return true;
   }
 
+  private boolean isCurrentLocalMoveConfirmation(long generation, BoardHistoryNode node) {
+    return hasLocalMoveConfirmationAuthority()
+        && isPendingLocalMoveAwaitingReadBoard()
+        && generation == pendingLocalMoveAckGeneration
+        && node != null
+        && node == pendingLocalMoveNode
+        && Lizzie.board == pendingLocalMoveBoard
+        && pendingLocalMoveBoard.getHistory() == pendingLocalMoveHistory
+        && pendingLocalMoveHistory.getMainEnd() == node;
+  }
+
   private Optional<BoardHistoryNode> discardFailedLocalMoveFromMainEnd() {
-    if (!failedLocalMoveRecoveryActive
-        || Lizzie.board == null
-        || Lizzie.board.getHistory() == null) {
-      localMoveSyncDebug(
-          "discard failed local move skip missing recovery " + pendingLocalMoveState());
+    if (!failedLocalMoveRecoveryActive || !matchesFailedLocalMove(pendingLocalMoveNode)) {
       return Optional.empty();
     }
-    BoardHistoryList history = Lizzie.board.getHistory();
-    BoardHistoryNode failedNode = history.getMainEnd();
-    if (pendingLocalMoveNode != null && failedNode != pendingLocalMoveNode) {
-      localMoveSyncDebug(
-          "discard failed local move skip main end moved away from pending node mainEnd="
-              + historyNodeSummary(failedNode)
-              + " pendingNode="
-              + historyNodeSummary(pendingLocalMoveNode)
-              + " "
-              + pendingLocalMoveState());
-      return Optional.empty();
+    Optional<BoardHistoryNode> rollback =
+        pendingLocalMoveBoard.discardFailedReadBoardMove(pendingLocalMoveNode);
+    if (rollback.isPresent()) {
+      historyJumpTracker.clear();
     }
-    if (failedNode == null || !matchesFailedLocalMove(failedNode)) {
-      localMoveSyncDebug(
-          "discard failed local move skip no matching main end node="
-              + historyNodeSummary(failedNode)
-              + " "
-              + pendingLocalMoveState());
-      return Optional.empty();
-    }
-    Optional<BoardHistoryNode> previous = failedNode.previous();
-    if (!previous.isPresent()) {
-      localMoveSyncDebug(
-          "discard failed local move skip no previous node="
-              + historyNodeSummary(failedNode)
-              + " "
-              + pendingLocalMoveState());
-      return Optional.empty();
-    }
-    BoardHistoryNode rollbackNode = previous.get();
-    int childIndex = rollbackNode.indexOfNode(failedNode);
-    if (childIndex < 0) {
-      localMoveSyncDebug(
-          "discard failed local move skip child not linked failed="
-              + historyNodeSummary(failedNode)
-              + " rollback="
-              + historyNodeSummary(rollbackNode)
-              + " "
-              + pendingLocalMoveState());
-      return Optional.empty();
-    }
-    moveToAnyPositionWithoutTracking(rollbackNode);
-    rollbackNode.deleteChild(childIndex);
-    historyJumpTracker.clear();
-    localMoveSyncDebug(
-        "discard failed local move rollback="
-            + historyNodeSummary(rollbackNode)
-            + " removed="
-            + historyNodeSummary(failedNode)
-            + " childIndex="
-            + childIndex
-            + " "
-            + pendingLocalMoveState());
-    if (Lizzie.frame != null) {
-      Lizzie.frame.redrawTree = true;
-      Lizzie.frame.renderVarTree(0, 0, false, false);
-      Lizzie.frame.refresh();
-    }
-    return Optional.of(rollbackNode);
+    return rollback;
   }
 
   private boolean matchesFailedLocalMove(BoardHistoryNode node) {
@@ -1245,11 +1231,21 @@ public class ReadBoard implements ReadBoardTrackingEligibilityAdapter.Eligibilit
   }
 
   private void restoreFloatBoardAfterPlaceResult() {
-    if (hideFloadBoardBeforePlace && hideFromPlace) {
-      hideFromPlace = false;
-      if (Lizzie.frame != null && Lizzie.frame.floatBoard != null) {
-        Lizzie.frame.floatBoard.setVisible(true);
-      }
+    FloatBoard floatBoard = Lizzie.frame == null ? null : Lizzie.frame.floatBoard;
+    if (floatBoard == null) {
+      return;
+    }
+    Runnable restore =
+        () -> {
+          if (hideFromPlace) {
+            hideFromPlace = false;
+            floatBoard.setVisible(true);
+          }
+        };
+    if (SwingUtilities.isEventDispatchThread()) {
+      restore.run();
+    } else {
+      SwingUtilities.invokeLater(restore);
     }
   }
 
@@ -2894,6 +2890,14 @@ public class ReadBoard implements ReadBoardTrackingEligibilityAdapter.Eligibilit
     }
   }
 
+  private void stopLocalMoveConfirmation() {
+    synchronized (LOCAL_MOVE_CONFIRMATION_LOCK) {
+      Lizzie.frame.syncBoard = false;
+      resetActiveSyncState();
+    }
+    restoreFloatBoardAfterPlaceResult();
+  }
+
   private void resetActiveSyncState() {
     resetActiveSyncState(false, false, false);
   }
@@ -2903,14 +2907,16 @@ public class ReadBoard implements ReadBoardTrackingEligibilityAdapter.Eligibilit
   }
 
   private void resetActiveSyncStateForReadBoardControlLine() {
-    boolean preserveFailedLocalMoveState = hasFailedLocalMoveStateToPreserve();
-    boolean preservePendingLocalMove = isPendingLocalMoveAwaitingReadBoard();
-    boolean preserveConfirmedLocalMove = confirmedLocalMoveActive;
-    resetActiveSyncState(
-        preserveFailedLocalMoveState,
-        preserveFailedLocalMoveState,
-        preservePendingLocalMove,
-        preserveConfirmedLocalMove);
+    synchronized (LOCAL_MOVE_CONFIRMATION_LOCK) {
+      boolean preserveFailedLocalMoveState = hasFailedLocalMoveStateToPreserve();
+      boolean preservePendingLocalMove = isPendingLocalMoveAwaitingReadBoard();
+      boolean preserveConfirmedLocalMove = confirmedLocalMoveActive;
+      resetActiveSyncState(
+          preserveFailedLocalMoveState,
+          preserveFailedLocalMoveState,
+          preservePendingLocalMove,
+          preserveConfirmedLocalMove);
+    }
   }
 
   private void resetActiveSyncState(
@@ -2935,37 +2941,39 @@ public class ReadBoard implements ReadBoardTrackingEligibilityAdapter.Eligibilit
       boolean preserveFailedLocalMoveSuppression,
       boolean preservePendingLocalMoveTracking,
       boolean preserveConfirmedLocalMove) {
-    conflictTracker.clear();
-    historyJumpTracker.clear();
-    if (preservePendingLocalMoveTracking && isPendingLocalMoveAwaitingReadBoard()) {
-      localMoveSyncDebug(
-          "preserve pending local move across active sync reset " + pendingLocalMoveState());
-    } else {
-      clearPendingLocalMoveTracking();
+    synchronized (LOCAL_MOVE_CONFIRMATION_LOCK) {
+      conflictTracker.clear();
+      historyJumpTracker.clear();
+      if (preservePendingLocalMoveTracking && isPendingLocalMoveAwaitingReadBoard()) {
+        localMoveSyncDebug(
+            "preserve pending local move across active sync reset " + pendingLocalMoveState());
+      } else {
+        clearPendingLocalMoveTracking();
+      }
+      if (preserveFailedLocalMoveSuppression && failedLocalMoveSuppressionActive) {
+        localMoveSyncDebug(
+            "preserve suppression across active sync reset " + pendingLocalMoveState());
+      } else {
+        clearFailedLocalMoveSuppression();
+      }
+      if (!preserveFailedLocalMoveRecovery) {
+        clearFailedLocalMoveRecovery();
+      } else if (failedLocalMoveRecoveryActive) {
+        localMoveSyncDebug(
+            "preserve failed local move recovery across active sync reset "
+                + pendingLocalMoveState());
+      }
+      if (preserveConfirmedLocalMove && confirmedLocalMoveActive) {
+        localMoveSyncDebug(
+            "preserve confirmed local move across active sync reset " + pendingLocalMoveState());
+      } else {
+        clearConfirmedLocalMove();
+      }
+      pendingRemoteContext = SyncRemoteContext.generic(false);
+      readBoardTurnTrusted = false;
+      awaitingFirstSyncFrame = true;
+      invalidatePendingSyncAnalysisResume();
     }
-    if (preserveFailedLocalMoveSuppression && failedLocalMoveSuppressionActive) {
-      localMoveSyncDebug(
-          "preserve suppression across active sync reset " + pendingLocalMoveState());
-    } else {
-      clearFailedLocalMoveSuppression();
-    }
-    if (!preserveFailedLocalMoveRecovery) {
-      clearFailedLocalMoveRecovery();
-    } else if (failedLocalMoveRecoveryActive) {
-      localMoveSyncDebug(
-          "preserve failed local move recovery across active sync reset "
-              + pendingLocalMoveState());
-    }
-    if (preserveConfirmedLocalMove && confirmedLocalMoveActive) {
-      localMoveSyncDebug(
-          "preserve confirmed local move across active sync reset " + pendingLocalMoveState());
-    } else {
-      clearConfirmedLocalMove();
-    }
-    pendingRemoteContext = SyncRemoteContext.generic(false);
-    readBoardTurnTrusted = false;
-    awaitingFirstSyncFrame = true;
-    invalidatePendingSyncAnalysisResume();
   }
 
   private void clearResumeState() {
@@ -3056,34 +3064,37 @@ public class ReadBoard implements ReadBoardTrackingEligibilityAdapter.Eligibilit
   }
 
   private boolean acknowledgeLocalMoveIfSnapshotCaughtUp(Stone[] stones, int[] snapshotCodes) {
-    if (!Lizzie.frame.bothSync || !lastMovePlayByLizzie) {
-      return false;
-    }
-    if (!currentPendingLocalMoveCoordinates().isPresent()) {
-      localMoveSyncDebug("ack skip no pending coordinates " + pendingLocalMoveState());
-      return false;
-    }
-    boolean pendingPresent = isCurrentPendingLocalMovePresentInSnapshot(snapshotCodes);
-    boolean noDiff = !snapshotDiffChecker().hasDiff(snapshotCodes, stones, false, Optional.empty());
-    localMoveSyncDebug(
-        "ack check pendingPresent="
-            + pendingPresent
-            + " noDiffWithoutIgnore="
-            + noDiff
-            + " snapshot="
-            + snapshotSummary(snapshotCodes)
-            + " "
-            + pendingLocalMoveState());
-    if (pendingPresent) {
-      localMoveSyncDebug("ack clear pending " + pendingLocalMoveState());
-      clearPendingLocalMoveTracking();
-      return true;
-    } else if (noDiff) {
+    synchronized (LOCAL_MOVE_CONFIRMATION_LOCK) {
+      if (!hasLocalMoveConfirmationAuthority() || !lastMovePlayByLizzie) {
+        return false;
+      }
+      if (!currentPendingLocalMoveCoordinates().isPresent()) {
+        localMoveSyncDebug("ack skip no pending coordinates " + pendingLocalMoveState());
+        return false;
+      }
+      boolean pendingPresent = isCurrentPendingLocalMovePresentInSnapshot(snapshotCodes);
+      boolean noDiff =
+          !snapshotDiffChecker().hasDiff(snapshotCodes, stones, false, Optional.empty());
       localMoveSyncDebug(
-          "ack keeps pending despite noDiff because pending move is not visible "
+          "ack check pendingPresent="
+              + pendingPresent
+              + " noDiffWithoutIgnore="
+              + noDiff
+              + " snapshot="
+              + snapshotSummary(snapshotCodes)
+              + " "
               + pendingLocalMoveState());
+      if (pendingPresent) {
+        localMoveSyncDebug("ack clear pending " + pendingLocalMoveState());
+        clearPendingLocalMoveTracking();
+        return true;
+      } else if (noDiff) {
+        localMoveSyncDebug(
+            "ack keeps pending despite noDiff because pending move is not visible "
+                + pendingLocalMoveState());
+      }
+      return false;
     }
-    return false;
   }
 
   private void finishSyncAfterAcknowledgedLocalMoveSnapshot() {
@@ -3124,19 +3135,22 @@ public class ReadBoard implements ReadBoardTrackingEligibilityAdapter.Eligibilit
   }
 
   private void startTrackingLocalMoveFromLizzie() {
-    invalidateTrackingEligibility(ReadBoardTrackingEligibilityAdapter.Reason.PENDING_LOCAL_MOVE);
-    clearConfirmedLocalMove();
-    capturePendingLocalMoveRecord(currentMainEndNode());
-    lastMovePlayByLizzie = true;
-    waitingForReadBoardLocalMoveAck = true;
-    pendingLocalMoveClickCompleted = false;
-    pendingLocalMoveRetryCount = 0;
-    ignoreReadBoardPlaceResultsForCurrentPending = ignoreReadBoardPlaceResultsForNextPending;
-    ignoreReadBoardPlaceResultsForNextPending = false;
-    lastPendingLocalMoveRetryTimeMs = System.currentTimeMillis();
-    pendingLocalMoveAckGeneration++;
-    localMoveSyncDebug("startTrackingLocalMoveFromLizzie " + pendingLocalMoveState());
-    schedulePendingLocalMoveAckTimeout();
+    synchronized (LOCAL_MOVE_CONFIRMATION_LOCK) {
+      clearConfirmedLocalMove();
+      capturePendingLocalMoveRecord(currentMainEndNode());
+      pendingLocalMoveBoard = Lizzie.board;
+      pendingLocalMoveHistory = Lizzie.board == null ? null : Lizzie.board.getHistory();
+      lastMovePlayByLizzie = true;
+      waitingForReadBoardLocalMoveAck = true;
+      pendingLocalMoveClickCompleted = false;
+      pendingLocalMoveRetryCount = 0;
+      ignoreReadBoardPlaceResultsForCurrentPending = ignoreReadBoardPlaceResultsForNextPending;
+      ignoreReadBoardPlaceResultsForNextPending = false;
+      lastPendingLocalMoveRetryTimeMs = System.currentTimeMillis();
+      pendingLocalMoveAckGeneration++;
+      localMoveSyncDebug("startTrackingLocalMoveFromLizzie " + pendingLocalMoveState());
+      schedulePendingLocalMoveAckTimeout();
+    }
   }
 
   private void schedulePendingLocalMoveAckTimeout() {
@@ -3150,13 +3164,17 @@ public class ReadBoard implements ReadBoardTrackingEligibilityAdapter.Eligibilit
     final int y = pendingLocalMoveY;
     final Stone color = pendingLocalMoveColor;
     timeoutExecutor.schedule(
-        () -> failPendingLocalMoveIfAckTimedOutWithoutSnapshot(generation, node, x, y, color),
+        () -> {
+          failPendingLocalMoveIfAckTimedOutWithoutSnapshot(generation, node, x, y, color);
+        },
         PENDING_LOCAL_MOVE_ACK_TIMEOUT_MS,
         TimeUnit.MILLISECONDS);
   }
 
   private ScheduledExecutorService ensurePendingLocalMoveTimeoutExecutor() {
-    if (shutdownStarted || System.getProperty("surefire.test.class.path") != null) {
+    if (shutdownStarted
+        || (pendingLocalMoveTimeoutExecutor == null
+            && System.getProperty("surefire.test.class.path") != null)) {
       return null;
     }
     if (pendingLocalMoveTimeoutExecutor == null || pendingLocalMoveTimeoutExecutor.isShutdown()) {
@@ -3172,23 +3190,25 @@ public class ReadBoard implements ReadBoardTrackingEligibilityAdapter.Eligibilit
   }
 
   private void markLocalMoveCommandCompleted() {
-    if (!isPendingLocalMoveAwaitingReadBoard()) {
-      pendingLocalMoveClickCompleted = false;
+    synchronized (LOCAL_MOVE_CONFIRMATION_LOCK) {
+      if (!isPendingLocalMoveAwaitingReadBoard()) {
+        pendingLocalMoveClickCompleted = false;
+        localMoveSyncDebug(
+            "markLocalMoveCommandCompleted ignored no pending " + pendingLocalMoveState());
+        return;
+      }
+      if (ignoreReadBoardPlaceResultsForCurrentPending) {
+        localMoveSyncDebug(
+            "markLocalMoveCommandCompleted ignored by stale-result quarantine "
+                + pendingLocalMoveState());
+        return;
+      }
+      pendingLocalMoveClickCompleted = true;
+      localMoveSyncDebug("markLocalMoveCommandCompleted " + pendingLocalMoveState());
       localMoveSyncDebug(
-          "markLocalMoveCommandCompleted ignored no pending " + pendingLocalMoveState());
-      return;
-    }
-    if (ignoreReadBoardPlaceResultsForCurrentPending) {
-      localMoveSyncDebug(
-          "markLocalMoveCommandCompleted ignored by stale-result quarantine "
+          "placeComplete noted pending local move; waiting for remote snapshot "
               + pendingLocalMoveState());
-      return;
     }
-    pendingLocalMoveClickCompleted = true;
-    localMoveSyncDebug("markLocalMoveCommandCompleted " + pendingLocalMoveState());
-    localMoveSyncDebug(
-        "placeComplete noted pending local move; waiting for remote snapshot "
-            + pendingLocalMoveState());
   }
 
   private void clearFailedLocalMoveStateIfCurrentMoveConfirmed() {
@@ -3210,28 +3230,45 @@ public class ReadBoard implements ReadBoardTrackingEligibilityAdapter.Eligibilit
   }
 
   private void clearPendingLocalMoveTracking() {
-    localMoveSyncDebug("clearPendingLocalMoveTracking before " + pendingLocalMoveState());
-    boolean wasPending = isPendingLocalMoveAwaitingReadBoard();
-    lastMovePlayByLizzie = false;
-    waitingForReadBoardLocalMoveAck = false;
-    pendingLocalMoveClickCompleted = false;
-    pendingLocalMoveRetryCount = 0;
-    lastPendingLocalMoveRetryTimeMs = 0L;
-    pendingLocalMoveNode = null;
-    pendingLocalMoveX = -1;
-    pendingLocalMoveY = -1;
-    pendingLocalMoveColor = Stone.EMPTY;
-    pendingLocalMoveBaselineKey = "";
-    ignoreReadBoardPlaceResultsForCurrentPending = false;
-    if (wasPending) {
-      pendingLocalMoveAckGeneration++;
-      ignoreReadBoardPlaceResultsForNextPending = true;
+    synchronized (LOCAL_MOVE_CONFIRMATION_LOCK) {
+      localMoveSyncDebug("clearPendingLocalMoveTracking before " + pendingLocalMoveState());
+      boolean wasPending = isPendingLocalMoveAwaitingReadBoard();
+      lastMovePlayByLizzie = false;
+      waitingForReadBoardLocalMoveAck = false;
+      pendingLocalMoveClickCompleted = false;
+      pendingLocalMoveRetryCount = 0;
+      lastPendingLocalMoveRetryTimeMs = 0L;
+      pendingLocalMoveNode = null;
+      pendingLocalMoveBoard = null;
+      pendingLocalMoveHistory = null;
+      pendingLocalMoveX = -1;
+      pendingLocalMoveY = -1;
+      pendingLocalMoveColor = Stone.EMPTY;
+      pendingLocalMoveBaselineKey = "";
+      ignoreReadBoardPlaceResultsForCurrentPending = false;
+      if (wasPending) {
+        pendingLocalMoveAckGeneration++;
+        ignoreReadBoardPlaceResultsForNextPending = true;
+      }
+      localMoveSyncDebug("clearPendingLocalMoveTracking after " + pendingLocalMoveState());
     }
-    localMoveSyncDebug("clearPendingLocalMoveTracking after " + pendingLocalMoveState());
+  }
+
+  public boolean hasLocalMoveConfirmationAuthority() {
+    synchronized (LOCAL_MOVE_CONFIRMATION_LOCK) {
+      return !shutdownStarted
+          && Lizzie.frame != null
+          && Lizzie.frame.readBoard == this
+          && Lizzie.frame.syncBoard
+          && Lizzie.frame.bothSync
+          && (usePipe ? process != null && process.isAlive() : readBoardStream != null);
+    }
   }
 
   public boolean isPendingLocalMoveAwaitingReadBoard() {
-    return lastMovePlayByLizzie && waitingForReadBoardLocalMoveAck;
+    synchronized (LOCAL_MOVE_CONFIRMATION_LOCK) {
+      return lastMovePlayByLizzie && waitingForReadBoardLocalMoveAck;
+    }
   }
 
   private boolean shouldIgnoreCurrentLastLocalMove() {
@@ -3361,15 +3398,17 @@ public class ReadBoard implements ReadBoardTrackingEligibilityAdapter.Eligibilit
   }
 
   private void clearConfirmedLocalMove() {
-    if (confirmedLocalMoveActive) {
-      localMoveSyncDebug("clear confirmed local move before " + pendingLocalMoveState());
+    synchronized (LOCAL_MOVE_CONFIRMATION_LOCK) {
+      if (confirmedLocalMoveActive) {
+        localMoveSyncDebug("clear confirmed local move before " + pendingLocalMoveState());
+      }
+      confirmedLocalMoveActive = false;
+      confirmedLocalMoveNode = null;
+      confirmedLocalMoveX = -1;
+      confirmedLocalMoveY = -1;
+      confirmedLocalMoveColor = Stone.EMPTY;
+      confirmedLocalMoveBaselineKey = "";
     }
-    confirmedLocalMoveActive = false;
-    confirmedLocalMoveNode = null;
-    confirmedLocalMoveX = -1;
-    confirmedLocalMoveY = -1;
-    confirmedLocalMoveColor = Stone.EMPTY;
-    confirmedLocalMoveBaselineKey = "";
   }
 
   private void updateConfirmedLocalMoveForSnapshot(int[] snapshotCodes) {
@@ -3415,172 +3454,63 @@ public class ReadBoard implements ReadBoardTrackingEligibilityAdapter.Eligibilit
   }
 
   private boolean retryPendingLocalMoveIfSnapshotStillMissing(int[] snapshotCodes) {
-    if (!Lizzie.frame.bothSync || !lastMovePlayByLizzie) {
-      return false;
+    long generation;
+    BoardHistoryNode node;
+    String failure = null;
+    String retryCommand = null;
+    synchronized (LOCAL_MOVE_CONFIRMATION_LOCK) {
+      generation = pendingLocalMoveAckGeneration;
+      node = pendingLocalMoveNode;
+      if (!isCurrentLocalMoveConfirmation(generation, node)) {
+        return false;
+      }
+      boolean pendingPresent = isCurrentPendingLocalMovePresentInSnapshot(snapshotCodes);
+      if (pendingPresent) {
+        return false;
+      }
+      String snapshotKey = snapshotPositionKey(snapshotCodes);
+      long now = System.currentTimeMillis();
+      long elapsed = now - lastPendingLocalMoveRetryTimeMs;
+      if (pendingLocalMoveBaselineKey != null
+          && !pendingLocalMoveBaselineKey.isEmpty()
+          && !snapshotKey.isEmpty()
+          && !pendingLocalMoveBaselineKey.equals(snapshotKey)) {
+        failure = "pending local move remote changed without target";
+      } else if (lastPendingLocalMoveRetryTimeMs != 0L
+          && elapsed >= PENDING_LOCAL_MOVE_ACK_TIMEOUT_MS) {
+        failure = "pending local move timed out without place result elapsedMs=" + elapsed;
+      } else if (pendingLocalMoveRetryCount < LOCAL_MOVE_PLACE_RETRY_LIMIT
+          && elapsed >= LOCAL_MOVE_PLACE_RETRY_INTERVAL_MS) {
+        pendingLocalMoveRetryCount++;
+        pendingLocalMoveClickCompleted = false;
+        lastPendingLocalMoveRetryTimeMs = now;
+        retryCommand = "place " + pendingLocalMoveX + " " + pendingLocalMoveY;
+      }
     }
-    if (!waitingForReadBoardLocalMoveAck) {
-      localMoveSyncDebug("retry skip not waiting " + pendingLocalMoveState());
-      return false;
+    if (failure != null) {
+      return handlePendingLocalMovePlacementFailure(failure, generation, node);
     }
-    boolean pendingPresent = isCurrentPendingLocalMovePresentInSnapshot(snapshotCodes);
-    if (failPendingLocalMoveIfRemoteChangedWithoutTarget(snapshotCodes, pendingPresent)) {
-      return true;
+    if (retryCommand != null) {
+      dispatchPlaceCommandOffEventThread(retryCommand, generation, node);
     }
-    if (failPendingLocalMoveIfAckTimedOut(snapshotCodes, pendingPresent)) {
-      return true;
-    }
-    if (pendingLocalMoveRetryCount >= LOCAL_MOVE_PLACE_RETRY_LIMIT || pendingPresent) {
-      localMoveSyncDebug(
-          "retry skip limit-or-present pendingPresent="
-              + pendingPresent
-              + " snapshot="
-              + snapshotSummary(snapshotCodes)
-              + " "
-              + pendingLocalMoveState());
-      return false;
-    }
-    Optional<int[]> currentPendingLocalMove = currentPendingLocalMoveCoordinates();
-    if (!currentPendingLocalMove.isPresent()) {
-      localMoveSyncDebug("retry skip no pending coordinates " + pendingLocalMoveState());
-      return false;
-    }
-    long now = System.currentTimeMillis();
-    if (!pendingLocalMoveClickCompleted
-        && now - lastPendingLocalMoveRetryTimeMs < LOCAL_MOVE_PLACE_RETRY_INTERVAL_MS) {
-      localMoveSyncDebug(
-          "retry wait no placeComplete elapsedMs="
-              + (now - lastPendingLocalMoveRetryTimeMs)
-              + " "
-              + pendingLocalMoveState());
-      return false;
-    }
-    if (now - lastPendingLocalMoveRetryTimeMs < LOCAL_MOVE_PLACE_RETRY_INTERVAL_MS) {
-      localMoveSyncDebug(
-          "retry wait interval elapsedMs="
-              + (now - lastPendingLocalMoveRetryTimeMs)
-              + " "
-              + pendingLocalMoveState());
-      return false;
-    }
-    int[] coords = currentPendingLocalMove.get();
-    pendingLocalMoveRetryCount++;
-    pendingLocalMoveClickCompleted = false;
-    lastPendingLocalMoveRetryTimeMs = now;
-    localMoveSyncDebug(
-        "retry sending place coords="
-            + coordsText(coords)
-            + " snapshot="
-            + snapshotSummary(snapshotCodes)
-            + " "
-            + pendingLocalMoveState());
-    sendPlaceCommandWithoutRestartingTracking(coords[0], coords[1]);
     return false;
-  }
-
-  private boolean failPendingLocalMoveIfRemoteChangedWithoutTarget(
-      int[] snapshotCodes, boolean pendingPresent) {
-    if (pendingPresent || !isPendingLocalMoveAwaitingReadBoard()) {
-      return false;
-    }
-    if (pendingLocalMoveBaselineKey == null || pendingLocalMoveBaselineKey.isEmpty()) {
-      return false;
-    }
-    String snapshotKey = snapshotPositionKey(snapshotCodes);
-    if (snapshotKey.isEmpty() || pendingLocalMoveBaselineKey.equals(snapshotKey)) {
-      return false;
-    }
-    localMoveSyncDebug(
-        "pending local move remote changed without target; treating as misplaced/failed move snapshot="
-            + snapshotSummary(snapshotCodes)
-            + " "
-            + pendingLocalMoveState());
-    return handlePendingLocalMovePlacementFailure(
-        "pending local move remote changed without target");
-  }
-
-  private boolean failPendingLocalMoveIfAckTimedOut(int[] snapshotCodes, boolean pendingPresent) {
-    if (pendingPresent || !isPendingLocalMoveAwaitingReadBoard()) {
-      return false;
-    }
-    Optional<int[]> currentPendingLocalMove = currentPendingLocalMoveCoordinates();
-    if (!currentPendingLocalMove.isPresent()) {
-      localMoveSyncDebug(
-          "pending local move ack timeout skip no coordinates " + pendingLocalMoveState());
-      return false;
-    }
-    long now = System.currentTimeMillis();
-    long elapsedMs =
-        lastPendingLocalMoveRetryTimeMs == 0L ? 0L : now - lastPendingLocalMoveRetryTimeMs;
-    if (lastPendingLocalMoveRetryTimeMs == 0L || elapsedMs < PENDING_LOCAL_MOVE_ACK_TIMEOUT_MS) {
-      localMoveSyncDebug(
-          "pending local move waits for place result elapsedMs="
-              + elapsedMs
-              + " timeoutMs="
-              + PENDING_LOCAL_MOVE_ACK_TIMEOUT_MS
-              + " snapshot="
-              + snapshotSummary(snapshotCodes)
-              + " "
-              + pendingLocalMoveState());
-      return false;
-    }
-    localMoveSyncDebug(
-        "pending local move timed out without place result elapsedMs="
-            + elapsedMs
-            + " timeoutMs="
-            + PENDING_LOCAL_MOVE_ACK_TIMEOUT_MS
-            + " snapshot="
-            + snapshotSummary(snapshotCodes)
-            + " "
-            + pendingLocalMoveState());
-    return handlePendingLocalMovePlacementFailure(
-        "pending local move timed out without place result elapsedMs=" + elapsedMs);
-  }
-
-  private boolean failPendingLocalMoveIfAckTimedOutWithoutSnapshot() {
-    return failPendingLocalMoveIfAckTimedOutWithoutSnapshot(
-        pendingLocalMoveAckGeneration,
-        pendingLocalMoveNode,
-        pendingLocalMoveX,
-        pendingLocalMoveY,
-        pendingLocalMoveColor);
   }
 
   private boolean failPendingLocalMoveIfAckTimedOutWithoutSnapshot(
       long generation, BoardHistoryNode node, int x, int y, Stone color) {
-    if (!isPendingLocalMoveAwaitingReadBoard()
-        || generation != pendingLocalMoveAckGeneration
-        || !samePendingLocalMove(node, x, y, color)) {
-      localMoveSyncDebug(
-          "pending local move timer skip stale generation="
-              + generation
-              + " currentGeneration="
-              + pendingLocalMoveAckGeneration
-              + " "
-              + pendingLocalMoveState());
-      return false;
+    long elapsedMs;
+    synchronized (LOCAL_MOVE_CONFIRMATION_LOCK) {
+      if (!isCurrentLocalMoveConfirmation(generation, node)
+          || !samePendingLocalMove(node, x, y, color)) {
+        return false;
+      }
+      elapsedMs = System.currentTimeMillis() - lastPendingLocalMoveRetryTimeMs;
+      if (lastPendingLocalMoveRetryTimeMs == 0L || elapsedMs < PENDING_LOCAL_MOVE_ACK_TIMEOUT_MS) {
+        return false;
+      }
     }
-    long now = System.currentTimeMillis();
-    long elapsedMs =
-        lastPendingLocalMoveRetryTimeMs == 0L ? 0L : now - lastPendingLocalMoveRetryTimeMs;
-    if (lastPendingLocalMoveRetryTimeMs == 0L || elapsedMs < PENDING_LOCAL_MOVE_ACK_TIMEOUT_MS) {
-      localMoveSyncDebug(
-          "pending local move timer skip before timeout elapsedMs="
-              + elapsedMs
-              + " timeoutMs="
-              + PENDING_LOCAL_MOVE_ACK_TIMEOUT_MS
-              + " "
-              + pendingLocalMoveState());
-      return false;
-    }
-    localMoveSyncDebug(
-        "pending local move timer timed out without sync frame elapsedMs="
-            + elapsedMs
-            + " timeoutMs="
-            + PENDING_LOCAL_MOVE_ACK_TIMEOUT_MS
-            + " "
-            + pendingLocalMoveState());
     return handlePendingLocalMovePlacementFailure(
-        "pending local move timed out without sync frame elapsedMs=" + elapsedMs);
+        "pending local move timed out without sync frame elapsedMs=" + elapsedMs, generation, node);
   }
 
   private boolean samePendingLocalMove(BoardHistoryNode node, int x, int y, Stone color) {
@@ -3591,22 +3521,75 @@ public class ReadBoard implements ReadBoardTrackingEligibilityAdapter.Eligibilit
   }
 
   public boolean shouldSuppressLocalPlaceAfterFailedSync(int x, int y, Stone color) {
-    if (!failedLocalMoveSuppressionActive || color == null) {
-      return false;
-    }
-    if (failedLocalMoveAwaitingRemoteObservation) {
-      if (releaseFailedLocalMoveObservationIfTimedOut("local-place")) {
+    synchronized (LOCAL_MOVE_CONFIRMATION_LOCK) {
+      if (!hasLocalMoveConfirmationAuthority()
+          || !failedLocalMoveSuppressionActive
+          || color == null) {
+        return false;
+      }
+      if (failedLocalMoveAwaitingRemoteObservation) {
+        if (releaseFailedLocalMoveObservationIfTimedOut("local-place")) {
+          return false;
+        }
+        YikeSyncDebugLog.log(
+            "ReadBoard suppress local place while awaiting failed-place observation x="
+                + x
+                + " y="
+                + y
+                + " color="
+                + color);
+        localMoveSyncDebug(
+            "suppress local place while awaiting failed-place observation x="
+                + x
+                + " y="
+                + y
+                + " color="
+                + color
+                + " "
+                + pendingLocalMoveState());
+        return true;
+      }
+      if (failedLocalMoveWaitingForOurTurnAfterRemoteChange) {
+        YikeSyncDebugLog.log(
+            "ReadBoard suppress local place while waiting for failed-place side turn x="
+                + x
+                + " y="
+                + y
+                + " color="
+                + color);
+        localMoveSyncDebug(
+            "suppress local place while waiting for failed-place side turn x="
+                + x
+                + " y="
+                + y
+                + " color="
+                + color
+                + " "
+                + pendingLocalMoveState());
+        return true;
+      }
+      boolean sameFailedMove =
+          x == failedLocalMoveSuppressionX
+              && y == failedLocalMoveSuppressionY
+              && color == failedLocalMoveSuppressionColor;
+      if (!sameFailedMove) {
+        localMoveSyncDebug(
+            "clear failed local move state because engine selected a different move x="
+                + x
+                + " y="
+                + y
+                + " color="
+                + color
+                + " "
+                + pendingLocalMoveState());
+        clearFailedLocalMoveSuppression();
+        clearFailedLocalMoveRecovery();
         return false;
       }
       YikeSyncDebugLog.log(
-          "ReadBoard suppress local place while awaiting failed-place observation x="
-              + x
-              + " y="
-              + y
-              + " color="
-              + color);
+          "ReadBoard suppress repeated failed local place x=" + x + " y=" + y + " color=" + color);
       localMoveSyncDebug(
-          "suppress local place while awaiting failed-place observation x="
+          "suppress repeated failed local place x="
               + x
               + " y="
               + y
@@ -3616,55 +3599,6 @@ public class ReadBoard implements ReadBoardTrackingEligibilityAdapter.Eligibilit
               + pendingLocalMoveState());
       return true;
     }
-    if (failedLocalMoveWaitingForOurTurnAfterRemoteChange) {
-      YikeSyncDebugLog.log(
-          "ReadBoard suppress local place while waiting for failed-place side turn x="
-              + x
-              + " y="
-              + y
-              + " color="
-              + color);
-      localMoveSyncDebug(
-          "suppress local place while waiting for failed-place side turn x="
-              + x
-              + " y="
-              + y
-              + " color="
-              + color
-              + " "
-              + pendingLocalMoveState());
-      return true;
-    }
-    boolean sameFailedMove =
-        x == failedLocalMoveSuppressionX
-            && y == failedLocalMoveSuppressionY
-            && color == failedLocalMoveSuppressionColor;
-    if (!sameFailedMove) {
-      localMoveSyncDebug(
-          "clear failed local move state because engine selected a different move x="
-              + x
-              + " y="
-              + y
-              + " color="
-              + color
-              + " "
-              + pendingLocalMoveState());
-      clearFailedLocalMoveSuppression();
-      clearFailedLocalMoveRecovery();
-      return false;
-    }
-    YikeSyncDebugLog.log(
-        "ReadBoard suppress repeated failed local place x=" + x + " y=" + y + " color=" + color);
-    localMoveSyncDebug(
-        "suppress repeated failed local place x="
-            + x
-            + " y="
-            + y
-            + " color="
-            + color
-            + " "
-            + pendingLocalMoveState());
-    return true;
   }
 
   private void rememberFailedLocalMoveSuppression() {
@@ -3716,50 +3650,52 @@ public class ReadBoard implements ReadBoardTrackingEligibilityAdapter.Eligibilit
   }
 
   private void updateFailedLocalMoveSuppressionForSnapshot(int[] snapshotCodes) {
-    if (!failedLocalMoveSuppressionActive || snapshotCodes == null || snapshotCodes.length == 0) {
-      return;
-    }
-    int[] coords = new int[] {failedLocalMoveSuppressionX, failedLocalMoveSuppressionY};
-    String snapshotKey = snapshotPositionKey(snapshotCodes);
-    if (failedLocalMoveAwaitingRemoteObservation) {
-      observeFailedLocalMoveSnapshot(snapshotCodes, coords, snapshotKey);
-      return;
-    }
-    if (failedLocalMoveWaitingForOurTurnAfterRemoteChange) {
-      localMoveSyncDebug(
-          "failed-place waiting for our turn keeps suppression snapshot="
-              + snapshotSummary(snapshotCodes)
-              + " "
-              + pendingLocalMoveState());
-      return;
-    }
-    if (snapshotContainsMove(snapshotCodes, coords, failedLocalMoveSuppressionColor)) {
-      localMoveSyncDebug(
-          "clear suppression because failed move is now visible snapshot="
-              + snapshotSummary(snapshotCodes)
-              + " "
-              + pendingLocalMoveState());
-      clearFailedLocalMoveSuppression();
-      clearFailedLocalMoveRecovery();
-      return;
-    }
-    if (failedLocalMoveSuppressionSnapshotKey.isEmpty()) {
-      failedLocalMoveSuppressionSnapshotKey = snapshotKey;
-      localMoveSyncDebug(
-          "bind suppression snapshot="
-              + snapshotSummary(snapshotCodes)
-              + " "
-              + pendingLocalMoveState());
-      return;
-    }
-    if (!failedLocalMoveSuppressionSnapshotKey.equals(snapshotKey)) {
-      localMoveSyncDebug(
-          "clear suppression due snapshot change snapshot="
-              + snapshotSummary(snapshotCodes)
-              + " "
-              + pendingLocalMoveState());
-      clearFailedLocalMoveSuppression();
-      clearFailedLocalMoveRecovery();
+    synchronized (LOCAL_MOVE_CONFIRMATION_LOCK) {
+      if (!failedLocalMoveSuppressionActive || snapshotCodes == null || snapshotCodes.length == 0) {
+        return;
+      }
+      int[] coords = new int[] {failedLocalMoveSuppressionX, failedLocalMoveSuppressionY};
+      String snapshotKey = snapshotPositionKey(snapshotCodes);
+      if (failedLocalMoveAwaitingRemoteObservation) {
+        observeFailedLocalMoveSnapshot(snapshotCodes, coords, snapshotKey);
+        return;
+      }
+      if (failedLocalMoveWaitingForOurTurnAfterRemoteChange) {
+        localMoveSyncDebug(
+            "failed-place waiting for our turn keeps suppression snapshot="
+                + snapshotSummary(snapshotCodes)
+                + " "
+                + pendingLocalMoveState());
+        return;
+      }
+      if (snapshotContainsMove(snapshotCodes, coords, failedLocalMoveSuppressionColor)) {
+        localMoveSyncDebug(
+            "clear suppression because failed move is now visible snapshot="
+                + snapshotSummary(snapshotCodes)
+                + " "
+                + pendingLocalMoveState());
+        clearFailedLocalMoveSuppression();
+        clearFailedLocalMoveRecovery();
+        return;
+      }
+      if (failedLocalMoveSuppressionSnapshotKey.isEmpty()) {
+        failedLocalMoveSuppressionSnapshotKey = snapshotKey;
+        localMoveSyncDebug(
+            "bind suppression snapshot="
+                + snapshotSummary(snapshotCodes)
+                + " "
+                + pendingLocalMoveState());
+        return;
+      }
+      if (!failedLocalMoveSuppressionSnapshotKey.equals(snapshotKey)) {
+        localMoveSyncDebug(
+            "clear suppression due snapshot change snapshot="
+                + snapshotSummary(snapshotCodes)
+                + " "
+                + pendingLocalMoveState());
+        clearFailedLocalMoveSuppression();
+        clearFailedLocalMoveRecovery();
+      }
     }
   }
 
@@ -3845,21 +3781,23 @@ public class ReadBoard implements ReadBoardTrackingEligibilityAdapter.Eligibilit
   }
 
   private boolean releaseFailedLocalMoveObservationIfTimedOut(String reason) {
-    if (!failedLocalMoveAwaitingRemoteObservation) {
-      return false;
+    synchronized (LOCAL_MOVE_CONFIRMATION_LOCK) {
+      if (!failedLocalMoveAwaitingRemoteObservation) {
+        return false;
+      }
+      long deadlineMs = failedLocalMoveObservationDeadlineMs;
+      if (deadlineMs > 0L && System.currentTimeMillis() < deadlineMs) {
+        return false;
+      }
+      localMoveSyncDebug(
+          "failed-place observation guard elapsed; release for fresh analysis reason="
+              + reason
+              + " "
+              + pendingLocalMoveState());
+      clearFailedLocalMoveSuppression();
+      clearFailedLocalMoveRecovery();
+      return true;
     }
-    long deadlineMs = failedLocalMoveObservationDeadlineMs;
-    if (deadlineMs > 0L && System.currentTimeMillis() < deadlineMs) {
-      return false;
-    }
-    localMoveSyncDebug(
-        "failed-place observation guard elapsed; release for fresh analysis reason="
-            + reason
-            + " "
-            + pendingLocalMoveState());
-    clearFailedLocalMoveSuppression();
-    clearFailedLocalMoveRecovery();
-    return true;
   }
 
   private void clearFailedLocalMoveRecovery() {
@@ -5221,33 +5159,6 @@ public class ReadBoard implements ReadBoardTrackingEligibilityAdapter.Eligibilit
     return builder.toString();
   }
 
-  private void sendPlaceCommandWithoutRestartingTracking(int x, int y) {
-    String command = "place " + x + " " + y;
-    localMoveSyncDebug(
-        "sendPlaceCommandWithoutRestartingTracking command="
-            + command
-            + " usePipe="
-            + usePipe
-            + " stream="
-            + (readBoardStream != null)
-            + " "
-            + pendingLocalMoveState());
-    YikeSyncDebugLog.log(
-        "ReadBoard retry pending local move command="
-            + command
-            + " retry="
-            + pendingLocalMoveRetryCount);
-    if (hideFloadBoardBeforePlace && Lizzie.frame.floatBoard != null) {
-      Lizzie.frame.floatBoard.setVisible(false);
-      hideFromPlace = true;
-    }
-    if (usePipe) {
-      sendCommandTo(command);
-    } else if (readBoardStream != null) {
-      readBoardStream.sendCommand(command);
-    }
-  }
-
   private void restoreViewedNodeAfterSync(
       boolean played, BoardHistoryNode currentNode, BoardHistoryNode syncEndNode) {
     if (Lizzie.frame.bothSync
@@ -5954,6 +5865,7 @@ public class ReadBoard implements ReadBoardTrackingEligibilityAdapter.Eligibilit
     retireTrackingEligibility();
     noMsg = true;
     resetActiveSyncState();
+    restoreFloatBoardAfterPlaceResult();
     clearResumeState();
     clearPendingRemoteContext();
     tempcount = new ArrayList<Integer>();
@@ -5968,12 +5880,14 @@ public class ReadBoard implements ReadBoardTrackingEligibilityAdapter.Eligibilit
     publishCurrentReadBoardDiagnosticsSnapshot();
   }
 
-  private synchronized boolean beginShutdown() {
-    if (shutdownStarted) {
-      return false;
+  private boolean beginShutdown() {
+    synchronized (LOCAL_MOVE_CONFIRMATION_LOCK) {
+      if (shutdownStarted) {
+        return false;
+      }
+      shutdownStarted = true;
+      return true;
     }
-    shutdownStarted = true;
-    return true;
   }
 
   @Override
@@ -6182,6 +6096,12 @@ public class ReadBoard implements ReadBoardTrackingEligibilityAdapter.Eligibilit
     if (shouldSuppressHistoryOverwriteInvalidation()) {
       return;
     }
+    synchronized (LOCAL_MOVE_CONFIRMATION_LOCK) {
+      clearPendingLocalMoveTracking();
+      clearFailedLocalMoveSuppression();
+      clearFailedLocalMoveRecovery();
+      clearConfirmedLocalMove();
+    }
     invalidateTrackingEligibility(ReadBoardTrackingEligibilityAdapter.Reason.NODE_MISMATCH);
     clearResumeState();
     publishCurrentReadBoardDiagnosticsSnapshot();
@@ -6230,30 +6150,26 @@ public class ReadBoard implements ReadBoardTrackingEligibilityAdapter.Eligibilit
               + isSyncing);
     }
     if (command.startsWith("place")) {
-      localMoveSyncDebug(
-          "sendCommand external place command="
-              + command
-              + " usePipe="
-              + usePipe
-              + " stream="
-              + (readBoardStream != null)
-              + " before "
-              + pendingLocalMoveState());
-      if (isPendingLocalMoveAwaitingReadBoard()) {
-        localMoveSyncDebug("sendCommand external place skipped; pending local move still active");
+      Board board = Lizzie.board;
+      if (board == null) {
         return;
       }
-      clearFailedLocalMoveStateIfOutgoingPlaceDiffers(command);
-      if (hideFloadBoardBeforePlace && Lizzie.frame.floatBoard != null) {
-        Lizzie.frame.floatBoard.setVisible(false);
-        hideFromPlace = true;
+      invalidateTrackingEligibility(ReadBoardTrackingEligibilityAdapter.Reason.PENDING_LOCAL_MOVE);
+      long generation;
+      BoardHistoryNode node;
+      synchronized (board) {
+        synchronized (LOCAL_MOVE_CONFIRMATION_LOCK) {
+          if (!hasLocalMoveConfirmationAuthority() || isPendingLocalMoveAwaitingReadBoard()) {
+            return;
+          }
+          clearFailedLocalMoveStateIfOutgoingPlaceDiffers(command);
+          startTrackingLocalMoveFromLizzie();
+          generation = pendingLocalMoveAckGeneration;
+          node = pendingLocalMoveNode;
+          if (Lizzie.frame.isPlayingAgainstLeelaz) needGenmove = true;
+        }
       }
-      startTrackingLocalMoveFromLizzie();
-      if (Lizzie.frame.isPlayingAgainstLeelaz) needGenmove = true;
-      localMoveSyncDebug("sendCommand external place after tracking " + pendingLocalMoveState());
-    }
-    if (command.startsWith("place ") && SwingUtilities.isEventDispatchThread()) {
-      dispatchPlaceCommandOffEventThread(command);
+      dispatchPlaceCommandOffEventThread(command, generation, node);
       return;
     }
     if (usePipe) {
@@ -6261,18 +6177,48 @@ public class ReadBoard implements ReadBoardTrackingEligibilityAdapter.Eligibilit
     } else if (readBoardStream != null) readBoardStream.sendCommand(command);
   }
 
-  private void dispatchPlaceCommandOffEventThread(String command) {
+  private void dispatchPlaceCommandOffEventThread(
+      String command, long generation, BoardHistoryNode node) {
     BufferedOutputStream pipeTarget = usePipe ? outputStream : null;
     ReadBoardStream socketTarget = usePipe ? null : readBoardStream;
     if (pipeTarget == null && socketTarget == null) {
       return;
     }
-    PLACE_COMMAND_DISPATCH_EXECUTOR.execute(
+    Executor dispatcher =
+        placeCommandDispatcher == null ? PLACE_COMMAND_DISPATCH_EXECUTOR : placeCommandDispatcher;
+    dispatcher.execute(
         () -> {
+          FloatBoard floatBoard = Lizzie.frame == null ? null : Lizzie.frame.floatBoard;
+          if (hideFloadBoardBeforePlace && floatBoard != null) {
+            runOnEdtAndWait(
+                () -> {
+                  synchronized (LOCAL_MOVE_CONFIRMATION_LOCK) {
+                    if (!isCurrentLocalMoveConfirmation(generation, node)) {
+                      return;
+                    }
+                    hideFromPlace = true;
+                  }
+                  floatBoard.setVisible(false);
+                });
+          }
           if (pipeTarget != null) {
-            sendCommandTo(pipeTarget, command);
+            synchronized (pipeTarget) {
+              synchronized (LOCAL_MOVE_CONFIRMATION_LOCK) {
+                if (!isCurrentLocalMoveConfirmation(generation, node)) {
+                  return;
+                }
+                // Dispatch starts here; already-started writes cannot be recalled by stop.
+              }
+              sendCommandTo(pipeTarget, command);
+            }
           } else {
-            socketTarget.sendCommand(command);
+            socketTarget.sendCommand(
+                command,
+                () -> {
+                  synchronized (LOCAL_MOVE_CONFIRMATION_LOCK) {
+                    return isCurrentLocalMoveConfirmation(generation, node);
+                  }
+                });
           }
         });
   }

--- a/src/main/java/featurecat/lizzie/analysis/ReadBoardStream.java
+++ b/src/main/java/featurecat/lizzie/analysis/ReadBoardStream.java
@@ -8,6 +8,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.UnsupportedEncodingException;
 import java.net.Socket;
+import java.util.function.BooleanSupplier;
 import org.json.JSONException;
 
 public class ReadBoardStream extends Thread implements Closeable {
@@ -73,11 +74,18 @@ public class ReadBoardStream extends Thread implements Closeable {
   }
 
   public void sendCommand(String command) {
+    sendCommand(command, null);
+  }
+
+  void sendCommand(String command, BooleanSupplier stillAuthorized) {
     if (out == null) {
       return;
     }
     try {
       synchronized (out) {
+        if (stillAuthorized != null && !stillAuthorized.getAsBoolean()) {
+          return;
+        }
         out.write((command + "\n").getBytes());
         out.flush();
       }

--- a/src/main/java/featurecat/lizzie/rules/Board.java
+++ b/src/main/java/featurecat/lizzie/rules/Board.java
@@ -2663,42 +2663,6 @@ public class Board {
       boolean forManual,
       boolean sendReadBoardPlaceOnHistoryNext) {
     boolean shouldLogLocalMovePlace = shouldLogLocalMovePlace(forSync);
-    if (shouldSuppressLocalPlaceAfterFailedReadBoardSync(x, y, color, forSync)) {
-      if (shouldLogLocalMovePlace) {
-        logLocalMovePlace(
-            "place suppressed after failed readboard sync x="
-                + x
-                + " y="
-                + y
-                + " color="
-                + color
-                + " newBranch="
-                + newBranch
-                + " forManual="
-                + forManual
-                + " "
-                + localMovePlaceState(forSync));
-      }
-      return;
-    }
-    if (shouldSuppressLocalPlaceWhileReadBoardPending(x, y, color, forSync)) {
-      if (shouldLogLocalMovePlace) {
-        logLocalMovePlace(
-            "place suppressed while readboard local move pending x="
-                + x
-                + " y="
-                + y
-                + " color="
-                + color
-                + " newBranch="
-                + newBranch
-                + " forManual="
-                + forManual
-                + " "
-                + localMovePlaceState(forSync));
-      }
-      return;
-    }
     if (shouldLogLocalMovePlace) {
       logLocalMovePlace(
           "place enter x="
@@ -2718,6 +2682,42 @@ public class Board {
     LizzieFrame.boardRenderer.removedrawmovestone();
     Lizzie.frame.suggestionclick = LizzieFrame.outOfBoundCoordinate;
     synchronized (this) {
+      if (shouldSuppressLocalPlaceAfterFailedReadBoardSync(x, y, color, forSync)) {
+        if (shouldLogLocalMovePlace) {
+          logLocalMovePlace(
+              "place suppressed after failed readboard sync x="
+                  + x
+                  + " y="
+                  + y
+                  + " color="
+                  + color
+                  + " newBranch="
+                  + newBranch
+                  + " forManual="
+                  + forManual
+                  + " "
+                  + localMovePlaceState(forSync));
+        }
+        return;
+      }
+      if (shouldSuppressLocalPlaceWhileReadBoardPending(x, y, color, forSync)) {
+        if (shouldLogLocalMovePlace) {
+          logLocalMovePlace(
+              "place suppressed while readboard local move pending x="
+                  + x
+                  + " y="
+                  + y
+                  + " color="
+                  + color
+                  + " newBranch="
+                  + newBranch
+                  + " forManual="
+                  + forManual
+                  + " "
+                  + localMovePlaceState(forSync));
+        }
+        return;
+      }
       boolean valid = isValid(x, y);
       boolean occupied = valid && history.getStones()[getIndex(x, y)] != Stone.EMPTY;
       if (!valid || (occupied && !newBranch)) {
@@ -3018,11 +3018,8 @@ public class Board {
         readBoard != null && readBoard.isPendingLocalMoveAwaitingReadBoard();
     boolean canSendReadBoardPlace =
         !forSync
-            && Lizzie.frame != null
-            && Lizzie.frame.bothSync
             && readBoard != null
-            && readBoard.process != null
-            && readBoard.process.isAlive()
+            && readBoard.hasLocalMoveConfirmationAuthority()
             && !pendingReadBoardLocalMove;
     if (shouldLogLocalMovePlace) {
       logLocalMovePlace(
@@ -3045,12 +3042,34 @@ public class Board {
     }
   }
 
+  /** Commits an authorized connector failure without engine or UI work under the board lock. */
+  public synchronized Optional<BoardHistoryNode> discardFailedReadBoardMove(
+      BoardHistoryNode failedNode) {
+    if (history.getMainEnd() != failedNode || failedNode == null) {
+      return Optional.empty();
+    }
+    BoardHistoryNode rollback = failedNode.previous().orElse(null);
+    if (rollback == null) {
+      return Optional.empty();
+    }
+    int childIndex = rollback.indexOfNode(failedNode);
+    if (childIndex < 0) {
+      return Optional.empty();
+    }
+    history.setHead(rollback);
+    rollback.deleteChild(childIndex);
+    advanceContextRevision();
+    markMoveNavigationForMovelistRefresh();
+    return Optional.of(rollback);
+  }
+
   private boolean shouldSuppressLocalPlaceAfterFailedReadBoardSync(
       int x, int y, Stone color, boolean forSync) {
     return !forSync
         && Lizzie.frame != null
         && Lizzie.frame.bothSync
         && Lizzie.frame.readBoard != null
+        && Lizzie.frame.readBoard.hasLocalMoveConfirmationAuthority()
         && Lizzie.frame.readBoard.shouldSuppressLocalPlaceAfterFailedSync(x, y, color);
   }
 
@@ -3060,6 +3079,7 @@ public class Board {
         && Lizzie.frame != null
         && Lizzie.frame.bothSync
         && Lizzie.frame.readBoard != null
+        && Lizzie.frame.readBoard.hasLocalMoveConfirmationAuthority()
         && Lizzie.frame.readBoard.isPendingLocalMoveAwaitingReadBoard();
   }
 
@@ -5976,7 +5996,9 @@ public class Board {
     setMovelistAll(null);
   }
 
-  /** Rebuilds move-list metadata asynchronously and runs {@code onComplete} after it is coherent. */
+  /**
+   * Rebuilds move-list metadata asynchronously and runs {@code onComplete} after it is coherent.
+   */
   public void setMovelistAll(Runnable onComplete) {
     final int generation = ++movelistRefreshGeneration;
     final BoardHistoryList refreshHistory = history;

--- a/src/test/java/featurecat/lizzie/analysis/ReadBoardEdtCommandDispatchTest.java
+++ b/src/test/java/featurecat/lizzie/analysis/ReadBoardEdtCommandDispatchTest.java
@@ -5,10 +5,16 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import featurecat.lizzie.Lizzie;
 import featurecat.lizzie.gui.LizzieFrame;
+import featurecat.lizzie.rules.Board;
+import featurecat.lizzie.rules.BoardData;
+import featurecat.lizzie.rules.BoardHistoryList;
+import featurecat.lizzie.rules.Stone;
+import featurecat.lizzie.rules.Zobrist;
 import java.io.BufferedOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.lang.reflect.Field;
+import java.util.Arrays;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -20,12 +26,39 @@ class ReadBoardEdtCommandDispatchTest {
   @Test
   void blockedReadBoardOutputNeverBlocksTheSwingEventThread() throws Exception {
     LizzieFrame previousFrame = Lizzie.frame;
+    Board previousBoard = Lizzie.board;
     BlockingOutput output = new BlockingOutput();
     try {
       ReadBoard readBoard = allocate(ReadBoard.class);
       LizzieFrame frame = allocate(LizzieFrame.class);
       frame.bothSync = true;
       Lizzie.frame = frame;
+      frame.syncBoard = true;
+      frame.readBoard = readBoard;
+      readBoard.process = new ReadBoardEngineResumeTest.AliveProcess();
+      Board board = allocate(Board.class);
+      Stone[] stones = new Stone[Board.boardWidth * Board.boardHeight];
+      Arrays.fill(stones, Stone.EMPTY);
+      stones[Board.getIndex(1, 1)] = Stone.BLACK;
+      Zobrist.init();
+      Zobrist hash = new Zobrist();
+      hash.toggleStone(1, 1, Stone.BLACK);
+      BoardHistoryList history =
+          new BoardHistoryList(
+              BoardData.move(
+                  stones,
+                  new int[] {1, 1},
+                  Stone.BLACK,
+                  false,
+                  hash,
+                  1,
+                  new int[stones.length],
+                  0,
+                  0,
+                  50,
+                  0));
+      setField(board, "history", history);
+      Lizzie.board = board;
       setField(readBoard, "usePipe", true);
       setField(readBoard, "outputStream", new BufferedOutputStream(output));
 
@@ -51,6 +84,7 @@ class ReadBoardEdtCommandDispatchTest {
       output.releaseWrite.countDown();
       output.writeCompleted.await(2, TimeUnit.SECONDS);
       Lizzie.frame = previousFrame;
+      Lizzie.board = previousBoard;
     }
   }
 
@@ -61,8 +95,8 @@ class ReadBoardEdtCommandDispatchTest {
     return (T) ((Unsafe) field.get(null)).allocateInstance(type);
   }
 
-  private static void setField(ReadBoard target, String name, Object value) throws Exception {
-    Field field = ReadBoard.class.getDeclaredField(name);
+  private static void setField(Object target, String name, Object value) throws Exception {
+    Field field = target.getClass().getDeclaredField(name);
     field.setAccessible(true);
     field.set(target, value);
   }

--- a/src/test/java/featurecat/lizzie/analysis/ReadBoardEngineResumeTest.java
+++ b/src/test/java/featurecat/lizzie/analysis/ReadBoardEngineResumeTest.java
@@ -11,6 +11,7 @@ import featurecat.lizzie.Config;
 import featurecat.lizzie.Lizzie;
 import featurecat.lizzie.gui.BoardRenderer;
 import featurecat.lizzie.gui.BottomToolbar;
+import featurecat.lizzie.gui.GtpConsolePane;
 import featurecat.lizzie.gui.JFontCheckBox;
 import featurecat.lizzie.gui.JFontTextField;
 import featurecat.lizzie.gui.LizzieFrame;
@@ -35,6 +36,12 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import javax.swing.JCheckBox;
 import javax.swing.JTextField;
@@ -43,6 +50,8 @@ import org.json.JSONObject;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 class ReadBoardEngineResumeTest {
   private static final int BOARD_SIZE = 3;
@@ -65,6 +74,339 @@ class ReadBoardEngineResumeTest {
     Board.boardWidth = previousBoardWidth;
     Board.boardHeight = previousBoardHeight;
     Zobrist.init();
+  }
+
+  @Test
+  void stoppedSynchronizationKeepsCompleteLocalPlacement() throws Exception {
+    try (EngineResumeHarness harness =
+        EngineResumeHarness.create(rootHistory(emptyStones(), true))) {
+      buildHistory(harness.board, placement(0, 0, Stone.BLACK), placement(1, 0, Stone.WHITE));
+      harness.readBoard.process = new AliveProcess();
+      setField(
+          harness.readBoard, "pendingLocalMoveTimeoutExecutor", new ScheduledThreadPoolExecutor(1));
+      harness.readBoard.parseLine("bothSync");
+      harness.readBoard.parseLine("sync");
+      harness.readBoard.parseLine("stopsync");
+
+      harness.board.place(0, 1, Stone.BLACK, false, false, false);
+      BoardHistoryNode localMove = harness.board.getHistory().getCurrentHistoryNode();
+      harness.leelaz.sentCommands.clear();
+      Thread.sleep(3400);
+      assertSame(localMove, harness.board.getHistory().getCurrentHistoryNode());
+      assertTrue(harness.leelaz.sentCommands.isEmpty());
+
+      assertEquals(3, localMove.getData().moveNumber);
+      assertEquals(Stone.BLACK, localMove.getData().stones[Board.getIndex(0, 1)]);
+      assertFalse(harness.protocolOutput().contains("place "));
+      assertTrue(harness.readBoard.process.isAlive());
+    }
+  }
+
+  @Test
+  void stoppingRetiresCapturedTimeoutAndAllowsNextLocalMove() throws Exception {
+    try (EngineResumeHarness harness =
+        EngineResumeHarness.create(rootHistory(emptyStones(), true))) {
+      CapturedTimeoutScheduler scheduler = harness.activateLocalPlacement();
+      harness.board.place(0, 1, Stone.BLACK, false, false, false);
+      BoardHistoryNode pending = harness.board.getHistory().getCurrentHistoryNode();
+      assertTrue(harness.readBoard.hasLocalMoveConfirmationAuthority());
+      assertEquals(3, pending.getData().moveNumber);
+      assertTrue(harness.protocolOutput().contains("place 0 1"), harness.protocolOutput());
+      Runnable timeout = scheduler.callbacks.get(0);
+
+      harness.readBoard.parseLine("stopsync");
+      setField(
+          harness.readBoard, "lastPendingLocalMoveRetryTimeMs", System.currentTimeMillis() - 4000);
+      harness.leelaz.sentCommands.clear();
+      timeout.run();
+
+      assertSame(pending, harness.board.getHistory().getCurrentHistoryNode());
+      assertTrue(harness.leelaz.sentCommands.isEmpty());
+      harness.board.place(2, 2, Stone.WHITE, false, false, false);
+      assertEquals(4, harness.board.getHistory().getData().moveNumber);
+      assertEquals(Stone.WHITE, harness.board.getHistory().getStones()[Board.getIndex(2, 2)]);
+    }
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"endsync", "shutdown"})
+  void endingHelperConfirmationPreservesPendingHistory(String end) throws Exception {
+    try (EngineResumeHarness harness =
+        EngineResumeHarness.create(rootHistory(emptyStones(), true))) {
+      CapturedTimeoutScheduler scheduler = harness.activateLocalPlacement();
+      harness.board.place(0, 1, Stone.BLACK, false, false, false);
+      BoardHistoryNode pending = harness.board.getHistory().getCurrentHistoryNode();
+      harness.readBoard.parseLine("re=1,2,2");
+      harness.readBoard.parseLine("re=0,0,0");
+      harness.readBoard.parseLine("re=0,0,0");
+      harness.leelaz.sentCommands.clear();
+      if (end.equals("shutdown")) {
+        harness.readBoard.shutdownAfterProcessEnd();
+      } else {
+        harness.readBoard.parseLine(end);
+      }
+      harness.expire(scheduler.callbacks.get(0));
+      assertSame(pending, harness.board.getHistory().getCurrentHistoryNode());
+      assertFalse(
+          harness.leelaz.sentCommands.stream().anyMatch(command -> command.startsWith("loadsgf ")));
+      harness.board.place(2, 2, Stone.WHITE, false, false, false);
+      assertEquals(4, harness.board.getHistory().getData().moveNumber);
+    }
+  }
+
+  @Test
+  void concurrentLocalPlacementsSharePendingAdmission() throws Exception {
+    try (EngineResumeHarness harness =
+        EngineResumeHarness.create(rootHistory(emptyStones(), true))) {
+      harness.activateLocalPlacement();
+      CountDownLatch bothPlacementsEntered = new CountDownLatch(2);
+      LizzieFrame.boardRenderer =
+          new BoardRenderer(false) {
+            @Override
+            public void removedrawmovestone() {
+              bothPlacementsEntered.countDown();
+              try {
+                assertTrue(bothPlacementsEntered.await(2, TimeUnit.SECONDS));
+              } catch (InterruptedException interrupted) {
+                Thread.currentThread().interrupt();
+                throw new AssertionError(interrupted);
+              }
+            }
+          };
+      CompletableFuture<Void> first =
+          CompletableFuture.runAsync(
+              () -> harness.board.place(0, 1, Stone.BLACK, false, false, false));
+      CompletableFuture<Void> second =
+          CompletableFuture.runAsync(
+              () -> harness.board.place(2, 2, Stone.BLACK, false, false, false));
+      CompletableFuture.allOf(first, second).get(3, TimeUnit.SECONDS);
+
+      BoardHistoryNode pending = harness.board.getHistory().getCurrentHistoryNode();
+      assertEquals(3, pending.getData().moveNumber);
+      assertEquals(
+          1, harness.protocolOutput().lines().filter(line -> line.startsWith("place ")).count());
+      harness.acceptSnapshot(pending);
+      harness.board.place(1, 2, Stone.WHITE, false, false, false);
+      assertEquals(4, harness.board.getHistory().getData().moveNumber);
+      assertTrue(harness.protocolOutput().contains("place 1 2"));
+    }
+  }
+
+  @Test
+  void restartedSyncConfirmsNewPendingDespiteOldTimeout() throws Exception {
+    try (EngineResumeHarness harness =
+        EngineResumeHarness.create(rootHistory(emptyStones(), true))) {
+      CapturedTimeoutScheduler scheduler = harness.activateLocalPlacement();
+      harness.board.place(0, 1, Stone.BLACK, false, false, false);
+      Runnable oldTimeout = scheduler.callbacks.get(0);
+      harness.readBoard.parseLine("stopsync");
+      harness.readBoard.parseLine("sync");
+      harness.board.place(2, 2, Stone.WHITE, false, false, false);
+      BoardHistoryNode newPending = harness.board.getHistory().getCurrentHistoryNode();
+      assertTrue(harness.protocolOutput().contains("place 2 2"));
+
+      harness.expire(oldTimeout);
+      assertSame(newPending, harness.board.getHistory().getCurrentHistoryNode());
+      harness.acceptSnapshot(newPending);
+      harness.expire(scheduler.callbacks.get(1));
+      assertSame(newPending, harness.board.getHistory().getCurrentHistoryNode());
+      harness.board.place(1, 2, Stone.BLACK, false, false, false);
+      assertEquals(5, harness.board.getHistory().getData().moveNumber);
+      assertTrue(harness.protocolOutput().contains("place 1 2"));
+    }
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"helper", "history"})
+  void replacementRetiresOldCapturedWork(String replacement) throws Exception {
+    try (EngineResumeHarness harness =
+        EngineResumeHarness.create(rootHistory(emptyStones(), true))) {
+      CapturedTimeoutScheduler scheduler = harness.activateLocalPlacement();
+      harness.board.place(0, 1, Stone.BLACK, false, false, false);
+      if (replacement.equals("helper")) {
+        harness.frame.readBoard = allocate(ReadBoard.class);
+      } else {
+        harness.board.setHistory(rootHistory(stones(placement(2, 1, Stone.WHITE)), true));
+      }
+      BoardHistoryList history = harness.board.getHistory();
+      BoardHistoryNode current = history.getCurrentHistoryNode();
+      harness.leelaz.sentCommands.clear();
+      harness.expire(scheduler.callbacks.get(0));
+      assertSame(history, harness.board.getHistory());
+      assertSame(current, history.getCurrentHistoryNode());
+      assertTrue(harness.leelaz.sentCommands.isEmpty());
+    }
+  }
+
+  @Test
+  void stopWinsWhileTimeoutWaitsForHistoryCommit() throws Exception {
+    try (EngineResumeHarness harness =
+        EngineResumeHarness.create(rootHistory(emptyStones(), true))) {
+      CapturedTimeoutScheduler scheduler = harness.activateLocalPlacement();
+      harness.board.place(0, 1, Stone.BLACK, false, false, false);
+      BoardHistoryNode pending = harness.board.getHistory().getCurrentHistoryNode();
+      setField(
+          harness.readBoard, "lastPendingLocalMoveRetryTimeMs", System.currentTimeMillis() - 4000);
+      CountDownLatch started = new CountDownLatch(1);
+      CompletableFuture<Void> completed = new CompletableFuture<>();
+      Thread timeout =
+          new Thread(
+              () -> {
+                started.countDown();
+                try {
+                  scheduler.callbacks.get(0).run();
+                  completed.complete(null);
+                } catch (Throwable failure) {
+                  completed.completeExceptionally(failure);
+                }
+              });
+      synchronized (harness.board) {
+        timeout.start();
+        assertTrue(started.await(2, TimeUnit.SECONDS));
+        long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(2);
+        while (timeout.getState() != Thread.State.BLOCKED && System.nanoTime() < deadline) {
+          Thread.yield();
+        }
+        assertEquals(Thread.State.BLOCKED, timeout.getState());
+        harness.readBoard.parseLine("stopsync");
+        harness.leelaz.sentCommands.clear();
+      }
+      completed.get(2, TimeUnit.SECONDS);
+      assertSame(pending, harness.board.getHistory().getCurrentHistoryNode());
+      assertTrue(harness.leelaz.sentCommands.isEmpty());
+    }
+  }
+
+  @Test
+  void committedTimeoutThenStopRestoresOrdinaryLocalEditing() throws Exception {
+    try (EngineResumeHarness harness =
+        EngineResumeHarness.create(rootHistory(emptyStones(), true))) {
+      CapturedTimeoutScheduler scheduler = harness.activateLocalPlacement();
+      harness.board.place(0, 1, Stone.BLACK, false, false, false);
+      harness.expire(scheduler.callbacks.get(0));
+      assertEquals(2, harness.board.getHistory().getData().moveNumber);
+      assertEquals(Stone.EMPTY, harness.board.getHistory().getStones()[Board.getIndex(0, 1)]);
+      assertTrue(
+          harness.leelaz.sentCommands.stream().anyMatch(command -> command.startsWith("loadsgf ")));
+      harness.board.place(0, 1, Stone.BLACK, false, false, false);
+      assertEquals(2, harness.board.getHistory().getData().moveNumber);
+
+      harness.readBoard.parseLine("stopsync");
+      harness.board.place(0, 1, Stone.BLACK, false, false, false);
+      harness.board.place(2, 2, Stone.WHITE, false, false, false);
+      assertEquals(4, harness.board.getHistory().getData().moveNumber);
+      assertEquals(Stone.BLACK, harness.board.getHistory().getStones()[Board.getIndex(0, 1)]);
+      assertEquals(Stone.WHITE, harness.board.getHistory().getStones()[Board.getIndex(2, 2)]);
+    }
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"pipe", "socket"})
+  void stopInvalidatesPlacementBeforeQueuedOutputStarts(String transport) throws Exception {
+    try (EngineResumeHarness harness =
+        EngineResumeHarness.create(rootHistory(emptyStones(), true))) {
+      harness.activateLocalPlacement();
+      if (transport.equals("socket")) harness.useSocketPlacement();
+      List<Runnable> output = new ArrayList<>();
+      setField(harness.readBoard, "placeCommandDispatcher", (Executor) output::add);
+      SwingUtilities.invokeAndWait(
+          () -> harness.board.place(0, 1, Stone.BLACK, false, false, false));
+      assertEquals(1, output.size());
+      harness.readBoard.parseLine("stopsync");
+      output.get(0).run();
+      assertFalse(harness.protocolOutput().contains("place "));
+      assertEquals(3, harness.board.getHistory().getData().moveNumber);
+    }
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"gap", "clear", "start 3 3", "socket"})
+  void activeFrameBoundariesKeepSnapshotAsAcknowledgement(String control) throws Exception {
+    try (EngineResumeHarness harness =
+        EngineResumeHarness.create(rootHistory(emptyStones(), true))) {
+      CapturedTimeoutScheduler scheduler = harness.activateLocalPlacement();
+      if (control.equals("socket")) harness.useSocketPlacement();
+      harness.board.place(0, 1, Stone.BLACK, false, false, false);
+      BoardHistoryNode pending = harness.board.getHistory().getCurrentHistoryNode();
+      assertTrue(harness.protocolOutput().contains("place 0 1"));
+      harness.readBoard.parseLine("placeComplete");
+      if (control.equals("clear") || control.startsWith("start"))
+        harness.readBoard.parseLine(control);
+      harness.board.place(2, 2, Stone.WHITE, false, false, false);
+      assertSame(pending, harness.board.getHistory().getCurrentHistoryNode());
+      harness.acceptSnapshot(pending);
+      harness.expire(scheduler.callbacks.get(0));
+      assertSame(pending, harness.board.getHistory().getCurrentHistoryNode());
+      harness.board.place(2, 2, Stone.WHITE, false, false, false);
+      assertEquals(4, harness.board.getHistory().getData().moveNumber);
+      assertTrue(harness.protocolOutput().contains("place 2 2"));
+    }
+  }
+
+  @Test
+  void oneTimeRecognitionImportsSnapshotWithoutContinuousSync() throws Exception {
+    try (EngineResumeHarness harness =
+        EngineResumeHarness.create(rootHistory(emptyStones(), true))) {
+      harness.readBoard.parseLine("start 3 3");
+      harness.readBoard.parseLine("re=1,2,0");
+      harness.readBoard.parseLine("re=0,0,0");
+      harness.readBoard.parseLine("re=0,0,0");
+      harness.readBoard.parseLine("end");
+      assertFalse(harness.frame.syncBoard);
+      assertEquals(Stone.BLACK, harness.board.getHistory().getStones()[Board.getIndex(0, 0)]);
+      assertEquals(Stone.WHITE, harness.board.getHistory().getStones()[Board.getIndex(1, 0)]);
+    }
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"error place failed", "changed-snapshot"})
+  void activeProtocolFailureRollsBackCompleteLocalMove(String failure) throws Exception {
+    GtpConsolePane previousConsole = Lizzie.gtpConsole;
+    try (EngineResumeHarness harness =
+        EngineResumeHarness.create(rootHistory(emptyStones(), true))) {
+      Lizzie.gtpConsole = allocate(SilentProtocolConsole.class);
+      harness.activateLocalPlacement();
+      harness.board.place(0, 1, Stone.BLACK, false, false, false);
+      if (failure.equals("changed-snapshot")) {
+        harness.readBoard.parseLine("re=1,2,2");
+        harness.readBoard.parseLine("re=0,0,0");
+        harness.readBoard.parseLine("re=0,0,0");
+        harness.readBoard.parseLine("end");
+      } else {
+        harness.readBoard.parseLine(failure);
+      }
+      assertEquals(2, harness.board.getHistory().getData().moveNumber);
+      assertEquals(Stone.EMPTY, harness.board.getHistory().getStones()[Board.getIndex(0, 1)]);
+      assertTrue(
+          harness.leelaz.sentCommands.stream().anyMatch(command -> command.startsWith("loadsgf ")));
+      harness.board.place(2, 2, Stone.BLACK, false, false, false);
+      assertEquals(2, harness.board.getHistory().getData().moveNumber);
+    } finally {
+      Lizzie.gtpConsole = previousConsole;
+    }
+  }
+
+  private static final class SilentProtocolConsole extends GtpConsolePane {
+    private SilentProtocolConsole() {
+      super(null);
+    }
+
+    @Override
+    public void addLineReadBoard(String line) {}
+  }
+
+  private static final class CapturedTimeoutScheduler extends ScheduledThreadPoolExecutor {
+    private final List<Runnable> callbacks = new ArrayList<>();
+
+    private CapturedTimeoutScheduler() {
+      super(1);
+    }
+
+    @Override
+    public ScheduledFuture<?> schedule(Runnable command, long delay, TimeUnit unit) {
+      callbacks.add(command);
+      return null;
+    }
   }
 
   @Test
@@ -234,6 +576,7 @@ class ReadBoardEngineResumeTest {
           placement(0, 1, Stone.BLACK));
       markPendingLocalMoveAwaitingReadBoard(harness.readBoard);
       invokePlacementFailed(harness.readBoard);
+      int previousGenmoveRequests = harness.leelaz.genmoveCount;
 
       harness.readBoard.parseLine("forceRebuild");
       harness.sync(
@@ -245,7 +588,7 @@ class ReadBoardEngineResumeTest {
               Optional.of(new int[] {2, 0}),
               Stone.WHITE));
 
-      assertEquals(1, harness.leelaz.genmoveCount);
+      assertEquals(previousGenmoveRequests + 1, harness.leelaz.genmoveCount);
       assertEquals("B", harness.leelaz.lastGenmoveColor);
       assertEquals(0, harness.frame.scheduleResumeAnalysisCount);
       assertFalse(getBooleanField(harness.readBoard, "failedLocalMoveRecoveryActive"));
@@ -381,17 +724,15 @@ class ReadBoardEngineResumeTest {
       setField(
           harness.readBoard, "lastPendingLocalMoveRetryTimeMs", System.currentTimeMillis() - 5000L);
 
-      assertTrue(invokeAckTimeoutWithoutSnapshot(harness.readBoard));
+      CapturedTimeoutScheduler scheduler =
+          (CapturedTimeoutScheduler) getField(harness.readBoard, "pendingLocalMoveTimeoutExecutor");
+      scheduler.callbacks.get(0).run();
 
       assertSame(
           remoteNode,
           harness.board.getHistory().getMainEnd(),
           "a pending place must not wait forever when readboard sends no follow-up board frame.");
-      assertFalse(harness.readBoard.lastMovePlayByLizzie);
-      assertFalse(getBooleanField(harness.readBoard, "waitingForReadBoardLocalMoveAck"));
       assertEquals(1, harness.leelaz.ponderCount);
-      assertTrue(getBooleanField(harness.readBoard, "failedLocalMoveRecoveryActive"));
-      assertTrue(getBooleanField(harness.readBoard, "failedLocalMoveAwaitingRemoteObservation"));
     }
   }
 
@@ -529,7 +870,7 @@ class ReadBoardEngineResumeTest {
   }
 
   @Test
-  void placementFailureObservationSurvivesReadBoardControlReset() throws Exception {
+  void placementFailureObservationSurvivesActiveFrameReset() throws Exception {
     try (EngineResumeHarness harness =
         EngineResumeHarness.create(rootHistory(emptyStones(), true))) {
       harness.frame.isAnaPlayingAgainstLeelaz = true;
@@ -545,7 +886,7 @@ class ReadBoardEngineResumeTest {
       markPendingLocalMoveAwaitingReadBoard(harness.readBoard);
       invokePlacementFailed(harness.readBoard);
 
-      harness.readBoard.parseLine("stopsync");
+      harness.readBoard.parseLine("clear");
 
       assertTrue(
           harness.readBoard.shouldSuppressLocalPlaceAfterFailedSync(0, 1, Stone.BLACK),
@@ -1831,6 +2172,11 @@ class ReadBoardEngineResumeTest {
     try (EngineResumeHarness harness =
         EngineResumeHarness.create(rootHistory(emptyStones(), true))) {
       harness.frame.bothSync = true;
+      harness.frame.syncBoard = true;
+      setField(
+          harness.readBoard,
+          "placeCommandDispatcher",
+          (java.util.concurrent.Executor) Runnable::run);
       HistoryPath path =
           buildHistory(
               harness.board,
@@ -2196,9 +2542,14 @@ class ReadBoardEngineResumeTest {
   }
 
   private static void markPendingLocalMoveAwaitingReadBoard(ReadBoard readBoard) throws Exception {
-    Method method = ReadBoard.class.getDeclaredMethod("startTrackingLocalMoveFromLizzie");
-    method.setAccessible(true);
-    method.invoke(readBoard);
+    readBoard.process = new AliveProcess();
+    Lizzie.frame.readBoard = readBoard;
+    Lizzie.frame.bothSync = true;
+    Lizzie.frame.syncBoard = true;
+    setField(readBoard, "placeCommandDispatcher", (java.util.concurrent.Executor) Runnable::run);
+    setField(readBoard, "pendingLocalMoveTimeoutExecutor", new CapturedTimeoutScheduler());
+    int[] coords = Lizzie.board.getHistory().getMainEnd().getData().lastMove.orElseThrow();
+    readBoard.sendCommand("place " + coords[0] + " " + coords[1]);
   }
 
   private static void invokePlacementFailed(ReadBoard readBoard) throws Exception {
@@ -2213,13 +2564,6 @@ class ReadBoardEngineResumeTest {
         ReadBoard.class.getDeclaredMethod("handleLocalMovePlacementFailed", String.class);
     method.setAccessible(true);
     method.invoke(readBoard, "error place failed");
-  }
-
-  private static boolean invokeAckTimeoutWithoutSnapshot(ReadBoard readBoard) throws Exception {
-    Method method =
-        ReadBoard.class.getDeclaredMethod("failPendingLocalMoveIfAckTimedOutWithoutSnapshot");
-    method.setAccessible(true);
-    return (boolean) method.invoke(readBoard);
   }
 
   private static boolean dispatchTrackingLine(Leelaz engine, String line) throws Exception {
@@ -2422,6 +2766,45 @@ class ReadBoardEngineResumeTest {
           protocolCapture);
     }
 
+    private CapturedTimeoutScheduler activateLocalPlacement() throws Exception {
+      buildHistory(board, placement(0, 0, Stone.BLACK), placement(1, 0, Stone.WHITE));
+      readBoard.process = new AliveProcess();
+      setField(readBoard, "placeCommandDispatcher", (java.util.concurrent.Executor) Runnable::run);
+      readBoard.parseLine("bothSync");
+      readBoard.parseLine("sync");
+      CapturedTimeoutScheduler scheduler = new CapturedTimeoutScheduler();
+      setField(readBoard, "pendingLocalMoveTimeoutExecutor", scheduler);
+      return scheduler;
+    }
+
+    private void useSocketPlacement() throws Exception {
+      ReadBoardStream stream = allocate(ReadBoardStream.class);
+      setField(stream, "out", new BufferedOutputStream(protocolCapture));
+      setField(readBoard, "readBoardStream", stream);
+      setField(readBoard, "usePipe", false);
+      readBoard.process = null;
+    }
+
+    private void expire(Runnable timeout) throws Exception {
+      setField(readBoard, "lastPendingLocalMoveRetryTimeMs", System.currentTimeMillis() - 4000);
+      timeout.run();
+    }
+
+    private void acceptSnapshot(BoardHistoryNode node) {
+      int[] codes =
+          snapshot(node.getData().stones, node.getData().lastMove, node.getData().lastMoveColor);
+      for (int y = 0; y < BOARD_SIZE; y++) {
+        readBoard.parseLine(
+            "re="
+                + codes[y * BOARD_SIZE]
+                + ","
+                + codes[y * BOARD_SIZE + 1]
+                + ","
+                + codes[y * BOARD_SIZE + 2]);
+      }
+      readBoard.parseLine("end");
+    }
+
     private void sync(int[] snapshotCodes) throws Exception {
       ArrayList<Integer> counts = new ArrayList<>(snapshotCodes.length);
       for (int code : snapshotCodes) {
@@ -2436,7 +2819,10 @@ class ReadBoardEngineResumeTest {
     }
 
     @Override
-    public void close() {
+    public void close() throws Exception {
+      ScheduledThreadPoolExecutor scheduler =
+          (ScheduledThreadPoolExecutor) getField(readBoard, "pendingLocalMoveTimeoutExecutor");
+      if (scheduler != null) scheduler.shutdownNow();
       leelaz.releaseBlockedLoadSgf();
       Lizzie.config = previousConfig;
       Lizzie.board = previousBoard;
@@ -2711,7 +3097,7 @@ class ReadBoardEngineResumeTest {
     }
   }
 
-  private static final class AliveProcess extends Process {
+  static final class AliveProcess extends Process {
     @Override
     public OutputStream getOutputStream() {
       return OutputStream.nullOutputStream();

--- a/src/test/java/featurecat/lizzie/analysis/ReadBoardPendingLocalMoveSyncTest.java
+++ b/src/test/java/featurecat/lizzie/analysis/ReadBoardPendingLocalMoveSyncTest.java
@@ -195,30 +195,6 @@ class ReadBoardPendingLocalMoveSyncTest {
   }
 
   @Test
-  void readBoardControlResetPreservesPendingLocalMoveAwaitingAck() throws Exception {
-    LizzieFrame previousFrame = Lizzie.frame;
-    try {
-      ReadBoard readBoard = allocate(ReadBoard.class);
-      setField(readBoard, "conflictTracker", new SyncConflictTracker());
-      setField(readBoard, "historyJumpTracker", new SyncHistoryJumpTracker());
-
-      LizzieFrame frame = allocate(LizzieFrame.class);
-      frame.bothSync = true;
-      Lizzie.frame = frame;
-
-      invokeStartTrackingLocalMove(readBoard);
-
-      invokeResetActiveSyncStateForReadBoardControlLine(readBoard);
-
-      assertTrue(
-          invokeShouldIgnoreCurrentLastLocalMove(readBoard),
-          "readboard start/clear control lines must not clear a local move before placeComplete or error place failed.");
-    } finally {
-      Lizzie.frame = previousFrame;
-    }
-  }
-
-  @Test
   void doesNotRetryPlaceCommandAfterPlaceCompleteWhileWaitingForSnapshot() throws Exception {
     int previousBoardWidth = Board.boardWidth;
     int previousBoardHeight = Board.boardHeight;
@@ -791,6 +767,10 @@ class ReadBoardPendingLocalMoveSyncTest {
   }
 
   private static void invokeStartTrackingLocalMove(ReadBoard readBoard) throws Exception {
+    Lizzie.frame.readBoard = readBoard;
+    Lizzie.frame.syncBoard = true;
+    readBoard.process = new ReadBoardEngineResumeTest.AliveProcess();
+    setField(readBoard, "usePipe", true);
     Method method = ReadBoard.class.getDeclaredMethod("startTrackingLocalMoveFromLizzie");
     method.setAccessible(true);
     method.invoke(readBoard);
@@ -798,14 +778,6 @@ class ReadBoardPendingLocalMoveSyncTest {
 
   private static void invokeMarkLocalMoveCommandCompleted(ReadBoard readBoard) throws Exception {
     Method method = ReadBoard.class.getDeclaredMethod("markLocalMoveCommandCompleted");
-    method.setAccessible(true);
-    method.invoke(readBoard);
-  }
-
-  private static void invokeResetActiveSyncStateForReadBoardControlLine(ReadBoard readBoard)
-      throws Exception {
-    Method method =
-        ReadBoard.class.getDeclaredMethod("resetActiveSyncStateForReadBoardControlLine");
     method.setAccessible(true);
     method.invoke(readBoard);
   }


### PR DESCRIPTION
## Summary

- Preserve ordinary local moves after ReadBoard continuous synchronization stops, while keeping the helper connected.
- Share confirmation authority across Board placement, pending/failure suppression, retries, and ReadBoard dispatch. Retire captured timeouts and queued output when synchronization stops, the helper changes, or history is replaced.
- Serialize placement admission and failure commits with Board history updates. Treat only exact `end` as frame completion so `endsync` discards buffered samples without deleting the pending move.
- Preserve active snapshot ACK, placement-failure recovery, frame resets, resume continuity, and one-time recognition. Document the synchronization authority contract.

Closes #432.

## Type Of Change

- [x] Bug fix
- [ ] Feature
- [ ] Packaging / release update
- [x] Docs / translation
- [ ] Refactor

## Testing

- [x] Tested locally
- [ ] Verified package contents if packaging changed — not applicable
- [x] Verified Fox sync flow if related — bounded Windows coverage on pre-rebase commit `4adf971d`, detailed below
- [ ] Added screenshots if UI changed — no UI layout/copy change
- [x] Updated README / docs if user-facing behavior changed — synchronization contract and changelog
- [x] Noted affected platforms if the change is platform-specific — reported on Windows/Fox; shared Java pipe/socket authority
- [x] Verified there is no unrelated formatting or line-ending churn — implementation review completed; line-ending check passed
- [x] Ran `python3 scripts/check_line_endings.py`

### Automated verification

- Before the final implementation review repairs: full `mvn verify` reported 3,940 tests, zero failures/errors, 21 skipped, plus one successful shaded-JAR smoke test.
- After those repairs: 363 focused tests passed, including deterministic regressions for concurrent local placement and buffered samples followed by `endsync`.
- After rebasing onto `860caa60` (#439): 291 tests passed with zero failures/errors/skips across ReadBoard engine resume, pending moves, EDT dispatch, streams, resume lifecycle, sync decisions, shutdown, and both position-confirmation suites. The line-ending check passed. The earlier full-suite run is not presented as a full-suite run of the rebased commit.

### Windows / Fox acceptance

An isolated shaded-JAR candidate at `4adf971d`, with its loaded ReadBoard path attributed to that candidate, passed:

- Stop synchronization, place locally, and retain the move beyond the watchdog interval without changing Fox.
- Resume Fox-to-Lizzie synchronization.
- Place in Lizzie, observe the move in Fox, and retain it beyond five seconds.
- Place, then stop synchronization, and retain the move under the observed ordering.
- On a controlled Fox record page, reject external placement and recover the local board; logs contain explicit `error place failed` followed by successful engine restoration.

The rebased commit has not been rerun on Windows. Native stop-before-ACK timing remains unverified: the attempted stop followed a matching snapshot. Deterministic Java regressions cover the pending-stop boundary.

## Notes

- Rebased onto #439 while preserving both its atomic analysis epoch and this change's local confirmation lock. Position confirmation and local placement confirmation remain separate responsibilities.
- `isSyncing` is a transient frame-processing flag, not continuous-sync authority. One-time recognition remains supported without a preceding `sync` command.
- Captured host callbacks are generation-bound; unnumbered legacy wire failure messages retain their existing correlation limitation.
- A pre-existing GMA runtime-restore timeout test showed inconsistent initialization/reservation-release timing during implementation verification; the complete class rerun passed. It remains a separate diagnosis candidate, not a confirmed production defect or part of this fix.
