### PR TITLE
feat(models): 更新默认 B11 为 2026-09-07 官方模型

### DIFF
--- a/.github/workflows/build-linux-release.yml
+++ b/.github/workflows/build-linux-release.yml
@@ -125,11 +125,11 @@ jobs:
           grep -qx "Linux bundle: katago-v1.18.1-eigen-linux-x64.zip" "$manifest"
           grep -qx "Linux OpenCL bundle: katago-v1.18.1-opencl-linux-x64.zip" "$manifest"
           grep -qx "Linux NVIDIA bundle: katago-v1.18.1-cuda12.1-cudnn9.8.0-linux-x64.zip" "$manifest"
-          grep -qx "Model source: b11c768h12nbt3tflrs-fson-silu.bin.gz" "$manifest"
+          grep -qx "Model source: kata1-tf3-b11c768-s11500M-d6163M.bin.gz" "$manifest"
           grep -qx "Model architecture: transformer" "$manifest"
           grep -qx "Minimum KataGo version: 1.17.0" "$manifest"
           test "$(sha256sum "dist/stage/${RELEASE_DATE_TAG}-linux64.with-katago/Lizzieyzy/weights/default.bin.gz" | awk '{print $1}')" = \
-            "1881600caab9e9d85a3dd6a019e9b8e7d2c237b5f984e13ed49a8645be3077c6"
+            "73f6454eba62d2f6d099af8ce66d8c3fde6225e223c55817da0627590e98b0ae"
           cpu_version="$("dist/stage/${RELEASE_DATE_TAG}-linux64.with-katago/Lizzieyzy/engines/katago/linux-x64/katago" version 2>&1)"
           echo "$cpu_version"
           echo "$cpu_version" | grep -q "KataGo v1.18.1"

--- a/.github/workflows/build-macos-amd64-release.yml
+++ b/.github/workflows/build-macos-amd64-release.yml
@@ -99,11 +99,11 @@ jobs:
         run: |
           app_root="dist/macos/app-image/LizzieYzy Next.app/Contents/app"
           grep -qx "KataGo release: v1.18.1" "$app_root/engines/katago/VERSION.txt"
-          grep -qx "Model source: b11c768h12nbt3tflrs-fson-silu.bin.gz" "$app_root/engines/katago/VERSION.txt"
+          grep -qx "Model source: kata1-tf3-b11c768-s11500M-d6163M.bin.gz" "$app_root/engines/katago/VERSION.txt"
           grep -qx "Model architecture: transformer" "$app_root/engines/katago/VERSION.txt"
           grep -qx "Minimum KataGo version: 1.17.0" "$app_root/engines/katago/VERSION.txt"
           test "$(shasum -a 256 "$app_root/weights/default.bin.gz" | awk '{print $1}')" = \
-            "1881600caab9e9d85a3dd6a019e9b8e7d2c237b5f984e13ed49a8645be3077c6"
+            "73f6454eba62d2f6d099af8ce66d8c3fde6225e223c55817da0627590e98b0ae"
           grep -q -- "java-options=-Dlizzie.next.version=$RELEASE_TAG" \
             "dist/macos/app-image/LizzieYzy Next.app/Contents/app/LizzieYzy Next.cfg"
           grep -q -- "java-options=-Xshare:auto" \

--- a/.github/workflows/build-macos-arm64-release.yml
+++ b/.github/workflows/build-macos-arm64-release.yml
@@ -99,11 +99,11 @@ jobs:
         run: |
           app_root="dist/macos/app-image/LizzieYzy Next.app/Contents/app"
           grep -qx "KataGo release: v1.18.1" "$app_root/engines/katago/VERSION.txt"
-          grep -qx "Model source: b11c768h12nbt3tflrs-fson-silu.bin.gz" "$app_root/engines/katago/VERSION.txt"
+          grep -qx "Model source: kata1-tf3-b11c768-s11500M-d6163M.bin.gz" "$app_root/engines/katago/VERSION.txt"
           grep -qx "Model architecture: transformer" "$app_root/engines/katago/VERSION.txt"
           grep -qx "Minimum KataGo version: 1.17.0" "$app_root/engines/katago/VERSION.txt"
           test "$(shasum -a 256 "$app_root/weights/default.bin.gz" | awk '{print $1}')" = \
-            "1881600caab9e9d85a3dd6a019e9b8e7d2c237b5f984e13ed49a8645be3077c6"
+            "73f6454eba62d2f6d099af8ce66d8c3fde6225e223c55817da0627590e98b0ae"
           grep -q -- "java-options=-Dlizzie.next.version=$RELEASE_TAG" \
             "dist/macos/app-image/LizzieYzy Next.app/Contents/app/LizzieYzy Next.cfg"
           grep -q -- "java-options=-Xshare:auto" \

--- a/.github/workflows/build-windows-release.yml
+++ b/.github/workflows/build-windows-release.yml
@@ -164,11 +164,11 @@ jobs:
           grep -qx "sha256=1ba4c265f560cd988be24f4ea0eeb29516883f42ece477bd32b72f8bccf6565d" "dist/windows/input-with-katago/readboard/lizzieyzy-next-readboard-manifest.txt"
           grep -qx 'KataGo release: v1.18.1' "dist/windows/input-with-katago/engines/katago/VERSION.txt"
           grep -qx 'Windows bundle: katago-v1.18.1-eigen-windows-x64.zip' "dist/windows/input-with-katago/engines/katago/VERSION.txt"
