### PR TITLE
fix(autosetup): restore responsive TensorRT action groups

### DIFF
--- a/src/main/java/featurecat/lizzie/gui/KataGoAccelerationLayout.java
+++ b/src/main/java/featurecat/lizzie/gui/KataGoAccelerationLayout.java
@@ -1,0 +1,399 @@
+package featurecat.lizzie.gui;
+
+import java.awt.BorderLayout;
+import java.awt.Color;
+import java.awt.Component;
+import java.awt.Container;
+import java.awt.Dimension;
+import java.awt.Font;
+import java.awt.FontMetrics;
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import java.awt.Insets;
+import java.awt.Rectangle;
+import javax.swing.BorderFactory;
+import javax.swing.JComponent;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JTextArea;
+import javax.swing.JViewport;
+import javax.swing.SwingUtilities;
+import javax.swing.UIManager;
+import javax.swing.text.View;
+
+/**
+ * Acceleration-page layout restored from c53265b, without its older engine/setup implementation.
+ * All state, permissions and actions continue to be owned by KataGoAutoSetupDialog.
+ */
+final class KataGoAccelerationLayout {
+  private KataGoAccelerationLayout() {}
+
+  static JPanel statusRow(JLabel title, JTextArea status) {
+    return new StatusRow(title, status);
+  }
+
+  static JPanel primaryActions(JComponent repair, JComponent enable) {
+    return new WrappingActions(repair, enable);
+  }
+
+  static JPanel maintenanceActions(
+      JComponent nvidiaRuntime, JComponent switchBack, JComponent cleanCache) {
+    return new WrappingActions(nvidiaRuntime, switchBack, cleanCache);
+  }
+
+  static JPanel experimentalActions(JComponent selector, JComponent install) {
+    JPanel column = new JPanel(new BorderLayout(0, 8));
+    column.setOpaque(false);
+    column.add(selector, BorderLayout.NORTH);
+    column.add(new WrappingActions(install), BorderLayout.SOUTH);
+    return column;
+  }
+
+  static JPanel actionBlock(JLabel title, JComponent hint, JComponent actions) {
+    JPanel block = new JPanel(new GridBagLayout());
+    block.setOpaque(false);
+    GridBagConstraints gbc = new GridBagConstraints();
+    gbc.gridx = 0;
+    gbc.gridy = 0;
+    gbc.weightx = 1;
+    gbc.anchor = GridBagConstraints.NORTHWEST;
+    gbc.fill = GridBagConstraints.HORIZONTAL;
+    gbc.insets = new Insets(0, 0, hint == null ? 8 : 4, 0);
+    block.add(title, gbc);
+    if (hint != null) {
+      gbc.gridy++;
+      gbc.insets = new Insets(0, 0, 8, 0);
+      block.add(hint, gbc);
+    }
+    gbc.gridy++;
+    gbc.insets = new Insets(0, 0, 0, 0);
+    block.add(actions, gbc);
+    return block;
+  }
+
+  static JTextArea statusChip(Font font, Color background, Color border) {
+    WrappingText area = new WrappingText(font, true);
+    area.setOpaque(true);
+    area.setBackground(background);
+    area.setBorder(
+        BorderFactory.createCompoundBorder(
+            BorderFactory.createLineBorder(border),
+            BorderFactory.createEmptyBorder(6, 8, 8, 8)));
+    return area;
+  }
+
+  static JTextArea hint(String message, Font font, Color foreground) {
+    WrappingText area = new WrappingText(font, false);
+    area.setForeground(foreground);
+    area.setBorder(BorderFactory.createEmptyBorder(2, 0, 4, 0));
+    setStatusText(area, message);
+    return area;
+  }
+
+  static void setStatusText(JTextArea area, String value) {
+    String plain = value == null ? "" : value;
+    if (!plain.equals(area.getText())) {
+      area.setText(plain);
+      area.setCaretPosition(0);
+    }
+    area.getAccessibleContext().setAccessibleName(plain);
+    area.revalidate();
+    area.repaint();
+  }
+
+  /** Width actually visible through the ancestor chain, not a stale oversized child width. */
+  private static int visibleWidth(JComponent component, int fallback) {
+    int width = component.getWidth() > 0 ? component.getWidth() : fallback;
+    int offset = component.getX();
+    for (Container parent = component.getParent(); parent != null; parent = parent.getParent()) {
+      if (parent.getWidth() > 0) {
+        Insets insets = parent.getInsets();
+        int right = parent.getWidth() - insets.right;
+        if (parent instanceof JViewport) {
+          Rectangle view = ((JViewport) parent).getViewRect();
+          right = view.x + view.width;
+        }
+        int available = right - Math.max(offset, insets.left);
+        if (available > 0) {
+          width = Math.min(width, available);
+        }
+      }
+      if (parent instanceof JViewport) {
+        break;
+      }
+      offset += parent.getX();
+    }
+    return Math.max(1, width);
+  }
+
+  private static int textHeightForWidth(JTextArea area, int width) {
+    Insets insets = area.getInsets();
+    Object caretWidth = area.getClientProperty("caretWidth");
+    if (!(caretWidth instanceof Number) || ((Number) caretWidth).intValue() < 0) {
+      caretWidth = UIManager.get("Caret.width");
+    }
+    int caretMargin = caretWidth instanceof Number ? ((Number) caretWidth).intValue() : 1;
+    if (caretMargin < 0) {
+      caretMargin = 1;
+    }
+    // BasicTextUI also reserves this margin when laying out even a read-only text area.
+    int innerWidth = Math.max(1, width - insets.left - insets.right - caretMargin);
+    // Use Swing's wrapped view, including word wrapping, newlines and long tokens.
+    View view = area.getUI().getRootView(area);
+    view.setSize(innerWidth, Integer.MAX_VALUE);
+    int height = (int) Math.ceil(view.getPreferredSpan(View.Y_AXIS));
+    return insets.top + insets.bottom
+        + Math.max(area.getFontMetrics(area.getFont()).getHeight(), height) + 4;
+  }
+
+  /** Preserve aligned status columns, but stack them before the value becomes unreadably narrow. */
+  private static final class StatusRow extends JPanel {
+    private static final int COLUMN_GAP = 10;
+    private static final int MINIMUM_VALUE_WIDTH = 160;
+    private final JLabel title;
+    private final JTextArea status;
+    private boolean relayoutPending;
+    private int lastWidth = -1;
+
+    StatusRow(JLabel title, JTextArea status) {
+      super(null);
+      this.title = title;
+      this.status = status;
+      setOpaque(false);
+      add(title);
+      add(status);
+    }
+
+    private int titleColumnWidth() {
+      int width = title.getPreferredSize().width;
+      if (getParent() != null) {
+        for (Component sibling : getParent().getComponents()) {
+          if (sibling instanceof StatusRow) {
+            width = Math.max(width, ((StatusRow) sibling).title.getPreferredSize().width);
+          }
+        }
+      }
+      return width;
+    }
+
+    private Dimension arrange(boolean apply) {
+      int width = visibleWidth(this, 740);
+      int titleWidth = titleColumnWidth();
+      boolean stacked = width < titleWidth + COLUMN_GAP + MINIMUM_VALUE_WIDTH;
+      int valueWidth = stacked ? width : width - titleWidth - COLUMN_GAP;
+      int titleHeight = title.getPreferredSize().height;
+      int valueHeight = textHeightForWidth(status, valueWidth);
+      if (apply) {
+        title.setBounds(0, 0, Math.min(width, titleWidth), titleHeight);
+        status.setBounds(stacked ? 0 : titleWidth + COLUMN_GAP,
+            stacked ? titleHeight + 4 : 0, valueWidth, valueHeight);
+      }
+      return new Dimension(width,
+          stacked ? titleHeight + 4 + valueHeight : Math.max(titleHeight, valueHeight));
+    }
+
+    @Override
+    public Dimension getPreferredSize() {
+      return arrange(false);
+    }
+
+    @Override
+    public Dimension getMinimumSize() {
+      return new Dimension(Math.min(80, getPreferredSize().width), getPreferredSize().height);
+    }
+
+    @Override
+    public void doLayout() {
+      arrange(true);
+    }
+
+    @Override
+    public void setBounds(int x, int y, int width, int height) {
+      super.setBounds(x, y, width, height);
+      if (width <= 0 || getParent() == null) {
+        return;
+      }
+      boolean widthChanged = lastWidth != width;
+      lastWidth = width;
+      if (!relayoutPending && (widthChanged || height < getPreferredSize().height)) {
+        relayoutPending = true;
+        SwingUtilities.invokeLater(() -> {
+          relayoutPending = false;
+          if (getParent() != null) {
+            getParent().invalidate();
+            getParent().revalidate();
+          }
+        });
+      }
+    }
+  }
+
+  /** Plain text so long paths and translated messages wrap without HTML ellipses. */
+  static final class WrappingText extends JTextArea {
+    private final boolean compact;
+    private boolean relayoutPending;
+    private int lastWidth = -1;
+
+    private WrappingText(Font font, boolean compact) {
+      this.compact = compact;
+      setFont(font);
+      setEditable(false);
+      setFocusable(false);
+      setOpaque(false);
+      setLineWrap(true);
+      setWrapStyleWord(true);
+      setHighlighter(null);
+      setMargin(new Insets(0, 0, 0, 0));
+    }
+
+    int heightForWidth(int width) {
+      return textHeightForWidth(this, width);
+    }
+
+    private int naturalWidth() {
+      FontMetrics metrics = getFontMetrics(getFont());
+      int width = 0;
+      for (String line : getText().split("\\R", -1)) {
+        width = Math.max(width, metrics.stringWidth(line));
+      }
+      Insets insets = getInsets();
+      return Math.max(24, width + insets.left + insets.right);
+    }
+
+    @Override
+    public Dimension getPreferredSize() {
+      int available = visibleWidth(this, compact ? 560 : 640);
+      int width = compact ? Math.min(naturalWidth(), available) : available;
+      return new Dimension(width, heightForWidth(width));
+    }
+
+    @Override
+    public Dimension getMinimumSize() {
+      Dimension preferred = getPreferredSize();
+      return new Dimension(Math.min(compact ? 160 : 80, preferred.width), preferred.height);
+    }
+
+    @Override
+    public Dimension getMaximumSize() {
+      return new Dimension(Integer.MAX_VALUE, Integer.MAX_VALUE);
+    }
+
+    @Override
+    public void setBounds(int x, int y, int width, int height) {
+      super.setBounds(x, y, width, height);
+      if (width <= 0 || getParent() == null || getUI() == null) {
+        return;
+      }
+      boolean widthChanged = lastWidth != width;
+      lastWidth = width;
+      if (!relayoutPending && (widthChanged || height < heightForWidth(width))) {
+        relayoutPending = true;
+        SwingUtilities.invokeLater(
+            () -> {
+              relayoutPending = false;
+              if (getParent() != null) {
+                getParent().invalidate();
+                getParent().revalidate();
+              }
+            });
+      }
+    }
+  }
+
+  /** Left-aligned, width-aware actions; never the shared dialog's fixed two-column grid. */
+  static final class WrappingActions extends JPanel {
+    private static final int GAP = 8;
+    private boolean relayoutPending;
+    private int lastWidth = -1;
+
+    WrappingActions(JComponent... actions) {
+      super(null);
+      setOpaque(false);
+      for (JComponent action : actions) {
+        add(action);
+      }
+    }
+
+    private int naturalWidth() {
+      int width = 0;
+      for (Component action : getComponents()) {
+        if (action.isVisible()) {
+          width += (width == 0 ? 0 : GAP) + action.getPreferredSize().width;
+        }
+      }
+      Insets insets = getInsets();
+      return Math.max(1, width + insets.left + insets.right);
+    }
+
+    private Dimension arrange(boolean apply) {
+      Insets insets = getInsets();
+      int width = visibleWidth(this, naturalWidth());
+      int inner = Math.max(1, width - insets.left - insets.right);
+      int x = 0;
+      int y = 0;
+      int rowHeight = 0;
+      int usedWidth = 0;
+      for (Component action : getComponents()) {
+        if (!action.isVisible()) {
+          continue;
+        }
+        Dimension preferred = action.getPreferredSize();
+        int actionWidth = Math.min(inner, preferred.width);
+        if (x > 0 && x + GAP + actionWidth > inner) {
+          y += rowHeight + GAP;
+          x = 0;
+          rowHeight = 0;
+        }
+        if (x > 0) {
+          x += GAP;
+        }
+        if (apply) {
+          action.setBounds(insets.left + x, insets.top + y, actionWidth, preferred.height);
+        }
+        x += actionWidth;
+        usedWidth = Math.max(usedWidth, x);
+        rowHeight = Math.max(rowHeight, preferred.height);
+      }
+      return new Dimension(
+          Math.min(width, insets.left + usedWidth + insets.right),
+          insets.top + y + rowHeight + insets.bottom);
+    }
+
+    @Override
+    public Dimension getPreferredSize() {
+      return arrange(false);
+    }
+
+    @Override
+    public Dimension getMinimumSize() {
+      Dimension preferred = getPreferredSize();
+      return new Dimension(Math.min(80, preferred.width), preferred.height);
+    }
+
+    @Override
+    public void doLayout() {
+      arrange(true);
+    }
+
+    @Override
+    public void setBounds(int x, int y, int width, int height) {
+      super.setBounds(x, y, width, height);
+      if (width <= 0 || getParent() == null) {
+        return;
+      }
+      boolean widthChanged = lastWidth != width;
+      lastWidth = width;
+      if (!relayoutPending && (widthChanged || height < getPreferredSize().height)) {
+        relayoutPending = true;
+        SwingUtilities.invokeLater(
+            () -> {
+              relayoutPending = false;
+              if (getParent() != null) {
+                getParent().invalidate();
+                getParent().revalidate();
+              }
+            });
+      }
+    }
+  }
+}

