### PR TITLE
test(logging): stabilize recovery checks and prepare pre-release

### DIFF
--- a/.github/release-notes/next-2026-09-13.2.md
+++ b/.github/release-notes/next-2026-09-13.2.md
@@ -1,0 +1,337 @@
+# LizzieYzy Next next-2026-09-13.2
+
+## 中文
+
+基于 next-2026-09-04.1 的稳定性与引擎管理改进预发布版。
+
+### 本版主要更新
+
+- 修复棋谱导入、同步及引擎恢复的规则与局面确认流程；引擎对局期间不再被规则窗口打断，并加强流式落子取消后的前台恢复。
+- 测速结果、线程来源和 Apple 调优配置按已保存引擎分别管理，支持自定义本地 KataGo；远程引擎继续使用服务端配置。
+- 完整包默认 B11 更新为 2026-09-07 官方模型 kata1-tf3-b11c768-s11500M-d6163M.bin.gz；主程序小更新不替换引擎和权重。
+- 修复 TensorRT 设置页分组、窄窗口换行与状态文字显示；改进诊断导出和分析缓存追踪，保留日志换行。
+- HumanSL 下载增加国内备用镜像，补充自建远程一键部署说明；重组 Linux/Windows CI 并严格保留全部测试门禁。
+- 感谢 qiyi71w 及参与反馈、审查和测试的贡献者。
+
+### 下载前先看
+
+- 现有 Windows 用户可选 core-update.zip，先退出软件，再覆盖原目录；更新前备份 user-data 和棋谱。
+- 新安装或需要新 B11 的用户请下载完整包。B11 单次判断较强但搜索较慢；追求速度可在“一键设置 → 权重”选择 B10。
+- RTX 30/40/50 优先 CUDA；TensorRT 是 RTX 20、GTX 16 的可选项，实际速度以本机测速为准。实验后端仍需对应硬件验证。
+- 本版不包含 #449 的实验性同树选点评估，现有官方 KataGo 尚不支持其所需能力。
+- 国内用户可从官网下载页面获取正式版：https://goagent.top/download/ 。本次预发布文件由下表 GitHub 链接下载，不替换官网下载正式版。
+
+### 下载建议
+
+| 你的电脑 | 直接下载这个 |
+| --- | --- |
+| Windows 64 位，RTX 20/30/40/50 NVIDIA CUDA 推荐版，免安装 | [2026-09-13-windows64.nvidia.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-13.2/2026-09-13-windows64.nvidia.portable.zip) |
+| 已有 Windows 免安装版，只更新主程序 | [2026-09-13-windows64.core-update.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-13.2/2026-09-13-windows64.core-update.zip) |
+| Windows 64 位，RTX 20/30/40/50 NVIDIA CUDA 推荐安装版 | [2026-09-13-windows64.nvidia.installer.exe](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-13.2/2026-09-13-windows64.nvidia.installer.exe) |
+| Windows 64 位，AMD / Intel / 旧 NVIDIA OpenCL 兼容版，免安装 | [2026-09-13-windows64.opencl.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-13.2/2026-09-13-windows64.opencl.portable.zip) |
+| Windows 64 位，AMD / Intel / 旧 NVIDIA OpenCL 兼容安装版 | [2026-09-13-windows64.opencl.installer.exe](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-13.2/2026-09-13-windows64.opencl.installer.exe) |
+| Windows 64 位，CPU 兼容版，免安装 | [2026-09-13-windows64.with-katago.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-13.2/2026-09-13-windows64.with-katago.portable.zip) |
+| Windows 64 位，CPU 兼容安装版 | [2026-09-13-windows64.with-katago.installer.exe](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-13.2/2026-09-13-windows64.with-katago.installer.exe) |
+| Windows DirectML 实验版 | [2026-09-13-windows64.experimental.directml.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-13.2/2026-09-13-windows64.experimental.directml.portable.zip) |
+| Windows Intel OpenVINO 实验版 | [2026-09-13-windows64.experimental.openvino.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-13.2/2026-09-13-windows64.experimental.openvino.portable.zip) |
+| Windows AMD RX 6000 ROCm 实验版 | [2026-09-13-windows64.experimental.rocm.gfx103x.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-13.2/2026-09-13-windows64.experimental.rocm.gfx103x.portable.zip) |
+| Windows AMD RX 7000 ROCm 实验版 | [2026-09-13-windows64.experimental.rocm.gfx110x.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-13.2/2026-09-13-windows64.experimental.rocm.gfx110x.portable.zip) |
+| Windows AMD Ryzen AI Max ROCm 实验版 | [2026-09-13-windows64.experimental.rocm.gfx1151.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-13.2/2026-09-13-windows64.experimental.rocm.gfx1151.portable.zip) |
+| Windows AMD RX 9000 ROCm 实验版 | [2026-09-13-windows64.experimental.rocm.gfx120x.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-13.2/2026-09-13-windows64.experimental.rocm.gfx120x.portable.zip) |
+| TensorRT (RTX 20 / GTX 16; 2 parts) | [2026-09-13-windows64.nvidia.tensorrt.portable.7z.001](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-13.2/2026-09-13-windows64.nvidia.tensorrt.portable.7z.001)<br>[2026-09-13-windows64.nvidia.tensorrt.portable.7z.002](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-13.2/2026-09-13-windows64.nvidia.tensorrt.portable.7z.002) |
+| Windows 64 位，自行配置引擎，免安装 | [2026-09-13-windows64.without.engine.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-13.2/2026-09-13-windows64.without.engine.portable.zip) |
+| Windows 64 位，自行配置引擎，安装版 | [2026-09-13-windows64.without.engine.installer.exe](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-13.2/2026-09-13-windows64.without.engine.installer.exe) |
+| macOS Apple Silicon，Metal | [2026-09-13-mac-apple-silicon.with-katago.dmg](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-13.2/2026-09-13-mac-apple-silicon.with-katago.dmg) |
+| macOS Intel | [2026-09-13-mac-intel.with-katago.dmg](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-13.2/2026-09-13-mac-intel.with-katago.dmg) |
+| Linux 64 位，CPU 兼容版 | [2026-09-13-linux64.with-katago.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-13.2/2026-09-13-linux64.with-katago.zip) |
+| Linux 64 位，OpenCL 版 | [2026-09-13-linux64.opencl.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-13.2/2026-09-13-linux64.opencl.zip) |
+| Linux 64 位，NVIDIA CUDA 版 | [2026-09-13-linux64.nvidia.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-13.2/2026-09-13-linux64.nvidia.zip) |
+
+### 验证结果
+
+- 公开前必须通过精确发布提交的 CI、四平台构建、签名/公证及资产大小、SHA-256 和来源校验。
+- 本机自动测试与实际已执行的冒烟结果记录在发布 PR；跳过项目不计通过。本轮未进行 Windows 原生桌面、各型号 GPU 或全部平台升级真机验收。
+
+### 交流
+
+- QQ: 299419120
+
+## 繁體中文
+
+基於 next-2026-09-04.1 的穩定性與引擎管理改進預發布版。
+
+### 本版主要更新
+
+- 修復棋譜匯入、同步及引擎恢復的規則與局面確認；引擎對局不再被規則視窗打斷，改善串流落子取消後的恢復。
+- 測速結果、執行緒來源與 Apple 調校設定按已儲存引擎分別管理，支援自訂本機 KataGo；遠端引擎沿用伺服器設定。
+- 完整包預設 B11 更新為 2026-09-07 官方模型 kata1-tf3-b11c768-s11500M-d6163M.bin.gz；小更新不替換引擎或權重。
+- 修復 TensorRT 設定頁分組、窄視窗換行及狀態文字；改善診斷匯出、分析快取追蹤及日誌換行。
+- HumanSL 下載增加中國大陸備用鏡像，補充自建遠端一鍵部署說明；重組 CI 並保留完整測試要求。
+- 感謝 qiyi71w 與參與回饋、審查和測試的貢獻者。
+
+### 下載前先看
+
+- Windows 現有用戶可用 core-update.zip；退出程式後覆蓋原目錄，先備份 user-data 和棋譜。
+- 新安裝或需要新 B11 請下載完整包。B11 單次判斷較強但搜尋較慢，重視速度可在一鍵設定的權重頁選擇 B10。
+- RTX 30/40/50 優先 CUDA；TensorRT 為 RTX 20、GTX 16 的可選項，速度以實測為準。實驗後端仍需硬體驗證。
+- 本版不含 #449 實驗性同樹選點評估，官方 KataGo 尚未提供所需能力。
+- 官網正式版：https://goagent.top/download/ 。本次預發布請使用下表 GitHub 連結，不替換官網正式版。
+
+### 下載建議
+
+| 你的電腦 | 直接下載這個 |
+| --- | --- |
+| Windows 64 位，RTX 20/30/40/50 NVIDIA CUDA 建議版，免安裝 | [2026-09-13-windows64.nvidia.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-13.2/2026-09-13-windows64.nvidia.portable.zip) |
+| 既有 Windows 免安裝版，只更新主程式 | [2026-09-13-windows64.core-update.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-13.2/2026-09-13-windows64.core-update.zip) |
+| Windows 64 位，RTX 20/30/40/50 NVIDIA CUDA 建議安裝版 | [2026-09-13-windows64.nvidia.installer.exe](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-13.2/2026-09-13-windows64.nvidia.installer.exe) |
+| Windows 64 位，AMD / Intel / 舊 NVIDIA OpenCL 相容版，免安裝 | [2026-09-13-windows64.opencl.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-13.2/2026-09-13-windows64.opencl.portable.zip) |
+| Windows 64 位，AMD / Intel / 舊 NVIDIA OpenCL 相容安裝版 | [2026-09-13-windows64.opencl.installer.exe](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-13.2/2026-09-13-windows64.opencl.installer.exe) |
+| Windows 64 位，CPU 相容版，免安裝 | [2026-09-13-windows64.with-katago.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-13.2/2026-09-13-windows64.with-katago.portable.zip) |
+| Windows 64 位，CPU 相容安裝版 | [2026-09-13-windows64.with-katago.installer.exe](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-13.2/2026-09-13-windows64.with-katago.installer.exe) |
+| Windows DirectML 實驗版 | [2026-09-13-windows64.experimental.directml.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-13.2/2026-09-13-windows64.experimental.directml.portable.zip) |
+| Windows Intel OpenVINO 實驗版 | [2026-09-13-windows64.experimental.openvino.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-13.2/2026-09-13-windows64.experimental.openvino.portable.zip) |
+| Windows AMD RX 6000 ROCm 實驗版 | [2026-09-13-windows64.experimental.rocm.gfx103x.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-13.2/2026-09-13-windows64.experimental.rocm.gfx103x.portable.zip) |
+| Windows AMD RX 7000 ROCm 實驗版 | [2026-09-13-windows64.experimental.rocm.gfx110x.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-13.2/2026-09-13-windows64.experimental.rocm.gfx110x.portable.zip) |
+| Windows AMD Ryzen AI Max ROCm 實驗版 | [2026-09-13-windows64.experimental.rocm.gfx1151.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-13.2/2026-09-13-windows64.experimental.rocm.gfx1151.portable.zip) |
+| Windows AMD RX 9000 ROCm 實驗版 | [2026-09-13-windows64.experimental.rocm.gfx120x.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-13.2/2026-09-13-windows64.experimental.rocm.gfx120x.portable.zip) |
+| TensorRT (RTX 20 / GTX 16; 2 parts) | [2026-09-13-windows64.nvidia.tensorrt.portable.7z.001](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-13.2/2026-09-13-windows64.nvidia.tensorrt.portable.7z.001)<br>[2026-09-13-windows64.nvidia.tensorrt.portable.7z.002](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-13.2/2026-09-13-windows64.nvidia.tensorrt.portable.7z.002) |
+| Windows 64 位，自行設定 engine，免安裝 | [2026-09-13-windows64.without.engine.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-13.2/2026-09-13-windows64.without.engine.portable.zip) |
+| Windows 64 位，自行設定 engine，安裝版 | [2026-09-13-windows64.without.engine.installer.exe](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-13.2/2026-09-13-windows64.without.engine.installer.exe) |
+| macOS Apple Silicon，Metal | [2026-09-13-mac-apple-silicon.with-katago.dmg](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-13.2/2026-09-13-mac-apple-silicon.with-katago.dmg) |
+| macOS Intel | [2026-09-13-mac-intel.with-katago.dmg](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-13.2/2026-09-13-mac-intel.with-katago.dmg) |
+| Linux 64 位，CPU 相容版 | [2026-09-13-linux64.with-katago.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-13.2/2026-09-13-linux64.with-katago.zip) |
+| Linux 64 位，OpenCL 版 | [2026-09-13-linux64.opencl.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-13.2/2026-09-13-linux64.opencl.zip) |
+| Linux 64 位，NVIDIA CUDA 版 | [2026-09-13-linux64.nvidia.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-13.2/2026-09-13-linux64.nvidia.zip) |
+
+### 驗證結果
+
+- 公開前須通過精確發布提交的 CI、四平台建置、簽章/公證、檔案大小、SHA-256 與來源校驗。
+- 實際自動測試及冒煙結果記錄於發布 PR；跳過項目不算通過。本輪未執行 Windows 原生桌面、所有 GPU 或各平台升級實機驗收。
+
+### 交流
+
+- QQ: 299419120
+
+## English
+
+A stability and engine-management pre-release based on next-2026-09-04.1.
+
+### Release highlights
+
+- Fix rule and position confirmation when importing SGF, synchronizing boards and restoring engines; prevent rule dialogs from interrupting engine matches and improve recovery after streaming move cancellation.
+- Scope benchmark results, thread sources and Apple tuning profiles to saved engines, including custom local KataGo setups. Remote engines retain server-managed settings.
+- Update the bundled default B11 to the official 2026-09-07 model kata1-tf3-b11c768-s11500M-d6163M.bin.gz. The core update does not replace engines or weights.
+- Restore responsive TensorRT setup groups and wrapped status text; improve diagnostic exports, analysis-cache tracing and exported log line boundaries.
+- Add a mainland-China fallback mirror for HumanSL downloads and one-click self-hosted remote deployment guidance. Split Linux/Windows CI without dropping test gates.
+- Thanks to qiyi71w and everyone contributing feedback, reviews and testing.
+
+### Before downloading
+
+- Existing Windows users can apply core-update.zip after exiting the app; back up user-data and game records first.
+- Download a full package for a new installation or the new B11. B11 offers stronger individual evaluations but slower search; choose B10 on the weight page if speed matters more.
+- Prefer CUDA for RTX 30/40/50. TensorRT remains optional for RTX 20 and GTX 16; benchmark your own hardware. Experimental backends still need device-specific verification.
+- This release excludes experimental same-tree move focus in #449; official KataGo does not yet provide the required capability.
+- The official stable download page is https://goagent.top/download/ . Use the GitHub links below for this pre-release; it does not replace the website stable version.
+
+### Download guide
+
+| Your computer | Download this file |
+| --- | --- |
+| Windows x64, recommended RTX 20/30/40/50 NVIDIA CUDA portable | [2026-09-13-windows64.nvidia.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-13.2/2026-09-13-windows64.nvidia.portable.zip) |
+| Existing Windows portable, app-only update | [2026-09-13-windows64.core-update.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-13.2/2026-09-13-windows64.core-update.zip) |
+| Windows x64, recommended RTX 20/30/40/50 NVIDIA CUDA installer | [2026-09-13-windows64.nvidia.installer.exe](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-13.2/2026-09-13-windows64.nvidia.installer.exe) |
+| Windows x64, OpenCL portable for AMD / Intel / older NVIDIA | [2026-09-13-windows64.opencl.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-13.2/2026-09-13-windows64.opencl.portable.zip) |
+| Windows x64, OpenCL installer for AMD / Intel / older NVIDIA | [2026-09-13-windows64.opencl.installer.exe](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-13.2/2026-09-13-windows64.opencl.installer.exe) |
+| Windows x64, CPU compatibility portable | [2026-09-13-windows64.with-katago.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-13.2/2026-09-13-windows64.with-katago.portable.zip) |
+| Windows x64, CPU compatibility installer | [2026-09-13-windows64.with-katago.installer.exe](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-13.2/2026-09-13-windows64.with-katago.installer.exe) |
+| Windows DirectML experimental | [2026-09-13-windows64.experimental.directml.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-13.2/2026-09-13-windows64.experimental.directml.portable.zip) |
+| Windows Intel OpenVINO experimental | [2026-09-13-windows64.experimental.openvino.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-13.2/2026-09-13-windows64.experimental.openvino.portable.zip) |
+| Windows AMD RX 6000 ROCm experimental | [2026-09-13-windows64.experimental.rocm.gfx103x.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-13.2/2026-09-13-windows64.experimental.rocm.gfx103x.portable.zip) |
+| Windows AMD RX 7000 ROCm experimental | [2026-09-13-windows64.experimental.rocm.gfx110x.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-13.2/2026-09-13-windows64.experimental.rocm.gfx110x.portable.zip) |
+| Windows AMD Ryzen AI Max ROCm experimental | [2026-09-13-windows64.experimental.rocm.gfx1151.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-13.2/2026-09-13-windows64.experimental.rocm.gfx1151.portable.zip) |
+| Windows AMD RX 9000 ROCm experimental | [2026-09-13-windows64.experimental.rocm.gfx120x.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-13.2/2026-09-13-windows64.experimental.rocm.gfx120x.portable.zip) |
+| TensorRT (RTX 20 / GTX 16; 2 parts) | [2026-09-13-windows64.nvidia.tensorrt.portable.7z.001](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-13.2/2026-09-13-windows64.nvidia.tensorrt.portable.7z.001)<br>[2026-09-13-windows64.nvidia.tensorrt.portable.7z.002](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-13.2/2026-09-13-windows64.nvidia.tensorrt.portable.7z.002) |
+| Windows x64, bring your own engine, portable | [2026-09-13-windows64.without.engine.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-13.2/2026-09-13-windows64.without.engine.portable.zip) |
+| Windows x64, bring your own engine, installer | [2026-09-13-windows64.without.engine.installer.exe](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-13.2/2026-09-13-windows64.without.engine.installer.exe) |
+| macOS Apple Silicon, Metal | [2026-09-13-mac-apple-silicon.with-katago.dmg](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-13.2/2026-09-13-mac-apple-silicon.with-katago.dmg) |
+| macOS Intel | [2026-09-13-mac-intel.with-katago.dmg](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-13.2/2026-09-13-mac-intel.with-katago.dmg) |
+| Linux x64, CPU compatibility | [2026-09-13-linux64.with-katago.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-13.2/2026-09-13-linux64.with-katago.zip) |
+| Linux x64, OpenCL | [2026-09-13-linux64.opencl.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-13.2/2026-09-13-linux64.opencl.zip) |
+| Linux x64, NVIDIA CUDA | [2026-09-13-linux64.nvidia.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-13.2/2026-09-13-linux64.nvidia.zip) |
+
+### Verification
+
+- Publication requires exact-commit CI, all four platform builds, signing/notarization, and asset size, SHA-256 and provenance verification.
+- Executed local tests and smoke checks are recorded in the release PR. Skips are not passes. Native Windows desktop, all GPU models and cross-platform upgrade acceptance were not rerun in this release cycle.
+
+### Contact
+
+- QQ: 299419120
+
+## 日本語
+
+next-2026-09-04.1 を基準とした安定性とエンジン管理の改善プレリリースです。
+
+### 主な更新
+
+- SGF 読み込み、盤面同期、エンジン復旧時のルールと局面確認を修正。エンジン対局をルール画面で中断せず、着手生成の取消後も復旧を改善しました。
+- 測定結果、スレッド設定、Apple 調整情報を保存済みエンジンごとに管理し、独自のローカル KataGo に対応。遠隔エンジンはサーバー設定を維持します。
+- 完全版の標準 B11 を 2026-09-07 の公式モデル kata1-tf3-b11c768-s11500M-d6163M.bin.gz に更新。小更新はエンジンや重みを置換しません。
+- TensorRT 設定のグループ、狭い画面の折り返し、状態表示を修正。診断出力、解析キャッシュ追跡、ログの改行を改善しました。
+- HumanSL に中国本土向け代替ミラーを追加し、自前遠隔環境の簡単な導入手順を整備。CI を分割し、全テスト要件を維持しました。
+- qiyi71w と報告・レビュー・テストの協力者に感謝します。
+
+### ダウンロード前に
+
+- Windows の既存利用者は終了後に core-update.zip を上書きできます。先に user-data と棋譜をバックアップしてください。
+- 新規導入や新しい B11 には完全版を使用してください。B11 は一回の評価が強力ですが探索は遅めです。速度重視なら重み画面で B10 を選べます。
+- RTX 30/40/50 は CUDA を優先。TensorRT は RTX 20、GTX 16 の選択肢であり、速度は実機測定で確認してください。実験版には対応機器の検証が必要です。
+- #449 の実験的な同一探索木の着手フォーカスは含みません。必要な機能は公式 KataGo にまだありません。
+- 公式安定版：https://goagent.top/download/ 。このプレリリースは下表の GitHub から取得し、公式サイトの安定版は更新しません。
+
+### ダウンロード案内
+
+| お使いの環境 | ダウンロードするファイル |
+| --- | --- |
+| Windows x64、RTX 20/30/40/50 NVIDIA CUDA 推奨 portable | [2026-09-13-windows64.nvidia.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-13.2/2026-09-13-windows64.nvidia.portable.zip) |
+| 既存 Windows portable、app のみ更新 | [2026-09-13-windows64.core-update.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-13.2/2026-09-13-windows64.core-update.zip) |
+| Windows x64、RTX 20/30/40/50 NVIDIA CUDA installer | [2026-09-13-windows64.nvidia.installer.exe](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-13.2/2026-09-13-windows64.nvidia.installer.exe) |
+| Windows x64、AMD / Intel / 旧 NVIDIA OpenCL portable | [2026-09-13-windows64.opencl.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-13.2/2026-09-13-windows64.opencl.portable.zip) |
+| Windows x64、AMD / Intel / 旧 NVIDIA OpenCL installer | [2026-09-13-windows64.opencl.installer.exe](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-13.2/2026-09-13-windows64.opencl.installer.exe) |
+| Windows x64、CPU 互換 portable | [2026-09-13-windows64.with-katago.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-13.2/2026-09-13-windows64.with-katago.portable.zip) |
+| Windows x64、CPU 互換 installer | [2026-09-13-windows64.with-katago.installer.exe](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-13.2/2026-09-13-windows64.with-katago.installer.exe) |
+| Windows DirectML experimental | [2026-09-13-windows64.experimental.directml.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-13.2/2026-09-13-windows64.experimental.directml.portable.zip) |
+| Windows Intel OpenVINO experimental | [2026-09-13-windows64.experimental.openvino.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-13.2/2026-09-13-windows64.experimental.openvino.portable.zip) |
+| Windows AMD RX 6000 ROCm experimental | [2026-09-13-windows64.experimental.rocm.gfx103x.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-13.2/2026-09-13-windows64.experimental.rocm.gfx103x.portable.zip) |
+| Windows AMD RX 7000 ROCm experimental | [2026-09-13-windows64.experimental.rocm.gfx110x.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-13.2/2026-09-13-windows64.experimental.rocm.gfx110x.portable.zip) |
+| Windows AMD Ryzen AI Max ROCm experimental | [2026-09-13-windows64.experimental.rocm.gfx1151.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-13.2/2026-09-13-windows64.experimental.rocm.gfx1151.portable.zip) |
+| Windows AMD RX 9000 ROCm experimental | [2026-09-13-windows64.experimental.rocm.gfx120x.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-13.2/2026-09-13-windows64.experimental.rocm.gfx120x.portable.zip) |
+| TensorRT (RTX 20 / GTX 16; 2 parts) | [2026-09-13-windows64.nvidia.tensorrt.portable.7z.001](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-13.2/2026-09-13-windows64.nvidia.tensorrt.portable.7z.001)<br>[2026-09-13-windows64.nvidia.tensorrt.portable.7z.002](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-13.2/2026-09-13-windows64.nvidia.tensorrt.portable.7z.002) |
+| Windows x64、独自 engine、portable | [2026-09-13-windows64.without.engine.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-13.2/2026-09-13-windows64.without.engine.portable.zip) |
+| Windows x64、独自 engine、installer | [2026-09-13-windows64.without.engine.installer.exe](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-13.2/2026-09-13-windows64.without.engine.installer.exe) |
+| macOS Apple Silicon、Metal | [2026-09-13-mac-apple-silicon.with-katago.dmg](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-13.2/2026-09-13-mac-apple-silicon.with-katago.dmg) |
+| macOS Intel | [2026-09-13-mac-intel.with-katago.dmg](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-13.2/2026-09-13-mac-intel.with-katago.dmg) |
+| Linux x64、CPU 互換 | [2026-09-13-linux64.with-katago.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-13.2/2026-09-13-linux64.with-katago.zip) |
+| Linux x64、OpenCL | [2026-09-13-linux64.opencl.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-13.2/2026-09-13-linux64.opencl.zip) |
+| Linux x64、NVIDIA CUDA | [2026-09-13-linux64.nvidia.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-13.2/2026-09-13-linux64.nvidia.zip) |
+
+### 検証
+
+- 公開には対象コミットの CI、4 プラットフォームのビルド、署名・公証、サイズ・SHA-256・由来の検証が必要です。
+- 実行済みのテストとスモーク確認は公開用 PR に記録します。スキップは合格に含めません。今回は Windows 実デスクトップ、全 GPU、各 OS の更新実機検証を再実行していません。
+
+### 連絡先
+
+- QQ: 299419120
+
+## 한국어
+
+next-2026-09-04.1 기반 안정성 및 엔진 관리 개선 사전 출시입니다.
+
+### 주요 업데이트
+
+- SGF 가져오기, 보드 동기화와 엔진 복원 시 규칙 및 국면 확인을 수정했습니다. 엔진 대국을 규칙 창이 방해하지 않으며 착수 생성 취소 후 복원도 개선했습니다.
+- 벤치마크 결과, 스레드 설정과 Apple 튜닝 정보를 저장된 엔진별로 관리하고 사용자 지정 로컬 KataGo를 지원합니다. 원격 엔진은 서버 설정을 유지합니다.
+- 전체 패키지의 기본 B11을 2026-09-07 공식 모델 kata1-tf3-b11c768-s11500M-d6163M.bin.gz로 업데이트했습니다. 소규모 업데이트는 엔진이나 가중치를 교체하지 않습니다.
+- TensorRT 설정 그룹, 좁은 창 줄바꿈과 상태 표시를 수정하고 진단 내보내기, 분석 캐시 추적 및 로그 줄바꿈을 개선했습니다.
+- HumanSL 다운로드에 중국 본토용 대체 미러와 자체 원격 서버 간편 배포 안내를 추가했습니다. 전체 테스트 요구사항을 유지하면서 CI를 분리했습니다.
+- qiyi71w 및 피드백, 검토와 테스트에 참여한 모든 분께 감사드립니다.
+
+### 다운로드 전 확인
+
+- Windows 기존 사용자는 앱 종료 후 core-update.zip을 덮어쓸 수 있습니다. user-data와 기보를 먼저 백업하세요.
+- 새 설치나 새 B11이 필요하면 전체 패키지를 받으세요. B11은 개별 평가가 강하지만 검색은 느립니다. 속도를 중시하면 가중치 페이지에서 B10을 선택하세요.
+- RTX 30/40/50은 CUDA를 우선 사용하세요. TensorRT는 RTX 20, GTX 16의 선택 사항이며 속도는 직접 측정하세요. 실험 백엔드는 해당 하드웨어 검증이 필요합니다.
+- 공식 KataGo가 필요한 기능을 아직 제공하지 않아 #449의 실험적 동일 검색 트리 착수 집중 기능은 포함하지 않습니다.
+- 공식 안정판 페이지: https://goagent.top/download/ . 이번 사전 출시는 아래 GitHub 링크로 제공하며 공식 안정판을 교체하지 않습니다.
+
+### 다운로드 안내
+
+| 내 컴퓨터 | 다운로드할 파일 |
+| --- | --- |
+| Windows x64, RTX 20/30/40/50 NVIDIA CUDA 권장 portable | [2026-09-13-windows64.nvidia.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-13.2/2026-09-13-windows64.nvidia.portable.zip) |
+| 기존 Windows portable, app-only update | [2026-09-13-windows64.core-update.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-13.2/2026-09-13-windows64.core-update.zip) |
+| Windows x64, RTX 20/30/40/50 NVIDIA CUDA installer | [2026-09-13-windows64.nvidia.installer.exe](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-13.2/2026-09-13-windows64.nvidia.installer.exe) |
+| Windows x64, AMD / Intel / 구형 NVIDIA OpenCL portable | [2026-09-13-windows64.opencl.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-13.2/2026-09-13-windows64.opencl.portable.zip) |
+| Windows x64, AMD / Intel / 구형 NVIDIA OpenCL installer | [2026-09-13-windows64.opencl.installer.exe](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-13.2/2026-09-13-windows64.opencl.installer.exe) |
+| Windows x64, CPU compatibility portable | [2026-09-13-windows64.with-katago.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-13.2/2026-09-13-windows64.with-katago.portable.zip) |
+| Windows x64, CPU compatibility installer | [2026-09-13-windows64.with-katago.installer.exe](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-13.2/2026-09-13-windows64.with-katago.installer.exe) |
+| Windows DirectML experimental | [2026-09-13-windows64.experimental.directml.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-13.2/2026-09-13-windows64.experimental.directml.portable.zip) |
+| Windows Intel OpenVINO experimental | [2026-09-13-windows64.experimental.openvino.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-13.2/2026-09-13-windows64.experimental.openvino.portable.zip) |
+| Windows AMD RX 6000 ROCm experimental | [2026-09-13-windows64.experimental.rocm.gfx103x.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-13.2/2026-09-13-windows64.experimental.rocm.gfx103x.portable.zip) |
+| Windows AMD RX 7000 ROCm experimental | [2026-09-13-windows64.experimental.rocm.gfx110x.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-13.2/2026-09-13-windows64.experimental.rocm.gfx110x.portable.zip) |
+| Windows AMD Ryzen AI Max ROCm experimental | [2026-09-13-windows64.experimental.rocm.gfx1151.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-13.2/2026-09-13-windows64.experimental.rocm.gfx1151.portable.zip) |
+| Windows AMD RX 9000 ROCm experimental | [2026-09-13-windows64.experimental.rocm.gfx120x.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-13.2/2026-09-13-windows64.experimental.rocm.gfx120x.portable.zip) |
+| TensorRT (RTX 20 / GTX 16; 2 parts) | [2026-09-13-windows64.nvidia.tensorrt.portable.7z.001](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-13.2/2026-09-13-windows64.nvidia.tensorrt.portable.7z.001)<br>[2026-09-13-windows64.nvidia.tensorrt.portable.7z.002](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-13.2/2026-09-13-windows64.nvidia.tensorrt.portable.7z.002) |
+| Windows x64, 사용자 engine, portable | [2026-09-13-windows64.without.engine.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-13.2/2026-09-13-windows64.without.engine.portable.zip) |
+| Windows x64, 사용자 engine, installer | [2026-09-13-windows64.without.engine.installer.exe](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-13.2/2026-09-13-windows64.without.engine.installer.exe) |
+| macOS Apple Silicon, Metal | [2026-09-13-mac-apple-silicon.with-katago.dmg](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-13.2/2026-09-13-mac-apple-silicon.with-katago.dmg) |
+| macOS Intel | [2026-09-13-mac-intel.with-katago.dmg](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-13.2/2026-09-13-mac-intel.with-katago.dmg) |
+| Linux x64, CPU compatibility | [2026-09-13-linux64.with-katago.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-13.2/2026-09-13-linux64.with-katago.zip) |
+| Linux x64, OpenCL | [2026-09-13-linux64.opencl.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-13.2/2026-09-13-linux64.opencl.zip) |
+| Linux x64, NVIDIA CUDA | [2026-09-13-linux64.nvidia.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-13.2/2026-09-13-linux64.nvidia.zip) |
+
+### 검증
+
+- 정확한 커밋의 CI, 네 플랫폼 빌드, 서명/공증 및 크기, SHA-256, 출처 검증 후에만 공개합니다.
+- 실행한 테스트와 스모크 결과는 출시 PR에 기록합니다. 건너뛴 항목은 통과가 아닙니다. 이번에는 Windows 실제 데스크톱, 모든 GPU 및 플랫폼별 업그레이드 실기 검증을 다시 수행하지 않았습니다.
+
+### 연락처
+
+- QQ: 299419120
+
+## ภาษาไทย
+
+รุ่นก่อนเผยแพร่ที่ปรับปรุงความเสถียรและการจัดการเอนจิน โดยอ้างอิง next-2026-09-04.1
+
+### ไฮไลต์ของเวอร์ชันนี้
+
+- แก้การยืนยันกติกาและตำแหน่งเมื่อเปิด SGF ซิงก์กระดานและคืนค่าเอนจิน ป้องกันหน้าต่างกติกาขัดจังหวะการแข่งระหว่างเอนจิน และปรับปรุงการคืนค่าหลังยกเลิกการสร้างตาเดิน
+- บันทึกผลทดสอบความเร็ว แหล่งตั้งค่าเธรดและการปรับแต่ง Apple แยกตามเอนจินที่บันทึก รองรับ KataGo ภายในเครื่องที่ตั้งเอง ส่วนเอนจินระยะไกลยังใช้ค่าของเซิร์ฟเวอร์
+- เปลี่ยน B11 เริ่มต้นในแพ็กเกจเต็มเป็นโมเดลทางการวันที่ 2026-09-07: kata1-tf3-b11c768-s11500M-d6163M.bin.gz แพ็กเกจอัปเดตเฉพาะโปรแกรมไม่เปลี่ยนเอนจินหรือน้ำหนัก
+- แก้กลุ่มการตั้งค่า TensorRT การตัดบรรทัดในหน้าต่างแคบและข้อความสถานะ ปรับปรุงการส่งออกข้อมูลวินิจฉัย การติดตามแคชวิเคราะห์และบรรทัดของบันทึก
+- เพิ่มมิเรอร์สำรองในจีนสำหรับ HumanSL และคำแนะนำติดตั้งเอนจินระยะไกลด้วยตนเองแบบง่าย แยก CI โดยยังคงการทดสอบทั้งหมด
+- ขอบคุณ qiyi71w และผู้ร่วมรายงาน ตรวจสอบและทดสอบทุกท่าน
+
+### ก่อนดาวน์โหลด
+
+- ผู้ใช้ Windows เดิมใช้ core-update.zip ได้หลังปิดโปรแกรม สำรอง user-data และบันทึกเกมก่อนอัปเดต
+- ติดตั้งใหม่หรือต้องการ B11 ใหม่ให้ใช้แพ็กเกจเต็ม B11 ประเมินแต่ละครั้งได้แข็งแกร่งแต่ค้นหาช้ากว่า หากเน้นความเร็วเลือก B10 ในหน้าจัดการน้ำหนัก
+- RTX 30/40/50 ควรใช้ CUDA ส่วน TensorRT เป็นทางเลือกสำหรับ RTX 20 และ GTX 16 ควรวัดความเร็วบนเครื่องจริง แบ็กเอนด์ทดลองต้องตรวจสอบกับฮาร์ดแวร์ที่รองรับ
+- ไม่รวมฟังก์ชันทดลอง move focus ในต้นไม้ค้นหาเดียวกันของ #449 เพราะ KataGo ทางการยังไม่มีความสามารถที่ต้องใช้
+- หน้าดาวน์โหลดรุ่นเสถียร: https://goagent.top/download/ รุ่นก่อนเผยแพร่นี้ใช้ลิงก์ GitHub ในตารางด้านล่างและไม่แทนที่รุ่นเสถียรบนเว็บไซต์
+
+### คำแนะนำดาวน์โหลด
+
+| คอมพิวเตอร์ของคุณ | ดาวน์โหลดไฟล์นี้ |
+| --- | --- |
+| Windows x64, RTX 20/30/40/50 NVIDIA CUDA portable ที่แนะนำ | [2026-09-13-windows64.nvidia.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-13.2/2026-09-13-windows64.nvidia.portable.zip) |
+| Windows portable เดิม, อัปเดตเฉพาะ app | [2026-09-13-windows64.core-update.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-13.2/2026-09-13-windows64.core-update.zip) |
+| Windows x64, RTX 20/30/40/50 NVIDIA CUDA installer | [2026-09-13-windows64.nvidia.installer.exe](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-13.2/2026-09-13-windows64.nvidia.installer.exe) |
+| Windows x64, OpenCL portable สำหรับ AMD / Intel / NVIDIA รุ่นเก่า | [2026-09-13-windows64.opencl.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-13.2/2026-09-13-windows64.opencl.portable.zip) |
+| Windows x64, OpenCL installer สำหรับ AMD / Intel / NVIDIA รุ่นเก่า | [2026-09-13-windows64.opencl.installer.exe](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-13.2/2026-09-13-windows64.opencl.installer.exe) |
+| Windows x64, CPU compatibility portable | [2026-09-13-windows64.with-katago.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-13.2/2026-09-13-windows64.with-katago.portable.zip) |
+| Windows x64, CPU compatibility installer | [2026-09-13-windows64.with-katago.installer.exe](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-13.2/2026-09-13-windows64.with-katago.installer.exe) |
+| Windows DirectML experimental | [2026-09-13-windows64.experimental.directml.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-13.2/2026-09-13-windows64.experimental.directml.portable.zip) |
+| Windows Intel OpenVINO experimental | [2026-09-13-windows64.experimental.openvino.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-13.2/2026-09-13-windows64.experimental.openvino.portable.zip) |
+| Windows AMD RX 6000 ROCm experimental | [2026-09-13-windows64.experimental.rocm.gfx103x.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-13.2/2026-09-13-windows64.experimental.rocm.gfx103x.portable.zip) |
+| Windows AMD RX 7000 ROCm experimental | [2026-09-13-windows64.experimental.rocm.gfx110x.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-13.2/2026-09-13-windows64.experimental.rocm.gfx110x.portable.zip) |
+| Windows AMD Ryzen AI Max ROCm experimental | [2026-09-13-windows64.experimental.rocm.gfx1151.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-13.2/2026-09-13-windows64.experimental.rocm.gfx1151.portable.zip) |
+| Windows AMD RX 9000 ROCm experimental | [2026-09-13-windows64.experimental.rocm.gfx120x.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-13.2/2026-09-13-windows64.experimental.rocm.gfx120x.portable.zip) |
+| TensorRT (RTX 20 / GTX 16; 2 parts) | [2026-09-13-windows64.nvidia.tensorrt.portable.7z.001](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-13.2/2026-09-13-windows64.nvidia.tensorrt.portable.7z.001)<br>[2026-09-13-windows64.nvidia.tensorrt.portable.7z.002](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-13.2/2026-09-13-windows64.nvidia.tensorrt.portable.7z.002) |
+| Windows x64, ใช้ engine ของคุณเอง, portable | [2026-09-13-windows64.without.engine.portable.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-13.2/2026-09-13-windows64.without.engine.portable.zip) |
+| Windows x64, ใช้ engine ของคุณเอง, installer | [2026-09-13-windows64.without.engine.installer.exe](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-13.2/2026-09-13-windows64.without.engine.installer.exe) |
+| macOS Apple Silicon, Metal | [2026-09-13-mac-apple-silicon.with-katago.dmg](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-13.2/2026-09-13-mac-apple-silicon.with-katago.dmg) |
+| macOS Intel | [2026-09-13-mac-intel.with-katago.dmg](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-13.2/2026-09-13-mac-intel.with-katago.dmg) |
+| Linux x64, CPU compatibility | [2026-09-13-linux64.with-katago.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-13.2/2026-09-13-linux64.with-katago.zip) |
+| Linux x64, OpenCL | [2026-09-13-linux64.opencl.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-13.2/2026-09-13-linux64.opencl.zip) |
+| Linux x64, NVIDIA CUDA | [2026-09-13-linux64.nvidia.zip](https://github.com/wimi321/lizzieyzy-next/releases/download/next-2026-09-13.2/2026-09-13-linux64.nvidia.zip) |
+
+### ผลการตรวจสอบ
+
+- เผยแพร่ได้หลัง CI ของคอมมิตที่กำหนด การสร้างทั้งสี่แพลตฟอร์ม การลงนาม/รับรอง และตรวจขนาด SHA-256 กับที่มาของไฟล์ผ่านแล้วเท่านั้น
+- ผลทดสอบและ smoke ที่รันจริงบันทึกไว้ใน PR การเผยแพร่ รายการที่ข้ามไม่นับว่าผ่าน รอบนี้ไม่ได้ทดสอบเดสก์ท็อป Windows จริง GPU ทุกรุ่นหรือการอัปเกรดทุกระบบซ้ำ
+
+### ติดต่อ
+
+- QQ: 299419120

--- a/.github/release-requests/next-2026-09-13.2.json
+++ b/.github/release-requests/next-2026-09-13.2.json
@@ -1,0 +1,7 @@
+{
+  "date_tag": "2026-09-13",
+  "release_tag": "next-2026-09-13.2",
+  "title": "LizzieYzy Next next-2026-09-13.2",
+  "prerelease": true,
+  "notes_file": ".github/release-notes/next-2026-09-13.2.md"
+}

--- a/src/test/java/featurecat/lizzie/logging/LoggingRuntimeTest.java
+++ b/src/test/java/featurecat/lizzie/logging/LoggingRuntimeTest.java
@@ -26,6 +26,8 @@ import java.util.stream.Stream;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.slf4j.LoggerFactory;
 import org.slf4j.helpers.NOPLoggerFactory;
 import org.slf4j.spi.SLF4JServiceProvider;
@@ -377,20 +379,22 @@ class LoggingRuntimeTest {
     assertEquals(1, count(err, "APP:failure"));
   }
 
-  @Test
-  void queueSaturationThenSuccessfulWriteMarksRecovered() throws Exception {
+  @ParameterizedTest
+  @ValueSource(longs = {0L, 600L})
+  void queueSaturationThenSuccessfulWriteMarksRecovered(long writeDelayMillis) throws Exception {
     LoggingRuntime runtime =
         LoggingRuntime.initialize(
             new WorkDirectoryResolution(tempDir, List.of()),
             new LoggingLimits(32, 4, 4, 4, 7, 10000, 1000));
     runtime.startFullTrace(EnumSet.of(TraceScope.ENGINE_GTP));
-    runtime.awaitIdle();
+    assertTrue(runtime.awaitIdle(10, TimeUnit.SECONDS), "trace startup must be persisted");
     CountDownLatch handoffEntered = new CountDownLatch(1);
     CountDownLatch handoffHold = new CountDownLatch(1);
     runtime.pauseHandoffForTests(LogStream.ENGINE_TRACE, handoffEntered, handoffHold);
     org.slf4j.Logger trace = LoggerFactory.getLogger(LogCategories.ENGINE_TRACE);
     trace.info("accepted-before-saturation");
     assertTrue(handoffEntered.await(1, TimeUnit.SECONDS));
+    runtime.delayNestedAppendForTests(LogStream.ENGINE_TRACE, writeDelayMillis);
     try {
       for (int i = 0; i < 64; i++) {
         trace.info("flood-{}", i);
@@ -400,20 +404,27 @@ class LoggingRuntimeTest {
       assertTrue(blocked.droppedCount() > 0);
       assertEquals("queue saturation", blocked.reason());
       assertFalse(blocked.recovered());
+      assertFalse(
+          runtime.awaitIdle(10, TimeUnit.MILLISECONDS),
+          "the completion barrier must not pass while the writer is held");
     } finally {
       handoffHold.countDown();
     }
-    runtime.awaitIdle();
+    // Wait for the admitted watermark, not the legacy best-effort 400 ms drain.
+    assertTrue(runtime.awaitIdle(10, TimeUnit.SECONDS), "saturated queue must fully drain");
     LoggingStatus.StreamStatus drained =
         runtime.status().stream(LogStream.ENGINE_TRACE).orElseThrow();
     assertFalse(
         drained.recovered(),
         "events admitted before saturation must not report that the stream recovered");
+    runtime.delayNestedAppendForTests(LogStream.ENGINE_TRACE, 0L);
     trace.info("after-drain");
-    runtime.awaitIdle();
+    assertTrue(runtime.awaitIdle(10, TimeUnit.SECONDS), "recovery event must be persisted");
     LoggingStatus.StreamStatus recovered =
         runtime.status().stream(LogStream.ENGINE_TRACE).orElseThrow();
     assertTrue(recovered.recovered());
+    assertTrue(read("logs/engine-trace.log").contains("after-drain"));
+    assertEquals(drained.droppedCount(), recovered.droppedCount());
     assertTrue(recovered.droppedCount() > 0);
     assertEquals("queue saturation", recovered.reason());
     assertNotNull(recovered.firstOccurrence());


### PR DESCRIPTION
## 原因与修复

#456 合并后的 Windows 主线 CI（34728678679）发现 LoggingRuntimeTest 的恢复断言偶发失败，发布门禁正确停止，未创建公开版本。

测试使用的旧 awaitIdle() 最多轮询约 400ms，超时没有返回值。慢写入时队列尚未排空，测试已开始提交恢复事件并检查 recovered。本次改用现有带超时返回值的提交序号完成屏障，并强制断言成功；生产日志、队列容量与恢复规则不变。

- 增加 0ms / 600ms 两种写入延迟。旧逻辑在受控 600ms 延迟下稳定失败于相同恢复断言，修复后两种场景通过。
- 明确验证写线程被阻塞时屏障不能通过。
- 验证排空前旧事件不能伪报恢复，排空后新事件确实落盘、恢复状态正确且不增加丢弃计数。
- 保留所有原始断言，不跳过或自动重试失败测试。

## 发布

新增 next-2026-09-13.2 的六语固定格式说明与发布请求，功能范围与 #456 相同。旧 .1 请求保留审计记录，不复用失败流程、不移动 tag。#449 仍为草稿并排除。

CI 和干净本机完整回归通过后合并；精确合并 SHA 再通过主线 CI、四个平台构建、签名/公证及资产来源与摘要校验后才公开 pre-release。正式版、官网 stable 和 R2 stable 不变。

## 验证

- 受控慢写入红/绿测试：原断言失败，修复后通过。
- LoggingRuntimeTest：28 项，0 失败、0 错误。
- 六语发布说明验证、git diff --check：通过。
- 完整 portable 门禁正在运行；GitHub Windows/Linux 检查须全部通过。
- Windows hosted CI 不等于所有真实显卡和桌面 UI 验收，不作该声明。