-          grep -qx 'Model source: b11c768h12nbt3tflrs-fson-silu.bin.gz' "dist/windows/input-with-katago/engines/katago/VERSION.txt"
+          grep -qx 'Model source: kata1-tf3-b11c768-s11500M-d6163M.bin.gz' "dist/windows/input-with-katago/engines/katago/VERSION.txt"
           grep -qx 'Model architecture: transformer' "dist/windows/input-with-katago/engines/katago/VERSION.txt"
           grep -qx 'Minimum KataGo version: 1.17.0' "dist/windows/input-with-katago/engines/katago/VERSION.txt"
           test "$(sha256sum "dist/windows/input-with-katago/weights/default.bin.gz" | awk '{print $1}')" = \
-            "1881600caab9e9d85a3dd6a019e9b8e7d2c237b5f984e13ed49a8645be3077c6"
+            "73f6454eba62d2f6d099af8ce66d8c3fde6225e223c55817da0627590e98b0ae"
           test -f "dist/windows/input-opencl/engines/katago/windows-x64/katago.exe"
           test -f "dist/windows/input-opencl/PROJECT_INFO.txt"
           test -f "dist/windows/input-opencl/readboard/readboard.exe"
@@ -241,7 +241,7 @@ jobs:
             test -f "dist/windows/app-image-${flavor}/${app_name}/${app_name}.exe"
             test -f "dist/release/${RELEASE_DATE_TAG}-windows64.${flavor}.portable.zip"
             test "$(sha256sum "dist/windows/app-image-${flavor}/${app_name}/app/weights/default.bin.gz" | awk '{print $1}')" = \
-              "1881600caab9e9d85a3dd6a019e9b8e7d2c237b5f984e13ed49a8645be3077c6"
+              "73f6454eba62d2f6d099af8ce66d8c3fde6225e223c55817da0627590e98b0ae"
           done
           test -d "dist/windows/app-image-experimental.rocm.gfx103x/LizzieYzy Next ROCm gfx103x Experimental/app/engines/katago/windows-x64/rocblas"
           test -d "dist/windows/app-image-experimental.rocm.gfx103x/LizzieYzy Next ROCm gfx103x Experimental/app/engines/katago/windows-x64/hipblaslt"

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -217,7 +217,7 @@ chmod +x start-linux64.sh
 当前默认内置信息：
 
 - KataGo 版本：`v1.18.1`
-- 默认权重：官方旗舰 B11 Transformer `b11c768h12nbt3tflrs-fson-silu.bin.gz`（界面显示“Transformer 11B 棋力优先”，`211,660,960` 字节，约 202 MiB）
+- 默认权重：官方旗舰 B11 Transformer `kata1-tf3-b11c768-s11500M-d6163M.bin.gz`（界面显示“Transformer B11 · 2026-09-07”，`211,568,937` 字节，约 202 MiB）
 - B11 单次判断更强、复杂局面效果更好，但搜索速度可能较慢；追求速度可在 `KataGo 一键设置` 中按需下载并切换 B10
 - 旧完整包升级：请安装最新完整包；`core-update.zip` 不包含新引擎和权重
 

--- a/docs/INSTALL_EN.md
+++ b/docs/INSTALL_EN.md
@@ -212,7 +212,7 @@ Notes:
 Current bundled defaults:
 
 - KataGo version: `v1.18.1`
-- Weight: official flagship B11 Transformer `b11c768h12nbt3tflrs-fson-silu.bin.gz` (shown as “Transformer 11B Strength First”, `211,660,960` bytes, about 202 MiB)
+- Weight: official flagship B11 Transformer `kata1-tf3-b11c768-s11500M-d6163M.bin.gz` (shown as “Transformer B11 · 2026-09-07”, `211,568,937` bytes, about 202 MiB)
 - B11 makes stronger individual evaluations and handles complex positions better, but search can be slower; users who prioritize throughput can download and switch to B10 in `KataGo Auto Setup`
 - Upgrading an older full bundle requires the latest full package; `core-update.zip` does not contain the new engine or weight
 

--- a/docs/PACKAGES.md
+++ b/docs/PACKAGES.md
@@ -132,8 +132,8 @@
 
 - KataGo 版本：`v1.18.1`，CPU、OpenCL、CUDA、TensorRT、Metal 和 Linux 包统一升级；Linux NVIDIA 为兼容系统运行时继续使用 CUDA `12.1`
 - macOS 发布构建固定使用官方 `v1.18.1` commit `92ee95c0a4b25fec214da00951ab69e97e207729`。如果 Homebrew 稳定版仍滞后，打包脚本会从该 commit 构建 Metal 引擎并校验真实二进制版本，不能只靠 `VERSION.txt` 宣称升级