--- a/src/main/java/featurecat/lizzie/gui/KataGoAutoSetupDialog.java
+++ b/src/main/java/featurecat/lizzie/gui/KataGoAutoSetupDialog.java
@@ -193,13 +193,13 @@ public class KataGoAutoSetupDialog extends JDialog {
   private final JLabel lblDiscoverySourceValue = new JFontLabel();
   private final JLabel lblPackageFlavorValue = new JFontLabel();
   private final JLabel lblEngineValidationValue = new JFontLabel();
-  private final JLabel lblNvidiaRuntimeValue = new JFontLabel();
-  private final JLabel lblNvidiaGpuValue = new JFontLabel();
-  private final JLabel lblTensorRtRuntimeValue = new JFontLabel();
-  private final JLabel lblTensorRtCompanionValue = new JFontLabel();
-  private final JLabel lblTensorRtEngineValue = new JFontLabel();
-  private final JLabel lblTensorRtActivationValue = new JFontLabel();
-  private final JLabel lblExperimentalBackendValue = new JFontLabel();
+  private final JTextArea lblNvidiaRuntimeValue = createAccelerationStatusChip();
+  private final JTextArea lblNvidiaGpuValue = createAccelerationStatusChip();
+  private final JTextArea lblTensorRtRuntimeValue = createAccelerationStatusChip();
+  private final JTextArea lblTensorRtCompanionValue = createAccelerationStatusChip();
+  private final JTextArea lblTensorRtEngineValue = createAccelerationStatusChip();
+  private final JTextArea lblTensorRtActivationValue = createAccelerationStatusChip();
+  private final JTextArea lblExperimentalBackendValue = createAccelerationStatusChip();
   private final JLabel lblBenchmarkNnValue = new JFontLabel();
   private final JLabel lblBenchmarkNnUnit = new JFontLabel();
   private final JLabel lblBenchmarkNnTechnical = new JFontLabel();
@@ -810,7 +810,7 @@ public class KataGoAutoSetupDialog extends JDialog {
     styleButton(btnDownloadQuickAnalysisModel, false);
     styleButton(btnInstallNvidiaRuntime, false);
     styleButton(btnInstallTensorRt, false);
-    styleButton(btnEnableTensorRt, false);
+    styleButton(btnEnableTensorRt, true);
     styleButton(btnSwitchBackCuda, false);
     styleButton(btnCleanTensorRtCache, false);
     styleButton(btnInstallExperimentalBackend, false);
@@ -1471,32 +1471,27 @@ public class KataGoAutoSetupDialog extends JDialog {
   private JPanel createAccelerationSection() {
     JPanel rows = createRowsPanel();
     GridBagConstraints gbc = createRowConstraints();
-    addInfoRow(rows, gbc, text("AutoSetup.nvidiaRuntime"), lblNvidiaRuntimeValue);
-    addInfoRow(rows, gbc, text("AutoSetup.nvidiaGpu"), lblNvidiaGpuValue);
-    addInfoRow(rows, gbc, text("AutoSetup.tensorRtRuntimeStatus"), lblTensorRtRuntimeValue);
-    addInfoRow(rows, gbc, text("AutoSetup.tensorRtCompanionStatus"), lblTensorRtCompanionValue);
-    addInfoRow(rows, gbc, text("AutoSetup.tensorRtEngineStatus"), lblTensorRtEngineValue);
-    addInfoRow(rows, gbc, text("AutoSetup.tensorRtActivationStatus"), lblTensorRtActivationValue);
+    addAccelerationStatusRow(rows, gbc, text("AutoSetup.nvidiaRuntime"), lblNvidiaRuntimeValue);
+    addAccelerationStatusRow(rows, gbc, text("AutoSetup.nvidiaGpu"), lblNvidiaGpuValue);
+    addAccelerationStatusRow(rows, gbc, text("AutoSetup.tensorRtRuntimeStatus"), lblTensorRtRuntimeValue);
+    addAccelerationStatusRow(rows, gbc, text("AutoSetup.tensorRtCompanionStatus"), lblTensorRtCompanionValue);
+    addAccelerationStatusRow(rows, gbc, text("AutoSetup.tensorRtEngineStatus"), lblTensorRtEngineValue);
+    addAccelerationStatusRow(rows, gbc, text("AutoSetup.tensorRtActivationStatus"), lblTensorRtActivationValue);
     makeTensorRtStatusRowsKeyboardReachable();
-    addInfoRow(rows, gbc, text("AutoSetup.experimentalBackendStatus"), lblExperimentalBackendValue);
+    addAccelerationStatusRow(rows, gbc, text("AutoSetup.experimentalBackendStatus"), lblExperimentalBackendValue);
 
-    JTextArea tensorRtHint = createHintText(text("AutoSetup.accelerationTensorRtHint"));
-    addComponentRow(rows, gbc, text("AutoSetup.installTensorRt"), tensorRtHint);
-
-    JTextArea experimentalHint = createHintText(text("AutoSetup.experimentalBackendHint"));
-    addComponentRow(rows, gbc, text("AutoSetup.experimentalBackends"), experimentalHint);
-    JPanel experimentalActions =
-        createResponsiveActionRow(cmbExperimentalBackend, btnInstallExperimentalBackend);
-    addComponentRow(rows, gbc, text("AutoSetup.experimentalBackendChoose"), experimentalActions);
-
-    JPanel actions =
-        createActionBar(
-            FlowLayout.RIGHT,
-            btnInstallNvidiaRuntime,
-            btnInstallTensorRt,
-            btnEnableTensorRt,
-            btnSwitchBackCuda,
-            btnCleanTensorRtCache);
+    addAccelerationActionBlock(
+        rows, gbc, text("AutoSetup.installTensorRt"),
+        text("AutoSetup.accelerationTensorRtHint"),
+        KataGoAccelerationLayout.primaryActions(btnInstallTensorRt, btnEnableTensorRt));
+    addAccelerationActionBlock(
+        rows, gbc, text("AutoSetup.experimentalBackends"),
+        text("AutoSetup.experimentalBackendHint"),
+        KataGoAccelerationLayout.experimentalActions(cmbExperimentalBackend, btnInstallExperimentalBackend));
+    addAccelerationActionBlock(
+        rows, gbc, text("AutoSetup.maintenanceActions"), null,
+        KataGoAccelerationLayout.maintenanceActions(
+            btnInstallNvidiaRuntime, btnSwitchBackCuda, btnCleanTensorRtCache));
     directedTensorRtBanner.setOpaque(true);
     directedTensorRtBanner.setBackground(new Color(255, 249, 235));
     directedTensorRtBanner.setBorder(
@@ -1513,7 +1508,48 @@ public class KataGoAutoSetupDialog extends JDialog {
         text("AutoSetup.accelerationTitle"),
         text("AutoSetup.accelerationSubtitle"),
         accelerationBody,
-        actions);
+        null);
+  }
+
+  private static JTextArea createAccelerationStatusChip() {
+    return KataGoAccelerationLayout.statusChip(new JFontLabel().getFont(), INFO_BG, INFO_BORDER);
+  }
+
+  private void addAccelerationStatusRow(
+      JPanel panel, GridBagConstraints gbc, String title, JTextArea status) {
+    JFontLabel titleLabel = new JFontLabel(title);
+    titleLabel.setForeground(TEXT_PRIMARY);
+    titleLabel.setVerticalAlignment(SwingConstants.TOP);
+    int titleWidth = localizedRowLabelWidth(titleLabel);
+    titleLabel.setPreferredSize(new Dimension(titleWidth, 32));
+    titleLabel.setMinimumSize(new Dimension(titleWidth, 32));
+    GridBagConstraints constraints = (GridBagConstraints) gbc.clone();
+    constraints.gridx = 0;
+    constraints.gridwidth = 2;
+    constraints.weightx = 1;
+    constraints.fill = GridBagConstraints.HORIZONTAL;
+    constraints.anchor = GridBagConstraints.NORTHWEST;
+    panel.add(KataGoAccelerationLayout.statusRow(titleLabel, status), constraints);
+    gbc.gridy++;
+  }
+
+  private void addAccelerationActionBlock(
+      JPanel panel, GridBagConstraints gbc, String title, String hint, JComponent actions) {
+    JFontLabel titleLabel = new JFontLabel(title);
+    titleLabel.setForeground(TEXT_PRIMARY);
+    titleLabel.setFont(titleLabel.getFont().deriveFont(Font.BOLD));
+    JTextArea hintArea = hint == null ? null
+        : KataGoAccelerationLayout.hint(hint, new JFontLabel().getFont(), TEXT_SECONDARY);
+    JPanel block = KataGoAccelerationLayout.actionBlock(titleLabel, hintArea, actions);
+    GridBagConstraints constraints = (GridBagConstraints) gbc.clone();
+    constraints.gridx = 0;
+    constraints.gridwidth = 2;
+    constraints.weightx = 1;
+    constraints.fill = GridBagConstraints.HORIZONTAL;
+    constraints.anchor = GridBagConstraints.NORTHWEST;
+    constraints.insets = new Insets(14, 0, 4, 0);
+    panel.add(block, constraints);
+    gbc.gridy++;
   }
 
   private JPanel createBenchmarkSection() {
@@ -2601,7 +2637,7 @@ public class KataGoAutoSetupDialog extends JDialog {
     KataGoRuntimeHelper.NvidiaRuntimeStatus status =
         snapshot == null ? null : KataGoRuntimeHelper.inspectNvidiaRuntime(snapshot);
     if (status == null || !status.applicable) {
-      setWrappedInfoText(lblNvidiaRuntimeValue, text("AutoSetup.nvidiaRuntimeNotApplicable"));
+      KataGoAccelerationLayout.setStatusText(lblNvidiaRuntimeValue, text("AutoSetup.nvidiaRuntimeNotApplicable"));
       lblNvidiaRuntimeValue.setToolTipText(null);
       lblNvidiaRuntimeValue.setForeground(Color.DARK_GRAY);
       AccessibilitySupport.named(
@@ -2612,7 +2648,7 @@ public class KataGoAutoSetupDialog extends JDialog {
       updateTensorRtInfo();
       return;
     }
-    setWrappedInfoText(lblNvidiaRuntimeValue, compactInfoText(status.detailText, 76));
+    KataGoAccelerationLayout.setStatusText(lblNvidiaRuntimeValue, status.detailText);
     lblNvidiaRuntimeValue.setToolTipText(status.detailText);
     lblNvidiaRuntimeValue.setForeground(status.ready ? OK_COLOR : WARN_COLOR);
     AccessibilitySupport.named(
@@ -2789,14 +2825,14 @@ public class KataGoAutoSetupDialog extends JDialog {
   }
 
   private void makeTensorRtStatusRowsKeyboardReachable() {
-    JLabel[] labels = {
+    JComponent[] labels = {
       lblNvidiaGpuValue,
       lblTensorRtRuntimeValue,
       lblTensorRtCompanionValue,
       lblTensorRtEngineValue,
       lblTensorRtActivationValue
     };
-    for (JLabel label : labels) {
+    for (JComponent label : labels) {
       label.setFocusable(true);
     }
   }
@@ -2814,7 +2850,8 @@ public class KataGoAutoSetupDialog extends JDialog {
   private void updateExperimentalBackendInfo() {
     Backend backend = (Backend) cmbExperimentalBackend.getSelectedItem();
     if (backend == null || snapshot == null) {
-      setInfoValue(lblExperimentalBackendValue, false, text("AutoSetup.notFound"));
+      String missing = text("AutoSetup.notFound");
+      setTensorRtLabel(lblExperimentalBackendValue, missing, ERROR_COLOR, missing);
       btnInstallExperimentalBackend.setEnabled(false);
       return;
     }
@@ -2826,12 +2863,20 @@ public class KataGoAutoSetupDialog extends JDialog {
             : status.installed()
                 ? text("AutoSetup.experimentalBackendInstalled")
                 : text("AutoSetup.experimentalBackendNotInstalled");
-    setInfoValue(
-        lblExperimentalBackendValue, status.installed(), backend.displayName() + " · " + state);
+    String visible = backend.displayName() + " · " + state;
+    setTensorRtLabel(
+        lblExperimentalBackendValue, visible, status.installed() ? OK_COLOR : ERROR_COLOR, visible);
     btnInstallExperimentalBackend.setText(
         status.installed()
             ? text("AutoSetup.enableExperimentalBackend")
             : text("AutoSetup.installExperimentalBackend"));
+    Dimension preferred = localizedButtonSize(btnInstallExperimentalBackend, 90, 32);
+    btnInstallExperimentalBackend.setPreferredSize(preferred);
+    btnInstallExperimentalBackend.setMinimumSize(preferred);
+    if (btnInstallExperimentalBackend.getParent() != null) {
+      btnInstallExperimentalBackend.getParent().revalidate();
+      btnInstallExperimentalBackend.getParent().repaint();
+    }
     btnInstallExperimentalBackend.setEnabled(
         activeDownloadSession == null
             && activeWorkerThread == null
@@ -2840,8 +2885,8 @@ public class KataGoAutoSetupDialog extends JDialog {
             && !status.active());
   }
 
-  private void setTensorRtLabel(JLabel label, String value, Color color, String tooltip) {
-    setWrappedInfoText(label, value);
+  private void setTensorRtLabel(JTextArea label, String value, Color color, String tooltip) {
+    KataGoAccelerationLayout.setStatusText(label, value);
     label.setForeground(color);
     label.setToolTipText(tooltip);
   }

--- a/src/main/resources/l10n/DisplayStrings.properties
+++ b/src/main/resources/l10n/DisplayStrings.properties
@@ -3815,6 +3815,7 @@ HumanSlTraining.report.summaryUnavailable=Review the highlighted positions to bu
 AutoSetup.experimentalBackends=Experimental backends
 AutoSetup.experimentalBackendStatus=Experimental backend status
 AutoSetup.experimentalBackendChoose=Choose and install
+AutoSetup.maintenanceActions=More actions
 AutoSetup.experimentalBackendHint=ROCm targets the matching AMD GPU family; OpenVINO targets Intel GPU/NPU; DirectML is a compatibility option for DirectX 12 GPUs. These are official self-contained KataGo v1.18.1 experimental builds and are never installed automatically or substituted silently.
 AutoSetup.installExperimentalBackend=Install and enable
 AutoSetup.enableExperimentalBackend=Enable installed backend

--- a/src/main/resources/l10n/DisplayStrings_en_US.properties
+++ b/src/main/resources/l10n/DisplayStrings_en_US.properties
@@ -3812,6 +3812,7 @@ HumanSlTraining.report.summaryUnavailable=Review the highlighted positions to bu
 AutoSetup.experimentalBackends=Experimental backends
 AutoSetup.experimentalBackendStatus=Experimental backend status
 AutoSetup.experimentalBackendChoose=Choose and install
+AutoSetup.maintenanceActions=More actions
 AutoSetup.experimentalBackendHint=ROCm targets the matching AMD GPU family; OpenVINO targets Intel GPU/NPU; DirectML is a compatibility option for DirectX 12 GPUs. These are official self-contained KataGo v1.18.1 experimental builds and are never installed automatically or substituted silently.
 AutoSetup.installExperimentalBackend=Install and enable
 AutoSetup.enableExperimentalBackend=Enable installed backend

--- a/src/main/resources/l10n/DisplayStrings_ja_JP.properties
+++ b/src/main/resources/l10n/DisplayStrings_ja_JP.properties
@@ -3812,6 +3812,7 @@ HumanSlTraining.report.summaryUnavailable=強調された局面を振り返り�
 AutoSetup.experimentalBackends=実験的バックエンド
 AutoSetup.experimentalBackendStatus=実験的バックエンドの状態
 AutoSetup.experimentalBackendChoose=選択してインストール
+AutoSetup.maintenanceActions=その他の操作
 AutoSetup.experimentalBackendHint=ROCm は対応する AMD GPU、OpenVINO は Intel GPU/NPU、DirectML は DirectX 12 GPU 向けの互換オプションです。いずれも公式の自己完結型 KataGo v1.18.1 実験ビルドで、自動インストールや無断切替は行いません。
 AutoSetup.installExperimentalBackend=インストールして有効化
 AutoSetup.enableExperimentalBackend=インストール済みを有効化

--- a/src/main/resources/l10n/DisplayStrings_ko.properties
+++ b/src/main/resources/l10n/DisplayStrings_ko.properties
@@ -3814,6 +3814,7 @@ HumanSlTraining.report.summaryUnavailable=표시된 핵심 장면을 복기해 �
 AutoSetup.experimentalBackends=실험용 백엔드
 AutoSetup.experimentalBackendStatus=실험용 백엔드 상태
 AutoSetup.experimentalBackendChoose=선택 및 설치
+AutoSetup.maintenanceActions=기타 작업
 AutoSetup.experimentalBackendHint=ROCm은 해당 AMD GPU 계열, OpenVINO는 Intel GPU/NPU, DirectML은 DirectX 12 GPU의 호환 옵션입니다. 모두 공식 독립형 KataGo v1.18.1 실험 빌드이며 자동 설치하거나 조용히 엔진을 바꾸지 않습니다.
 AutoSetup.installExperimentalBackend=설치하고 사용
 AutoSetup.enableExperimentalBackend=설치된 백엔드 사용

--- a/src/main/resources/l10n/DisplayStrings_th_TH.properties
+++ b/src/main/resources/l10n/DisplayStrings_th_TH.properties
@@ -3814,6 +3814,7 @@ HumanSlTraining.report.summaryUnavailable=ทบทวนจุดสำคั�
 AutoSetup.experimentalBackends=แบ็กเอนด์ทดลอง
 AutoSetup.experimentalBackendStatus=สถานะแบ็กเอนด์ทดลอง
 AutoSetup.experimentalBackendChoose=เลือกและติดตั้ง
+AutoSetup.maintenanceActions=การดำเนินการเพิ่มเติม
 AutoSetup.experimentalBackendHint=ROCm ใช้กับตระกูล AMD GPU ที่ตรงกัน, OpenVINO ใช้กับ Intel GPU/NPU และ DirectML เป็นตัวเลือกความเข้ากันได้สำหรับ DirectX 12 GPU ทั้งหมดเป็น KataGo v1.18.1 รุ่นทดลองแบบครบในตัวจากทางการ และจะไม่ติดตั้งหรือสลับเอนจินโดยอัตโนมัติ
 AutoSetup.installExperimentalBackend=ติดตั้งและเปิดใช้
 AutoSetup.enableExperimentalBackend=เปิดใช้แบ็กเอนด์ที่ติดตั้งแล้ว

--- a/src/main/resources/l10n/DisplayStrings_zh_CN.properties
+++ b/src/main/resources/l10n/DisplayStrings_zh_CN.properties
@@ -3812,6 +3812,7 @@ HumanSlTraining.report.summaryUnavailable=回看标出的关键局面，建立�
 AutoSetup.experimentalBackends=实验后端
 AutoSetup.experimentalBackendStatus=实验后端状态
 AutoSetup.experimentalBackendChoose=选择并安装
+AutoSetup.maintenanceActions=其他操作
 AutoSetup.experimentalBackendHint=ROCm 面向对应 AMD GPU；OpenVINO 面向 Intel GPU/NPU；DirectML 可在 DirectX 12 GPU 上作为兼容方案尝试。它们均为 KataGo v1.18.1 官方自包含实验构建，不会自动安装或静默替换当前引擎。
 AutoSetup.installExperimentalBackend=安装并启用
 AutoSetup.enableExperimentalBackend=启用已安装后端

--- a/src/main/resources/l10n/DisplayStrings_zh_HK.properties
+++ b/src/main/resources/l10n/DisplayStrings_zh_HK.properties
@@ -3812,6 +3812,7 @@ HumanSlTraining.report.summaryUnavailable=覆盤標出的關鍵局面，逐步�
 AutoSetup.experimentalBackends=實驗後端
 AutoSetup.experimentalBackendStatus=實驗後端狀態
 AutoSetup.experimentalBackendChoose=選擇並安裝
+AutoSetup.maintenanceActions=其他操作
 AutoSetup.experimentalBackendHint=ROCm 適用對應 AMD GPU；OpenVINO 適用 Intel GPU/NPU；DirectML 可在 DirectX 12 GPU 上作為相容方案。這些均為 KataGo v1.18.1 官方自包含實驗構建，不會自動安裝或靜默取代目前引擎。
 AutoSetup.installExperimentalBackend=安裝並啟用
 AutoSetup.enableExperimentalBackend=啟用已安裝後端

--- a/src/main/resources/l10n/DisplayStrings_zh_TW.properties
+++ b/src/main/resources/l10n/DisplayStrings_zh_TW.properties
@@ -3812,6 +3812,7 @@ HumanSlTraining.report.summaryUnavailable=覆盤標出的關鍵局面，逐步�
 AutoSetup.experimentalBackends=實驗後端
 AutoSetup.experimentalBackendStatus=實驗後端狀態
 AutoSetup.experimentalBackendChoose=選擇並安裝
+AutoSetup.maintenanceActions=其他操作
 AutoSetup.experimentalBackendHint=ROCm 適用對應的 AMD GPU；OpenVINO 適用 Intel GPU/NPU；DirectML 可在 DirectX 12 GPU 上作為相容方案嘗試。這些都是 KataGo v1.18.1 官方自包含實驗構建，不會自動安裝或靜默替換目前引擎。
 AutoSetup.installExperimentalBackend=安裝並啟用
 AutoSetup.enableExperimentalBackend=啟用已安裝後端

--- a/src/test/java/featurecat/lizzie/gui/KataGoAccelerationLayoutTest.java
+++ b/src/test/java/featurecat/lizzie/gui/KataGoAccelerationLayoutTest.java
@@ -1,0 +1,501 @@
+package featurecat.lizzie.gui;
+
+import java.awt.BorderLayout;
+import java.awt.Color;
+import java.awt.Component;
+import java.awt.Container;
+import java.awt.Dimension;
+import java.awt.Font;
+import java.awt.GridLayout;
+import java.util.Locale;
+import java.util.ResourceBundle;
+import java.awt.Rectangle;
+import javax.swing.BorderFactory;
+import javax.swing.JButton;
+import javax.swing.JComboBox;
+import javax.swing.JComponent;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JTextArea;
+import javax.swing.JViewport;
+import javax.swing.SwingUtilities;
+import org.junit.jupiter.api.Test;
+
+/** These fixtures use the production layout on the EDT; no engine or network is started. */
+class KataGoAccelerationLayoutTest {
+  private static final Font FONT = new Font(Font.DIALOG, Font.PLAIN, 14);
+
+  @Test
+  void statusRowsKeepTheirSharedTitleColumn() throws Exception {
+    onEdt(() -> {
+      JTextArea first = status("Ready");
+      JTextArea second = status("HumanSL CUDA companion is missing");
+      JPanel rows = new JPanel(new GridLayout(2, 1, 0, 7));
+      rows.add(KataGoAccelerationLayout.statusRow(title("GPU", 132), first));
+      rows.add(KataGoAccelerationLayout.statusRow(title("HumanSL CUDA companion", 190), second));
+      rows.setSize(740, 150);
+      layout(rows);
+      equal(200, first.getX(), "first status uses shared title width");
+      equal(first.getX(), second.getX(), "status columns remain aligned");
+    });
+  }
+
+  @Test
+  void narrowStatusRowUsesTheFullWidthInsteadOfA24PixelValueColumn() throws Exception {
+    onEdt(() -> {
+      JTextArea status = status("TensorRT acceleration requires Windows NVIDIA components.\n"
+          + "Missing: NVIDIA GPU, runtime, HumanSL CUDA companion, TensorRT engine, weight, GTP config.");
+      JLabel title = title("TensorRT profile", 187);
+      JPanel row = KataGoAccelerationLayout.statusRow(title, status);
+      row.setSize(221, 1500);
+      layout(row);
+      equal(0, status.getX(), "narrow status starts at the left edge");
+      equal(221, status.getWidth(), "status uses the full visible row width");
+      check(status.getY() >= title.getHeight(), "title and status do not overlap");
+      assertTextFits(status);
+    });
+  }
+
+  @Test
+  void statusRowReturnsToColumnsAfterGrowing() throws Exception {
+    onEdt(() -> {
+      JTextArea status = status("C:\\engines\\" + "long-directory-".repeat(12) + "\\katago.exe");
+      JPanel row = KataGoAccelerationLayout.statusRow(title("TensorRT profile", 190), status);
+      row.setSize(221, 2000);
+      layout(row);
+      int narrow = row.getPreferredSize().height;
+      row.setSize(740, 2000);
+      layout(row);
+      equal(200, status.getX(), "growing restores the title column");
+      equal(0, status.getY(), "growing restores inline status");
+      check(row.getPreferredSize().height < narrow, "growing releases wrapped height");
+      assertTextFits(status);
+      row.setSize(221, 2000);
+      layout(row);
+      equal(narrow, row.getPreferredSize().height, "second shrink is stable");
+      assertTextFits(status);
+    });
+  }
+
+  @Test
+  void actualLocalizedExperimentalButtonSizeTracksBothLabels() throws Exception {
+    onEdt(() -> {
+      JFontButton install = new JFontButton("Install and enable");
+      JPanel group = KataGoAccelerationLayout.experimentalActions(new JComboBox<>(), install);
+      install.setPreferredSize(KataGoAutoSetupDialog.localizedButtonSize(install, 90, 32));
+      int initial = install.getPreferredSize().width;
+      install.setText("Enable installed backend");
+      Dimension longer = KataGoAutoSetupDialog.localizedButtonSize(install, 90, 32);
+      install.setPreferredSize(longer);
+      install.setMinimumSize(longer);
+      group.setSize(longer.width + 20, 100);
+      layout(group);
+      check(longer.width > initial, "real label measurement grows the application button");
+      equal(longer.width, install.getWidth(), "layout honors the remeasured button");
+      equal(install.getText(), install.getAccessibleContext().getAccessibleName(), "button remains named");
+    });
+  }
+
+  @Test
+  void allEightResourceBundlesKeepNarrowStatusAndHintsVisible() throws Exception {
+    onEdt(() -> {
+      Locale[] locales = {Locale.ROOT, Locale.US, Locale.JAPAN, Locale.KOREAN,
+          Locale.forLanguageTag("th-TH"), Locale.CHINA, Locale.forLanguageTag("zh-HK"), Locale.TAIWAN};
+      for (Locale locale : locales) {
+        ResourceBundle bundle = ResourceBundle.getBundle("l10n.DisplayStrings", locale);
+        JTextArea text = status(bundle.getString("AutoSetup.accelerationTensorRtHint"));
+        JPanel row = KataGoAccelerationLayout.statusRow(
+            title(bundle.getString("AutoSetup.tensorRtActivationStatus"), 230), text);
+        for (int width : new int[] {260, 740, 260}) {
+          row.setSize(width, 4000);
+          layout(row);
+          assertTextFits(text);
+          assertInside(row, text);
+        }
+        check(!bundle.getString("AutoSetup.maintenanceActions").isBlank(), "maintenance title is translated");
+      }
+    });
+  }
+
+  @Test
+  void wrappedHeightIncludesSwingsCaretMarginAtLineBreakBoundaries() throws Exception {
+    onEdt(() -> {
+      JTextArea hint = KataGoAccelerationLayout.hint(
+          ResourceBundle.getBundle("l10n.DisplayStrings", Locale.US)
+              .getString("AutoSetup.accelerationTensorRtHint"), FONT, Color.DARK_GRAY);
+      for (int caretWidth : new int[] {1, 3}) {
+        hint.putClientProperty("caretWidth", caretWidth);
+        for (int width = 120; width <= 360; width++) {
+          hint.setSize(width, 5000);
+          int height = hint.getPreferredSize().height;
+          hint.setSize(width, height);
+          assertTextFits(hint);
+        }
+      }
+    });
+  }
+
+  private static JLabel title(String text, int width) {
+    JLabel title = new JLabel(text);
+    title.setFont(FONT);
+    title.setPreferredSize(new Dimension(width, 32));
+    return title;
+  }
+
+  private static void assertTextFits(JTextArea text) {
+    try {
+      java.awt.geom.Rectangle2D last = text.modelToView2D(text.getDocument().getLength());
+      check(last != null && last.getMaxY() <= text.getHeight(), "actual final text line is visible");
+      check(last.getMaxX() <= text.getWidth(), "actual final text line stays within width");
+    } catch (javax.swing.text.BadLocationException error) {
+      throw new AssertionError(error);
+    }
+  }
+
+  @Test
+  void primaryActionsAreAdjacentAndLeftAligned() throws Exception {
+    onEdt(() -> {
+      JButton repair = button("修复 TensorRT", 120);
+      JButton enable = button("启用 TensorRT 加速", 160);
+      JPanel row = KataGoAccelerationLayout.primaryActions(repair, enable);
+      row.setSize(800, 100);
+      row.doLayout();
+      equal(0, repair.getX(), "left aligned");
+      equal(repair.getY(), enable.getY(), "same row");
+      equal(128, enable.getX(), "eight-pixel gap");
+      equal(32, row.getPreferredSize().height, "single-row height");
+    });
+  }
+
+  @Test
+  void primaryActionsWrapWhenNarrow() throws Exception {
+    onEdt(() -> {
+      JButton repair = button("修复 TensorRT", 120);
+      JButton enable = button("启用 TensorRT 加速", 160);
+      JPanel row = KataGoAccelerationLayout.primaryActions(repair, enable);
+      row.setSize(180, 100);
+      row.doLayout();
+      check(enable.getY() > repair.getY(), "narrow primary actions wrap");
+      assertInside(row, repair, enable);
+      equal(72, row.getPreferredSize().height, "height includes both rows");
+    });
+  }
+
+  @Test
+  void maintenanceActionsAreSeparateFromPrimary() throws Exception {
+    onEdt(() -> {
+      JPanel primary = KataGoAccelerationLayout.primaryActions(button("repair", 120), button("enable", 140));
+      JPanel maintenance = maintenance();
+      equal(2, primary.getComponentCount(), "only repair and enable");
+      equal(3, maintenance.getComponentCount(), "only maintenance actions");
+      maintenance.setSize(800, 100);
+      maintenance.doLayout();
+      for (Component item : maintenance.getComponents()) {
+        equal(0, item.getY(), "wide maintenance group stays on one row");
+      }
+    });
+  }
+
+  @Test
+  void maintenanceActionsWrapWithoutLeavingTheirGroup() throws Exception {
+    onEdt(() -> {
+      JPanel row = maintenance();
+      row.setSize(200, 200);
+      row.doLayout();
+      check(row.getComponent(2).getY() > row.getComponent(0).getY(), "maintenance wraps");
+      assertInside(row, row.getComponents());
+      check(row.getPreferredSize().height >= 72, "all rows have height");
+    });
+  }
+
+  @Test
+  void hiddenButtonsDoNotReserveAColumn() throws Exception {
+    onEdt(() -> {
+      JPanel row = maintenance();
+      row.getComponent(1).setVisible(false);
+      row.setSize(400, 100);
+      row.doLayout();
+      equal(168, row.getComponent(2).getX(), "hidden button leaves no hole");
+    });
+  }
+
+  @Test
+  void overwideChildUsesTheVisibleAncestorWidth() throws Exception {
+    onEdt(() -> {
+      JPanel row = maintenance();
+      JPanel ancestor = new JPanel(null);
+      ancestor.setSize(210, 300);
+      ancestor.add(row);
+      row.setBounds(10, 0, 900, 200);
+      row.doLayout();
+      for (Component item : row.getComponents()) {
+        check(item.getX() + item.getWidth() <= 200, "button fits visible ancestor");
+      }
+      check(row.getComponent(2).getY() > 0, "ancestor forces wrapping");
+    });
+  }
+
+  @Test
+  void viewportWidthIsRespected() throws Exception {
+    onEdt(() -> {
+      JPanel row = maintenance();
+      JViewport viewport = new JViewport();
+      viewport.setSize(220, 300);
+      viewport.setView(row);
+      row.setSize(900, 200);
+      row.doLayout();
+      for (Component item : row.getComponents()) {
+        check(item.getX() + item.getWidth() <= 220, "button remains in viewport");
+      }
+    });
+  }
+
+  @Test
+  void aVeryLongButtonDoesNotOverflowItsParent() throws Exception {
+    onEdt(() -> {
+      JButton longButton = button("ติดตั้งและใช้แบ็กเอนด์ทดลองที่เลือก", 600);
+      JPanel row = new KataGoAccelerationLayout.WrappingActions(longButton);
+      row.setSize(240, 100);
+      row.doLayout();
+      equal(240, longButton.getWidth(), "component width is bounded");
+      check(longButton.getText().endsWith("ที่เลือก"), "full accessible button text retained");
+      assertInside(row, longButton);
+    });
+  }
+
+  @Test
+  void anExactFitDoesNotWrap() throws Exception {
+    onEdt(() -> {
+      JButton first = button("first", 120);
+      JButton second = button("second", 160);
+      JPanel row = KataGoAccelerationLayout.primaryActions(first, second);
+      row.setSize(288, 100);
+      row.doLayout();
+      equal(0, second.getY(), "exact fit stays inline");
+    });
+  }
+
+  @Test
+  void growingAndShrinkingReflowsBothDirections() throws Exception {
+    onEdt(() -> {
+      JPanel row = maintenance();
+      row.setSize(190, 200);
+      row.doLayout();
+      int narrowHeight = row.getPreferredSize().height;
+      row.setSize(800, 200);
+      row.doLayout();
+      equal(0, row.getComponent(2).getY(), "growing restores horizontal layout");
+      check(row.getPreferredSize().height < narrowHeight, "growing releases excess height");
+      row.setSize(190, 200);
+      row.doLayout();
+      equal(narrowHeight, row.getPreferredSize().height, "shrinking restores wrapped height");
+    });
+  }
+
+  @Test
+  void changedButtonTextCanTriggerReflow() throws Exception {
+    onEdt(() -> {
+      JButton first = button("first", 120);
+      JButton second = button("install", 120);
+      JPanel row = KataGoAccelerationLayout.primaryActions(first, second);
+      row.setSize(280, 100);
+      row.doLayout();
+      equal(0, second.getY(), "initially inline");
+      second.setText("Enable installed backend");
+      second.setPreferredSize(new Dimension(190, 32));
+      row.doLayout();
+      check(second.getY() > 0, "new longer text gets its own row");
+    });
+  }
+
+  @Test
+  void experimentalSelectorAndButtonAreStacked() throws Exception {
+    onEdt(() -> {
+      JComboBox<String> selector = new JComboBox<>(new String[] {"DirectML（DirectX 12 显卡）"});
+      selector.setPreferredSize(new Dimension(390, 32));
+      JButton install = button("启用已安装后端", 190);
+      JPanel group = KataGoAccelerationLayout.experimentalActions(selector, install);
+      group.setSize(420, 120);
+      layout(group);
+      Rectangle buttonBounds = SwingUtilities.convertRectangle(install.getParent(), install.getBounds(), group);
+      check(buttonBounds.y >= selector.getY() + selector.getHeight(), "button below selector");
+      check(buttonBounds.x + buttonBounds.width <= 420, "long label does not clip outside group");
+    });
+  }
+
+  @Test
+  void shortStatusHasCompactIntrinsicWidth() throws Exception {
+    onEdt(() -> {
+      JTextArea status = status("Ready");
+      check(status.getPreferredSize().width < 390, "short status does not demand a full column");
+      check(!status.getText().startsWith("<html>"), "status is plain text");
+    });
+  }
+
+  @Test
+  void longStatusPreservesAllTextAndAccessibleName() throws Exception {
+    onEdt(() -> {
+      String text = "不支持：TensorRT 10.x 需要 SM 7.5+；这张显卡请使用 CUDA/OpenCL。";
+      JTextArea status = status(text);
+      equal(text, status.getText(), "full visible content");
+      equal(text, status.getAccessibleContext().getAccessibleName(), "full accessible content");
+      check(!status.isEditable(), "status cannot be edited");
+      status.setFocusable(true);
+      check(status.isFocusable(), "dialog can retain keyboard-reachable status");
+    });
+  }
+
+  @Test
+  void narrowStatusIsTallEnoughForItsWrappedView() throws Exception {
+    onEdt(() -> {
+      JTextArea status = status("尚未启用 TensorRT profile — NVIDIA 运行库, HumanSL CUDA companion, TensorRT 引擎尚未就绪");
+      status.setSize(180, 20);
+      int required = ((KataGoAccelerationLayout.WrappingText) status).heightForWidth(180);
+      check(required > 32, "precondition: wrapped status needs multiple lines");
+      check(status.getPreferredSize().height >= required, "height includes all wrapped lines");
+    });
+  }
+
+  @Test
+  void explicitNewlinesAreIncludedInHeight() throws Exception {
+    onEdt(() -> {
+      JTextArea status = status("one\ntwo\nthree");
+      status.setSize(500, 20);
+      int lineHeight = status.getFontMetrics(status.getFont()).getHeight();
+      check(status.getPreferredSize().height >= lineHeight * 3, "newlines are not flattened for height");
+    });
+  }
+
+  @Test
+  void longPathsWrapWithoutEllipses() throws Exception {
+    onEdt(() -> {
+      String path = "C:\\Users\\测试用户\\" + "long-directory-".repeat(20) + "\\katago.exe";
+      JTextArea status = status(path);
+      status.setSize(200, 32);
+      check(status.getPreferredSize().height > 64, "unbroken path wraps");
+      equal(path, status.getText(), "path remains complete");
+    });
+  }
+
+  @Test
+  void translatedTextAndScaledFontsKeepAllLines() throws Exception {
+    onEdt(() -> {
+      String[] messages = {
+          "TensorRT runtime and verified CUDA companion are missing; open Auto Setup to repair them.",
+          "TensorRT 运行库与 HumanSL CUDA companion 尚未就绪，请修复后再启用。",
+          "TensorRT 実行環境と CUDA コンパニオンを修復してください。",
+          "TensorRT 런타임 및 CUDA 구성 요소를 복구하십시오.",
+          "โปรดซ่อมแซมรันไทม์ TensorRT และส่วนประกอบ CUDA ก่อนเปิดใช้งาน"
+      };
+      for (int pointSize : new int[] {14, 21, 28}) {
+        for (String message : messages) {
+          JTextArea status = status(message);
+          status.setFont(FONT.deriveFont((float) pointSize));
+          status.setSize(240, 20);
+          int required = ((KataGoAccelerationLayout.WrappingText) status).heightForWidth(240);
+          check(status.getPreferredSize().height >= required, "scaled translation has sufficient height");
+          equal(message, status.getText(), "translation remains complete");
+        }
+      }
+    });
+  }
+
+  @Test
+  void hintAndActionsDoNotOverlapInNarrowBlock() throws Exception {
+    onEdt(() -> {
+      JTextArea hint = KataGoAccelerationLayout.hint(
+          "KataGo 1.18 的 Transformer 模型在许多较新 NVIDIA 显卡上使用 CUDA 更快。下载支持断点续传，首次启动可能需要数分钟生成缓存。",
+          FONT, Color.DARK_GRAY);
+      JPanel actions = KataGoAccelerationLayout.primaryActions(button("修复 TensorRT", 120), button("启用 TensorRT 加速", 160));
+      JPanel block = KataGoAccelerationLayout.actionBlock(new JLabel("TensorRT"), hint, actions);
+      JPanel host = new JPanel(new BorderLayout());
+      host.add(block, BorderLayout.NORTH);
+      host.setSize(220, 1200);
+      for (int attempt = 0; attempt < 6; attempt++) {
+        layout(host);
+      }
+      int required = ((KataGoAccelerationLayout.WrappingText) hint).heightForWidth(hint.getWidth());
+      check(hint.getHeight() >= required, "hint is fully visible");
+      check(actions.getY() >= hint.getY() + hint.getHeight(), "actions below complete hint");
+      check(actions.getHeight() >= actions.getPreferredSize().height, "actions have enough height");
+      assertInside(actions, actions.getComponents());
+    });
+  }
+
+  @Test
+  void emptyAndNullStatusAreSafe() throws Exception {
+    onEdt(() -> {
+      JTextArea status = status("previous");
+      KataGoAccelerationLayout.setStatusText(status, null);
+      equal("", status.getText(), "null clears status");
+      equal("", status.getAccessibleContext().getAccessibleName(), "null clears accessible name");
+      check(status.getPreferredSize().height > 0, "empty row retains usable height");
+    });
+  }
+
+  @Test
+  void rowInsetsAreRespected() throws Exception {
+    onEdt(() -> {
+      JPanel row = maintenance();
+      row.setBorder(BorderFactory.createEmptyBorder(5, 11, 7, 13));
+      row.setSize(230, 300);
+      row.doLayout();
+      for (Component item : row.getComponents()) {
+        check(item.getX() >= 11, "left inset");
+        check(item.getX() + item.getWidth() <= 217, "right inset");
+        check(item.getY() >= 5, "top inset");
+      }
+    });
+  }
+
+  private static JButton button(String text, int width) {
+    JButton button = new JButton(text);
+    button.setFont(FONT);
+    button.setPreferredSize(new Dimension(width, 32));
+    return button;
+  }
+
+  private static JPanel maintenance() {
+    return KataGoAccelerationLayout.maintenanceActions(
+        button("检查英伟达整合包", 160), button("切回 CUDA", 110), button("清理 TensorRT 缓存", 170));
+  }
+
+  private static JTextArea status(String text) {
+    JTextArea status = KataGoAccelerationLayout.statusChip(FONT, Color.WHITE, Color.GRAY);
+    KataGoAccelerationLayout.setStatusText(status, text);
+    return status;
+  }
+
+  private static void assertInside(JComponent parent, Component... children) {
+    for (Component child : children) {
+      check(child.getX() >= 0, "nonnegative x");
+      check(child.getX() + child.getWidth() <= parent.getWidth(), "within parent width");
+      check(child.getY() + child.getHeight() <= parent.getHeight(), "within parent height");
+    }
+  }
+
+  private static void layout(Container parent) {
+    parent.doLayout();
+    for (Component child : parent.getComponents()) {
+      if (child instanceof Container) {
+        layout((Container) child);
+      }
+    }
+  }
+
+  private static void onEdt(Runnable action) throws Exception {
+    SwingUtilities.invokeAndWait(action);
+  }
+
+  private static void check(boolean condition, String message) {
+    if (!condition) {
+      throw new AssertionError(message);
+    }
+  }
+
+  private static void equal(Object expected, Object actual, String message) {
+    if (!java.util.Objects.equals(expected, actual)) {
+      throw new AssertionError(message + ": expected=" + expected + ", actual=" + actual);
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Restores the responsive grouping and visible-width layout for **KataGo Auto Setup → NVIDIA GPU acceleration**.

The layout intent was originally implemented in `c53265b93eaa5b04083c737dc553f234eca9ff1f` and was still present in the final commit of #391. PR #392 replaced #391 and merged the DirectML/TensorRT repair behavior, while the corresponding acceleration-page layout changes were not carried over completely.

This PR restores that UI behavior on the current `main` baseline:

- Groups the page into three left-aligned sections: **Install TensorRT acceleration**, **Experimental backends**, and **More actions**.
- Keeps actions on one row when space allows, wraps them according to the actual visible width when the window narrows, and returns them to one row when the window grows again.
- Keeps status text, descriptions, explicit line breaks, and long paths fully visible by measuring wrapped Swing text at the available width.
- Reflows narrow status rows vertically when the label column would otherwise leave too little room for the value.
- Recomputes the experimental-backend action button size when its label changes between install and enable states.
- Restores `AutoSetup.maintenanceActions` in all eight localization bundles.
- Restores the existing primary-action treatment for **Enable TensorRT acceleration** through `styleButton(btnEnableTensorRt, true)`.

The existing TensorRT behavior remains intact, including DirectML repair eligibility, separate repair and enable actions, directed repair through `TensorRtRepairContext`, hardware/state gating, and the existing installation and recovery flow.

## Type Of Change

- [x] Bug fix
- [ ] Feature
- [ ] Packaging / release update
- [x] Docs / translation
- [ ] Refactor

## Testing

- [x] Tested locally
- [ ] Verified package contents if packaging changed
- [ ] Verified Fox sync flow if related
- [ ] Added screenshots if UI changed
- [ ] Updated README / docs if user-facing behavior changed
- [x] Noted affected platforms if the change is platform-specific
- [x] Verified there is no unrelated formatting or line-ending churn
- [x] Ran `python3 scripts/check_line_endings.py` (or equivalent `python` on Windows)

Focused regression suite:

```bash
mvn -B -Dfmt.skip=true -Djava.awt.headless=true \
  -Dtest=KataGoAccelerationLayoutTest,KataGoAutoSetupDialogLayoutTest,TensorRtAccelerationViewTest,TensorRtRepairabilityStateTest,TensorRtDirectedRepairTest,LocalizationResourceParityTest \
  test
```

Result: **105 tests, 0 failures, 0 errors, 0 skipped**.

Repository verification:

```bash
bash scripts/run_local_ci.sh --profile portable
python3 scripts/check_line_endings.py
git diff --check
```

Result: local portable CI **PASS**, all **26/26** steps passed. The final Maven verification ran **4,119 unit tests with 0 failures and 0 errors** (`23` environment-gated skips), plus the shaded-JAR `LoggingProviderSmokeIT` integration test.

The final shaded JAR was opened in WSLg with the real application theme. The acceleration page was exercised at **1200 → 780 → 1200 px**, with **75 layout/status boundary checks** passing. Wide, narrow, regrown, weights-page, and performance-page screenshots were captured and reviewed locally.

Native Windows acceptance also passed at **100% display scaling** with the actual application theme. The acceleration page was checked at its default **1200×900** size, its enforced minimum **900×900** size, and after regrowing to **1200×900**. Status rows, wrapped descriptions, action groups, the backend selector, and the vertical scrollbar remained visible and usable without clipping or overlap.

## Notes

This PR is based on upstream `main` at `e044191a0ed28b398fcfcefe6c539415e4060f3c` and changes 11 files: the auto-setup dialog, a dedicated acceleration-layout helper, its regression tests, and eight localization bundles.

Related context: #380, #391, #392.
