### PR TITLE
ci: remove legacy aggregate gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,32 +154,3 @@ jobs:
         run: |
           printf '%s\n' "repository-checks=$REPOSITORY" "script-tests=$SCRIPTS" "windows-script-tests=$WINDOWS_SCRIPTS" "java-linux=$JAVA_LINUX" "java-windows=$JAVA_WINDOWS"
           [[ "$REPOSITORY" == success && "$SCRIPTS" == success && "$WINDOWS_SCRIPTS" == success && "$JAVA_LINUX" == success && "$JAVA_WINDOWS" == success ]]
-
-  build:
-    if: ${{ always() }}
-    needs: [repository-checks, script-tests, java-linux]
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    steps:
-      - name: Require Linux execution jobs
-        env:
-          REPOSITORY: ${{ needs.repository-checks.result }}
-          SCRIPTS: ${{ needs.script-tests.result }}
-          JAVA_LINUX: ${{ needs.java-linux.result }}
-        run: |
-          printf '%s\n' "repository-checks=$REPOSITORY" "script-tests=$SCRIPTS" "java-linux=$JAVA_LINUX"
-          [[ "$REPOSITORY" == success && "$SCRIPTS" == success && "$JAVA_LINUX" == success ]]
-
-  windows-script-validation:
-    if: ${{ always() }}
-    needs: [windows-script-tests, java-windows]
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    steps:
-      - name: Require Windows execution jobs
-        env:
-          WINDOWS_SCRIPTS: ${{ needs.windows-script-tests.result }}
-          JAVA_WINDOWS: ${{ needs.java-windows.result }}
-        run: |
-          printf '%s\n' "windows-script-tests=$WINDOWS_SCRIPTS" "java-windows=$JAVA_WINDOWS"
-          [[ "$WINDOWS_SCRIPTS" == success && "$JAVA_WINDOWS" == success ]]

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -103,13 +103,12 @@ Windows 脚本 job 依次运行 `windows/repository` 与 `windows/scripts`，摘
 两平台 Java job 保留全量测试、`LoggingProviderSmokeIT`、shaded JAR 和 JaCoCo；
 验证成功但 coverage artifact 缺失仍失败。各组失败时仍尝试上传本组摘要。
 
-`ci-required` 直接要求五项全部成功。迁移期间 `build` 汇总两个 Portable 非 Java job
-和 `java-linux`；`windows-script-validation` 汇总两个 Windows job。三个汇总器均拒绝
-失败、取消、跳过、缺失或未知结果。发布仍仅接受目标 SHA 的 `ci.yml` push 成功运行。
+`ci-required` 是唯一汇总门禁，直接要求五项全部成功，拒绝失败、取消、跳过、缺失或
+未知结果。发布仍仅接受目标 SHA 的完整 `ci.yml` push 成功运行。
 
-首个 PR 合并且对应 main push CI 成功后，请 wimi321 将 main required checks 替换为
-GitHub Actions 来源的 `ci-required`，其他保护设置不变。确认设置生效后，后续 PR
-才删除两个旧汇总门禁；当前 PR 不需要管理员预先修改保护。
+main 分支保护要求 GitHub Actions 来源的 `ci-required`。回退 workflow 时必须保留
+可运行且真实验证五项执行结果的 `ci-required`；不能直接回退到缺少该检查的版本。
+如需调整 required checks，由维护者协调保护设置与 workflow，始终保留有效合并门禁。
 
 本地预检用于在推送前尽早发现问题，不能代替受保护分支上的干净 Windows 和
 Ubuntu runner，也不能代替 macOS 签名、公证与多平台发布资产审计。


### PR DESCRIPTION
## Summary

- Complete the required-check migration introduced in #454 by removing the `build` and `windows-script-validation` aggregate jobs.
- Retain the five execution jobs and the direct `ci-required` gate unchanged: all five results must be `success`.
- Update the development guide with the final gate and protection-aware rollback requirements.

## Type Of Change

- [x] Refactor (CI workflow)
- [x] Docs / translation

## Testing

- [x] Synchronized upstream `main` at `062a8cf461bc2adf3e91112e542c8feb7ed3e463` through a conflict-free merge commit. The final tree is identical to the reviewed implementation `8dfe02b6f67159ee5f3805ab84067801e604063c`; the PR changes only `.github/workflows/ci.yml` and `docs/DEVELOPMENT.md`.
- [x] Confirmed that the six retained job definitions and workflow settings are unchanged. Commands, runners, versions, caches, JUnit/JaCoCo and report handling retain the coverage from #454.
- [x] Passed actionlint and the portable repository-check group, including line-ending tests, the line-ending policy, Markdown links and diff checks.
- [x] Executed the actual gate Bash body in 31 local scenarios: all-success passes; each dependency's failure, cancellation, skip, empty, unknown or unset result fails.
- [x] Passed all 67 publisher fixture tests, including exact-SHA `ci.yml` push lookup, waiting, failure rejection and the pre-publication recheck. No real Release was created.
- [x] Completed independent Standards and Spec review and verification: both SUCCESS, zero follow-up items. The final HEAD and hosted test merge have the same complete tree as that reviewed implementation; synchronization introduced no source changes requiring another broad review.
- [x] All six jobs succeeded on final PR HEAD `6caf46b26f7486e6ffb63ffe20c384032ac31e36`: [CI run 34561189536](https://github.com/wimi321/lizzieyzy-next/actions/runs/34561189536).
- [x] The PR-specific GraphQL check reports `ci-required.isRequired=true`, `conclusion=SUCCESS`, and GitHub Actions (`app_id=15368`, `slug=github-actions`). `gh pr checks --required` also reports [ci-required passing](https://github.com/wimi321/lizzieyzy-next/actions/runs/34561189536/job/103145071248).

Downloaded run summaries report Linux Java: 4120 tests, 23 skipped; Windows Java: 4119 tests, 49 skipped; both have zero failures/errors. Skips are not executed passes. All six profile/group command lists match #454 apart from the Windows per-run temporary-directory ID. Both JaCoCo coverage artifacts were uploaded successfully.

All summaries identify tested PR merge `d6efcb91d9c29e7f3ffafbf2d749b1d7b1f62e57`. Its tree, the final HEAD tree, and the reviewed implementation tree are identical: `6ac8732d790598364b5cccc2ddfe3a8284a51bc9`.

The [superseded run 34560913291](https://github.com/wimi321/lizzieyzy-next/actions/runs/34560913291) supplies an actual six-job cancellation case: Windows Java was cancelled, the other four execution jobs succeeded, and `ci-required` failed. That cancelled run is not final-head success evidence.

## Notes

Effective protection was reread at `2026-09-11T04:04:10Z`: `main` requires only `ci-required`, with GitHub Actions `app_id=15368`. Neither legacy name is required.

Release publication continues to wait for the complete `ci.yml` push run at the exact target SHA. A PR run does not replace that evidence. Rollbacks must preserve a working, genuinely validating `ci-required` while it remains required by protection.

Final-head hosted checks and required-check identity are verified; this PR is ready for review. Ticket 04 remains open: completion requires maintainer merge and a successful six-job `ci.yml` push run for the exact merged `main` SHA. Ticket 05 waits for those results. The PR has not been merged, and branch protection is unchanged.