-- 默认权重：官方旗舰 B11 Transformer `b11c768h12nbt3tflrs-fson-silu.bin.gz`，界面显示为“Transformer 11B 棋力优先”
-- 默认权重大小：`211,660,960` 字节（约 202 MiB），SHA-256：`1881600caab9e9d85a3dd6a019e9b8e7d2c237b5f984e13ed49a8645be3077c6`
+- 默认权重：官方旗舰 B11 Transformer `kata1-tf3-b11c768-s11500M-d6163M.bin.gz`，界面显示为“Transformer B11 · 2026-09-07”
+- 默认权重大小：`211,568,937` 字节（约 202 MiB），SHA-256：`73f6454eba62d2f6d099af8ce66d8c3fde6225e223c55817da0627590e98b0ae`
 - B11 单次判断更强、复杂局面效果更好，但搜索速度可能较慢；B10 保留为“速度优先”按需下载，不重复内置
 - Windows NVIDIA 统一使用 CUDA `12.8` + cuDNN `9.8`，覆盖 RTX 20/30/40/50；不再发布独立 `nvidia50` 包
 - Windows NVIDIA 运行时同时携带对应版本的 NVRTC 编译器与 builtins，发布审计会检查精确 DLL、官方资产 SHA 和 manifest 记录，避免解压即引擎启动失败

--- a/docs/PACKAGES_EN.md
+++ b/docs/PACKAGES_EN.md
@@ -112,8 +112,8 @@ Current bundled defaults:
 
 - KataGo version: `v1.18.1` across CPU, OpenCL, CUDA, TensorRT, Metal, and Linux bundles; Linux NVIDIA remains on CUDA `12.1` for runtime compatibility
 - macOS release builds pin the official `v1.18.1` commit `92ee95c0a4b25fec214da00951ab69e97e207729`. If Homebrew lags, packaging builds Metal from that commit and verifies the real binary version instead of trusting `VERSION.txt` alone
-- Default weight: official flagship B11 Transformer `b11c768h12nbt3tflrs-fson-silu.bin.gz`, shown as “Transformer 11B Strength First”
-- Default weight size: `211,660,960` bytes (about 202 MiB), SHA-256: `1881600caab9e9d85a3dd6a019e9b8e7d2c237b5f984e13ed49a8645be3077c6`
+- Default weight: official flagship B11 Transformer `kata1-tf3-b11c768-s11500M-d6163M.bin.gz`, shown as “Transformer B11 · 2026-09-07”
+- Default weight size: `211,568,937` bytes (about 202 MiB), SHA-256: `73f6454eba62d2f6d099af8ce66d8c3fde6225e223c55817da0627590e98b0ae`
 - B11 makes stronger individual evaluations and performs better in complex positions, but search can be slower; B10 remains available as an on-demand speed-first model and is not duplicated in full packages
 - The single Windows NVIDIA package uses CUDA `12.8` + cuDNN `9.8` for RTX 20/30/40/50; separate `nvidia50` assets are no longer published
 - Windows NVIDIA runtimes include matching NVRTC compiler and builtins; release audits verify exact DLLs, official asset hashes, and manifest records

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -153,9 +153,9 @@ python3 scripts/generate_app_icons.py
 当前默认：
 
 - KataGo 版本：`v1.18.1`
-- 默认模型：`b11c768h12nbt3tflrs-fson-silu.bin.gz`
-- 默认模型 SHA-256：`1881600caab9e9d85a3dd6a019e9b8e7d2c237b5f984e13ed49a8645be3077c6`
-- 默认模型大小：`211,660,960` 字节；架构：`transformer`；最低 KataGo：`1.17.0`
+- 默认模型：`kata1-tf3-b11c768-s11500M-d6163M.bin.gz`
+- 默认模型 SHA-256：`73f6454eba62d2f6d099af8ce66d8c3fde6225e223c55817da0627590e98b0ae`
+- 默认模型大小：`211,568,937` 字节；架构：`transformer`；最低 KataGo：`1.17.0`
 - Windows NVIDIA 包：官方 `cuda12.8-cudnn9.8.0` 构建，统一覆盖 RTX 20/30/40/50
 - Linux NVIDIA 包：官方 CUDA `12.1` 构建，避免提高现有 Linux 系统运行时要求
 - Windows TensorRT：不内嵌到普通 Windows 主推荐包；RTX 30 系及以下用户由软件内 `KataGo 一键设置` 显式下载安装官方 KataGo `v1.18.1` `trt10.9.0-cuda12.8` 构建和所需运行库；RTX 40/50 默认使用 CUDA；当前预发布链路仍强制生成并上传可选离线 TensorRT 分卷及其 README、manifest、SHA-256 文件，缺少任一项都不能公开 pre-release

--- a/scripts/katago_asset_catalog.py
+++ b/scripts/katago_asset_catalog.py
@@ -44,6 +44,11 @@ def validate_catalog(catalog: dict[str, Any]) -> None:
         validate_entry(model, f"model {model_id}")
         require_text(model, "fileName")
         require_text(model, "minimumKataGoVersion")
+        override = model.get("downloadUrl", "")
+        if override and override != (
+            "https://media.katagotraining.org/uploaded/networks/models/kata1/" + model["fileName"]
+        ):
+            raise ValueError(f"model {model_id} has unsupported official downloadUrl")
     for asset_id, asset in assets.items():
         validate_entry(asset, f"asset {asset_id}")
         name = require_text(asset, "assetName")
@@ -85,6 +90,14 @@ def resolve(catalog: dict[str, Any], dotted_path: str) -> Any:
     return current
 
 
