### PR TITLE
fix(tracking): retain evaluations across identical frames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable maintenance updates to this fork are documented here.
 
 ## Unreleased
 
+- Preserve selected-point evaluation results and active computation across identical ReadBoard frames, while retaining unstable-frame admission checks, semantic invalidation, and progress timeouts (#433).
 - Preserved diagnostic log record boundaries and stack-trace whitespace during export without weakening privacy redaction (#431).
 - Made diagnostic export estimates describe approximate uncompressed content, pruned proven irrelevant archives before reading using native Windows file identities where needed, and displayed publication success independently of folder opening (#430).
 - Preserved complete custom match rules, distinguished official rule presets, clarified unverified participation, and enabled match-rule inspection from independent-board shortcuts (#422).

--- a/docs/TRACKING_ANALYSIS_CONTRACT.md
+++ b/docs/TRACKING_ANALYSIS_CONTRACT.md
@@ -63,6 +63,36 @@ to-play、rules、komi、engine/incarnation、参数或 ReadBoard identity/revis
 ReadBoard stable 条件与失效顺序由 `ReadBoardTrackingEligibilityAdapter` 和 `ReadBoard`
 eligibility snapshot 拥有。Tracking 不拦截 helper protocol，不推导或补造 `MOVE/PASS`。
 
+ReadBoard revision 是已接受语义上下文的版本，不是帧计数。`FRAME_PENDING`、纯帧处理
+`SYNCING` 和同尺寸 start/clear 的采样边界只关闭新请求准入；只要已接受 node、Board revision
+及上述完整 context 仍有效，就保留选点、已完成结果、当前进展与原 active stream。
+完整帧在处理成功、最终导航落定后发布；相同上下文恢复 stable 不增加语义 revision。
+HOLD、真实局面变化、停止同步、helper/engine retirement 仍使旧 context 失效；未收齐或处理
+失败的帧不能发布 stable。中间的 turn-trust 更新不是 accepted context 的发布点。
+
+最终发布必须复验该次处理捕获的 admission epoch；处理期间发生的历史替换、导航或退休
+不能被迟到的 frame publication 覆盖。非法行宽或 cell code 使整帧不可接受，但不删除仍
+属于上一个有效 context 的结果。
+
+每份独立 point lease 都进行 stable 准入前后复验，并用 owner-local admission epoch 检测
+获取期间的帧边界，包括恢复为相同 stable 局面的 ABA。epoch 不进入长期结果 context。
+获取后复验成功是准入线性化点；此后 initial fence 在 pending 期间结束也可启动已准入的
+request。未准入的新请求只拒绝自身，不清除有效的其他结果，也不在稳定后自动重试。
+
+此前已接受的 pending points 不属于被拒绝的新请求。当前点在 pending 期间完成时，保留
+这些等待点，直到同一完整 context 恢复 stable 后继续 newest-first 调度。等待点在获取中
+失去准入时，也先安全关闭该次 lease，再等待/恢复调度；语义失效则清除整个旧队列。
+invalidation 和 settled 通知绑定其原 context，迟到通知不能修改替代 context。
+
+ReadBoard eligibility 使用独立窄锁；controller 查询不取得 ReadBoard owner monitor。
+通知在 eligibility lock 外执行；外层仍持 ReadBoard monitor 时交由 EDT 异步通知，不能把
+controller 调用、helper I/O、引擎恢复或阻塞 EDT handoff 放入该状态锁。
+
+语义失效使用 context-invalidated cleanup，不得恢复旧 ponder；用户 remove/clear 仍使用
+clean cancellation handback。帧流量不续期 8 秒无进展 timeout。现有 ReadBoard/engine
+diagnostics 分别记录 pending/settled retention、semantic/context invalidation 和 progress
+timeout；timeout 包含坐标、last visits、target visits 和 8000ms，不逐条记录 info。
+
 ## Display 与 renderer
 
 - `DisplaySnapshot` 是 immutable value；renderer 不读取 controller 内部 mutable state。

--- a/docs/TRACKING_ANALYSIS_DEVELOPER_GUIDE.md
+++ b/docs/TRACKING_ANALYSIS_DEVELOPER_GUIDE.md
@@ -102,11 +102,12 @@ TrackingAnalysisController -- immutable DisplaySnapshot --> BoardRenderer
 1. `RightClickMenu` 把棋盘坐标交给 `LizzieFrame.addTrackingPoint(...)`。
 2. `LizzieFrame.currentTrackingContext()` 捕获 history/node、棋盘、行棋方、规则、贴目、引擎、
    reader incarnation、interval、visits，以及可选 ReadBoard context。
-3. 若 ReadBoard 存在，adapter 在 acquisition 前检查 stable snapshot，注册 identity invalidation
-   listener，并在 acquisition 后再次检查同一 frame。
+3. 若 ReadBoard 存在，adapter 检查 stable snapshot 并注册绑定完整 context 的 invalidated / settled
+   通知。每次独立 acquisition 前捕获准入快照，获取后复验完整 context 与 admission epoch。
 4. Controller 校验坐标与 context。已有 current attempt 时，新点进入 deque 头部；否则创建新的
    generation 并请求 lease。
-5. `Leelaz` 完成 initial fence 后调用 ready callback。只有 acquisition validator 仍成立才发送：
+5. 获取后复验成功即接受该 attempt；initial fence 完成后发送以下命令，之后的纯 pending
+   不撤销已接受 attempt，也不释放或重建其 stream：
 
    ```text
    kata-analyze <interval> allow B <coord> 1 allow W <coord> 1
@@ -179,11 +180,28 @@ Tracking context 绑定以下事实：
 Controller generation 同时隔离旧 line、旧 timer、旧 ready/closed callback。任何异步入口都应
 先用 captured generation 和 exact lease identity 复验，再接触 current state。
 
+ReadBoard semantic revision 只表示已接受 context 变化或退休。新帧首行、同尺寸 start/clear
+只推进 owner-local admission epoch、关闭新准入；相同完整帧处理成功并完成最终导航后恢复
+stable，保留语义 revision。`updateReadBoardTurnTrustFromAcceptedFrame` 只更新轮次可信度；
+`syncBoardStones` 持有本次处理的局部接受结果，最终发布还在 eligibility lock 内复验进入
+处理时捕获的 admission epoch，不能覆盖期间发生的 history/lifecycle 失效。异常、未收齐
+或含非法 cell code 的帧不能发布 stable；非法帧只在下一采样/reset/end 边界清除拒绝状态。
+
+当前点在 pending 中完成时，controller 留住已接受等待点与首个 receipt，不获取下一份 lease。
+同 context 的 settled 通知复验 LizzieFrame 捕获的完整 context，再恢复 newest-first 调度。
+等待点在 acquisition 前后遇到帧切换时，先完成该次 lease 的安全关闭，再继续等待；新用户
+请求失去准入时则只删除自身，不保留 retry。不要将这两类意图合并。
+
+ReadBoard 的 invalidation 走 `contextInvalidated(expected)`，不是用户 `clear()`；settled 也
+先核对 expected context。迟到的旧通知不能清空或调度更新的 context。现有 observation 类
+提供 tracking-eligibility 的 pending/settled/invalidated，以及 tracking progress-timeout；
+只在相应 diagnostics 开启时输出。帧接收和 stable 发布都不修改 progress timeout。
+
 ## 7. Stream arbitration 与普通命令
 
 ### 7.1 锁序
 
-唯一允许的锁序是：
+引擎内部锁序保持：
 
 ```text
 engineArbitrationLock -> commandQueue
@@ -191,6 +209,12 @@ engineArbitrationLock -> commandQueue
 
 callback、observer、target activation/failure 和 queue wakeup 应在 ownership locks 外执行。
 不要为了方便在 callback 中反向取得 arbitration lock。
+
+ReadBoard tracking 状态由独立 `trackingEligibilityLock` 保护；controller 持自身 monitor
+查询 eligibility 时不能再取得 ReadBoard owner monitor。读取既有 Board revision 与 engine
+eligibility facts 不触发恢复。状态锁内只更新 accepted facts / listener ownership，不调用
+controller。外层持 ReadBoard monitor 的入口把通知异步交给 EDT；实际 frame/lease 验收使用
+latch 控制这种交错，并验证下一 EDT event 能完成，不给整个 parser 加锁。
 
 ### 7.2 为什么 ordinary command 必须先入原 queue
 

--- a/src/main/java/featurecat/lizzie/analysis/ReadBoard.java
+++ b/src/main/java/featurecat/lizzie/analysis/ReadBoard.java
@@ -241,14 +241,18 @@ public class ReadBoard implements ReadBoardTrackingEligibilityAdapter.Eligibilit
   private boolean hideFromPlace = false;
   public boolean editMode = false;
   private volatile boolean shutdownStarted = false;
-  private Object trackingEligibilityIdentity = new Object();
+  private volatile Object trackingEligibilityIdentity = new Object();
   private long trackingEligibilityRevision = 0L;
+  private long trackingAdmissionEpoch;
+  private volatile Object trackingEligibilityLock = new Object();
   private BoardHistoryNode trackingEligibilityNode;
   private long trackingEligibilityBoardRevision = 0L;
   private ReadBoardTrackingEligibilityAdapter.Reason trackingEligibilityReason =
       ReadBoardTrackingEligibilityAdapter.Reason.NO_ACCEPTED_FRAME;
   private Object trackingEligibilityObserverIdentity;
   private Runnable trackingEligibilityInvalidationListener;
+  private Runnable trackingEligibilitySettledListener;
+  private boolean malformedSyncFrame;
   private final SyncConflictTracker conflictTracker = new SyncConflictTracker();
   private final SyncHistoryJumpTracker historyJumpTracker = new SyncHistoryJumpTracker();
   private final SyncLocalNavigationTracker localNavigationTracker =
@@ -660,9 +664,23 @@ public class ReadBoard implements ReadBoardTrackingEligibilityAdapter.Eligibilit
         invalidateTrackingEligibility(ReadBoardTrackingEligibilityAdapter.Reason.FRAME_PENDING);
       }
       String[] params = line.substring(3).split(",");
-      if (params.length == Board.boardWidth) {
-        for (int i = 0; i < params.length; i++)
-          tempcount.add(Integer.parseInt(params[i].substring(0, 1)));
+      if (params.length != Board.boardWidth) {
+        malformedSyncFrame = true;
+      } else {
+        for (String param : params) {
+          if (param.length() != 1 || param.charAt(0) < '0' || param.charAt(0) > '4') {
+            malformedSyncFrame = true;
+            throw new IllegalArgumentException("Malformed ReadBoard cell code");
+          }
+        }
+      }
+      if (malformedSyncFrame) {
+        ReadBoardObservation.recordTrackingEligibility(
+            "pending", "malformed-frame", snapshot().retainsContext());
+        return;
+      }
+      for (String param : params) {
+        tempcount.add(param.charAt(0) - '0');
       }
     }
     if (line.startsWith("foxMoveNumber")) {
@@ -756,9 +774,11 @@ public class ReadBoard implements ReadBoardTrackingEligibilityAdapter.Eligibilit
       if (!isSyncing && !isYikePlatform) syncBoardStones(false);
       clearPendingRemoteContext();
       tempcount = new ArrayList<Integer>();
+      malformedSyncFrame = false;
       publishCurrentReadBoardDiagnosticsSnapshot();
     }
     if (line.trim().equals("clear")) {
+      invalidateTrackingEligibility(ReadBoardTrackingEligibilityAdapter.Reason.FRAME_PENDING);
       resetActiveSyncStateForReadBoardControlLine();
       clearPendingRemoteContext();
       tempcount = new ArrayList<Integer>();
@@ -819,6 +839,7 @@ public class ReadBoard implements ReadBoardTrackingEligibilityAdapter.Eligibilit
       LizzieFrame.toolbar.isAutoPlay = false;
     }
     if (line.startsWith("endsync")) {
+      invalidateTrackingEligibility(ReadBoardTrackingEligibilityAdapter.Reason.RETIRED);
       clearReadBoardGmaAutoPlay("endsync");
       noMsg = true;
       resetActiveSyncStateForReadBoardControlLine();
@@ -835,6 +856,7 @@ public class ReadBoard implements ReadBoardTrackingEligibilityAdapter.Eligibilit
       publishCurrentReadBoardDiagnosticsSnapshot();
     }
     if (line.startsWith("stopsync")) {
+      invalidateTrackingEligibility(ReadBoardTrackingEligibilityAdapter.Reason.RETIRED);
       clearReadBoardGmaAutoPlay("stopsync");
       resetActiveSyncStateForReadBoardControlLine();
       clearPendingRemoteContext();
@@ -1511,6 +1533,9 @@ public class ReadBoard implements ReadBoardTrackingEligibilityAdapter.Eligibilit
   }
 
   private void syncBoardStones(boolean isSecondTime) {
+    if (malformedSyncFrame) {
+      return;
+    }
     //    if (!isSecondTime) {
     //      long thisTime = System.currentTimeMillis();
     //      if (thisTime - startSyncTime < Lizzie.config.readBoardArg2 / 2) return;
@@ -1522,7 +1547,13 @@ public class ReadBoard implements ReadBoardTrackingEligibilityAdapter.Eligibilit
       resetActiveSyncState();
       return;
     }
-    isSyncing = true;
+    final long processingEpoch;
+    synchronized (trackingEligibilityLock()) {
+      trackingAdmissionEpoch++;
+      processingEpoch = trackingAdmissionEpoch;
+      isSyncing = true;
+    }
+    boolean frameAccepted = false;
     try {
       boolean needReSync = false;
       boolean played = false;
@@ -1582,6 +1613,7 @@ public class ReadBoard implements ReadBoardTrackingEligibilityAdapter.Eligibilit
             currentFoxMoveNumber,
             false);
         finishSyncAfterAcknowledgedLocalMoveSnapshot();
+        frameAccepted = true;
         return;
       }
       updateConfirmedLocalMoveForSnapshot(currentSnapshotCodes);
@@ -1729,6 +1761,7 @@ public class ReadBoard implements ReadBoardTrackingEligibilityAdapter.Eligibilit
                   + pendingLocalMoveState());
           rebuildFromSnapshot(node2, currentSnapshotCodes, snapshotDelta, currentFoxMoveNumber);
           publishReadBoardDiagnosticsSnapshot(trace);
+          frameAccepted = true;
           return;
         }
         updateReadBoardTurnTrustFromAcceptedFrame(
@@ -1772,6 +1805,7 @@ public class ReadBoard implements ReadBoardTrackingEligibilityAdapter.Eligibilit
             currentSyncEndNode, currentRemoteContext, currentSnapshotCodes, snapshotDelta)) {
           rebuildFromSnapshot(
               currentSyncEndNode, currentSnapshotCodes, snapshotDelta, currentFoxMoveNumber);
+          frameAccepted = true;
           return;
         }
         updateReadBoardTurnTrustFromAcceptedFrame(
@@ -1788,6 +1822,7 @@ public class ReadBoard implements ReadBoardTrackingEligibilityAdapter.Eligibilit
       if (!needReSync) {
         conflictTracker.clear();
         awaitingFirstSyncFrame = false;
+        frameAccepted = true;
       }
       if (completeSnapshotTrace != null && !needReSync) {
         publishReadBoardDiagnosticsSnapshot(completeSnapshotTrace);
@@ -1810,9 +1845,16 @@ public class ReadBoard implements ReadBoardTrackingEligibilityAdapter.Eligibilit
         }.start();
       }
       continueGameAfterSyncIfNeeded("sync", Lizzie.board.getHistory().getCurrentHistoryNode());
