### PR TITLE
Accelerate HumanSL downloads with a verified R2 mirror

### DIFF
--- a/.github/workflows/mirror-humansl.yml
+++ b/.github/workflows/mirror-humansl.yml
@@ -1,0 +1,37 @@
+name: Mirror HumanSL model to R2
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: stable-r2-promotion
+  cancel-in-progress: false
+
+jobs:
+  mirror:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    environment: stable-release
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+      - name: Install publisher dependencies
+        run: python -m pip install --disable-pip-version-check boto3 cryptography requests
+      - name: Test publisher
+        run: python -m unittest scripts.test_r2_release
+      - name: Mirror and verify pinned HumanSL model
+        env:
+          CLOUDFLARE_R2_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_R2_ACCOUNT_ID }}
+          CLOUDFLARE_R2_ACCESS_KEY_ID: ${{ secrets.CLOUDFLARE_R2_ACCESS_KEY_ID }}
+          CLOUDFLARE_R2_SECRET_ACCESS_KEY: ${{ secrets.CLOUDFLARE_R2_SECRET_ACCESS_KEY }}
+          R2_BUCKET: ${{ vars.CLOUDFLARE_R2_BUCKET }}
+          R2_PUBLIC_BASE: ${{ vars.R2_PUBLIC_BASE_URL }}
+        run: |
+          python scripts/r2_release.py mirror-humansl \
+            --bucket "${R2_BUCKET:-lizzieyzy-next-downloads}" \
+            --public-base "${R2_PUBLIC_BASE:-https://download.goagent.top}"

--- a/docs/R2_RELEASES.md
+++ b/docs/R2_RELEASES.md
@@ -2,7 +2,7 @@
 
 用户唯一公开入口是 `https://goagent.top/download/`。`download.goagent.top` 只作为安装包、
 公开目录和软件更新接口的技术后台；GitHub Release 始终保留完整资产、安装器、Linux 包、
-历史版本和自动备用下载，pre-release 不上传 R2。
+历史版本和自动备用下载，pre-release 安装包不上传 R2。
 
 测试通道不走 R2。签名测试清单只发布到 GitHub：版本化 pre-release 上的
 `lizzieyzy-next-update-envelope.json`，以及固定 tag `channel-beta` 上的同名指针。
@@ -13,7 +13,7 @@
 
 ## 固定资源范围
 
-R2 桶名固定为 `lizzieyzy-next-downloads`，只保留一个正式版。发布脚本要求每个正式版恰好
+R2 桶名固定为 `lizzieyzy-next-downloads`，安装包只保留一个正式版。发布脚本要求每个正式版恰好
 包含以下 13 个镜像对象，数量或名称不一致会直接停止：
 
 - 4 个 Windows 免安装包：OpenCL、CPU、统一 NVIDIA CUDA、无引擎
@@ -21,6 +21,19 @@ R2 桶名固定为 `lizzieyzy-next-downloads`，只保留一个正式版。发�
 - macOS Apple Silicon 与 Intel 两个 DMG
 - Windows AMD RX 9000 / RDNA4 `gfx120x` ROCm 实验免安装包
 - TensorRT `.7z.001`、`.7z.002`、README、manifest、SHA-256 文件
+
+另独立保留 HumanSL 人类模型 `models/humansl/b18c384nbt-humanv0.bin.gz`（99,066,230 字节），
+供软件内“一键设置”与“AI 陪练”按需下载。模型与版本无关，不加入安装包目录或更新清单，
+也不随 `releases/` 清理。客户端优先使用
+`https://download.goagent.top/models/humansl/b18c384nbt-humanv0.bin.gz`，
+连接、下载或校验失败时回退 KataGo 官方源；用户取消时不启动备用下载。
+两源均必须通过相同的大小与 SHA-256 校验：
+`637746e44f0efe00ad1245a50aa9bbf0716efe364c43965ead97bd6835d84ab5`。
+已有校验通过的模型直接复用；旧版客户端仍使用其内置官方地址，需要更新软件后使用镜像。
+
+首次上传或修复镜像运行 `Mirror HumanSL model to R2` 工作流。它与正式发布共用并发锁，
+先检查桶容量并验证官方原文件，再上传固定对象，最后从公网完整下载校验大小、SHA 和 Range。
+工作流复用现有桶级凭据，不改 Release、安装包、catalog 或签名更新清单。
 
 Windows 安装器、Linux 包、其他 AMD ROCm 架构、pre-release 和历史版本不占用 R2。
 RX 6000、RX 7000 与 Ryzen AI Max 的实验包继续由 GitHub Release 提供。版本化对象位于