+def model_download_url(catalog: dict[str, Any], model_id: str) -> str:
+    model = catalog["models"][model_id]
+    return model.get("downloadUrl") or (
+        f"https://github.com/lightvector/KataGo/releases/download/{catalog['modelReleaseTag']}/"
+        + model["fileName"]
+    )
+
+
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--catalog", type=Path, default=DEFAULT_CATALOG)
@@ -92,9 +105,13 @@ def main() -> int:
     subparsers.add_parser("validate")
     get_parser = subparsers.add_parser("get")
     get_parser.add_argument("path")
+    model_url_parser = subparsers.add_parser("model-url")
+    model_url_parser.add_argument("model_id")
     args = parser.parse_args()
 
     catalog = load_catalog(args.catalog)
+    if args.command == "model-url":
+        print(model_download_url(catalog, args.model_id))
     if args.command == "get":
         value = resolve(catalog, args.path)
         if isinstance(value, (dict, list)):

--- a/scripts/prepare_bundled_katago.sh
+++ b/scripts/prepare_bundled_katago.sh
@@ -33,7 +33,11 @@ PREFERRED_MODEL_SIZE_BYTES="${PREFERRED_MODEL_SIZE_BYTES:-$(catalog_get models.$
 PREFERRED_MODEL_ARCHITECTURE="${PREFERRED_MODEL_ARCHITECTURE:-$(catalog_get models.$DEFAULT_MODEL_ID.architecture)}"
 PREFERRED_MODEL_MINIMUM_KATAGO="${PREFERRED_MODEL_MINIMUM_KATAGO:-$(catalog_get models.$DEFAULT_MODEL_ID.minimumKataGoVersion)}"
 MODEL_RELEASE_TAG="$(catalog_get modelReleaseTag)"
-MODEL_URL="${MODEL_URL:-https://github.com/lightvector/KataGo/releases/download/$MODEL_RELEASE_TAG/$PREFERRED_MODEL_NAME}"
+if [[ "$PREFERRED_MODEL_NAME" == "$(catalog_get models.$DEFAULT_MODEL_ID.fileName)" ]]; then
+  MODEL_URL="${MODEL_URL:-$("$CATEGORY_READER" "$ASSET_CATALOG_READER" model-url "$DEFAULT_MODEL_ID")}"
+else
+  MODEL_URL="${MODEL_URL:-https://github.com/lightvector/KataGo/releases/download/$MODEL_RELEASE_TAG/$PREFERRED_MODEL_NAME}"
+fi
 MODEL_SOURCE="${MODEL_SOURCE:-}"
 
 ENGINES_ROOT="$ROOT_DIR/engines/katago"

--- a/scripts/test_generate_release_notes.py
+++ b/scripts/test_generate_release_notes.py
@@ -75,7 +75,7 @@ class GenerateReleaseNotesTest(unittest.TestCase):
 
         self.assertEqual("v1.18.1", metadata["katago_version"])
         self.assertEqual(
-            "b11c768h12nbt3tflrs-fson-silu.bin.gz", metadata["model_source"]
+            "kata1-tf3-b11c768-s11500M-d6163M.bin.gz", metadata["model_source"]
         )
         self.assertEqual(
             "katago-v1.18.1-cuda12.8-cudnn9.8.0-windows-x64.zip",

--- a/scripts/test_katago_asset_catalog.py
+++ b/scripts/test_katago_asset_catalog.py
@@ -14,8 +14,8 @@ class KataGoAssetCatalogTest(unittest.TestCase):
         default_model = catalog["models"][catalog["defaultModelId"]]
 
         self.assertEqual("1.18.1", catalog["katagoVersion"])
-        self.assertEqual("b11c768h12nbt3tflrs-fson-silu.bin.gz", default_model["fileName"])
-        self.assertEqual(211660960, default_model["sizeBytes"])
+        self.assertEqual("kata1-tf3-b11c768-s11500M-d6163M.bin.gz", default_model["fileName"])
+        self.assertEqual(211568937, default_model["sizeBytes"])
         self.assertTrue(default_model["bundled"])
 
     def test_cli_reads_a_scalar_path(self):
@@ -32,6 +32,21 @@ class KataGoAssetCatalogTest(unittest.TestCase):
         )
 
         self.assertEqual("cuda12.8-cudnn9", completed.stdout.strip())
+
+    def test_model_urls_preserve_release_fallback(self):
+        catalog = katago_asset_catalog.load_catalog(katago_asset_catalog.DEFAULT_CATALOG)
+        self.assertEqual(
+            "https://media.katagotraining.org/uploaded/networks/models/kata1/"
+            "kata1-tf3-b11c768-s11500M-d6163M.bin.gz",
+            katago_asset_catalog.model_download_url(catalog, "b11-flagship"),
+        )
+        self.assertIn("/v1.17.1/", katago_asset_catalog.model_download_url(catalog, "b10-balanced"))
+
+    def test_validation_rejects_untrusted_model_origin(self):
+        catalog = katago_asset_catalog.load_catalog(katago_asset_catalog.DEFAULT_CATALOG)
+        catalog["models"]["b11-flagship"]["downloadUrl"] = "https://example.com/model.bin.gz"
+        with self.assertRaisesRegex(ValueError, "unsupported official downloadUrl"):
+            katago_asset_catalog.validate_catalog(catalog)
 
     def test_validation_rejects_unpinned_asset(self):
         catalog = katago_asset_catalog.load_catalog(katago_asset_catalog.DEFAULT_CATALOG)

