### PR TITLE
Make startup cancellation race test deterministic

### DIFF
--- a/src/test/java/featurecat/lizzie/analysis/EngineManagerInitialStartupSynchronizationTest.java
+++ b/src/test/java/featurecat/lizzie/analysis/EngineManagerInitialStartupSynchronizationTest.java
@@ -5393,6 +5393,7 @@ class EngineManagerInitialStartupSynchronizationTest {
         assertTrue(engine.startupPostActionWorkerEntered.await(2, TimeUnit.SECONDS));
         // Freeze the startup command in the ordinary queue without letting it claim output.
         engine.requireResponseBeforeSend = true;
+        engine.sendCommandWithResponseForTest("known_command name", () -> {});
         setLeelazField(engine, "cmdNumber", 4);
         setLeelazField(engine, "currentCmdNum", 0);
         engine.startupPostActionWorkerGate.countDown();


### PR DESCRIPTION
## Summary
- establish a real outstanding response before freezing startup command delivery
- exercise the current pending-response gate instead of relying only on legacy command counters
- keep production engine behavior unchanged

## Validation
- reproduced the stale test deterministically before the fix
- targeted race test passed three consecutive runs after the fix
- git diff --check passed

Found during the final full regression for #427.