@@ -35,9 +48,11 @@ RX 6000、RX 7000 与 Ryzen AI Max 的实验包继续由 GitHub Release 提供�
 
 Cloudflare Redirect Rule 必须仅匹配 `download.goagent.top` 的 `/` 和 `/index.html`，以 301
 跳转到 `https://goagent.top/download/` 并保留查询字符串。`/releases/*` 与 `/channels/*`
-不能被重定向。发布器会同时验证两个根入口的 301，以及目录、更新清单和安装包接口。
+以及 `/models/*` 不能被重定向。发布器会同时验证两个根入口的 301，以及目录、更新清单和安装包接口。
 
-镜像资产总量不得超过 `9,000,000,000` 字节。门禁失败、旧版本对象清理失败或任一 SHA-256
+镜像资产、持久模型和现有元数据总量不得超过 `9,000,000,000` 字节。
+发布前为 HumanSL 预留空间，查询桶中非版本对象并合并核算，防止后续发布挤占模型容量。
+门禁失败、旧版本对象清理失败或任一 SHA-256
 不一致时，GitHub Release 保持原状态，不会被晋升为正式版。
 
 ## 发布流程

--- a/scripts/r2_release.py
+++ b/scripts/r2_release.py
@@ -12,6 +12,7 @@ import json
 import os
 import re
 import sys
+import tempfile
 import time
 import urllib.parse
 from pathlib import Path
@@ -19,6 +20,11 @@ from typing import Any, Iterable
 
 
 R2_SIZE_LIMIT = 9_000_000_000
+HUMAN_SL_SIZE_BYTES = 99_066_230
+HUMAN_SL_FILE = "b18c384nbt-humanv0.bin.gz"
+HUMAN_SL_KEY = "models/humansl/" + HUMAN_SL_FILE
+HUMAN_SL_SHA256 = "637746e44f0efe00ad1245a50aa9bbf0716efe364c43965ead97bd6835d84ab5"
+HUMAN_SL_ORIGIN = "https://media.katagotraining.org/uploaded/networks/models_extra/" + HUMAN_SL_FILE
 DEFAULT_REPOSITORY = "wimi321/lizzieyzy-next"
 DEFAULT_BUCKET = "lizzieyzy-next-downloads"
 DEFAULT_PUBLIC_BASE = "https://download.goagent.top"