--- a/scripts/test_prepare_bundled_katago.sh
+++ b/scripts/test_prepare_bundled_katago.sh
@@ -6,10 +6,11 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 source "$ROOT_DIR/scripts/prepare_bundled_katago.sh"
 
 [[ "$KATAGO_TAG" == "v1.18.1" ]]
-[[ "$PREFERRED_MODEL_NAME" == "b11c768h12nbt3tflrs-fson-silu.bin.gz" ]]
-[[ "$PREFERRED_MODEL_SIZE_BYTES" == "211660960" ]]
+[[ "$PREFERRED_MODEL_NAME" == "kata1-tf3-b11c768-s11500M-d6163M.bin.gz" ]]
+[[ "$PREFERRED_MODEL_SIZE_BYTES" == "211568937" ]]
+[[ "$MODEL_URL" == "https://media.katagotraining.org/uploaded/networks/models/kata1/$PREFERRED_MODEL_NAME" ]]
 [[ "$PREFERRED_MODEL_SHA256" == \
-  "1881600caab9e9d85a3dd6a019e9b8e7d2c237b5f984e13ed49a8645be3077c6" ]]
+  "73f6454eba62d2f6d099af8ce66d8c3fde6225e223c55817da0627590e98b0ae" ]]
 [[ "$HUMAN_SL_CUDA_COMPANION_SHA256" == \
   "e207abb6e2403f0f34e9f4cac6079b988bf853537367d18f899c4b246eeb044c" ]]
 [[ "$(expected_asset_sha256 "$WINDOWS_ASSET")" == \

--- a/scripts/test_windows_download_guidance.py
+++ b/scripts/test_windows_download_guidance.py
@@ -69,7 +69,7 @@ class WindowsDownloadGuidanceTest(unittest.TestCase):
             asset_map,
             {
                 "katago_version": "v1.18.1",
-                "model_source": "b11c768h12nbt3tflrs-fson-silu.bin.gz",
+                "model_source": "kata1-tf3-b11c768-s11500M-d6163M.bin.gz",
             },
             "wimi321/lizzieyzy-next",
             "next-2099-01-01.1",

--- a/src/main/java/featurecat/lizzie/util/KataGoAssetCatalog.java
+++ b/src/main/java/featurecat/lizzie/util/KataGoAssetCatalog.java
@@ -95,7 +95,9 @@ public final class KataGoAssetCatalog {
   }
 
   public String modelDownloadUrl(Model model) {
-    return releaseUrl(modelReleaseTag, model.fileName());
+    return model.downloadUrl().isEmpty()
+        ? releaseUrl(modelReleaseTag, model.fileName())
+        : model.downloadUrl();
   }
 
   public String assetDownloadUrl(Asset asset) {
@@ -121,9 +123,22 @@ public final class KataGoAssetCatalog {
               required(value, "minimumKataGoVersion"),
               value.getLong("sizeBytes"),
               requiredSha256(value, "sha256"),
-              value.optBoolean("bundled", false)));
+              value.optBoolean("bundled", false),
+              modelDownloadOverride(value),
+              value.optString("publishedAt", "2026-07-29")));
     }
     return parsed;
