### PR TITLE
Make localized SGF rule marker test unambiguous

### DIFF
--- a/src/test/java/featurecat/lizzie/rules/SGFParserEngineGameRecordTest.java
+++ b/src/test/java/featurecat/lizzie/rules/SGFParserEngineGameRecordTest.java
@@ -1,5 +1,6 @@
 package featurecat.lizzie.rules;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -117,11 +118,13 @@ class SGFParserEngineGameRecordTest {
       String second = SGFParser.saveToString(false);
       int firstIndex = first.indexOf(bundle.getString("MatchRules.sgf.begin"));
       int secondBegin = second.indexOf(bundle.getString("MatchRules.sgf.begin"));
-      int thirdBegin =
-          second.indexOf(bundle.getString("MatchRules.sgf.begin"), secondBegin + 1);
+      long beginLines =
+          Lizzie.board.getHistory().getStart().getData().comment.lines()
+              .filter(bundle.getString("MatchRules.sgf.begin")::equals)
+              .count();
       assertTrue(firstIndex >= 0, first);
       assertTrue(secondBegin >= 0, second);
-      assertTrue(thirdBegin < 0, second);
+      assertEquals(1, beginLines, second);
     }
   }
 


### PR DESCRIPTION
## Summary
- count the persisted match-rules opening marker as an exact comment line
- avoid treating Chinese end markers such as `本局规则结束` as a second opening marker
- keep the production SGF behavior unchanged

## Validation
- `mvn -B -Dfmt.skip=true -Dtest=featurecat.lizzie.rules.SGFParserEngineGameRecordTest test`
- `git diff --check`

Found while rebasing and fully validating #427 against the latest main.