@@ -176,9 +182,10 @@ def select_r2_assets(
     if len(names) != len(set(names)):
         raise ReleaseError("R2 asset whitelist contains duplicate names")
     total = sum(asset.size for asset in selected)
-    if enforce_size_limit and total > R2_SIZE_LIMIT:
+    if enforce_size_limit and total + HUMAN_SL_SIZE_BYTES > R2_SIZE_LIMIT:
         raise ReleaseError(
-            f"R2 stable assets total {total:,} bytes, above the {R2_SIZE_LIMIT:,}-byte hard limit"
+            f"R2 stable assets total {total:,} bytes plus {HUMAN_SL_SIZE_BYTES:,} reserved "
+            f"for HumanSL, above the {R2_SIZE_LIMIT:,}-byte hard limit"
         )
     return sorted(selected, key=lambda asset: asset.name)
 
@@ -983,6 +990,34 @@ def stale_release_keys(existing: Iterable[str], keep_keys: set[str]) -> list[str
     return sorted(key for key in existing if key not in keep_keys)
 
 
+def verify_combined_storage_budget(client, bucket: str, release_bytes: int) -> None:
+    """Keep persistent models and metadata inside the same release storage budget."""
+    persistent_bytes = 0
+    model_bytes = 0
+    token = None
+    while True:
+        kwargs = {"Bucket": bucket}
+        if token:
+            kwargs["ContinuationToken"] = token
+        response = client.list_objects_v2(**kwargs)
+        for entry in response.get("Contents", []):
+            key = str(entry["Key"])
+            if not key.startswith("releases/"):
+                size = int(entry["Size"])
+                persistent_bytes += size
+                if key == HUMAN_SL_KEY:
+                    model_bytes = size
+        if not response.get("IsTruncated"):
+            break
+        token = response["NextContinuationToken"]
+    total = release_bytes + persistent_bytes + max(0, HUMAN_SL_SIZE_BYTES - model_bytes)
+    if total > R2_SIZE_LIMIT:
+        raise ReleaseError(
+            f"R2 releases, persistent objects and HumanSL reserve total {total:,} bytes, "
+            f"above the {R2_SIZE_LIMIT:,}-byte hard limit"
+        )
+
+
 def delete_unselected_release_objects(
     client, bucket: str, keep_keys: set[str]
 ) -> None:
@@ -1054,6 +1089,7 @@ def verify_r2_inventory(client, bucket: str, assets: Iterable[Asset]) -> None:
             f"R2 actual release inventory is {total:,} bytes, above the "
             f"{R2_SIZE_LIMIT:,}-byte hard limit"
         )
+    verify_combined_storage_budget(client, bucket, total)
 
 
 def download_small_asset(session, asset: Asset) -> bytes:
@@ -1609,6 +1645,7 @@ def promote(args: argparse.Namespace) -> None:
     legacy = build_legacy_manifest(manifest)
 
     client = r2_client(account_id, access_key, secret_key)
+    verify_combined_storage_budget(client, args.bucket, total)
     publish_maintenance_catalog(
         client,
         args.bucket,
@@ -1679,6 +1716,59 @@ def plan(args: argparse.Namespace) -> None:
     print(json.dumps(result, ensure_ascii=False, indent=2))
 
 
+def receive_humansl(session, url: str, output) -> None:
+    digest = hashlib.sha256()
+    size = 0
+    with session.get(url, stream=True, timeout=(30, 60),
+                     headers={"Accept-Encoding": "identity"}) as response:
+        if response.status_code != 200:
+            raise ReleaseError(f"HumanSL download returned HTTP {response.status_code}")
+        for chunk in response.iter_content(chunk_size=1024 * 1024):
+            size += len(chunk)
+            if size > HUMAN_SL_SIZE_BYTES:
+                raise ReleaseError("HumanSL download exceeds pinned size")
+            digest.update(chunk)
+            output.write(chunk)
+    if size != HUMAN_SL_SIZE_BYTES or digest.hexdigest() != HUMAN_SL_SHA256:
+        raise ReleaseError("HumanSL download failed pinned size/SHA-256 verification")
+
+
+def mirror_humansl(args: argparse.Namespace) -> None:
+    import requests
+
+    names = ("CLOUDFLARE_R2_ACCOUNT_ID", "CLOUDFLARE_R2_ACCESS_KEY_ID",
+             "CLOUDFLARE_R2_SECRET_ACCESS_KEY")
+    values = [os.environ.get(name, "").strip() for name in names]
+    if not all(values):
+        raise ReleaseError("Missing R2 publisher credentials")
+    client = r2_client(*values)
+    release_bytes = 0
+    for page in client.get_paginator("list_objects_v2").paginate(Bucket=args.bucket, Prefix="releases/"):
+        release_bytes += sum(int(entry["Size"]) for entry in page.get("Contents", []))
+    verify_combined_storage_budget(client, args.bucket, release_bytes)
+    asset = Asset(HUMAN_SL_FILE, HUMAN_SL_SIZE_BYTES, HUMAN_SL_SHA256,
+                  HUMAN_SL_ORIGIN, HUMAN_SL_ORIGIN, "human-sl-model", r2_key=HUMAN_SL_KEY)
+    with requests.Session() as session:
+        if not object_matches(client, args.bucket, asset):
+            with tempfile.TemporaryFile() as model:
+                receive_humansl(session, HUMAN_SL_ORIGIN, model)
+                model.seek(0)
+                client.put_object(
+                    Bucket=args.bucket, Key=HUMAN_SL_KEY, Body=model,
+                    ContentLength=HUMAN_SL_SIZE_BYTES, ContentType="application/octet-stream",
+                    CacheControl="public, max-age=31536000, immutable",
+                    ContentDisposition=f'attachment; filename="{HUMAN_SL_FILE}"',
+                    Metadata={"sha256": HUMAN_SL_SHA256})
+        if not object_matches(client, args.bucket, asset):
+            raise ReleaseError("HumanSL R2 metadata verification failed")
+        public_url = args.public_base.rstrip("/") + "/" + HUMAN_SL_KEY
+        _verify_public_object(session, public_url, asset)
+        with tempfile.TemporaryFile() as downloaded:
+            receive_humansl(session, public_url, downloaded)
+    verify_combined_storage_budget(client, args.bucket, release_bytes)
+    print(f"HumanSL public download verified: {public_url}; {HUMAN_SL_SIZE_BYTES} bytes; SHA-256 {HUMAN_SL_SHA256}")
+
+
 def parser() -> argparse.ArgumentParser:
     root = argparse.ArgumentParser(description=__doc__)
     subcommands = root.add_subparsers(dest="command", required=True)
@@ -1701,6 +1791,9 @@ def parser() -> argparse.ArgumentParser:
     test_channel.add_argument("--tag", required=True)
     test_channel.add_argument("--private-key", required=True)
     test_channel.add_argument("--key-id", default=DEFAULT_KEY_ID)
+    human_sl = subcommands.add_parser("mirror-humansl")
+    human_sl.add_argument("--bucket", default=DEFAULT_BUCKET)
+    human_sl.add_argument("--public-base", default=DEFAULT_PUBLIC_BASE)
     return root
 
 
@@ -1711,6 +1804,8 @@ def main() -> int:
             plan(args)
         elif args.command == "publish-test-channel":
             publish_test_channel(args)
+        elif args.command == "mirror-humansl":
+            mirror_humansl(args)
         else:
             promote(args)
         return 0

--- a/scripts/test_r2_release.py
+++ b/scripts/test_r2_release.py
@@ -1,4 +1,6 @@
 import base64
+import hashlib
+import io
 import json
 import sys
 import unittest
@@ -55,6 +57,89 @@ def release():
 
 
 class R2ReleaseTest(unittest.TestCase):
+    def test_humansl_stream_requires_exact_size_and_digest(self):
+        data = b"pinned-model"
+        session = mock.Mock()
+        response = mock.MagicMock()
+        session.get.return_value = response
+        response.__enter__.return_value = response
+        response.status_code = 200
+        with mock.patch.object(r2_release, "HUMAN_SL_SIZE_BYTES", len(data)), \
+             mock.patch.object(r2_release, "HUMAN_SL_SHA256", hashlib.sha256(data).hexdigest()):
+            for received in (data, data[:-1], data + b"x", b"X" * len(data)):
+                response.iter_content.return_value = [received]
+                output = io.BytesIO()
+                if received == data:
+                    r2_release.receive_humansl(session, "https://example/model", output)
+                    self.assertEqual(data, output.getvalue())
+                else:
+                    with self.assertRaises(r2_release.ReleaseError):
+                        r2_release.receive_humansl(session, "https://example/model", output)
+            response.status_code = 503
+            with self.assertRaises(r2_release.ReleaseError):
+                r2_release.receive_humansl(session, "https://example/model", io.BytesIO())
+
+    def test_humansl_reservation_rejects_release_that_would_fill_bucket(self):
+        source = release()
+        source["assets"][0]["size"] = r2_release.R2_SIZE_LIMIT - 12_000
+        with self.assertRaises(r2_release.ReleaseError):
+            r2_release.select_r2_assets(source, r2_release.DEFAULT_PUBLIC_BASE)
+
+    def test_model_publisher_verifies_before_upload_and_reuses_existing_object(self):
+        args = r2_release.parser().parse_args(["mirror-humansl"])
+        client = mock.Mock()
+        client.get_paginator.return_value.paginate.return_value = [
+            {"Contents": [{"Size": 7_800_000_000}]}]
+        credentials = {name: "test-only" for name in (
+            "CLOUDFLARE_R2_ACCOUNT_ID", "CLOUDFLARE_R2_ACCESS_KEY_ID",
+            "CLOUDFLARE_R2_SECRET_ACCESS_KEY")}
+        with mock.patch.dict("os.environ", credentials), \
+             mock.patch.dict(sys.modules, {"requests": mock.MagicMock()}), \
+             mock.patch.object(r2_release, "r2_client", return_value=client), \
+             mock.patch.object(r2_release, "verify_combined_storage_budget") as budget, \
+             mock.patch.object(r2_release, "object_matches", side_effect=[False, True]) as matches, \
+             mock.patch.object(r2_release, "receive_humansl") as receive, \
+             mock.patch.object(r2_release, "_verify_public_object"):
+            r2_release.mirror_humansl(args)
+            self.assertEqual(2, receive.call_count)
+            self.assertEqual(r2_release.HUMAN_SL_KEY, client.put_object.call_args.kwargs["Key"])
+            self.assertEqual(r2_release.HUMAN_SL_SIZE_BYTES,
+                             client.put_object.call_args.kwargs["ContentLength"])
+            budget.assert_called_with(client, args.bucket, 7_800_000_000)
+            client.reset_mock()
+            matches.side_effect = [True, True]
+            r2_release.mirror_humansl(args)
+            client.put_object.assert_not_called()
+            matches.side_effect = [False]
+            receive.side_effect = r2_release.ReleaseError("checksum failure")
+            with self.assertRaises(r2_release.ReleaseError):
+                r2_release.mirror_humansl(args)
+            client.put_object.assert_not_called()
+            client.delete_objects.assert_not_called()
+
+    def test_storage_budget_counts_persistent_objects_across_pages_without_double_counting(self):
+        client = mock.Mock()
+        pages = [
+            {"Contents": [{"Key": "releases/old/large.zip", "Size": 8_000_000_000}],
+             "IsTruncated": True, "NextContinuationToken": "next"},
+            {"Contents": [
+                {"Key": "models/humansl/b18c384nbt-humanv0.bin.gz",
+                 "Size": r2_release.HUMAN_SL_SIZE_BYTES},
+                {"Key": "channels/stable/catalog.json", "Size": 1000}]}]
+        client.list_objects_v2.side_effect = pages
+        available = r2_release.R2_SIZE_LIMIT - r2_release.HUMAN_SL_SIZE_BYTES - 1000
+        r2_release.verify_combined_storage_budget(client, "bucket", available)
+        client.list_objects_v2.assert_called_with(Bucket="bucket", ContinuationToken="next")
+        client.list_objects_v2.side_effect = pages
+        with self.assertRaises(r2_release.ReleaseError):
+            r2_release.verify_combined_storage_budget(client, "bucket", available + 1)
+
+    def test_storage_budget_reserves_model_before_first_upload(self):
+        client = mock.Mock()
+        client.list_objects_v2.return_value = {"Contents": []}
+        with self.assertRaises(r2_release.ReleaseError):
+            r2_release.verify_combined_storage_budget(client, "bucket", r2_release.R2_SIZE_LIMIT)
+
     def test_whitelist_is_exact_and_excludes_installers_linux_and_older_amd(self):
         selected = r2_release.select_r2_assets(release(), r2_release.DEFAULT_PUBLIC_BASE)
 

--- a/src/main/java/featurecat/lizzie/util/KataGoAutoSetupHelper.java
+++ b/src/main/java/featurecat/lizzie/util/KataGoAutoSetupHelper.java
@@ -136,6 +136,8 @@ public final class KataGoAutoSetupHelper {
   private static final String BUNDLED_2026_06_28B_DISPLAY_NAME = "28B 2026-06";
   public static final String HUMAN_SL_MODEL_FILE_NAME = "b18c384nbt-humanv0.bin.gz";
   public static final String HUMAN_SL_MODEL_DOWNLOAD_URL =
+      "https://download.goagent.top/models/humansl/" + HUMAN_SL_MODEL_FILE_NAME;
+  public static final String HUMAN_SL_MODEL_ORIGIN_URL =
       "https://media.katagotraining.org/uploaded/networks/models_extra/" + HUMAN_SL_MODEL_FILE_NAME;
   public static final long HUMAN_SL_MODEL_SIZE_BYTES = 99066230L;
   public static final String HUMAN_SL_MODEL_SHA256 =
@@ -1138,6 +1140,11 @@ public final class KataGoAutoSetupHelper {
 
   public static Path downloadHumanSlModel(ProgressListener listener, DownloadSession session)
       throws IOException {
+    return downloadHumanSlModel(listener, session, humanSlModelDownloadUrls());
+  }
+
+  static Path downloadHumanSlModel(
+      ProgressListener listener, DownloadSession session, List<String> sources) throws IOException {
     SetupSnapshot snapshot = inspectLocalSetup();
     Path modelsDir = humanSlModelsDir(snapshot.workingDir);
     Files.createDirectories(modelsDir);
@@ -1155,11 +1162,43 @@ public final class KataGoAutoSetupHelper {
     Files.deleteIfExists(target);
 
     Path temp = modelsDir.resolve(HUMAN_SL_MODEL_FILE_NAME + ".part");
+    IOException failure = null;
+    for (String source : sources) {
+      activeSession.throwIfCancelled();
+      try {
+        downloadHumanSlModelFromSource(source, temp, listener, activeSession);
+      } catch (DownloadCancelledException e) {
+        throw e;
+      } catch (IOException e) {
+        if (failure != null) {
+          e.addSuppressed(failure);
+        }
+        failure = e;
+        continue;
+      }
+      try {
+        activeSession.throwIfCancelled();
+        try {
+          Files.move(
+              temp, target, StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE);
+        } catch (AtomicMoveNotSupportedException e) {
+          Files.move(temp, target, StandardCopyOption.REPLACE_EXISTING);
+        }
+        rememberHumanSlModel(target);
+        return target;
+      } finally {
+        Files.deleteIfExists(temp);
+      }
+    }
+    throw failure != null ? failure : new IOException("No HumanSL download source configured");
+  }
+
+  private static void downloadHumanSlModelFromSource(
+      String source, Path temp, ProgressListener listener, DownloadSession activeSession)
+      throws IOException {
     HttpURLConnection conn = null;
     try {
-      conn =
-          (HttpURLConnection)
-              NetworkProxy.openConnection(URI.create(humanSlModelDownloadUrl()).toURL());
+      conn = (HttpURLConnection) NetworkProxy.openConnection(URI.create(source).toURL());
       activeSession.attach(conn);
       activeSession.throwIfCancelled();
       conn.setInstanceFollowRedirects(true);
@@ -1169,11 +1208,15 @@ public final class KataGoAutoSetupHelper {
       conn.setRequestProperty("User-Agent", USER_AGENT);
       conn.setRequestProperty("Accept", "application/octet-stream,*/*");
       int code = conn.getResponseCode();
-      if (code < 200 || code >= 400) {
-        throw new IOException("HTTP " + code + " from " + humanSlModelDownloadUrl());
+      if (code != HttpURLConnection.HTTP_OK) {
+        throw new IOException("HTTP " + code + " from " + source);
       }
       long totalBytes = conn.getContentLengthLong();
       long expectedBytes = humanSlModelSizeBytes();
+      if (expectedBytes > 0L && totalBytes > 0L && totalBytes != expectedBytes) {
+        throw new IOException(
+            resource("AutoSetup.humanSlModelIncomplete", "HumanSL model download is incomplete."));
+      }
       if (totalBytes <= 0L && expectedBytes > 0L) {
         totalBytes = expectedBytes;
       }
@@ -1192,6 +1235,11 @@ public final class KataGoAutoSetupHelper {
           }
           output.write(buffer, 0, read);
           downloaded += read;
+          if (expectedBytes > 0L && downloaded > expectedBytes) {
+            throw new IOException(
+                resource(
+                    "AutoSetup.humanSlModelIncomplete", "HumanSL model download is incomplete."));
+          }
           activeSession.throwIfCancelled();
           long now = System.currentTimeMillis();
           if (listener != null && (now - lastReportTime > 120 || totalBytes == downloaded)) {
@@ -1206,14 +1254,6 @@ public final class KataGoAutoSetupHelper {
             resource("AutoSetup.humanSlModelIncomplete", "HumanSL model download is incomplete."));
       }
       verifyOfficialHumanSlModel(temp);
-      try {
-        Files.move(
-            temp, target, StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE);
-      } catch (AtomicMoveNotSupportedException e) {
-        Files.move(temp, target, StandardCopyOption.REPLACE_EXISTING);
-      }
-      rememberHumanSlModel(target);
-      return target;
     } catch (IOException e) {
       Files.deleteIfExists(temp);
       if (activeSession.isCancelled() && !(e instanceof DownloadCancelledException)) {
@@ -3427,9 +3467,11 @@ public final class KataGoAutoSetupHelper {
     }
   }
 
-  private static String humanSlModelDownloadUrl() {
+  static List<String> humanSlModelDownloadUrls() {
     String value = System.getProperty(HUMAN_SL_MODEL_URL_PROPERTY, "").trim();
-    return value.isEmpty() ? HUMAN_SL_MODEL_DOWNLOAD_URL : value;
+    return value.isEmpty()
+        ? Arrays.asList(HUMAN_SL_MODEL_DOWNLOAD_URL, HUMAN_SL_MODEL_ORIGIN_URL)
+        : Collections.singletonList(value);
   }
 
   private static String humanSlModelSha256() {

--- a/src/test/java/featurecat/lizzie/util/KataGoAutoSetupHelperTest.java
+++ b/src/test/java/featurecat/lizzie/util/KataGoAutoSetupHelperTest.java
@@ -1502,6 +1502,98 @@ public class KataGoAutoSetupHelperTest {
   }
 
   @Test
+  void humanSlDownloadDefaultsToMirrorAndKeepsExplicitOverrideIsolated() throws Exception {
+    String previous = System.getProperty("lizzie.humansl.model.url");
+    try {
+      System.clearProperty("lizzie.humansl.model.url");
+      assertEquals(
+          java.util.Arrays.asList(
+              "https://download.goagent.top/models/humansl/b18c384nbt-humanv0.bin.gz",
+              KataGoAutoSetupHelper.HUMAN_SL_MODEL_ORIGIN_URL),
+          KataGoAutoSetupHelper.humanSlModelDownloadUrls());
+      System.setProperty("lizzie.humansl.model.url", "http://127.0.0.1/model");
+      assertEquals(
+          java.util.Collections.singletonList("http://127.0.0.1/model"),
+          KataGoAutoSetupHelper.humanSlModelDownloadUrls());
+    } finally {
+      restoreProperty("lizzie.humansl.model.url", previous);
+    }
+  }
+
+  @Test
+  void humanSlFallsBackAfterHttpFailureOrCorruptMirrorAndReusesVerifiedModel() throws Exception {
+    byte[] bytes = repeatedBytes(4096, (byte) 7);
+    try (ErrorFixtureServer unavailable = ErrorFixtureServer.start();
+        FixtureServer corrupt = FixtureServer.start(repeatedBytes(4096, (byte) 8));
+        FixtureServer shortFile = FixtureServer.start(repeatedBytes(128, (byte) 7));
+        FixtureServer origin = FixtureServer.start(bytes)) {
+      for (String mirror :
+          java.util.Arrays.asList(unavailable.url(), corrupt.url(), shortFile.url())) {
+        Path root = Files.createTempDirectory("humansl-mirror-fallback");
+        withUserDirAndConfig(
+            root,
+            () ->
+                withHumanSlDownloadProperties(
+                    origin.url(),
+                    sha256(bytes),
+                    bytes.length,
+                    () -> {
+                      Path downloaded =
+                          KataGoAutoSetupHelper.downloadHumanSlModel(
+                              null, null, java.util.Arrays.asList(mirror, origin.url()));
+                      assertEquals(sha256(bytes), sha256(Files.readAllBytes(downloaded)));
+                      assertFalse(
+                          Files.exists(
+                              downloaded.resolveSibling(downloaded.getFileName() + ".part")));
+                      assertEquals(
+                          downloaded.toString(),
+                          Lizzie.config.uiConfig.optString("katago-human-sl-model-path"));
+                      assertEquals(
+                          downloaded,
+                          KataGoAutoSetupHelper.downloadHumanSlModel(
+                              null, null, java.util.Collections.singletonList(unavailable.url())));
+                    }));
+      }
+    }
+  }
+
+  @Test
+  void cancellingHumanSlDownloadDoesNotStartFallbackOrInstallPartialFile() throws Exception {
+    byte[] bytes = repeatedBytes(32768, (byte) 7);
+    Path root = Files.createTempDirectory("humansl-mirror-cancel");
+    try (FixtureServer mirror = FixtureServer.start(bytes)) {
+      withUserDirAndConfig(
+          root,
+          () ->
+              withHumanSlDownloadProperties(
+                  mirror.url(),
+                  sha256(bytes),
+                  bytes.length,
+                  () -> {
+                    KataGoAutoSetupHelper.DownloadSession session =
+                        new KataGoAutoSetupHelper.DownloadSession();
+                    assertThrows(
+                        KataGoAutoSetupHelper.DownloadCancelledException.class,
+                        () ->
+                            KataGoAutoSetupHelper.downloadHumanSlModel(
+                                (name, downloaded, total) -> session.cancel(),
+                                session,
+                                java.util.Arrays.asList(
+                                    mirror.url(), "invalid fallback must not be accessed")));
+                    assertFalse(
+                        Files.exists(
+                            root.resolve("human-sl-models")
+                                .resolve(KataGoAutoSetupHelper.HUMAN_SL_MODEL_FILE_NAME)));
+                    assertFalse(
+                        Files.exists(
+                            root.resolve("human-sl-models")
+                                .resolve(
+                                    KataGoAutoSetupHelper.HUMAN_SL_MODEL_FILE_NAME + ".part")));
+                  }));
+    }
+  }
+
+  @Test
   void inspectHumanSlModelRejectsTruncatedOfficialModel() throws Exception {
     Path tempRoot = Files.createTempDirectory("katago-humansl-truncated");
     Files.createDirectories(tempRoot.resolve("human-sl-models"));
@@ -1649,7 +1741,11 @@ public class KataGoAutoSetupHelperTest {
           ArrayList<EngineData> engines = new ArrayList<>();
           EngineData autoSetupEngine =
               engineData(
-                  KataGoAutoSetupHelper.getAutoSetupEngineName(), engine, gtpConfig, weight, false);
+                  KataGoAutoSetupHelper.getAutoSetupEngineName(),
+                  engine,
+                  gtpConfig,
+                  weight,
+                  false);
           autoSetupEngine.komi = 6.5F;
           autoSetupEngine.preload = true;
           autoSetupEngine.width = 13;
@@ -1695,11 +1791,7 @@ public class KataGoAutoSetupHelperTest {
         () -> {
           EngineData existing =
               engineData(
-                  KataGoAutoSetupHelper.getAutoSetupEngineName(),
-                  engine,
-                  gtpConfig,
-                  weight,
-                  false);
+                  KataGoAutoSetupHelper.getAutoSetupEngineName(), engine, gtpConfig, weight, false);
           Utils.saveEngineSettings(new ArrayList<>(List.of(existing)));
           Lizzie.config.uiConfig.remove("autoload-default");
           Lizzie.config.uiConfig.remove("autoload-empty");

--- a/src/test/java/featurecat/lizzie/util/KataGoAutoSetupHelperTest.java
+++ b/src/test/java/featurecat/lizzie/util/KataGoAutoSetupHelperTest.java
@@ -1741,11 +1741,7 @@ public class KataGoAutoSetupHelperTest {
           ArrayList<EngineData> engines = new ArrayList<>();
           EngineData autoSetupEngine =
               engineData(
-                  KataGoAutoSetupHelper.getAutoSetupEngineName(),
-                  engine,
-                  gtpConfig,
-                  weight,
-                  false);
+                  KataGoAutoSetupHelper.getAutoSetupEngineName(), engine, gtpConfig, weight, false);
           autoSetupEngine.komi = 6.5F;
           autoSetupEngine.preload = true;
           autoSetupEngine.width = 13;
@@ -1791,7 +1787,11 @@ public class KataGoAutoSetupHelperTest {
         () -> {
           EngineData existing =
               engineData(
-                  KataGoAutoSetupHelper.getAutoSetupEngineName(), engine, gtpConfig, weight, false);
+                  KataGoAutoSetupHelper.getAutoSetupEngineName(),
+                  engine,
+                  gtpConfig,
+                  weight,
+                  false);
           Utils.saveEngineSettings(new ArrayList<>(List.of(existing)));
           Lizzie.config.uiConfig.remove("autoload-default");
           Lizzie.config.uiConfig.remove("autoload-empty");


### PR DESCRIPTION
## Problem and Change

HumanSL downloads currently depend on the KataGo origin, which can be slow for users in mainland China. Both AI training and one-click setup now use the project download domain first, with the official KataGo URL as fallback. Existing verified models are reused; both sources must match the pinned 99,066,230-byte size and SHA-256, and cancellation never starts fallback.

A manual `Mirror HumanSL model to R2` workflow uploads only the pinned model under `models/humansl/`, using the existing bucket-scoped credentials and stable-promotion concurrency lock. It verifies the origin before upload, then public HEAD, Range and a full-file SHA-256. Release cleanup still touches only `releases/`; the 9 GB budget now includes persistent models and metadata.

## Validation

- HumanSL downloader tests cover HTTP failure, corruption, truncation, cancellation, verified-file reuse and explicit URL overrides.
- Publisher tests cover pinned downloads, reuse, rejecting corrupt uploads, pagination and combined storage limits.
- Local JDK 21 full suite: 4,019 tests, 0 failures/errors, 19 skipped. Final downloader suite and shaded-JAR packaging pass. Markdown links, line endings and `git diff --check` pass; publisher suite has 25 passing tests. [Windows/Linux CI passed](https://github.com/wimi321/lizzieyzy-next/actions/runs/34245252065).
- [Production R2 deployment passed](https://github.com/wimi321/lizzieyzy-next/actions/runs/34245905626): public HEAD and Range headers verified; full public download matches the pinned size and SHA-256. No new application Release is created by this change; existing released clients retain their original embedded download URL until upgraded.
- Real macOS Java downloader smoke passed with an isolated configuration and R2 as the only allowed source: all 99,066,230 bytes downloaded and verified, installed model recognized successfully (98.01 seconds on this connection; not a mainland-China speed benchmark).