+    } catch (RuntimeException | Error failure) {
+      frameAccepted = false;
+      throw failure;
     } finally {
       localNavigationTracker.clear();
       isSyncing = false;
+      if (frameAccepted) {
+        publishAcceptedTrackingEligibility(
+            Lizzie.board.getHistory().getCurrentHistoryNode(), processingEpoch);
+      }
     }
     //	    if (played && Lizzie.config.alwaysGotoLastOnLive) {
     //	      int moveNumber = Lizzie.board.getHistory().getMainEnd().getData().moveNumber;
@@ -2534,11 +2576,6 @@ public class ReadBoard implements ReadBoardTrackingEligibilityAdapter.Eligibilit
                     foxMoveNumber))
             || isMarkerlessOrdinaryFoxTurnFallback(
                 syncStartNode, snapshotDelta, lastMoveSource, foxMoveNumber);
-    BoardHistoryNode acceptedNode =
-        Lizzie.board == null || Lizzie.board.getHistory() == null
-            ? null
-            : Lizzie.board.getHistory().getCurrentHistoryNode();
-    publishAcceptedTrackingEligibility(acceptedNode);
   }
 
   private boolean isTrustedUnchangedSnapshotTurn(
@@ -2904,6 +2941,7 @@ public class ReadBoard implements ReadBoardTrackingEligibilityAdapter.Eligibilit
       boolean preserveFailedLocalMoveSuppression,
       boolean preservePendingLocalMoveTracking,
       boolean preserveConfirmedLocalMove) {
+    malformedSyncFrame = false;
     conflictTracker.clear();
     historyJumpTracker.clear();
     if (preservePendingLocalMoveTracking && isPendingLocalMoveAwaitingReadBoard()) {
@@ -5906,15 +5944,17 @@ public class ReadBoard implements ReadBoardTrackingEligibilityAdapter.Eligibilit
   }
 
   @Override
-  public synchronized ReadBoardTrackingEligibilityAdapter.Snapshot snapshot() {
-    ensureTrackingEligibilityInitialized();
-    ReadBoardTrackingEligibilityAdapter.Reason reason = currentTrackingEligibilityReason();
-    return new ReadBoardTrackingEligibilityAdapter.Snapshot(
-        trackingEligibilityIdentity,
-        trackingEligibilityRevision,
-        trackingEligibilityNode,
-        trackingEligibilityBoardRevision,
-        reason);
+  public ReadBoardTrackingEligibilityAdapter.Snapshot snapshot() {
+    synchronized (trackingEligibilityLock()) {
+      ensureTrackingEligibilityInitialized();
+      return new ReadBoardTrackingEligibilityAdapter.Snapshot(
+          trackingEligibilityIdentity,
+          trackingEligibilityRevision,
+          trackingEligibilityNode,
+          trackingEligibilityBoardRevision,
+          currentTrackingEligibilityReason(),
+          trackingAdmissionEpoch);
+    }
   }
 
   synchronized Object currentReadBoardGmaIdentity() {
@@ -5926,28 +5966,42 @@ public class ReadBoard implements ReadBoardTrackingEligibilityAdapter.Eligibilit
   }
 
   @Override
-  public void observeInvalidation(Object identity, Runnable listener) {
+  public boolean observeEligibility(
+      ReadBoardTrackingEligibilityAdapter.Snapshot expected,
+      Runnable invalidated,
+      Runnable settled) {
     boolean invalid;
-    synchronized (this) {
-      ensureTrackingEligibilityInitialized();
-      invalid = identity != trackingEligibilityIdentity || shutdownStarted;
+    synchronized (trackingEligibilityLock()) {
+      invalid = !expected.sameFrame(snapshot());
       if (!invalid) {
-        trackingEligibilityObserverIdentity = identity;
-        trackingEligibilityInvalidationListener = listener;
+        trackingEligibilityObserverIdentity = expected.identity();
+        trackingEligibilityInvalidationListener = invalidated;
+        trackingEligibilitySettledListener = settled;
       }
     }
-    if (invalid) {
-      runTrackingEligibilityInvalidationListener(listener);
-    }
+    return !invalid;
   }
 
-  private synchronized void ensureTrackingEligibilityInitialized() {
+  private void ensureTrackingEligibilityInitialized() {
     if (trackingEligibilityIdentity == null) {
       trackingEligibilityIdentity = new Object();
     }
     if (trackingEligibilityReason == null) {
       trackingEligibilityReason = ReadBoardTrackingEligibilityAdapter.Reason.NO_ACCEPTED_FRAME;
     }
+  }
+
+  private Object trackingEligibilityLock() {
+    Object lock = trackingEligibilityLock;
+    if (lock == null) {
+      synchronized (this) {
+        if (trackingEligibilityLock == null) {
+          trackingEligibilityLock = new Object();
+        }
+        lock = trackingEligibilityLock;
+      }
+    }
+    return lock;
   }
 
   private ReadBoardTrackingEligibilityAdapter.Reason currentTrackingEligibilityReason() {
@@ -5959,12 +6013,6 @@ public class ReadBoard implements ReadBoardTrackingEligibilityAdapter.Eligibilit
     }
     if (trackingEligibilityNode == null) {
       return trackingEligibilityReason;
-    }
-    if (awaitingFirstSyncFrame) {
-      return ReadBoardTrackingEligibilityAdapter.Reason.FIRST_FRAME;
-    }
-    if (isSyncing) {
-      return ReadBoardTrackingEligibilityAdapter.Reason.SYNCING;
     }
     if (isPendingLocalMoveAwaitingReadBoard()) {
       return ReadBoardTrackingEligibilityAdapter.Reason.PENDING_LOCAL_MOVE;
@@ -5984,32 +6032,63 @@ public class ReadBoard implements ReadBoardTrackingEligibilityAdapter.Eligibilit
         || Lizzie.board.getContextRevision() != trackingEligibilityBoardRevision) {
       return ReadBoardTrackingEligibilityAdapter.Reason.NODE_MISMATCH;
     }
+    if (awaitingFirstSyncFrame) {
+      return ReadBoardTrackingEligibilityAdapter.Reason.FIRST_FRAME;
+    }
+    if (isSyncing) {
+      return ReadBoardTrackingEligibilityAdapter.Reason.SYNCING;
+    }
     return trackingEligibilityReason;
   }
 
-  private void publishAcceptedTrackingEligibility(BoardHistoryNode acceptedNode) {
+  private void publishAcceptedTrackingEligibility(
+      BoardHistoryNode acceptedNode, long processingEpoch) {
     if (acceptedNode == null || Lizzie.board == null) {
       return;
     }
     Runnable listener;
-    synchronized (this) {
+    synchronized (trackingEligibilityLock()) {
       ensureTrackingEligibilityInitialized();
-      trackingEligibilityRevision++;
+      if (trackingAdmissionEpoch != processingEpoch) {
+        return;
+      }
+      long boardRevision = Lizzie.board.getContextRevision();
+      boolean changed =
+          trackingEligibilityNode != acceptedNode
+              || trackingEligibilityBoardRevision != boardRevision;
+      if (changed) {
+        trackingEligibilityRevision++;
+      }
       trackingEligibilityNode = acceptedNode;
-      trackingEligibilityBoardRevision = Lizzie.board.getContextRevision();
+      trackingEligibilityBoardRevision = boardRevision;
       trackingEligibilityReason = ReadBoardTrackingEligibilityAdapter.Reason.STABLE;
-      listener = takeTrackingEligibilityInvalidationListener();
+      listener =
+          changed
+              ? takeTrackingEligibilityInvalidationListener()
+              : trackingEligibilitySettledListener;
+      ReadBoardObservation.recordTrackingEligibility(
+          changed ? "invalidated" : "settled", "accepted-context", !changed);
     }
     runTrackingEligibilityInvalidationListener(listener);
   }
 
   private void invalidateTrackingEligibility(ReadBoardTrackingEligibilityAdapter.Reason reason) {
     Runnable listener;
-    synchronized (this) {
+    synchronized (trackingEligibilityLock()) {
       ensureTrackingEligibilityInitialized();
+      trackingAdmissionEpoch++;
+      if (reason == ReadBoardTrackingEligibilityAdapter.Reason.FRAME_PENDING
+          || reason == ReadBoardTrackingEligibilityAdapter.Reason.FIRST_FRAME) {
+        trackingEligibilityReason = reason;
+        ReadBoardObservation.recordTrackingEligibility(
+            "pending", reason.name(), trackingEligibilityNode != null);
+        return;
+      }
       trackingEligibilityRevision++;
+      trackingEligibilityNode = null;
       trackingEligibilityReason = reason;
       listener = takeTrackingEligibilityInvalidationListener();
+      ReadBoardObservation.recordTrackingEligibility("invalidated", reason.name(), false);
     }
     runTrackingEligibilityInvalidationListener(listener);
   }
@@ -6026,15 +6105,18 @@ public class ReadBoard implements ReadBoardTrackingEligibilityAdapter.Eligibilit
     Object retiredGmaIdentity;
     long retiredGmaGeneration;
     synchronized (this) {
-      ensureTrackingEligibilityInitialized();
-      listener = takeTrackingEligibilityInvalidationListener();
-      retiredGmaIdentity = readBoardGmaPendingIdentity;
-      retiredGmaGeneration = readBoardGmaPendingGeneration;
-      trackingEligibilityRevision++;
-      trackingEligibilityIdentity = new Object();
-      trackingEligibilityNode = null;
-      trackingEligibilityBoardRevision = 0L;
-      trackingEligibilityReason = ReadBoardTrackingEligibilityAdapter.Reason.RETIRED;
+      synchronized (trackingEligibilityLock()) {
+        ensureTrackingEligibilityInitialized();
+        listener = takeTrackingEligibilityInvalidationListener();
+        retiredGmaIdentity = readBoardGmaPendingIdentity;
+        retiredGmaGeneration = readBoardGmaPendingGeneration;
+        trackingEligibilityRevision++;
+        trackingEligibilityIdentity = new Object();
+        trackingEligibilityNode = null;
+        trackingEligibilityBoardRevision = 0L;
+        trackingEligibilityReason = ReadBoardTrackingEligibilityAdapter.Reason.RETIRED;
+        trackingAdmissionEpoch++;
+      }
       retiredReadBoardGmaTerminalPending = readBoardGmaPending;
       retiredReadBoardGmaIdentity = retiredReadBoardGmaTerminalPending ? retiredGmaIdentity : null;
       retiredReadBoardGmaGeneration =
@@ -6073,11 +6155,16 @@ public class ReadBoard implements ReadBoardTrackingEligibilityAdapter.Eligibilit
             : null;
     trackingEligibilityObserverIdentity = null;
     trackingEligibilityInvalidationListener = null;
+    trackingEligibilitySettledListener = null;
     return listener;
   }
 
-  private static void runTrackingEligibilityInvalidationListener(Runnable listener) {
+  private void runTrackingEligibilityInvalidationListener(Runnable listener) {
     if (listener == null) {
+      return;
+    }
+    if (Thread.holdsLock(this)) {
+      SwingUtilities.invokeLater(() -> runTrackingEligibilityInvalidationListener(listener));
       return;
     }
     try {

--- a/src/main/java/featurecat/lizzie/analysis/ReadBoard.java
+++ b/src/main/java/featurecat/lizzie/analysis/ReadBoard.java
@@ -663,7 +663,14 @@ public class ReadBoard implements ReadBoardTrackingEligibilityAdapter.Eligibilit
       if (tempcount.isEmpty()) {
         invalidateTrackingEligibility(ReadBoardTrackingEligibilityAdapter.Reason.FRAME_PENDING);
       }
-      String[] params = line.substring(3).split(",");
+      int rowEnd = line.length();
+      if (rowEnd > 3 && line.charAt(rowEnd - 1) == '\n') {
+        rowEnd--;
+        if (rowEnd > 3 && line.charAt(rowEnd - 1) == '\r') {
+          rowEnd--;
+        }
+      }
+      String[] params = line.substring(3, rowEnd).split(",", -1);
       if (params.length != Board.boardWidth) {
         malformedSyncFrame = true;
       } else {

--- a/src/main/java/featurecat/lizzie/analysis/ReadBoardTrackingEligibilityAdapter.java
+++ b/src/main/java/featurecat/lizzie/analysis/ReadBoardTrackingEligibilityAdapter.java
@@ -26,14 +26,21 @@ public final class ReadBoardTrackingEligibilityAdapter {
     private final Object nodeIdentity;
     private final long boardRevision;
     private final Reason reason;
+    private final long admissionEpoch;
 
     public Snapshot(
-        Object identity, long revision, Object nodeIdentity, long boardRevision, Reason reason) {
+        Object identity,
+        long revision,
+        Object nodeIdentity,
+        long boardRevision,
+        Reason reason,
+        long admissionEpoch) {
       this.identity = Objects.requireNonNull(identity, "identity");
       this.revision = revision;
       this.nodeIdentity = nodeIdentity;
       this.boardRevision = boardRevision;
       this.reason = Objects.requireNonNull(reason, "reason");
+      this.admissionEpoch = admissionEpoch;
     }
 
     public Object identity() {
@@ -60,6 +67,14 @@ public final class ReadBoardTrackingEligibilityAdapter {
       return reason == Reason.STABLE;
     }
 
+    public boolean retainsContext() {
+      return nodeIdentity != null
+          && (stable()
+              || reason == Reason.FRAME_PENDING
+              || reason == Reason.SYNCING
+              || reason == Reason.FIRST_FRAME);
+    }
+
     boolean matches(TrackingAnalysisController.ReadBoardContext context) {
       return context != null
           && stable()
@@ -75,6 +90,7 @@ public final class ReadBoardTrackingEligibilityAdapter {
           && other.stable()
           && identity == other.identity
           && revision == other.revision
+          && admissionEpoch == other.admissionEpoch
           && nodeIdentity == other.nodeIdentity
           && boardRevision == other.boardRevision;
     }
@@ -83,16 +99,20 @@ public final class ReadBoardTrackingEligibilityAdapter {
   public interface EligibilitySource {
     Snapshot snapshot();
 
-    void observeInvalidation(Object identity, Runnable listener);
+    boolean observeEligibility(Snapshot expected, Runnable invalidated, Runnable settled);
   }
 
   private final TrackingAnalysisController controller;
   private final EligibilitySource source;
+  private final java.util.function.Supplier<TrackingAnalysisController.Context> currentContext;
 
   public ReadBoardTrackingEligibilityAdapter(
-      TrackingAnalysisController controller, EligibilitySource source) {
+      TrackingAnalysisController controller,
+      EligibilitySource source,
+      java.util.function.Supplier<TrackingAnalysisController.Context> currentContext) {
     this.controller = Objects.requireNonNull(controller, "controller");
     this.source = Objects.requireNonNull(source, "source");
+    this.currentContext = Objects.requireNonNull(currentContext, "currentContext");
   }
 
   public TrackingAnalysisController.AddResult addPoint(
@@ -103,13 +123,22 @@ public final class ReadBoardTrackingEligibilityAdapter {
     if (!before.matches(readBoardContext)) {
       return TrackingAnalysisController.AddResult.LEASE_UNAVAILABLE;
     }
-    source.observeInvalidation(before.identity(), controller::clear);
+    if (!source.observeEligibility(
+        before,
+        () -> controller.contextInvalidated(context),
+        () -> controller.contextSettled(context, currentContext.get()))) {
+      return TrackingAnalysisController.AddResult.LEASE_UNAVAILABLE;
+    }
     return controller.addPoint(
         coordinate,
         context,
         () -> {
-          Snapshot after = source.snapshot();
-          return before.sameFrame(after) && after.matches(readBoardContext);
+          Snapshot admission = source.snapshot();
+          if (!admission.matches(readBoardContext)) {
+            return null;
+          }
+          return () ->
+              context.matches(currentContext.get()) && admission.sameFrame(source.snapshot());
         });
   }
 }

--- a/src/main/java/featurecat/lizzie/analysis/TrackingAnalysisController.java
+++ b/src/main/java/featurecat/lizzie/analysis/TrackingAnalysisController.java
@@ -1,5 +1,6 @@
 package featurecat.lizzie.analysis;
 
+import featurecat.lizzie.logging.EngineObservation;
 import java.util.ArrayDeque;
 import java.util.Collections;
 import java.util.Deque;
@@ -201,7 +202,7 @@ public final class TrackingAnalysisController {
       return java.util.Optional.ofNullable(readBoardContext);
     }
 
-    private boolean matches(Context other) {
+    boolean matches(Context other) {
       return other != null
           && historyIdentity == other.historyIdentity
           && displayNodeIdentity == other.displayNodeIdentity
@@ -331,6 +332,7 @@ public final class TrackingAnalysisController {
     private boolean acquisitionValidated;
     private boolean ready;
     private boolean requestSent;
+    private boolean acquisitionRejected;
     private Leelaz.TrackingReleaseDisposition disposition =
         Leelaz.TrackingReleaseDisposition.ACTIVE;
 
@@ -350,6 +352,7 @@ public final class TrackingAnalysisController {
   private PointAttempt current;
   private Leelaz.TrackingStreamLeaseReceipt initialReceipt;
   private volatile DisplaySnapshot snapshot = DisplaySnapshot.EMPTY;
+  private java.util.function.Supplier<java.util.function.BooleanSupplier> admission;
 
   public TrackingAnalysisController() {
     this(new DaemonTimeoutScheduler(), () -> {});
@@ -373,7 +376,9 @@ public final class TrackingAnalysisController {
   }
 
   synchronized AddResult addPoint(
-      String coordinate, Context requestedContext, java.util.function.BooleanSupplier validator) {
+      String coordinate,
+      Context requestedContext,
+      java.util.function.Supplier<java.util.function.BooleanSupplier> admission) {
     Objects.requireNonNull(requestedContext, "requestedContext");
     String normalized = normalizeCoordinate(coordinate, requestedContext);
     if (normalized == null) {
@@ -383,8 +388,7 @@ public final class TrackingAnalysisController {
       return AddResult.CONTEXT_MISMATCH;
     }
     if (current != null
-        && (current.cancelled
-            || current.disposition != Leelaz.TrackingReleaseDisposition.ACTIVE)) {
+        && (current.cancelled || current.disposition != Leelaz.TrackingReleaseDisposition.ACTIVE)) {
       return AddResult.LEASE_UNAVAILABLE;
     }
     if (current == null && snapshot.frozen()) {
@@ -396,6 +400,11 @@ public final class TrackingAnalysisController {
       return AddResult.DUPLICATE;
     }
 
+    java.util.function.BooleanSupplier validator = admission == null ? () -> true : admission.get();
+    if (validator == null || !validator.getAsBoolean()) {
+      return AddResult.LEASE_UNAVAILABLE;
+    }
+    this.admission = admission;
     context = requestedContext;
     selectedPoints.add(normalized);
     if (current != null) {
@@ -403,7 +412,7 @@ public final class TrackingAnalysisController {
       publishSnapshot(true, false);
       return AddResult.ADDED;
     }
-    return startPoint(normalized, validator);
+    return startPoint(normalized, validator, false);
   }
 
   public synchronized boolean removePoint(String coordinate) {
@@ -432,6 +441,7 @@ public final class TrackingAnalysisController {
   }
 
   public synchronized void clear() {
+    recordTracking("user-clear");
     PointAttempt attempt = current;
     clearPointState();
     if (attempt == null) {
@@ -455,7 +465,38 @@ public final class TrackingAnalysisController {
     }
   }
 
+  synchronized void contextInvalidated(Context expected) {
+    if (context != null && context.matches(expected)) {
+      clearState();
+    }
+  }
+
+  synchronized void contextSettled(Context expected, Context accepted) {
+    if (context == null || !context.matches(expected)) {
+      return;
+    }
+    contextChanged(accepted);
+    resumePendingPoints(expected);
+  }
+
+  synchronized void resumePendingPoints(Context expected) {
+    if (context == null
+        || !context.matches(expected)
+        || current != null
+        || pendingPoints.isEmpty()) {
+      return;
+    }
+    java.util.function.BooleanSupplier validator = admission == null ? () -> true : admission.get();
+    if (validator == null) {
+      publishSnapshot(false, false);
+      return;
+    }
+    String next = pendingPoints.pollFirst();
+    startPoint(next, validator, true);
+  }
+
   private void clearState() {
+    recordTracking("context-mismatch");
     PointAttempt attempt = current;
     generation++;
     current = null;
@@ -466,18 +507,17 @@ public final class TrackingAnalysisController {
     clearPointState();
     context = null;
     initialReceipt = null;
+    admission = null;
     publishEmptySnapshot();
     if (attempt != null && attempt.lease != null) {
       attempt.lease.release();
     }
   }
 
-  private AddResult startPoint(String coordinate) {
-    return startPoint(coordinate, null);
-  }
-
   private AddResult startPoint(
-      String coordinate, java.util.function.BooleanSupplier acquisitionValidator) {
+      String coordinate,
+      java.util.function.BooleanSupplier acquisitionValidator,
+      boolean wasWaiting) {
     PointAttempt attempt = new PointAttempt(++generation, coordinate);
     current = attempt;
     publishSnapshot(true, false);
@@ -492,33 +532,14 @@ public final class TrackingAnalysisController {
         || acquisition.receipt() == null
         || acquisition.receipt().engine() != context.engine
         || acquisition.receipt().engineIncarnation() != context.engineIncarnation) {
-      if (acquisition.lease() != null) {
-        acquisition.lease().release();
-      }
-      if (current == attempt) {
-        current = null;
-      }
-      clearPointState();
-      context = null;
-      initialReceipt = null;
-      publishEmptySnapshot();
+      rejectAttempt(attempt, acquisition.lease(), false);
       return AddResult.LEASE_UNAVAILABLE;
     }
     attempt.lease = acquisition.lease();
     boolean validAfterAcquisition =
         acquisitionValidator == null || acquisitionValidator.getAsBoolean();
     if (!validAfterAcquisition || current != attempt) {
-      attempt.cancelled = true;
-      if (attempt.lease != null) {
-        attempt.lease.release();
-      }
-      if (current == attempt) {
-        current = null;
-        clearPointState();
-        context = null;
-        initialReceipt = null;
-        publishEmptySnapshot();
-      }
+      rejectAttempt(attempt, attempt.lease, wasWaiting);
       return AddResult.LEASE_UNAVAILABLE;
     }
     attempt.acquisitionValidated = true;
@@ -529,6 +550,31 @@ public final class TrackingAnalysisController {
       sendTrackingRequest(attempt);
     }
     return AddResult.ADDED;
+  }
+
+  private void rejectAttempt(
+      PointAttempt attempt, Leelaz.TrackingStreamLease lease, boolean keepWaiting) {
+    attempt.cancelled = true;
+    attempt.acquisitionRejected = true;
+    attempt.lease = lease;
+    if (current == attempt) {
+      if (lease == null) current = null;
+      if (keepWaiting) {
+        pendingPoints.addFirst(attempt.coordinate);
+      } else {
+        selectedPoints.remove(attempt.coordinate);
+        results.remove(attempt.coordinate);
+      }
+      if (selectedPoints.isEmpty()) {
+        context = null;
+        initialReceipt = null;
+        admission = null;
+      }
+      publishSnapshot(false, false);
+    }
+    if (lease != null) {
+      lease.release();
+    }
   }
 
   public DisplaySnapshot snapshot() {
@@ -618,13 +664,16 @@ public final class TrackingAnalysisController {
       }
       return;
     }
+    if (attempt.acquisitionRejected) {
+      resumePendingPoints(context);
+      return;
+    }
     boolean completed =
         !attempt.cancelled
             && lease.failureReason().isEmpty()
             && attempt.result != null
             && attempt.result.visits >= context.parameters.targetVisits();
-    boolean cleanUserCancellation =
-        attempt.restorePonderOnClose && lease.failureReason().isEmpty();
+    boolean cleanUserCancellation = attempt.restorePonderOnClose && lease.failureReason().isEmpty();
     if (!completed) {
       selectedPoints.remove(attempt.coordinate);
       results.remove(attempt.coordinate);
@@ -632,9 +681,8 @@ public final class TrackingAnalysisController {
       attempt.result = attempt.result.asCompleted();
       results.put(attempt.coordinate, attempt.result);
     }
-    String next = pendingPoints.pollFirst();
-    if (next != null) {
-      startPoint(next);
+    if (!pendingPoints.isEmpty()) {
+      resumePendingPoints(context);
     } else {
       publishSnapshot(false, false);
       Leelaz.TrackingStreamLeaseReceipt handbackReceipt = initialReceipt;
@@ -668,9 +716,20 @@ public final class TrackingAnalysisController {
         || attempt.disposition != Leelaz.TrackingReleaseDisposition.ACTIVE) {
       return;
     }
+    recordTracking("progress-timeout");
     attempt.timeout = null;
     attempt.timeoutToken++;
     attempt.lease.release();
+  }
+
+  private void recordTracking(String reason) {
+    PointAttempt attempt = current;
+    EngineObservation.recordTracking(
+        reason,
+        attempt == null ? null : attempt.coordinate,
+        attempt == null || attempt.result == null ? 0 : attempt.result.visits,
+        context == null ? 0 : context.parameters.targetVisits(),
+        PROGRESS_TIMEOUT_MILLIS);
   }
 
   private synchronized void handleDisposition(

--- a/src/main/java/featurecat/lizzie/gui/LizzieFrame.java
+++ b/src/main/java/featurecat/lizzie/gui/LizzieFrame.java
@@ -15858,6 +15858,9 @@ public class LizzieFrame extends JFrame {
   }
 
   public TrackingAnalysisController.AddResult addTrackingPoint(String coordinate) {
+    if (!canStartTrackingAnalysis()) {
+      return TrackingAnalysisController.AddResult.LEASE_UNAVAILABLE;
+    }
     TrackingAnalysisController.Context context = currentTrackingContext();
     if (context == null) {
       return TrackingAnalysisController.AddResult.LEASE_UNAVAILABLE;
@@ -15866,7 +15869,8 @@ public class LizzieFrame extends JFrame {
     if (readBoard == null) {
       return controller.addPoint(coordinate, context);
     }
-    return new ReadBoardTrackingEligibilityAdapter(controller, readBoard)
+    return new ReadBoardTrackingEligibilityAdapter(
+            controller, readBoard, this::currentTrackingContext)
         .addPoint(coordinate, context);
   }
 
@@ -15939,7 +15943,10 @@ public class LizzieFrame extends JFrame {
   }
 
   private TrackingAnalysisController.Context currentTrackingContext() {
-    if (Lizzie.config == null || !canStartTrackingAnalysis()) {
+    if (Lizzie.config == null
+        || Lizzie.board == null
+        || Lizzie.leelaz == null
+        || !Lizzie.leelaz.isEligibleLocalKataGoForReadBoardTracking()) {
       return null;
     }
     BoardHistoryList history = Lizzie.board.getHistory();
@@ -15953,7 +15960,7 @@ public class LizzieFrame extends JFrame {
     TrackingAnalysisController.ReadBoardContext readBoardContext = null;
     if (readBoard != null) {
       ReadBoardTrackingEligibilityAdapter.Snapshot readBoardSnapshot = readBoard.snapshot();
-      if (!readBoardSnapshot.stable() || readBoardSnapshot.nodeIdentity() != node) {
+      if (!readBoardSnapshot.retainsContext() || readBoardSnapshot.nodeIdentity() != node) {
         return null;
       }
       readBoardContext =

--- a/src/main/java/featurecat/lizzie/logging/EngineObservation.java
+++ b/src/main/java/featurecat/lizzie/logging/EngineObservation.java
@@ -48,6 +48,22 @@ public final class EngineObservation {
         && TRACE.isInfoEnabled();
   }
 
+  public static void recordTracking(
+      String reason, String point, int visits, int targetVisits, long timeoutMillis) {
+    try {
+      if (engineDiagnosticsEnabled()) {
+        ENGINE.debug(
+            "engine event=tracking reason={} point={} visits={} targetVisits={} timeoutMillis={}",
+            reason,
+            point,
+            visits,
+            targetVisits,
+            timeoutMillis);
+      }
+    } catch (RuntimeException ignored) {
+    }
+  }
+
   public static String identityFor(Object owner) {
     if (owner == null) {
       return null;

--- a/src/main/java/featurecat/lizzie/logging/ReadBoardObservation.java
+++ b/src/main/java/featurecat/lizzie/logging/ReadBoardObservation.java
@@ -110,6 +110,19 @@ public final class ReadBoardObservation {
     }
   }
 
+  public static void recordTrackingEligibility(String event, String reason, boolean retained) {
+    try {
+      if (diagnosticsEnabled()) {
+        DIAG.debug(
+            "readboard event=tracking-eligibility phase={} reason={} retained={}",
+            event,
+            reason,
+            retained);
+      }
+    } catch (RuntimeException ignored) {
+    }
+  }
+
   public static void recordFailure(String reason, Throwable error) {
     try {
       if (!initialized() || !DIAG.isWarnEnabled()) {

--- a/src/test/java/featurecat/lizzie/analysis/ReadBoardSyncDecisionTest.java
+++ b/src/test/java/featurecat/lizzie/analysis/ReadBoardSyncDecisionTest.java
@@ -2795,30 +2795,6 @@ class ReadBoardSyncDecisionTest {
   }
 
   @Test
-  void acceptedCompleteFramePublishesStableTrackingEligibilityAndNextFrameInvalidatesFirst()
-      throws Exception {
-    try (SyncHarness harness = SyncHarness.create(false, emptyHistory())) {
-      harness.leelaz.enableReadBoardGmaSupport();
-      harness.sync(snapshot(stones(), Optional.empty(), Stone.EMPTY));
-      ReadBoardTrackingEligibilityAdapter.Snapshot stable = harness.readBoard.snapshot();
-      AtomicInteger invalidations = new AtomicInteger();
-      harness.readBoard.observeInvalidation(stable.identity(), invalidations::incrementAndGet);
-
-      assertEquals(ReadBoardTrackingEligibilityAdapter.Reason.STABLE, stable.reason());
-      assertSame(harness.board.getHistory().getCurrentHistoryNode(), stable.nodeIdentity());
-      assertEquals(harness.board.getContextRevision(), stable.boardRevision());
-
-      setField(harness.readBoard, "tempcount", new ArrayList<Integer>());
-      harness.readBoard.parseLine("re=0,0,0");
-      ReadBoardTrackingEligibilityAdapter.Snapshot pending = harness.readBoard.snapshot();
-
-      assertEquals(ReadBoardTrackingEligibilityAdapter.Reason.FRAME_PENDING, pending.reason());
-      assertTrue(pending.revision() > stable.revision());
-      assertEquals(1, invalidations.get());
-    }
-  }
-
-  @Test
   void trackingEligibilityExplainsFirstFramePendingLocalGmaRestoreAndNodeMismatch()
       throws Exception {
     try (SyncHarness harness = SyncHarness.create(false, emptyHistory())) {
@@ -2866,7 +2842,7 @@ class ReadBoardSyncDecisionTest {
       harness.sync(snapshot(stones(), Optional.empty(), Stone.EMPTY));
       ReadBoardTrackingEligibilityAdapter.Snapshot first = harness.readBoard.snapshot();
       AtomicInteger invalidations = new AtomicInteger();
-      harness.readBoard.observeInvalidation(first.identity(), invalidations::incrementAndGet);
+      harness.readBoard.observeEligibility(first, invalidations::incrementAndGet, () -> {});
       setField(
           harness.readBoard, "localNavigationTracker", new SyncLocalNavigationTracker(() -> true));
 
@@ -2879,7 +2855,7 @@ class ReadBoardSyncDecisionTest {
 
       harness.sync(snapshot(stones(), Optional.empty(), Stone.EMPTY));
       ReadBoardTrackingEligibilityAdapter.Snapshot second = harness.readBoard.snapshot();
-      harness.readBoard.observeInvalidation(second.identity(), invalidations::incrementAndGet);
+      harness.readBoard.observeEligibility(second, invalidations::incrementAndGet, () -> {});
 
       harness.readBoard.onHistoryOverwritten();
 

--- a/src/test/java/featurecat/lizzie/analysis/TrackingAnalysisControllerTest.java
+++ b/src/test/java/featurecat/lizzie/analysis/TrackingAnalysisControllerTest.java
@@ -69,7 +69,13 @@ class TrackingAnalysisControllerTest {
       MutableEligibilitySource source =
           new MutableEligibilitySource(state.output, 1L, state.output, 7L, true);
       ReadBoardTrackingEligibilityAdapter adapter =
-          new ReadBoardTrackingEligibilityAdapter(controller, source);
+          new ReadBoardTrackingEligibilityAdapter(
+              controller,
+              source,
+              () ->
+                  state.contextWithReadBoard(
+                      new TrackingAnalysisController.ReadBoardContext(
+                          state.output, 1L, state.output, 7L)));
       TrackingAnalysisController.Context context =
           state.contextWithReadBoard(
               new TrackingAnalysisController.ReadBoardContext(state.output, 1L, state.output, 7L));
@@ -92,7 +98,13 @@ class TrackingAnalysisControllerTest {
       MutableEligibilitySource source =
           new MutableEligibilitySource(state.output, 1L, state.output, 7L, false);
       ReadBoardTrackingEligibilityAdapter adapter =
-          new ReadBoardTrackingEligibilityAdapter(controller, source);
+          new ReadBoardTrackingEligibilityAdapter(
+              controller,
+              source,
+              () ->
+                  state.contextWithReadBoard(
+                      new TrackingAnalysisController.ReadBoardContext(
+                          state.output, 1L, state.output, 7L)));
 
       assertEquals(
           TrackingAnalysisController.AddResult.LEASE_UNAVAILABLE,
@@ -921,7 +933,8 @@ class TrackingAnalysisControllerTest {
               boardRevision,
               stable
                   ? ReadBoardTrackingEligibilityAdapter.Reason.STABLE
-                  : ReadBoardTrackingEligibilityAdapter.Reason.FRAME_PENDING);
+                  : ReadBoardTrackingEligibilityAdapter.Reason.FRAME_PENDING,
+              revision);
       Runnable listener = invalidationListener;
       if (listener != null && !stable) {
         listener.run();
@@ -934,8 +947,12 @@ class TrackingAnalysisControllerTest {
     }
 
     @Override
-    public void observeInvalidation(Object identity, Runnable listener) {
+    public boolean observeEligibility(
+        ReadBoardTrackingEligibilityAdapter.Snapshot expected,
+        Runnable listener,
+        Runnable settled) {
       invalidationListener = listener;
+      return expected.sameFrame(snapshot);
     }
   }
 

--- a/src/test/java/featurecat/lizzie/gui/TrackingProductionCutoverTest.java
+++ b/src/test/java/featurecat/lizzie/gui/TrackingProductionCutoverTest.java
@@ -3,6 +3,7 @@ package featurecat.lizzie.gui;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import featurecat.lizzie.Config;
@@ -31,8 +32,526 @@ import java.lang.reflect.Method;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 class TrackingProductionCutoverTest {
+  @ParameterizedTest
+  @ValueSource(strings = {"re=9,0", "re=0", "re=,0"})
+  void malformedFrameCannotPublishStableAdmission(String malformedRow) throws Exception {
+    try (TestEnvironment environment = TestEnvironment.open()) {
+      environment.installParsingReadBoard();
+      environment.receiveEmptyFrame();
+      assertEquals(
+          TrackingAnalysisController.AddResult.ADDED, environment.frame.addTrackingPoint("A1"));
+      environment.completeInitialFence(800000000);
+      environment.sendTrackingInfo("info move A1 visits 40 winrate 0.51 scoreLead 2.5 pv A1");
+      if (malformedRow.equals("re=0")) {
+        environment.frame.readBoard.parseLine(malformedRow);
+      } else {
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> environment.frame.readBoard.parseLine(malformedRow));
+      }
+      environment.frame.readBoard.parseLine("re=0,0");
+      environment.frame.readBoard.parseLine("end");
+      assertEquals(
+          TrackingAnalysisController.AddResult.LEASE_UNAVAILABLE,
+          environment.frame.addTrackingPoint("B2"));
+      assertEquals(40, environment.frame.trackingDisplaySnapshot().results().get("A1").visits());
+      environment.receiveEmptyFrame();
+      assertTrue(environment.frame.canStartTrackingAnalysis());
+    }
+  }
+
+  @Test
+  void historyReplacementDuringAcceptedFrameProcessingCannotReopenAdmission() throws Exception {
+    BoardRenderer previous = LizzieFrame.boardRenderer;
+    try (TestEnvironment environment = TestEnvironment.open()) {
+      LizzieFrame.boardRenderer = new BoardRenderer(false);
+      environment.installParsingReadBoard();
+      environment.receiveEmptyFrame();
+      ((TrackingFrame) environment.frame).nextRefresh =
+          () -> Lizzie.board.setHistory(new BoardHistoryList(BoardData.empty(2, 2)));
+      environment.frame.readBoard.parseLine("re=3,0");
+      environment.frame.readBoard.parseLine("re=0,0");
+      environment.frame.readBoard.parseLine("end");
+      assertEquals(Stone.EMPTY, Lizzie.board.getHistory().getData().stones[Board.getIndex(0, 0)]);
+      assertFalse(environment.frame.canStartTrackingAnalysis());
+    } finally {
+      LizzieFrame.boardRenderer = previous;
+    }
+  }
+
+  @Test
+  void identicalReadBoardFramesRetainProgressAndRejectUnstableNewRequests() throws Exception {
+    try (TestEnvironment environment = TestEnvironment.open()) {
+      environment.installParsingReadBoard();
+      environment.receiveEmptyFrame();
+      assertEquals(
+          TrackingAnalysisController.AddResult.ADDED, environment.frame.addTrackingPoint("A1"));
+      environment.completeInitialFence(800000000);
+      environment.sendTrackingInfo("info move A1 visits 40 winrate 0.51 scoreLead 2.5 pv A1");
+      String commands = environment.commands();
+
+      environment.frame.readBoard.parseLine("re=0,0");
+      assertEquals(
+          List.of("A1"), List.copyOf(environment.frame.trackingDisplaySnapshot().selectedPoints()));
+      assertEquals(
+          TrackingAnalysisController.AddResult.LEASE_UNAVAILABLE,
+          environment.frame.addTrackingPoint("B2"));
+      environment.sendTrackingInfo("info move A1 visits 50 winrate 0.52 scoreLead 3.5 pv A1");
+      environment.frame.readBoard.parseLine("re=0,0");
+      environment.frame.readBoard.parseLine("end");
+      environment.receiveEmptyFrame();
+
+      TrackingAnalysisController.PointResult result =
+          environment.frame.trackingDisplaySnapshot().results().get("A1");
+      assertEquals(50, result.visits());
+      assertEquals(52.0, result.winrate());
+      assertEquals(3.5, result.scoreLead());
+      assertEquals(
+          List.of("A1"), List.copyOf(environment.frame.trackingDisplaySnapshot().selectedPoints()));
+      assertEquals(commands, environment.commands());
+      assertTrue(environment.frame.canStartTrackingAnalysis());
+    }
+  }
+
+  @Test
+  void completedAndWaitingPointsSurvivePendingAndResumeNewestFirst() throws Exception {
+    try (TestEnvironment environment = TestEnvironment.open()) {
+      environment.installParsingReadBoard();
+      environment.receiveEmptyFrame();
+      assertEquals(
+          TrackingAnalysisController.AddResult.ADDED, environment.frame.addTrackingPoint("A1"));
+      environment.completeInitialFence(800000000);
+      assertEquals(
+          TrackingAnalysisController.AddResult.ADDED, environment.frame.addTrackingPoint("A2"));
+      assertEquals(
+          TrackingAnalysisController.AddResult.ADDED, environment.frame.addTrackingPoint("B2"));
+      environment.frame.readBoard.parseLine("re=0,0");
+      environment.sendTrackingInfo("info move A1 visits 100 winrate 0.51 scoreLead 2.5 pv A1");
+      environment.completeFinalFence(800000002);
+      String pendingCommands = environment.commands();
+      assertTrue(environment.frame.trackingDisplaySnapshot().results().get("A1").completed());
+      assertEquals(
+          List.of("A1", "A2", "B2"),
+          List.copyOf(environment.frame.trackingDisplaySnapshot().selectedPoints()));
+      assertFalse(pendingCommands.contains("800000003 stop"), pendingCommands);
+      environment.frame.readBoard.parseLine("re=0,0");
+      environment.frame.readBoard.parseLine("end");
+      environment.completeInitialFence(800000003);
+      assertTrue(
+          environment.commands().endsWith("kata-analyze 10 allow B B2 1 allow W B2 1\n"),
+          environment.commands());
+      environment.sendTrackingInfo("info move B2 visits 40 winrate 0.52 scoreLead 3.5 pv B2");
+      String activeCommands = environment.commands();
+      environment.receiveEmptyFrame();
+      assertEquals(40, environment.frame.trackingDisplaySnapshot().results().get("B2").visits());
+      assertTrue(environment.frame.trackingDisplaySnapshot().results().get("A1").completed());
+      assertEquals(activeCommands, environment.commands());
+      environment.sendTrackingInfo("info move B2 visits 100 winrate 0.52 scoreLead 3.5 pv B2");
+      environment.completeFinalFence(800000005);
+      environment.completeInitialFence(800000006);
+      assertTrue(
+          environment.commands().endsWith("kata-analyze 10 allow B A2 1 allow W A2 1\n"),
+          environment.commands());
+      environment.sendTrackingInfo("info move A2 visits 100 winrate 0.53 scoreLead 4.5 pv A2");
+      environment.completeFinalFence(800000008);
+      String completedCommands = environment.commands();
+      for (int i = 0; i < 3; i++) environment.receiveEmptyFrame();
+      assertTrue(
+          environment.frame.trackingDisplaySnapshot().results().values().stream()
+              .allMatch(TrackingAnalysisController.PointResult::completed));
+      assertEquals(3, environment.frame.trackingDisplaySnapshot().results().size());
+      assertEquals(completedCommands, environment.commands());
+    }
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"endsync", "stopsync", "helper-replacement"})
+  void stoppingSynchronizationRetiresCompletedAndWaitingPointsWithoutPonderHandback(
+      String lifecycle) throws Exception {
+    try (TestEnvironment environment = TestEnvironment.open()) {
+      environment.installParsingReadBoard();
+      environment.receiveEmptyFrame();
+      environment.engine.ponder();
+      environment.processCommandResponse("=");
+      assertEquals(
+          TrackingAnalysisController.AddResult.ADDED, environment.frame.addTrackingPoint("A1"));
+      environment.completeInitialFence(800000000);
+      assertEquals(
+          TrackingAnalysisController.AddResult.ADDED, environment.frame.addTrackingPoint("B2"));
+      environment.frame.readBoard.parseLine("re=0,0");
+      environment.sendTrackingInfo("info move A1 visits 100 winrate 0.51 scoreLead 2.5 pv A1");
+      environment.completeFinalFence(800000002);
+      if (lifecycle.equals("helper-replacement")) {
+        environment.frame.readBoard.shutdown();
+        environment.installParsingReadBoard();
+      } else {
+        environment.frame.readBoard.parseLine(lifecycle);
+      }
+      assertTrue(environment.frame.trackingDisplaySnapshot().selectedPoints().isEmpty());
+      String stoppedCommands = environment.commands();
+      environment.receiveEmptyFrame();
+      assertTrue(environment.frame.trackingDisplaySnapshot().selectedPoints().isEmpty());
+      assertEquals(stoppedCommands, environment.commands());
+      assertFalse(environment.engine.isPondering());
+    }
+  }
+
+  @Test
+  void admittedInitialFenceCanBecomeReadyDuringPendingReception() throws Exception {
+    try (TestEnvironment environment = TestEnvironment.open()) {
+      environment.installParsingReadBoard();
+      environment.receiveEmptyFrame();
+      assertEquals(
+          TrackingAnalysisController.AddResult.ADDED, environment.frame.addTrackingPoint("A1"));
+      environment.frame.readBoard.parseLine("re=0,0");
+      environment.completeInitialFence(800000000);
+      assertTrue(environment.commands().endsWith("kata-analyze 10 allow B A1 1 allow W A1 1\n"));
+      environment.sendTrackingInfo("info move A1 visits 40 winrate 0.51 scoreLead 2.5 pv A1");
+      assertEquals(40, environment.frame.trackingDisplaySnapshot().results().get("A1").visits());
+    }
+  }
+
+  @Test
+  void acquisitionLosingAdmissionPreservesCompletedResultAndNeverRetriesRejectedPoint()
+      throws Exception {
+    try (TestEnvironment environment = TestEnvironment.open()) {
+      environment.installParsingReadBoard();
+      environment.receiveEmptyFrame();
+      assertEquals(
+          TrackingAnalysisController.AddResult.ADDED, environment.frame.addTrackingPoint("A1"));
+      environment.completeInitialFence(800000000);
+      environment.sendTrackingInfo("info move A1 visits 100 winrate 0.51 scoreLead 2.5 pv A1");
+      environment.completeFinalFence(800000002);
+      environment.onNextEngineWrite(() -> environment.frame.readBoard.parseLine("re=0,0"));
+      assertEquals(
+          TrackingAnalysisController.AddResult.LEASE_UNAVAILABLE,
+          environment.frame.addTrackingPoint("B2"));
+      assertEquals(
+          List.of("A1"), List.copyOf(environment.frame.trackingDisplaySnapshot().selectedPoints()));
+      assertTrue(environment.frame.trackingDisplaySnapshot().results().get("A1").completed());
+      environment.completeInitialFence(800000003);
+      environment.frame.readBoard.parseLine("re=0,0");
+      environment.frame.readBoard.parseLine("end");
+      assertFalse(environment.commands().contains("allow B B2"));
+      assertEquals(
+          List.of("A1"), List.copyOf(environment.frame.trackingDisplaySnapshot().selectedPoints()));
+    }
+  }
+
+  @Test
+  void completeIdenticalFrameDuringAcquisitionDoesNotHideAdmissionTransition() throws Exception {
+    try (TestEnvironment environment = TestEnvironment.open()) {
+      environment.installParsingReadBoard();
+      environment.receiveEmptyFrame();
+      environment.onNextEngineWrite(environment::receiveEmptyFrame);
+      assertEquals(
+          TrackingAnalysisController.AddResult.LEASE_UNAVAILABLE,
+          environment.frame.addTrackingPoint("A1"));
+      environment.completeInitialFence(800000000);
+      assertFalse(environment.commands().contains("allow B A1"));
+      assertTrue(environment.frame.trackingDisplaySnapshot().selectedPoints().isEmpty());
+    }
+  }
+
+  @Test
+  void waitingPointLosingAdmissionDuringAcquisitionSurvivesUntilItsLeaseCloses() throws Exception {
+    try (TestEnvironment environment = TestEnvironment.open()) {
+      environment.installParsingReadBoard();
+      environment.receiveEmptyFrame();
+      assertEquals(
+          TrackingAnalysisController.AddResult.ADDED, environment.frame.addTrackingPoint("A1"));
+      environment.completeInitialFence(800000000);
+      assertEquals(
+          TrackingAnalysisController.AddResult.ADDED, environment.frame.addTrackingPoint("B2"));
+      environment.sendTrackingInfo("info move A1 visits 100 winrate 0.51 scoreLead 2.5 pv A1");
+      environment.onNextEngineWrite(() -> environment.frame.readBoard.parseLine("re=0,0"));
+      environment.completeFinalFence(800000002);
+      assertEquals(
+          List.of("A1", "B2"),
+          List.copyOf(environment.frame.trackingDisplaySnapshot().selectedPoints()));
+      environment.frame.readBoard.parseLine("re=0,0");
+      environment.frame.readBoard.parseLine("end");
+      assertFalse(environment.commands().contains("allow B B2"));
+      environment.completeInitialFence(800000003);
+      environment.completeInitialFence(800000004);
+      assertTrue(
+          environment.commands().endsWith("kata-analyze 10 allow B B2 1 allow W B2 1\n"),
+          environment.commands());
+    }
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"rules", "komi", "turn", "interval", "visits", "history"})
+  void acceptedFrameRevalidatesAllProductionContextFields(String component) throws Exception {
+    try (TestEnvironment environment = TestEnvironment.open()) {
+      environment.installParsingReadBoard();
+      environment.receiveEmptyFrame();
+      assertEquals(
+          TrackingAnalysisController.AddResult.ADDED, environment.frame.addTrackingPoint("A1"));
+      environment.completeInitialFence(800000000);
+      environment.sendTrackingInfo("info move A1 visits 40 winrate 0.51 scoreLead 2.5 pv A1");
+      environment.frame.readBoard.parseLine("re=0,0");
+      switch (component) {
+        case "rules":
+          Lizzie.config.currentKataGoRules = "japanese";
+          break;
+        case "komi":
+          Lizzie.board.getHistory().getGameInfo().setKomi(6.5);
+          break;
+        case "turn":
+          Lizzie.board.getHistory().getData().blackToPlay = false;
+          break;
+        case "interval":
+          Lizzie.config.analyzeUpdateIntervalCentisec = 20;
+          break;
+        case "visits":
+          Lizzie.config.trackingAnalysisMaxVisits = 200;
+          break;
+        case "history":
+          Lizzie.board.setHistory(new BoardHistoryList(BoardData.empty(2, 2)));
+          break;
+        default:
+          throw new AssertionError(component);
+      }
+      environment.frame.readBoard.parseLine("re=0,0");
+      environment.frame.readBoard.parseLine("end");
+      assertTrue(environment.frame.trackingDisplaySnapshot().selectedPoints().isEmpty(), component);
+      environment.completeFinalFence(800000002);
+      environment.sendTrackingInfo("info move A1 visits 80 winrate 0.53 scoreLead 4.5 pv A1");
+      assertTrue(environment.frame.trackingDisplaySnapshot().results().isEmpty(), component);
+      assertFalse(environment.engine.isPondering());
+    }
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"clear", "start 2 2", "incomplete"})
+  void samplingBoundariesKeepAcceptedResultButDoNotOpenAdmission(String boundary) throws Exception {
+    try (TestEnvironment environment = TestEnvironment.open()) {
+      environment.installParsingReadBoard();
+      environment.receiveEmptyFrame();
+      assertEquals(
+          TrackingAnalysisController.AddResult.ADDED, environment.frame.addTrackingPoint("A1"));
+      environment.completeInitialFence(800000000);
+      environment.sendTrackingInfo("info move A1 visits 40 winrate 0.51 scoreLead 2.5 pv A1");
+      String commands = environment.commands();
+      if (boundary.equals("incomplete")) {
+        environment.frame.readBoard.parseLine("re=0,0");
+        environment.frame.readBoard.parseLine("end");
+      } else {
+        environment.frame.readBoard.parseLine(boundary);
+      }
+      assertFalse(environment.frame.canStartTrackingAnalysis());
+      environment.frame.onMainEnginePonder();
+      assertEquals(40, environment.frame.trackingDisplaySnapshot().results().get("A1").visits());
+      environment.receiveEmptyFrame();
+      assertTrue(environment.frame.canStartTrackingAnalysis());
+      assertEquals(commands, environment.commands());
+    }
+  }
+
+  @Test
+  void realRemoteMoveClearsTrackingAndDoesNotAcceptOldProgress() throws Exception {
+    BoardRenderer previous = LizzieFrame.boardRenderer;
+    try (TestEnvironment environment = TestEnvironment.open()) {
+      LizzieFrame.boardRenderer = new BoardRenderer(false);
+      environment.installParsingReadBoard();
+      environment.receiveEmptyFrame();
+      assertEquals(
+          TrackingAnalysisController.AddResult.ADDED, environment.frame.addTrackingPoint("A1"));
+      environment.completeInitialFence(800000000);
+      environment.sendTrackingInfo("info move A1 visits 40 winrate 0.51 scoreLead 2.5 pv A1");
+      BoardHistoryNode old = Lizzie.board.getHistory().getCurrentHistoryNode();
+      environment.frame.readBoard.parseLine("re=3,0");
+      environment.frame.readBoard.parseLine("re=0,0");
+      environment.frame.readBoard.parseLine("end");
+      assertFalse(old == Lizzie.board.getHistory().getCurrentHistoryNode());
+      assertTrue(environment.frame.trackingDisplaySnapshot().selectedPoints().isEmpty());
+      environment.sendTrackingInfo("info move A1 visits 80 winrate 0.53 scoreLead 4.5 pv A1");
+      assertTrue(environment.frame.trackingDisplaySnapshot().results().isEmpty());
+      assertTrue(Lizzie.board.getHistory().getData().bestMoves.isEmpty());
+    } finally {
+      LizzieFrame.boardRenderer = previous;
+    }
+  }
+
+  @Test
+  void markerOnlyChangeRetainsAcceptedStonePositionAndStream() throws Exception {
+    try (TestEnvironment environment = TestEnvironment.open()) {
+      Lizzie.board.getHistory().place(0, 0, Stone.BLACK, true);
+      environment.installParsingReadBoard();
+      environment.frame.readBoard.parseLine("re=3,0");
+      environment.frame.readBoard.parseLine("re=0,0");
+      environment.frame.readBoard.parseLine("end");
+      assertEquals(
+          TrackingAnalysisController.AddResult.ADDED, environment.frame.addTrackingPoint("A1"));
+      environment.completeInitialFence(800000000);
+      environment.sendTrackingInfo("info move A1 visits 40 winrate 0.51 scoreLead 2.5 pv A1");
+      String commands = environment.commands();
+      environment.frame.readBoard.parseLine("re=1,0");
+      environment.frame.readBoard.parseLine("re=0,0");
+      environment.frame.readBoard.parseLine("end");
+      assertEquals(40, environment.frame.trackingDisplaySnapshot().results().get("A1").visits());
+      assertEquals(commands, environment.commands());
+    }
+  }
+
+  @Test
+  void unchangedRecoveryNavigatingToExistingNodeInvalidatesOldDisplayContext() throws Exception {
+    BoardRenderer previous = LizzieFrame.boardRenderer;
+    try (TestEnvironment environment = TestEnvironment.open()) {
+      LizzieFrame.boardRenderer = new BoardRenderer(false);
+      Lizzie.board.getHistory().place(0, 0, Stone.BLACK, true);
+      BoardHistoryNode earlier = Lizzie.board.getHistory().getCurrentHistoryNode();
+      Lizzie.board.getHistory().place(1, 0, Stone.WHITE, true);
+      environment.installParsingReadBoard();
+      environment.frame.readBoard.parseLine("syncPlatform fox");
+      environment.frame.readBoard.parseLine("roomToken tracking-test");
+      environment.frame.readBoard.parseLine("liveTitleMove 2");
+      environment.frame.readBoard.parseLine("foxMoveNumber 2");
+      environment.frame.readBoard.parseLine("re=1,4");
+      environment.frame.readBoard.parseLine("re=0,0");
+      environment.frame.readBoard.parseLine("end");
+      assertEquals(
+          TrackingAnalysisController.AddResult.ADDED, environment.frame.addTrackingPoint("A1"));
+      environment.completeInitialFence(800000000);
+      environment.sendTrackingInfo("info move A1 visits 40 winrate 0.51 scoreLead 2.5 pv A1");
+      environment.frame.readBoard.parseLine("syncPlatform fox");
+      environment.frame.readBoard.parseLine("roomToken tracking-test");
+      environment.frame.readBoard.parseLine("liveTitleMove 1");
+      environment.frame.readBoard.parseLine("foxMoveNumber 1");
+      environment.frame.readBoard.parseLine("re=3,0");
+      environment.frame.readBoard.parseLine("re=0,0");
+      environment.frame.readBoard.parseLine("end");
+      assertSame(earlier, Lizzie.board.getHistory().getCurrentHistoryNode());
+      assertTrue(environment.frame.trackingDisplaySnapshot().selectedPoints().isEmpty());
+    } finally {
+      LizzieFrame.boardRenderer = previous;
+    }
+  }
+
+  @Test
+  void delayedRetirementNotificationCannotClearReplacementContext() throws Exception {
+    java.util.concurrent.CountDownLatch entered = new java.util.concurrent.CountDownLatch(1);
+    java.util.concurrent.CountDownLatch release = new java.util.concurrent.CountDownLatch(1);
+    try (TestEnvironment environment = TestEnvironment.open()) {
+      environment.installParsingReadBoard();
+      environment.receiveEmptyFrame();
+      assertEquals(
+          TrackingAnalysisController.AddResult.ADDED, environment.frame.addTrackingPoint("A1"));
+      environment.completeInitialFence(800000000);
+      environment.sendTrackingInfo("info move A1 visits 100 winrate 0.51 scoreLead 2.5 pv A1");
+      environment.completeFinalFence(800000002);
+      javax.swing.SwingUtilities.invokeLater(
+          () -> {
+            entered.countDown();
+            try {
+              release.await();
+            } catch (InterruptedException failure) {
+              Thread.currentThread().interrupt();
+            }
+          });
+      assertTrue(entered.await(3, java.util.concurrent.TimeUnit.SECONDS));
+      synchronized (environment.frame.readBoard) {
+        environment.frame.readBoard.parseLine("endsync");
+      }
+      environment.receiveEmptyFrame();
+      environment.frame.onMainEnginePonder();
+      assertEquals(
+          TrackingAnalysisController.AddResult.ADDED, environment.frame.addTrackingPoint("B2"));
+      environment.completeInitialFence(800000003);
+      environment.sendTrackingInfo("info move B2 visits 40 winrate 0.52 scoreLead 3.5 pv B2");
+      release.countDown();
+      javax.swing.SwingUtilities.invokeAndWait(() -> {});
+      assertEquals(
+          List.of("B2"), List.copyOf(environment.frame.trackingDisplaySnapshot().selectedPoints()));
+      assertEquals(40, environment.frame.trackingDisplaySnapshot().results().get("B2").visits());
+    } finally {
+      release.countDown();
+      javax.swing.SwingUtilities.invokeAndWait(() -> {});
+    }
+  }
+
+  @Test
+  void acquisitionValidationDoesNotWaitForOuterReadBoardOwnerLock() throws Exception {
+    java.util.concurrent.CountDownLatch writing = new java.util.concurrent.CountDownLatch(1);
+    java.util.concurrent.CountDownLatch proceed = new java.util.concurrent.CountDownLatch(1);
+    java.util.concurrent.ExecutorService executor =
+        java.util.concurrent.Executors.newSingleThreadExecutor();
+    try (TestEnvironment environment = TestEnvironment.open()) {
+      environment.installParsingReadBoard();
+      environment.receiveEmptyFrame();
+      environment.onNextEngineWrite(
+          () -> {
+            writing.countDown();
+            try {
+              proceed.await();
+            } catch (InterruptedException failure) {
+              Thread.currentThread().interrupt();
+            }
+          });
+      java.util.concurrent.Future<TrackingAnalysisController.AddResult> result =
+          executor.submit(() -> environment.frame.addTrackingPoint("A1"));
+      assertTrue(writing.await(3, java.util.concurrent.TimeUnit.SECONDS));
+      synchronized (environment.frame.readBoard) {
+        environment.frame.readBoard.parseLine("endsync");
+        proceed.countDown();
+        assertEquals(
+            TrackingAnalysisController.AddResult.LEASE_UNAVAILABLE,
+            result.get(3, java.util.concurrent.TimeUnit.SECONDS));
+      }
+      javax.swing.SwingUtilities.invokeAndWait(() -> {});
+      assertTrue(environment.frame.trackingDisplaySnapshot().selectedPoints().isEmpty());
+    } finally {
+      proceed.countDown();
+      executor.shutdownNow();
+      assertTrue(executor.awaitTermination(3, java.util.concurrent.TimeUnit.SECONDS));
+    }
+  }
+
+  @Test
+  void incomingFramesDoNotRenewProgressTimeoutOrLetOldTimerReleaseNewWork() throws Exception {
+    try (TestEnvironment environment = TestEnvironment.open()) {
+      List<Runnable> timeouts = environment.installManualTimeouts();
+      environment.installParsingReadBoard();
+      environment.receiveEmptyFrame();
+      assertEquals(
+          TrackingAnalysisController.AddResult.ADDED, environment.frame.addTrackingPoint("A1"));
+      environment.completeInitialFence(800000000);
+      environment.sendTrackingInfo("info move A1 visits 100 winrate 0.51 scoreLead 2.5 pv A1");
+      environment.completeFinalFence(800000002);
+      assertEquals(
+          TrackingAnalysisController.AddResult.ADDED, environment.frame.addTrackingPoint("B2"));
+      environment.completeInitialFence(800000003);
+      Runnable beforeProgress = timeouts.get(timeouts.size() - 1);
+      environment.sendTrackingInfo("info move B2 visits 40 winrate 0.52 scoreLead 3.5 pv B2");
+      Runnable progressTimeout = timeouts.get(timeouts.size() - 1);
+      environment.receiveEmptyFrame();
+      environment.receiveEmptyFrame();
+      environment.frame.readBoard.parseLine("re=0,0");
+      String commands = environment.commands();
+      beforeProgress.run();
+      assertEquals(commands, environment.commands());
+      progressTimeout.run();
+      assertTrue(environment.commands().endsWith("800000005 stop\n"), environment.commands());
+      environment.completeFinalFence(800000005);
+      assertEquals(
+          List.of("A1"), List.copyOf(environment.frame.trackingDisplaySnapshot().selectedPoints()));
+      assertTrue(environment.frame.trackingDisplaySnapshot().results().get("A1").completed());
+      environment.frame.readBoard.parseLine("re=0,0");
+      environment.frame.readBoard.parseLine("end");
+      assertEquals(
+          TrackingAnalysisController.AddResult.ADDED, environment.frame.addTrackingPoint("A2"));
+      environment.completeInitialFence(800000006);
+      commands = environment.commands();
+      progressTimeout.run();
+      assertEquals(commands, environment.commands());
+    }
+  }
+
   @Test
   void localAndStableReadBoardEntriesUseTheSameCurrentEngineController() throws Exception {
     try (TestEnvironment environment = TestEnvironment.open()) {
@@ -792,6 +1311,73 @@ class TrackingProductionCutoverTest {
           frame);
     }
 
+    List<Runnable> installManualTimeouts() throws Exception {
+      List<Runnable> callbacks = new java.util.ArrayList<>();
+      Class<?> schedulerType =
+          Class.forName(TrackingAnalysisController.class.getName() + "$TimeoutScheduler");
+      Class<?> cancellableType =
+          Class.forName(TrackingAnalysisController.class.getName() + "$Cancellable");
+      Object scheduler =
+          java.lang.reflect.Proxy.newProxyInstance(
+              schedulerType.getClassLoader(),
+              new Class<?>[] {schedulerType},
+              (proxy, method, arguments) -> {
+                callbacks.add((Runnable) arguments[1]);
+                return java.lang.reflect.Proxy.newProxyInstance(
+                    cancellableType.getClassLoader(),
+                    new Class<?>[] {cancellableType},
+                    (ignored, cancel, unused) -> null);
+              });
+      java.lang.reflect.Constructor<TrackingAnalysisController> constructor =
+          TrackingAnalysisController.class.getDeclaredConstructor(schedulerType);
+      constructor.setAccessible(true);
+      setField(
+          frame,
+          LizzieFrame.class,
+          "trackingAnalysisController",
+          constructor.newInstance(scheduler));
+      return callbacks;
+    }
+
+    void onNextEngineWrite(Runnable action) throws Exception {
+      setField(
+          engine,
+          Leelaz.class,
+          "outputStream",
+          new BufferedOutputStream(
+              new java.io.FilterOutputStream(output) {
+                private Runnable pending = action;
+
+                @Override
+                public void write(byte[] bytes, int offset, int length) throws java.io.IOException {
+                  out.write(bytes, offset, length);
+                  Runnable callback = pending;
+                  pending = null;
+                  if (callback != null) callback.run();
+                }
+              }));
+    }
+
+    void installParsingReadBoard() throws Exception {
+      ReadBoard readBoard = allocate(ReadBoard.class);
+      for (String name :
+          List.of("conflictTracker", "historyJumpTracker", "localNavigationTracker")) {
+        Field field = ReadBoard.class.getDeclaredField(name);
+        field.setAccessible(true);
+        java.lang.reflect.Constructor<?> constructor = field.getType().getDeclaredConstructor();
+        constructor.setAccessible(true);
+        field.set(readBoard, constructor.newInstance());
+      }
+      setField(readBoard, ReadBoard.class, "tempcount", new java.util.ArrayList<Integer>());
+      frame.readBoard = readBoard;
+    }
+
+    void receiveEmptyFrame() {
+      frame.readBoard.parseLine("re=0,0");
+      frame.readBoard.parseLine("re=0,0");
+      frame.readBoard.parseLine("end");
+    }
+
     void installStableReadBoard() throws Exception {
       ReadBoard readBoard = allocate(ReadBoard.class);
       BoardHistoryNode node = Lizzie.board.getHistory().getCurrentHistoryNode();
@@ -900,9 +1486,14 @@ class TrackingProductionCutoverTest {
 
   private static final class TrackingFrame extends LizzieFrame {
     private int analysisRefreshRequests;
+    private Runnable nextRefresh;
 
     @Override
-    public void refresh() {}
+    public void refresh() {
+      Runnable action = nextRefresh;
+      nextRefresh = null;
+      if (action != null) action.run();
+    }
 
     @Override
     public void requestAnalysisRefresh() {

--- a/src/test/java/featurecat/lizzie/gui/TrackingProductionCutoverTest.java
+++ b/src/test/java/featurecat/lizzie/gui/TrackingProductionCutoverTest.java
@@ -83,6 +83,27 @@ class TrackingProductionCutoverTest {
     }
   }
 
+  @ParameterizedTest
+  @ValueSource(strings = {"\n", "\r\n"})
+  void pipeTerminatedFramesRetainEvaluationAndAcceptStableRequests(String ending) throws Exception {
+    try (TestEnvironment environment = TestEnvironment.open()) {
+      environment.installParsingReadBoard();
+      for (int frame = 0; frame < 2; frame++) {
+        environment.frame.readBoard.parseLine("re=0,0" + ending);
+        environment.frame.readBoard.parseLine("re=0,0" + ending);
+        environment.frame.readBoard.parseLine("end" + ending);
+        if (frame == 0) {
+          assertEquals(TrackingAnalysisController.AddResult.ADDED, environment.frame.addTrackingPoint("A1"));
+          environment.completeInitialFence(800000000);
+          environment.sendTrackingInfo("info move A1 visits 40 winrate 0.51 scoreLead 2.5 pv A1");
+        }
+      }
+      assertEquals(40, environment.frame.trackingDisplaySnapshot().results().get("A1").visits());
+      assertEquals(TrackingAnalysisController.AddResult.ADDED, environment.frame.addTrackingPoint("B2"));
+      assertFalse(environment.commands().contains("800000002 stop"));
+    }
+  }
+
   @Test
   void identicalReadBoardFramesRetainProgressAndRejectUnstableNewRequests() throws Exception {
     try (TestEnvironment environment = TestEnvironment.open()) {


### PR DESCRIPTION
## Summary

- Separate ReadBoard frame admission from retained tracking context validity.
- Preserve selected points, completed results and active evaluation progress across identical frames.
- Validate final accepted-frame publication and retain context-bound invalidation for semantic and lifecycle changes.
- Handle native pipe frame line endings and reject malformed frames without reopening admission.
- Update tracking contracts, diagnostics and focused regression coverage.

## Verification

Recorded implementation verification:
- Before bounded review repairs, the full suite ran 3,954 tests with zero failures/errors and 21 skipped.
- The repair-surface run exposed a parse-error observation regression; the affected logging tests and production-entry suite passed after correction.
- Controlled-transport smoke checks confirmed retained progress without stream restart, rejection of unstable new requests, and unchanged progress-timeout behavior.
- Standards and Spec review records report the admitted implementation findings resolved.

Windows acceptance at c883b10ff5f7feb38512650b172b8d289e7e8abf:
- PASS: native synchronization.
- PASS: selected-point retention.
- PASS: completed-result retention.
- PASS: invalidation after a real remote move.
- PASS: navigation clears old results without reviving them on return.
- PASS: stopping synchronization clears old results without reviving them on restart.
- FAIL: navigation readmission remains unavailable until another remote move (#444).
- FAIL: engine restart final confirmation is rejected with a retired bootstrap receipt (#445).

Native selected-point retention was confirmed by the user; exact stream continuity was demonstrated by controlled-transport checks, not independently captured in the Windows run.

## Draft Gates

- [ ] Resolve navigation readmission (#444) and verify return to the accepted position without a new helper frame.
- [ ] Resolve the shared restart confirmation defect (#445) and complete engine-restart acceptance.
- [ ] Integrate current upstream main, including #439 and #440, and run focused tracking/synchronization cross-regressions.

Acceptance is paused with known defects. This PR is not ready to merge.

## Related

- Addresses #433.
- Navigation readmission: #444.
- Engine-restart acceptance blocker: #445.