+  }
+
+  private static String modelDownloadOverride(JSONObject value) {
+    String url = value.optString("downloadUrl", "").trim();
+    if (!url.isEmpty()
+        && !url.equals(
+            "https://media.katagotraining.org/uploaded/networks/models/kata1/"
+                + required(value, "fileName"))) {
+      throw new IllegalStateException("Unsupported official model download URL");
+    }
+    return url;
   }
 
   private static Map<String, Asset> parseAssets(JSONObject values) {
@@ -196,7 +211,9 @@ public final class KataGoAssetCatalog {
       String minimumKataGoVersion,
       long sizeBytes,
       String sha256,
-      boolean bundled) {
+      boolean bundled,
+      String downloadUrl,
+      String publishedAt) {
     public String modelName() {
       return fileName.endsWith(".bin.gz")
           ? fileName.substring(0, fileName.length() - ".bin.gz".length())

--- a/src/main/java/featurecat/lizzie/util/KataGoAutoSetupHelper.java
+++ b/src/main/java/featurecat/lizzie/util/KataGoAutoSetupHelper.java
@@ -58,10 +58,6 @@ public final class KataGoAutoSetupHelper {
           + "(KHTML, like Gecko) Chrome/123.0.0.0 Safari/537.36";
   private static final String NETWORKS_URL = "https://katagotraining.org/networks/";
   private static final String NETWORKS_URL_PROPERTY = "lizzie.katago.networks.url";
-  private static final String KATAGO_MODEL_RELEASE_BASE =
-      "https://github.com/lightvector/KataGo/releases/download/"
-          + ASSET_CATALOG.modelReleaseTag()
-          + "/";
   private static final Pattern STRONGEST_PATTERN =
       Pattern.compile(
           "Strongest confidently-rated network:</span>\\s*<a href=\"([^\"]+)\">([^<]+)</a>",
@@ -1130,7 +1126,35 @@ public final class KataGoAutoSetupHelper {
   public static List<RemoteWeightInfo> fetchOfficialWeights() throws IOException {
     List<RemoteWeightInfo> weights = new ArrayList<>(officialTransformerWeights());
     try {
-      weights.addAll(parseOfficialWeights(httpGet(officialNetworksUrl())));
+      for (RemoteWeightInfo info : parseOfficialWeights(httpGet(officialNetworksUrl()))) {
+        int pinnedIndex = -1;
+        for (int i = 0; i < weights.size(); i++) {
+          if (weights.get(i).fileName().equals(info.fileName())) {
+            pinnedIndex = i;
+            break;
+          }
+        }
+        if (pinnedIndex < 0) {
+          weights.add(info);
+        } else {
+          // Keep trusted integrity metadata while refreshing the online rating.
+          RemoteWeightInfo pinned = weights.get(pinnedIndex);
+          weights.set(
+              pinnedIndex,
+              new RemoteWeightInfo(
+                  pinned.typeLabel,
+                  pinned.modelName,
+                  pinned.downloadUrl,
+                  pinned.uploadedAt,
+                  info.eloRating,
+                  pinned.recommended,
+                  info.latest,
+                  pinned.sha256,
+                  pinned.sizeBytes,
+                  pinned.minimumKataGoVersion,
+                  pinned.transformerTier));
+        }
+      }
     } catch (IOException e) {
       if (weights.isEmpty()) {
         throw e;
@@ -1172,17 +1196,21 @@ public final class KataGoAutoSetupHelper {
 
   private static RemoteWeightInfo transformerWeight(
       String typeLabel, String modelName, long sizeBytes, String sha256, TransformerTier tier) {
+    KataGoAssetCatalog.Model model =
+        tier == TransformerTier.STRONGEST
+            ? TRANSFORMER_STRONGEST
+            : tier == TransformerTier.BALANCED ? TRANSFORMER_BALANCED : TRANSFORMER_LIGHTWEIGHT;
     return new RemoteWeightInfo(
         typeLabel,
         modelName,
-        KATAGO_MODEL_RELEASE_BASE + modelName + ".bin.gz",
-        "2026-07-29",
+        ASSET_CATALOG.modelDownloadUrl(model),
+        model.publishedAt(),
         "",
         tier == TransformerTier.STRONGEST,
         true,
         sha256,
         sizeBytes,
-        TRANSFORMER_MINIMUM_KATAGO_VERSION,
+        model.minimumKataGoVersion(),
         tier);
   }
 
@@ -1370,7 +1398,7 @@ public final class KataGoAutoSetupHelper {
         resource("AutoSetup.quickAnalysisModel", "Quick curve lightweight model"),
         TRANSFORMER_LIGHTWEIGHT_MODEL,
         quickAnalysisModelDownloadUrl(),
-        "2026-07-29",
+        TRANSFORMER_LIGHTWEIGHT.publishedAt(),
         "",
         false,
         false,
@@ -1857,6 +1885,7 @@ public final class KataGoAutoSetupHelper {
     return normalized.equals(TRANSFORMER_LIGHTWEIGHT_MODEL)
         || normalized.equals(TRANSFORMER_BALANCED_MODEL)
         || normalized.equals(TRANSFORMER_STRONGEST_MODEL)
+        || normalized.matches("kata1-tf[23]-b\\d+c\\d+-.*")
         || normalized.contains("tflrs");
   }
 
@@ -2482,6 +2511,9 @@ public final class KataGoAutoSetupHelper {
       return resource("AutoSetup.transformerBalancedModel", "Transformer Balanced 10B");
     }
     if (TRANSFORMER_STRONGEST_MODEL.equalsIgnoreCase(baseName)) {
+      return "Transformer B11 · " + TRANSFORMER_STRONGEST.publishedAt();
+    }
+    if ("b11c768h12nbt3tflrs-fson-silu".equalsIgnoreCase(baseName)) {
       return resource("AutoSetup.transformerStrongestModel", "Transformer Flagship 11B");
     }
     if (BUNDLED_2026_06_28B_MODEL.equalsIgnoreCase(baseName)) {

--- a/src/main/resources/katago-assets.json
+++ b/src/main/resources/katago-assets.json
@@ -7,13 +7,15 @@
   "defaultModelId": "b11-flagship",
   "models": {
     "b11-flagship": {
-      "fileName": "b11c768h12nbt3tflrs-fson-silu.bin.gz",
+      "fileName": "kata1-tf3-b11c768-s11500M-d6163M.bin.gz",
+      "downloadUrl": "https://media.katagotraining.org/uploaded/networks/models/kata1/kata1-tf3-b11c768-s11500M-d6163M.bin.gz",
+      "publishedAt": "2026-09-07",
       "displayFamily": "11B",
       "tier": "strongest",
       "architecture": "transformer",
       "minimumKataGoVersion": "1.17.0",
-      "sizeBytes": 211660960,
-      "sha256": "1881600caab9e9d85a3dd6a019e9b8e7d2c237b5f984e13ed49a8645be3077c6",
+      "sizeBytes": 211568937,
+      "sha256": "73f6454eba62d2f6d099af8ce66d8c3fde6225e223c55817da0627590e98b0ae",
       "bundled": true
     },
     "b10-balanced": {

--- a/src/test/java/featurecat/lizzie/util/KataGoAssetCatalogTest.java
+++ b/src/test/java/featurecat/lizzie/util/KataGoAssetCatalogTest.java
@@ -14,13 +14,21 @@ class KataGoAssetCatalogTest {
 
     assertEquals("1.18.1", catalog.katagoVersion());
     assertEquals("v1.18.1", catalog.katagoReleaseTag());
-    assertEquals("b11c768h12nbt3tflrs-fson-silu.bin.gz", model.fileName());
-    assertEquals(211_660_960L, model.sizeBytes());
+    assertEquals("kata1-tf3-b11c768-s11500M-d6163M.bin.gz", model.fileName());
+    assertEquals(211_568_937L, model.sizeBytes());
     assertEquals(
-        "1881600caab9e9d85a3dd6a019e9b8e7d2c237b5f984e13ed49a8645be3077c6",
+        "73f6454eba62d2f6d099af8ce66d8c3fde6225e223c55817da0627590e98b0ae",
         model.sha256());
     assertTrue(model.bundled());
     assertFalse(catalog.model("b10-balanced").bundled());
+    assertEquals("2026-09-07", model.publishedAt());
+    assertEquals(
+        "https://media.katagotraining.org/uploaded/networks/models/kata1/" + model.fileName(),
+        catalog.modelDownloadUrl(model));
+    assertEquals(
+        "https://github.com/lightvector/KataGo/releases/download/v1.17.1/"
+            + catalog.model("b10-balanced").fileName(),
+        catalog.modelDownloadUrl(catalog.model("b10-balanced")));
   }
 
   @Test

--- a/src/test/java/featurecat/lizzie/util/KataGoAutoSetupHelperTest.java
+++ b/src/test/java/featurecat/lizzie/util/KataGoAutoSetupHelperTest.java
@@ -24,6 +24,7 @@ import featurecat.lizzie.logging.WorkDirectoryResolution;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.security.MessageDigest;
@@ -693,7 +694,15 @@ public class KataGoAutoSetupHelperTest {
             .orElseThrow()
             .recommended);
     assertTrue(weights.stream().allMatch(KataGoAutoSetupHelper.RemoteWeightInfo::isTransformer));
-    assertTrue(weights.stream().allMatch(info -> info.downloadUrl.contains("/v1.17.1/")));
+    assertEquals("2026-09-07", strongest.uploadedAt);
+    assertEquals(
+        "https://media.katagotraining.org/uploaded/networks/models/kata1/"
+            + KataGoAutoSetupHelper.DEFAULT_TRANSFORMER_FILE_NAME,
+        strongest.downloadUrl);
+    assertTrue(
+        weights.stream()
+            .filter(info -> info != strongest)
+            .allMatch(info -> info.downloadUrl.contains("/v1.17.1/")));
   }
 
   @Test
@@ -736,8 +745,52 @@ public class KataGoAutoSetupHelperTest {
     assertTrue(KataGoAutoSetupHelper.isTransformerWeight(weight));
     String displayName = KataGoAutoSetupHelper.resolveWeightDisplayName(weight);
     assertTrue(displayName.contains("Transformer"));
-    assertTrue(displayName.contains("11B"));
+    assertEquals("Transformer B11 · 2026-09-07", displayName);
     assertFalse(displayName.equals("default"));
+  }
+
+  @Test
+  void recognizesTrainedTransformersWithoutRelabelingOldModels() {
+    assertTrue(
+        KataGoAutoSetupHelper.isTransformerWeight("kata1-tf3-b11c768-s11500M-d6163M.bin.gz"));
+    assertTrue(
+        KataGoAutoSetupHelper.isTransformerWeight("b11c768h12nbt3tflrs-fson-silu.bin.gz"));
+    assertFalse(
+        KataGoAutoSetupHelper.isTransformerWeight(
+            "kata1-b28c512nbt-s12763923712-d5805955894.bin.gz"));
+    assertFalse(
+        KataGoAutoSetupHelper.resolveWeightDisplayName("b11c768h12nbt3tflrs-fson-silu.bin.gz")
+            .contains("2026-09-07"));
+  }
+
+  @Test
+  void onlineCatalogKeepsPinnedIntegrityAndRatingWithoutDuplicateB11() throws Exception {
+    String model = KataGoAutoSetupHelper.DEFAULT_TRANSFORMER_MODEL;
+    String html =
+        "<table class=\"table mt-3\"><tr><td>"
+            + model
+            + "</td><td>2026-09-07</td><td>14545.3 Elo</td><td>"
+            + officialLink(model)
+            + "</td></tr></table>";
+    try (FixtureServer server = FixtureServer.start(html.getBytes(StandardCharsets.UTF_8))) {
+      String previous = System.getProperty("lizzie.katago.networks.url");
+      try {
+        System.setProperty("lizzie.katago.networks.url", server.url());
+        List<KataGoAutoSetupHelper.RemoteWeightInfo> weights =
+            KataGoAutoSetupHelper.fetchOfficialWeights();
+        assertEquals(3, weights.size());
+        KataGoAutoSetupHelper.RemoteWeightInfo b11 =
+            weights.stream()
+                .filter(info -> info.modelName.equals(model))
+                .findFirst()
+                .orElseThrow();
+        assertEquals("14545.3 Elo", b11.eloRating);
+        assertEquals(KataGoAutoSetupHelper.DEFAULT_TRANSFORMER_SHA256, b11.sha256);
+        assertEquals(KataGoAutoSetupHelper.DEFAULT_TRANSFORMER_SIZE_BYTES, b11.sizeBytes);
+      } finally {
+        restoreProperty("lizzie.katago.networks.url", previous);
+      }
+    }
   }
 
   @Test

--- a/src/test/java/featurecat/lizzie/util/KataGoRuntimeLayeredTuningTest.java
+++ b/src/test/java/featurecat/lizzie/util/KataGoRuntimeLayeredTuningTest.java
@@ -360,7 +360,10 @@ class KataGoRuntimeLayeredTuningTest {
   void currentOfficialGpuRecommendationsAreAppliedButStaleModelResultsAreIgnored()
       throws Exception {
     Config previousConfig = Lizzie.config;
+    String previousOsArch = System.getProperty("os.arch");
     try {
+      // CUDA recommendations intentionally do not apply on Apple Silicon hosts.
+      System.setProperty("os.arch", "amd64");
       Config config =
           ConfigTestHelper.createForTests(
               Files.createDirectories(temporaryDirectory.resolve("gpu-recommendation-config")));
@@ -397,6 +400,7 @@ class KataGoRuntimeLayeredTuningTest {
           KataGoRuntimeHelper.applyEntryLaunchPolicy(command, snapshot.enginePath, entry);
       assertTrue(KataGoCommandSpec.parse(stale).effectiveOverrides().isEmpty());
     } finally {
+      restoreProperty("os.arch", previousOsArch);
       Lizzie.config = previousConfig;
     }
   }


### PR DESCRIPTION
## Summary

- 默认完整包 B11 更新为官方训练站 2026-09-07 发布的 `kata1-tf3-b11c768-s11500M-d6163M.bin.gz`，界面显示 `Transformer B11 · 2026-09-07`。
- 模型目录支持固定的官方训练站地址，Java 下载与 Shell 打包共用来源、发布日期、大小和 SHA-256；保留 B10 的 GitHub Release 下载地址与构建环境覆盖参数。
- 官网列表与内置目录去重，同时保留在线 Elo 和本地固定的完整性校验信息；新命名的 Transformer 继续受最低引擎版本检查保护。
- 同步四个平台构建工作流的模型校验及中英文安装/打包文档。旧 B11 不会被误标为新模型。
- 单独提交修正已有 CUDA 调优测试的主机架构前提，解决 Apple Silicon 上运行完整回归时的测试失败，不修改运行时调优逻辑。

感谢用户提供新模型线索。本次不宣称其棋力已经通过本项目实测证明为“官网最强”。

## Model Integrity

- [官方模型下载](https://media.katagotraining.org/uploaded/networks/models/kata1/kata1-tf3-b11c768-s11500M-d6163M.bin.gz)
- 实际下载大小：`211568937` 字节。
- 实际 SHA-256：`73f6454eba62d2f6d099af8ce66d8c3fde6225e223c55817da0627590e98b0ae`。
- KataGo 仍为 `1.18.1`，模型最低版本仍为 `1.17.0`；不修改 B10、HumanSL 模型或引擎配置迁移逻辑。

## Type Of Change

- [x] Packaging / release update
- [x] Docs / translation
- [x] Bug fix (catalog deduplication and platform-specific test setup)

## Testing

- [x] JDK 21 完整 `mvn -B -Dfmt.skip=true test`：4038 项，0 failures，0 errors，32 项按环境跳过。
- [x] `mvn -B -Dfmt.skip=true -DskipTests package` 成功。
- [x] Python 发布脚本测试：230 项通过。
- [x] `bash scripts/test_prepare_bundled_katago.sh`、Shell 语法检查、换行规则、Markdown 本地链接检查和 `git diff --check` 通过。
- [x] 使用真实下载文件执行打包脚本的大小与 SHA-256 检查。
- [x] macOS Apple M4 Pro / Metal / KataGo 1.18.1：新旧 B11 对相同三个局面分别完成 128 visits 分析，返回有效结果；这是加载与协议兼容检查，不作为棋力或性能结论。
- [x] 新 B11 与 HumanSL `rank_7d` 配合完成三个局面分析，返回完整人类策略概率。
- [x] GTP 实测 19/13/9 路的 boardsize、clear_board、komi、play、genmove、quit。
- [x] 使用隔离配置启动新构建的 Swing 应用，主引擎进程命令指向新权重，日志确认 engine ready；未改动用户安装或配置。
- [x] 无无关格式化或换行改写。
- [ ] Windows GPU 真机验证及各平台最终完整包资产验收尚未执行，不能以单元测试或 CI 代替。
- [ ] 本轮未获得可用的 Java 窗口自动化截图；模型名称由自动化测试核对，未声称完成截图视觉验收。

## Compatibility And Delivery

- 不覆盖用户自定义权重、远程算力或启动方式；旧模型名称继续兼容。
- 新默认权重随后续完整包交付；`core-update.zip` 仍不包含模型或引擎，不会静默下载替换用户模型。
- 历史 Release、tag、发布资产和官网当前下载版本均不改动。本 PR 只提交评审，不自动合并或发布。
