### PR TITLE
ci(windows): capture stalled test diagnostics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,6 +109,11 @@ jobs:
     runs-on: windows-latest
     timeout-minutes: 30
     steps:
+      - name: Set Windows diagnostic deadline
+        shell: pwsh
+        run: |
+          $deadline = [DateTimeOffset]::UtcNow.AddMinutes(27).ToUnixTimeSeconds()
+          Add-Content -LiteralPath $env:GITHUB_ENV -Value "LIZZIE_CI_DEADLINE_UNIX_SECONDS=$deadline" -Encoding utf8
       - name: Checkout
         uses: actions/checkout@v5
       - name: Set up Python
@@ -123,7 +128,19 @@ jobs:
           cache: maven
       - name: Run Windows Java verification
         shell: pwsh
-        run: python scripts/run_local_ci.py --profile windows --group java --require-clean --summary-dir target/local-ci/windows-java
+        timeout-minutes: 25
+        run: ./scripts/run_windows_ci_diagnostics.ps1
+      - name: Upload Windows Java diagnostics
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: windows-java-diagnostics
+          retention-days: 14
+          path: |
+            target/ci-diagnostics
+            target/surefire-reports
+            target/failsafe-reports
+          if-no-files-found: warn
       - name: Upload local CI summary
         if: always()
         uses: actions/upload-artifact@v6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable maintenance updates to this fork are documented here.
 
 ## Unreleased
 
+- Preserve Windows CI stall evidence with per-test JUnit events, paired process/thread snapshots, bounded execution, and owned-process cleanup before artifact upload.
 - Split CI into independent repository, script, and Java jobs with grouped local entrypoints and a unified `ci-required` gate; retain the existing required-check names during migration.
 - Save KataGo rule preferences on confirmation and close the settings dialog after successful application.
 - Keep SGF rule-failure navigation local until explicit confirmed restore, preserve trial-return rules and positions, and resume both comparison engines after synchronization (#448).

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -75,7 +75,7 @@ powershell -ExecutionPolicy Bypass -File scripts/run_local_ci.ps1 -Profile All -
 | Group | Portable | Windows | 额外工具 |
 | --- | --- | --- | --- |
 | `repository` | 换行自测、换行、Markdown 链接 | 换行 | 无 |
-| `scripts` | Python 辅助脚本、KataGo shell、Bash 语法 | JCEF、NVIDIA、RTX50 PowerShell 语法 | Portable 需 Bash；Windows 需 PowerShell |
+| `scripts` | Python 辅助脚本、KataGo shell、Bash 语法 | JCEF、NVIDIA、RTX50 PowerShell 语法、原生 CI 进程监督检查 | Portable 需 Bash；Windows 需 PowerShell 7 |
 | `java` | 原完整 Maven verify | 凭据专项，再执行原完整 Maven verify | Maven、JDK 21；不查找 Bash/PowerShell |
 
 例如仅运行无 Java 的仓库检查：
@@ -114,6 +114,46 @@ main 分支保护要求 GitHub Actions 来源的 `ci-required`。回退 workflow
 Ubuntu runner，也不能代替 macOS 签名、公证与多平台发布资产审计。
 
 如果你改了打包、引擎路径、首次启动流程、野狐抓谱流程，建议再做对应平台的手工验证。
+
+### Windows Java 停滞取证
+
+`java-windows` 使用 `scripts/run_windows_ci_diagnostics.ps1` 包裹原有完整 Java 检查，
+不重试失败用例，也不把抓栈成功视为测试通过。job 上限仍为 30 分钟：第一步记录
+27 分钟的绝对截止时间，监督器取它与自身 23 分钟预算的较早值，运行步骤另设
+25 分钟上限，为摘要与 artifact 上传留出时间。
+
+测试 JVM 通过 test-scope JUnit listener 逐条刷新 `PLAN_STARTED`、`START`、`FINISH`、
+`SKIPPED`、`PLAN_FINISHED` 事件，包含 PID、时间、JUnit unique ID 和用例名称。
+只有设置了 `LIZZIE_CI_EVIDENCE_DIR` 才启用；普通本地测试不写取证文件。
+监督器仅给受监督进程设置该变量，读取完整 JSONL 行并按 PID 跟踪嵌套测试计划。
+存在活动计划时，控制台输出不算测试进展。
+
+默认 120 秒无进展后，保留两次相隔 30 秒的进程/CPU 快照，并对所属 JVM 调用
+`JAVA_HOME/bin/jcmd.exe Thread.print -l`，单次最多等待 10 秒。第一次停滞取证不终止
+任务，同一段未恢复的停滞不重复抓取；到执行预算前也会尝试取证。截止时终止所属
+Windows Job Object，独立写出失败摘要，即使 Python 执行器尚未生成自己的摘要。
+命令正常完成则保留退出码；命令退出后仍留有子进程会失败并清理，不误报成功。
+
+Actions 始终尝试上传 `windows-java-diagnostics`（保留 14 天），包含：
+
+- `target/ci-diagnostics/summary.json`：退出状态、预算、运行身份及进程清理结果。
+- `console.stdout.log`、`console.stderr.log` 和 `junit-<pid>.jsonl`：原始控制台与用例事件。
+- `snapshot-<episode>-<1|2>.json` 和成功抓取的 `threads-<episode>-<1|2>-<pid>.txt`。
+- `target/surefire-reports`、`target/failsafe-reports` 中已落盘的测试报告。
+
+先从 JSONL 找最后启动但未结束的用例，再比较两份线程栈与 CPU 时间。`jcmd` 缺失或
+失败会记入快照，仍保留第二份进程快照和其余证据。原始日志没有通用秘密脱敏；
+不要让测试输出凭据。runner 丢失、强制取消或磁盘写入失败时，不能保证摘要及上传完成。
+
+本地需要 Windows、PowerShell 7、Python、Maven 和 JDK 21。在干净工作树运行：
+
+```powershell
+pwsh -NoProfile -File scripts/run_windows_ci_diagnostics.ps1 -OutputDirectory target/ci-diagnostics-local
+```
+
+输出目录必须不存在或为空；再次运行请换新目录，避免混入旧证据。
+原生监督器回归检查由 `windows/scripts` 组执行，无需启动 Maven 或 JDK。
+
 
 ## 换行规则
 

--- a/pom.xml
+++ b/pom.xml
@@ -206,6 +206,13 @@
 		</dependency>
 
 		<dependency>
+			<groupId>org.junit.platform</groupId>
+			<artifactId>junit-platform-launcher</artifactId>
+			<version>1.11.4</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
 			<groupId>me.friwi</groupId>
 			<artifactId>jcefmaven</artifactId>
 			<version>127.3.1</version>

--- a/scripts/run_local_ci.py
+++ b/scripts/run_local_ci.py
@@ -54,6 +54,7 @@ PY_COMPILE_FILES = (
     "scripts/test_validate_windows_release_assets.py",
     "scripts/test_validate_release_workflow_identity.py",
     "scripts/test_windows_launcher_packaging.py",
+    "scripts/test_windows_ci_diagnostics.py",
     "scripts/validate_release_notes.py",
     "scripts/validate_windows_release_assets.py",
     "scripts/validate_release_workflow_identity.py",
@@ -251,6 +252,10 @@ def windows_steps(maven: str, powershell: str) -> list[Step]:
         Step(
             "Parse RTX 50 benchmark PowerShell",
             (powershell, "-NoProfile", "-Command", parser_script),
+        ),
+        Step(
+            "Verify Windows CI process supervision",
+            (python, "-m", "unittest", "scripts.test_windows_ci_diagnostics"),
         ),
         Step(
             "Verify Windows credential persistence",

--- a/scripts/run_windows_ci_diagnostics.ps1
+++ b/scripts/run_windows_ci_diagnostics.ps1
@@ -1,0 +1,991 @@
+#requires -Version 7.0
+
+[CmdletBinding()]
+param(
+    [string]$Executable = 'python',
+    [string[]]$CommandArguments = @(
+        'scripts/run_local_ci.py'
+        '--profile'
+        'windows'
+        '--group'
+        'java'
+        '--require-clean'
+        '--summary-dir'
+        'target/local-ci/windows-java'
+    ),
+    [string]$WorkingDirectory = (Split-Path -Parent $PSScriptRoot),
+    [string]$OutputDirectory = 'target/ci-diagnostics',
+    [ValidateRange(1, [int]::MaxValue)]
+    [int]$TimeoutSeconds = 1380,
+    [ValidateRange(1, [int]::MaxValue)]
+    [int]$StallSeconds = 120,
+    [ValidateRange(1, [int]::MaxValue)]
+    [int]$DumpIntervalSeconds = 30,
+    [ValidateRange(1, [int]::MaxValue)]
+    [int]$DumpTimeoutSeconds = 10
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+
+$Utf8NoBom = [System.Text.UTF8Encoding]::new($false)
+$WorkingDirectory = (Resolve-Path -LiteralPath $WorkingDirectory).Path
+if (-not [System.IO.Path]::IsPathRooted($OutputDirectory)) {
+    $OutputDirectory = Join-Path -Path $WorkingDirectory -ChildPath $OutputDirectory
+}
+$OutputDirectory = [System.IO.Path]::GetFullPath($OutputDirectory)
+
+if (Test-Path -LiteralPath $OutputDirectory) {
+    if (-not (Test-Path -LiteralPath $OutputDirectory -PathType Container)) {
+        throw "Diagnostics output is not a directory: $OutputDirectory"
+    }
+    if ([System.IO.Directory]::EnumerateFileSystemEntries($OutputDirectory).GetEnumerator().MoveNext()) {
+        throw "Refusing to mix diagnostics with existing evidence: $OutputDirectory"
+    }
+}
+else {
+    [System.IO.Directory]::CreateDirectory($OutputDirectory) | Out-Null
+}
+
+function Write-JsonFile {
+    param(
+        [Parameter(Mandatory)] [string]$Path,
+        [Parameter(Mandatory)] [object]$Value
+    )
+
+    $json = $Value | ConvertTo-Json -Depth 12
+    [System.IO.File]::WriteAllText($Path, $json + [Environment]::NewLine, $script:Utf8NoBom)
+}
+
+function Get-ProcessCreationTicks {
+    param([Parameter(Mandatory)] [object]$Process)
+
+    return ([datetime]$Process.CreationDate).ToUniversalTime().Ticks
+}
+
+function Get-ProcessIdentityKey {
+    param([Parameter(Mandatory)] [object]$Process)
+
+    $ticks = Get-ProcessCreationTicks -Process $Process
+    return "$($Process.ProcessId):$ticks"
+}
+
+function Get-JobProcessIds {
+    if ($script:JobHandle -eq [IntPtr]::Zero) { return @() }
+    return @([WindowsCiJob]::GetProcessIds($script:JobHandle))
+}
+
+function Update-OwnedProcesses {
+    $jobPids = @(Get-JobProcessIds)
+    if ($jobPids.Count -eq 0) { return @() }
+
+    $pidSet = [System.Collections.Generic.HashSet[int]]::new()
+    foreach ($processId in $jobPids) { $pidSet.Add([int]$processId) | Out-Null }
+
+    $owned = [System.Collections.Generic.List[object]]::new()
+    foreach ($item in @(Get-CimInstance -ClassName Win32_Process -ErrorAction Stop)) {
+        if (-not $item.CreationDate -or -not $pidSet.Contains([int]$item.ProcessId)) { continue }
+        $key = Get-ProcessIdentityKey -Process $item
+        $script:OwnedProcesses[$key] = [pscustomobject]@{
+            ProcessId = [int]$item.ProcessId
+            CreationTicks = Get-ProcessCreationTicks -Process $item
+        }
+        $owned.Add([pscustomobject]@{ Key = $key; Process = $item })
+    }
+    return @($owned)
+}
+
+function Test-OwnedIdentity {
+    param(
+        [Parameter(Mandatory)] [int]$ProcessId,
+        [Parameter(Mandatory)] [long]$CreationTicks
+    )
+
+    $candidate = Get-CimInstance -ClassName Win32_Process -Filter "ProcessId = $ProcessId" -ErrorAction SilentlyContinue
+    if (-not $candidate -or -not $candidate.CreationDate) { return $false }
+    if ((Get-ProcessCreationTicks -Process $candidate) -ne $CreationTicks) { return $false }
+
+    $nativeProcess = $null
+    try {
+        $nativeProcess = [System.Diagnostics.Process]::GetProcessById($ProcessId)
+        return [WindowsCiJob]::ContainsProcess($script:JobHandle, $nativeProcess.Handle)
+    }
+    catch {
+        return $false
+    }
+    finally {
+        if ($nativeProcess) { $nativeProcess.Dispose() }
+    }
+}
+
+function Stop-OwnedTree {
+    param([int]$BudgetSeconds = 8)
+
+    $before = @(Get-JobProcessIds)
+    $failed = @()
+    if ($script:JobHandle -eq [IntPtr]::Zero -or $before.Count -eq 0) {
+        return [pscustomobject]@{ Stopped = @(); Failed = @() }
+    }
+
+    try {
+        [WindowsCiJob]::Terminate($script:JobHandle, 125)
+    }
+    catch {
+        $failed += [ordered]@{ pid = $null; reason = $_.Exception.Message }
+    }
+
+    $deadline = [datetime]::UtcNow.AddSeconds($BudgetSeconds)
+    do {
+        $remaining = @(Get-JobProcessIds)
+        if ($remaining.Count -eq 0) { break }
+        Start-Sleep -Milliseconds 100
+    } while ([datetime]::UtcNow -lt $deadline)
+
+    foreach ($processId in $remaining) {
+        $failed += [ordered]@{ pid = $processId; reason = 'job termination timed out' }
+    }
+    return [pscustomobject]@{ Stopped = @($before | Where-Object { $remaining -notcontains $_ }); Failed = @($failed) }
+}
+
+function Convert-ProcessSnapshot {
+    param([Parameter(Mandatory)] [object]$Entry)
+
+    $process = $Entry.Process
+    $kernel = if ($null -eq $process.KernelModeTime) { 0L } else { [long]$process.KernelModeTime }
+    $user = if ($null -eq $process.UserModeTime) { 0L } else { [long]$process.UserModeTime }
+    return [ordered]@{
+        pid = [int]$process.ProcessId
+        parentPid = [int]$process.ParentProcessId
+        creationTimeUtc = ([datetime]$process.CreationDate).ToUniversalTime().ToString('o')
+        name = $process.Name
+        executablePath = $process.ExecutablePath
+        kernelTime100ns = $kernel
+        userTime100ns = $user
+        cpuSeconds = ($kernel + $user) / 10000000.0
+        workingSetBytes = [long]$process.WorkingSetSize
+        threadCount = [int]$process.ThreadCount
+        handleCount = [int]$process.HandleCount
+    }
+}
+
+function Test-JavaProcess {
+    param([Parameter(Mandatory)] [object]$Process)
+
+    return $Process.Name -in @('java.exe', 'javaw.exe', 'java', 'javaw')
+}
+
+function Invoke-JcmdDumps {
+    param(
+        [Parameter(Mandatory)] [object[]]$Owned,
+        [Parameter(Mandatory)] [int]$Episode,
+        [Parameter(Mandatory)] [int]$Ordinal,
+        [Parameter(Mandatory)] [datetime]$HardDeadlineUtc
+    )
+
+    $results = [System.Collections.Generic.List[object]]::new()
+    $jcmd = if ($env:JAVA_HOME) { Join-Path -Path $env:JAVA_HOME -ChildPath 'bin\jcmd.exe' } else { $null }
+    $javaEntries = @($Owned | Where-Object { Test-JavaProcess -Process $_.Process })
+    if ($javaEntries.Count -eq 0) {
+        return @()
+    }
+
+
+    if (-not $jcmd -or -not (Test-Path -LiteralPath $jcmd -PathType Leaf)) {
+        $results.Add([ordered]@{
+            status = 'unavailable'
+            reason = 'JAVA_HOME/bin/jcmd.exe was not found'
+            javaHome = $env:JAVA_HOME
+        })
+        return @($results)
+    }
+
+    $running = [System.Collections.Generic.List[object]]::new()
+    foreach ($entry in $javaEntries) {
+        $identity = $script:OwnedProcesses[$entry.Key]
+        if (-not (Test-OwnedIdentity -ProcessId $identity.ProcessId -CreationTicks $identity.CreationTicks)) {
+            $results.Add([ordered]@{ pid = $identity.ProcessId; status = 'exited_before_dump' })
+            continue
+        }
+
+        $threadPath = Join-Path -Path $OutputDirectory -ChildPath "threads-$Episode-$Ordinal-$($identity.ProcessId).txt"
+        $stdoutPath = "$threadPath.tmp"
+        $stderrPath = "$threadPath.stderr.tmp"
+        $stdoutFile = $null
+        $stderrFile = $null
+        try {
+            $stdoutFile = [System.IO.FileStream]::new($stdoutPath, [System.IO.FileMode]::CreateNew, [System.IO.FileAccess]::Write, [System.IO.FileShare]::Read, 65536, $true)
+            $stderrFile = [System.IO.FileStream]::new($stderrPath, [System.IO.FileMode]::CreateNew, [System.IO.FileAccess]::Write, [System.IO.FileShare]::Read, 65536, $true)
+            $startInfo = [System.Diagnostics.ProcessStartInfo]::new()
+            $startInfo.FileName = $jcmd
+            $startInfo.UseShellExecute = $false
+            $startInfo.CreateNoWindow = $true
+            $startInfo.RedirectStandardOutput = $true
+            $startInfo.RedirectStandardError = $true
+            $startInfo.ArgumentList.Add([string]$identity.ProcessId)
+            $startInfo.ArgumentList.Add('Thread.print')
+            $startInfo.ArgumentList.Add('-l')
+            $dumpProcess = [System.Diagnostics.Process]::Start($startInfo)
+            $stdoutCopy = $dumpProcess.StandardOutput.BaseStream.CopyToAsync($stdoutFile)
+            $stderrCopy = $dumpProcess.StandardError.BaseStream.CopyToAsync($stderrFile)
+            $running.Add([pscustomobject]@{
+                TargetPid = $identity.ProcessId
+                Process = $dumpProcess
+                ThreadPath = $threadPath
+                StdoutPath = $stdoutPath
+                StderrPath = $stderrPath
+                StdoutFile = $stdoutFile
+                StderrFile = $stderrFile
+                StdoutCopy = $stdoutCopy
+                StderrCopy = $stderrCopy
+                StartedUtc = [datetime]::UtcNow
+            })
+        }
+        catch {
+            if ($stdoutFile) { $stdoutFile.Dispose() }
+            if ($stderrFile) { $stderrFile.Dispose() }
+            Remove-Item -LiteralPath $stdoutPath, $stderrPath -Force -ErrorAction SilentlyContinue
+            $results.Add([ordered]@{ pid = $identity.ProcessId; status = 'launch_failed'; reason = $_.Exception.Message })
+        }
+    }
+
+    foreach ($dump in $running) {
+        $perDumpDeadline = $dump.StartedUtc.AddSeconds($DumpTimeoutSeconds)
+        while (-not $dump.Process.HasExited -and [datetime]::UtcNow -lt $perDumpDeadline -and [datetime]::UtcNow -lt $HardDeadlineUtc) {
+            Start-Sleep -Milliseconds 100
+        }
+        $timedOut = -not $dump.Process.HasExited
+        if ($timedOut) {
+            try { $dump.Process.Kill($true) } catch { }
+        }
+        if ($dump.Process.HasExited) {
+            $dump.Process.WaitForExit()
+        }
+        $remainingWaitMs = [math]::Max(0, [math]::Min(1000, [int]($HardDeadlineUtc - [datetime]::UtcNow).TotalMilliseconds))
+        try { $dump.StdoutCopy.Wait($remainingWaitMs) | Out-Null } catch { }
+        try { $dump.StderrCopy.Wait($remainingWaitMs) | Out-Null } catch { }
+        $dump.StdoutFile.Dispose()
+        $dump.StderrFile.Dispose()
+
+        $stderrText = try { [System.IO.File]::ReadAllText($dump.StderrPath, $Utf8NoBom) } catch { '' }
+        $stdoutText = try { [System.IO.File]::ReadAllText($dump.StdoutPath, $Utf8NoBom) } catch { '' }
+        if (-not $timedOut -and $dump.Process.ExitCode -eq 0) {
+            Move-Item -LiteralPath $dump.StdoutPath -Destination $dump.ThreadPath -ErrorAction Stop
+            $results.Add([ordered]@{
+                pid = $dump.TargetPid
+                status = 'completed'
+                exitCode = 0
+                threadFile = [System.IO.Path]::GetFileName($dump.ThreadPath)
+            })
+        }
+        else {
+            Remove-Item -LiteralPath $dump.StdoutPath -Force -ErrorAction SilentlyContinue
+            $results.Add([ordered]@{
+                pid = $dump.TargetPid
+                status = if ($timedOut) { 'timed_out' } else { 'failed' }
+                exitCode = if ($timedOut) { $null } else { $dump.Process.ExitCode }
+                reason = if ($timedOut) {
+                    "jcmd exceeded ${DumpTimeoutSeconds}s"
+                }
+                else {
+                    $detail = ($stderrText + [Environment]::NewLine + $stdoutText).Trim()
+                    if ($detail) { $detail } else { "jcmd exited with code $($dump.Process.ExitCode)" }
+                }
+            })
+        }
+        Remove-Item -LiteralPath $dump.StderrPath -Force -ErrorAction SilentlyContinue
+        $dump.Process.Dispose()
+    }
+
+    return @($results)
+}
+
+function Save-DiagnosticSnapshot {
+    param(
+        [Parameter(Mandatory)] [string]$Reason,
+        [Parameter(Mandatory)] [int]$Episode,
+        [Parameter(Mandatory)] [int]$Ordinal,
+        [Parameter(Mandatory)] [datetime]$HardDeadlineUtc
+    )
+
+    $capturedUtc = [datetime]::UtcNow
+    $processes = @()
+    $jcmdResults = @()
+    $captureErrors = [System.Collections.Generic.List[string]]::new()
+    try {
+        $owned = Update-OwnedProcesses
+        $processes = @($owned | ForEach-Object { Convert-ProcessSnapshot -Entry $_ })
+        try {
+            $jcmdResults = @(Invoke-JcmdDumps -Owned $owned -Episode $Episode -Ordinal $Ordinal -HardDeadlineUtc $HardDeadlineUtc)
+        }
+        catch {
+            $captureErrors.Add("jcmd capture: $($_.Exception.Message)")
+        }
+    }
+    catch {
+        $captureErrors.Add("process capture: $($_.Exception.Message)")
+    }
+
+    $snapshotPath = Join-Path -Path $OutputDirectory -ChildPath "snapshot-$Episode-$Ordinal.json"
+    Write-JsonFile -Path $snapshotPath -Value ([ordered]@{
+        capturedUtc = $capturedUtc.ToString('o')
+        reason = $Reason
+        episode = $Episode
+        ordinal = $Ordinal
+        processes = $processes
+        jcmd = $jcmdResults
+        captureErrors = @($captureErrors)
+    })
+}
+
+function Save-DiagnosticPair {
+    param(
+        [Parameter(Mandatory)] [string]$Reason,
+        [Parameter(Mandatory)] [int]$Episode,
+        [Parameter(Mandatory)] [datetime]$HardDeadlineUtc
+    )
+
+    Save-DiagnosticSnapshot -Reason $Reason -Episode $Episode -Ordinal 1 -HardDeadlineUtc $HardDeadlineUtc
+
+    $secondAt = [datetime]::UtcNow.AddSeconds($DumpIntervalSeconds)
+    while ([datetime]::UtcNow -lt $secondAt -and [datetime]::UtcNow -lt $HardDeadlineUtc) {
+        Start-Sleep -Milliseconds 200
+    }
+    if ([datetime]::UtcNow -lt $HardDeadlineUtc) {
+        Save-DiagnosticSnapshot -Reason $Reason -Episode $Episode -Ordinal 2 -HardDeadlineUtc $HardDeadlineUtc
+    }
+    else {
+        Write-JsonFile -Path (Join-Path -Path $OutputDirectory -ChildPath "snapshot-$Episode-2.json") -Value ([ordered]@{
+            capturedUtc = [datetime]::UtcNow.ToString('o')
+            reason = $Reason
+            episode = $Episode
+            ordinal = 2
+            processes = @()
+            jcmd = @()
+            captureErrors = @('hard deadline reached before second snapshot')
+        })
+    }
+}
+
+function Read-JunitProgress {
+    param([hashtable]$KnownFiles)
+
+    $changed = $false
+    $lastEvent = $null
+    foreach ($file in @(Get-ChildItem -LiteralPath $OutputDirectory -Filter 'junit-*.jsonl' -File -ErrorAction SilentlyContinue)) {
+        $key = $file.FullName
+        $previous = $KnownFiles[$key]
+        if (-not $previous) {
+            $previous = [pscustomobject]@{
+                Offset = 0L
+                PlanDepth = 0
+                PendingBytes = [byte[]]::new(0)
+            }
+            $KnownFiles[$key] = $previous
+        }
+
+        $stream = $null
+        try {
+            # Windows can leave FileInfo.Length at zero while Java holds the
+            # append stream open. The opened stream length is authoritative.
+            $stream = [System.IO.FileStream]::new(
+                $key,
+                [System.IO.FileMode]::Open,
+                [System.IO.FileAccess]::Read,
+                [System.IO.FileShare]::ReadWrite -bor [System.IO.FileShare]::Delete
+            )
+            if ($stream.Length -lt $previous.Offset) {
+                $previous.Offset = 0L
+                $previous.PlanDepth = 0
+                $previous.PendingBytes = [byte[]]::new(0)
+            }
+            if ($stream.Length -eq $previous.Offset) { continue }
+
+            $changed = $true
+            $newPlanDepth = $previous.PlanDepth
+            $stream.Position = $previous.Offset
+            $remaining = $stream.Length - $previous.Offset
+            if ($remaining -gt [int]::MaxValue) {
+                throw "JUnit progress increment is too large to inspect safely: $remaining bytes"
+            }
+            $newBytes = [byte[]]::new([int]$remaining)
+            $read = 0
+            while ($read -lt $newBytes.Length) {
+                $count = $stream.Read($newBytes, $read, $newBytes.Length - $read)
+                if ($count -eq 0) { break }
+                $read += $count
+            }
+            if ($read -ne $newBytes.Length) {
+                $actualBytes = [byte[]]::new($read)
+                [array]::Copy($newBytes, 0, $actualBytes, 0, $read)
+                $newBytes = $actualBytes
+            }
+
+            $combined = [byte[]]::new($previous.PendingBytes.Length + $newBytes.Length)
+            [array]::Copy($previous.PendingBytes, 0, $combined, 0, $previous.PendingBytes.Length)
+            [array]::Copy($newBytes, 0, $combined, $previous.PendingBytes.Length, $newBytes.Length)
+            $lastNewline = -1
+            for ($index = $combined.Length - 1; $index -ge 0; $index--) {
+                if ($combined[$index] -eq 10) {
+                    $lastNewline = $index
+                    break
+                }
+            }
+
+            if ($lastNewline -ge 0) {
+                $text = $Utf8NoBom.GetString($combined, 0, $lastNewline + 1)
+                foreach ($line in ($text -split "`n")) {
+                    $line = $line.TrimEnd("`r")
+                    if (-not $line) { continue }
+                    try { $event = $line | ConvertFrom-Json -ErrorAction Stop } catch { continue }
+                    if ($event.event -eq 'PLAN_STARTED') { $newPlanDepth++ }
+                    if ($event.event -eq 'PLAN_FINISHED') { $newPlanDepth = [math]::Max(0, $newPlanDepth - 1) }
+                    $lastEvent = $event
+                }
+                $pendingLength = $combined.Length - $lastNewline - 1
+                $newPending = [byte[]]::new($pendingLength)
+                if ($pendingLength -gt 0) {
+                    [array]::Copy($combined, $lastNewline + 1, $newPending, 0, $pendingLength)
+                }
+            }
+            else {
+                $newPending = $combined
+            }
+            $previous.PlanDepth = $newPlanDepth
+            $previous.PendingBytes = $newPending
+            $previous.Offset = $stream.Position
+        }
+        catch {
+            # Preserve the last complete offset/depth and retry on the next poll.
+        }
+        finally {
+            if ($stream) { $stream.Dispose() }
+        }
+    }
+
+    return [pscustomobject]@{
+        Changed = $changed
+        ActivePlan = @($KnownFiles.Values | Where-Object { $_.PlanDepth -gt 0 }).Count -gt 0
+        LastEvent = $lastEvent
+    }
+}
+
+if (-not ('WindowsCiJob' -as [type])) {
+    Add-Type -TypeDefinition @'
+using System;
+using System.ComponentModel;
+using System.Runtime.InteropServices;
+using System.Threading;
+
+public static class WindowsCiJob {
+    private const uint JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE = 0x00002000;
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct JOBOBJECT_BASIC_LIMIT_INFORMATION {
+        public long PerProcessUserTimeLimit;
+        public long PerJobUserTimeLimit;
+        public uint LimitFlags;
+        public UIntPtr MinimumWorkingSetSize;
+        public UIntPtr MaximumWorkingSetSize;
+        public uint ActiveProcessLimit;
+        public UIntPtr Affinity;
+        public uint PriorityClass;
+        public uint SchedulingClass;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct IO_COUNTERS {
+        public ulong ReadOperationCount;
+        public ulong WriteOperationCount;
+        public ulong OtherOperationCount;
+        public ulong ReadTransferCount;
+        public ulong WriteTransferCount;
+        public ulong OtherTransferCount;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct JOBOBJECT_EXTENDED_LIMIT_INFORMATION {
+        public JOBOBJECT_BASIC_LIMIT_INFORMATION BasicLimitInformation;
+        public IO_COUNTERS IoInfo;
+        public UIntPtr ProcessMemoryLimit;
+        public UIntPtr JobMemoryLimit;
+        public UIntPtr PeakProcessMemoryUsed;
+        public UIntPtr PeakJobMemoryUsed;
+    }
+
+    [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+    private static extern IntPtr CreateJobObject(IntPtr securityAttributes, string name);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    private static extern bool SetInformationJobObject(IntPtr job, int infoClass, IntPtr info, uint length);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    private static extern bool AssignProcessToJobObject(IntPtr job, IntPtr process);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    private static extern bool QueryInformationJobObject(IntPtr job, int infoClass, IntPtr info, uint length, out uint returnLength);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    private static extern bool IsProcessInJob(IntPtr process, IntPtr job, out bool result);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    private static extern bool TerminateJobObject(IntPtr job, uint exitCode);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    private static extern bool CloseHandle(IntPtr handle);
+
+    public static IntPtr CreateKillOnClose() {
+        IntPtr job = CreateJobObject(IntPtr.Zero, null);
+        if (job == IntPtr.Zero) throw new Win32Exception(Marshal.GetLastWin32Error());
+        var limits = new JOBOBJECT_EXTENDED_LIMIT_INFORMATION();
+        limits.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
+        int size = Marshal.SizeOf<JOBOBJECT_EXTENDED_LIMIT_INFORMATION>();
+        IntPtr buffer = Marshal.AllocHGlobal(size);
+        try {
+            Marshal.StructureToPtr(limits, buffer, false);
+            if (!SetInformationJobObject(job, 9, buffer, (uint)size)) {
+                int error = Marshal.GetLastWin32Error();
+                CloseHandle(job);
+                throw new Win32Exception(error);
+            }
+            return job;
+        } finally {
+            Marshal.FreeHGlobal(buffer);
+        }
+    }
+
+    public static void Assign(IntPtr job, IntPtr process) {
+        if (!AssignProcessToJobObject(job, process)) throw new Win32Exception(Marshal.GetLastWin32Error());
+    }
+
+    public static int[] GetProcessIds(IntPtr job) {
+        const int size = 65536;
+        IntPtr buffer = Marshal.AllocHGlobal(size);
+        try {
+            uint returned;
+            if (!QueryInformationJobObject(job, 3, buffer, size, out returned)) {
+                throw new Win32Exception(Marshal.GetLastWin32Error());
+            }
+            int count = Marshal.ReadInt32(buffer, 4);
+            int capacity = (size - 8) / IntPtr.Size;
+            if (count < 0 || count > capacity) throw new InvalidOperationException("Invalid job process count.");
+            var result = new int[count];
+            for (int i = 0; i < count; i++) {
+                long value = IntPtr.Size == 8
+                    ? Marshal.ReadInt64(buffer, 8 + i * IntPtr.Size)
+                    : Marshal.ReadInt32(buffer, 8 + i * IntPtr.Size);
+                result[i] = checked((int)value);
+            }
+            return result;
+        } finally {
+            Marshal.FreeHGlobal(buffer);
+        }
+    }
+
+    public static bool ContainsProcess(IntPtr job, IntPtr process) {
+        bool result;
+        if (!IsProcessInJob(process, job, out result)) throw new Win32Exception(Marshal.GetLastWin32Error());
+        return result;
+    }
+
+    public static void Terminate(IntPtr job, uint exitCode) {
+        if (!TerminateJobObject(job, exitCode)) throw new Win32Exception(Marshal.GetLastWin32Error());
+    }
+
+    public static void Close(IntPtr job) {
+        if (job != IntPtr.Zero && !CloseHandle(job)) throw new Win32Exception(Marshal.GetLastWin32Error());
+    }
+}
+
+public sealed class WindowsCiChild : IDisposable {
+    [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+    private struct STARTUPINFO {
+        public int Size;
+        public string Reserved;
+        public string Desktop;
+        public string Title;
+        public uint X, Y, XSize, YSize, XCountChars, YCountChars, FillAttribute, Flags;
+        public ushort ShowWindow, ReservedBytes;
+        public IntPtr ReservedPointer, StandardInput, StandardOutput, StandardError;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct PROCESS_INFORMATION {
+        public IntPtr Process, Thread;
+        public uint ProcessId, ThreadId;
+    }
+
+    [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+    private static extern bool CreateProcessW(string application, System.Text.StringBuilder command,
+        IntPtr processAttributes, IntPtr threadAttributes, bool inheritHandles, uint flags,
+        IntPtr environment, string directory, ref STARTUPINFO startup, out PROCESS_INFORMATION process);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    private static extern uint ResumeThread(IntPtr thread);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    private static extern bool TerminateProcess(IntPtr process, uint exitCode);
+
+    [DllImport("kernel32.dll")]
+    private static extern bool CloseHandle(IntPtr handle);
+
+    public System.Diagnostics.Process Process { get; private set; }
+    public System.IO.Pipes.AnonymousPipeServerStream StandardOutput { get; private set; }
+    public System.IO.Pipes.AnonymousPipeServerStream StandardError { get; private set; }
+
+    private static string Quote(string argument) {
+        var result = new System.Text.StringBuilder("\"");
+        int slashes = 0;
+        foreach (char value in argument) {
+            if (value == '\\') { slashes++; continue; }
+            result.Append('\\', value == '"' ? slashes * 2 + 1 : slashes);
+            result.Append(value);
+            slashes = 0;
+        }
+        return result.Append('\\', slashes * 2).Append('"').ToString();
+    }
+
+    public static WindowsCiChild Start(IntPtr job, System.Diagnostics.ProcessStartInfo info) {
+        var child = new WindowsCiChild();
+        var native = new PROCESS_INFORMATION();
+        IntPtr environment = IntPtr.Zero;
+        try {
+            child.StandardOutput = new System.IO.Pipes.AnonymousPipeServerStream(
+                System.IO.Pipes.PipeDirection.In, System.IO.HandleInheritability.Inheritable);
+            child.StandardError = new System.IO.Pipes.AnonymousPipeServerStream(
+                System.IO.Pipes.PipeDirection.In, System.IO.HandleInheritability.Inheritable);
+            using (var input = new System.IO.Pipes.AnonymousPipeServerStream(
+                System.IO.Pipes.PipeDirection.Out, System.IO.HandleInheritability.Inheritable)) {
+                var startup = new STARTUPINFO {
+                    Size = Marshal.SizeOf<STARTUPINFO>(),
+                    Flags = 0x00000100,
+                    StandardInput = input.ClientSafePipeHandle.DangerousGetHandle(),
+                    StandardOutput = child.StandardOutput.ClientSafePipeHandle.DangerousGetHandle(),
+                    StandardError = child.StandardError.ClientSafePipeHandle.DangerousGetHandle()
+                };
+                var command = new System.Text.StringBuilder(Quote(info.FileName));
+                foreach (string argument in info.ArgumentList) command.Append(' ').Append(Quote(argument));
+                var variables = new System.Collections.Generic.List<string>();
+                foreach (var entry in info.Environment) variables.Add(entry.Key + "=" + entry.Value);
+                variables.Sort(StringComparer.OrdinalIgnoreCase);
+                environment = Marshal.StringToHGlobalUni(string.Join("\0", variables) + "\0\0");
+
+                // Assign the real target before it can run or create descendants.
+                // A packaged PowerShell bootstrap can break children out of its job.
+                if (!CreateProcessW(info.FileName, command, IntPtr.Zero, IntPtr.Zero, true,
+                    0x08000404, environment, info.WorkingDirectory, ref startup, out native)) {
+                    throw new Win32Exception(Marshal.GetLastWin32Error());
+                }
+                input.DisposeLocalCopyOfClientHandle();
+                child.StandardOutput.DisposeLocalCopyOfClientHandle();
+                child.StandardError.DisposeLocalCopyOfClientHandle();
+                WindowsCiJob.Assign(job, native.Process);
+                child.Process = System.Diagnostics.Process.GetProcessById(checked((int)native.ProcessId));
+                // Retain an identity-bound handle even if the command exits immediately after resume.
+                IntPtr retainedHandle = child.Process.Handle;
+                if (ResumeThread(native.Thread) == uint.MaxValue) {
+                    throw new Win32Exception(Marshal.GetLastWin32Error());
+                }
+            }
+            return child;
+        } catch {
+            if (native.Process != IntPtr.Zero) TerminateProcess(native.Process, 125);
+            child.Dispose();
+            if (child.Process != null) child.Process.Dispose();
+            throw;
+        } finally {
+            if (native.Thread != IntPtr.Zero) CloseHandle(native.Thread);
+            if (native.Process != IntPtr.Zero) CloseHandle(native.Process);
+            if (environment != IntPtr.Zero) Marshal.FreeHGlobal(environment);
+        }
+    }
+
+    public void Dispose() {
+        if (StandardOutput != null) StandardOutput.Dispose();
+        if (StandardError != null) StandardError.Dispose();
+    }
+}
+
+public static class LizzieCiCancellation {
+    private static int requested;
+    public static bool Requested { get { return Volatile.Read(ref requested) != 0; } }
+    public static void Install() {
+        Interlocked.Exchange(ref requested, 0);
+        Console.CancelKeyPress += OnCancel;
+    }
+    public static void Uninstall() { Console.CancelKeyPress -= OnCancel; }
+    private static void OnCancel(object sender, ConsoleCancelEventArgs e) {
+        e.Cancel = true;
+        Interlocked.Exchange(ref requested, 1);
+    }
+}
+'@
+}
+
+$startedUtc = [datetime]::UtcNow
+$finishedUtc = $null
+$status = 'monitor_error'
+$supervisorExitCode = 125
+$childExitCode = $null
+$process = $null
+$launched = $null
+$stdoutFile = $null
+$stderrFile = $null
+$stdoutCopy = $null
+$stderrCopy = $null
+$cleanup = $null
+$monitorError = $null
+$configurationError = $false
+$deadlineExpired = $false
+$configuredDeadlineUnix = $env:LIZZIE_CI_DEADLINE_UNIX_SECONDS
+$absoluteDeadlineUtc = $null
+$deadlineCaptureUtc = $null
+$script:JobHandle = [IntPtr]::Zero
+$script:OwnedProcesses = @{}
+$knownJunitFiles = @{}
+$episode = 0
+$pairCapturedThisEpisode = $false
+$deadlinePairCaptured = $false
+$lastProgressUtc = $startedUtc
+$lastOutputLength = 0L
+$lastConsoleProgressUtc = [datetime]::MinValue
+
+try {
+    [LizzieCiCancellation]::Install()
+    $stdoutPath = Join-Path -Path $OutputDirectory -ChildPath 'console.stdout.log'
+    $stderrPath = Join-Path -Path $OutputDirectory -ChildPath 'console.stderr.log'
+    $stdoutFile = [System.IO.FileStream]::new($stdoutPath, [System.IO.FileMode]::CreateNew, [System.IO.FileAccess]::Write, [System.IO.FileShare]::ReadWrite, 65536, $true)
+    $stderrFile = [System.IO.FileStream]::new($stderrPath, [System.IO.FileMode]::CreateNew, [System.IO.FileAccess]::Write, [System.IO.FileShare]::ReadWrite, 65536, $true)
+
+    $absoluteDeadlineUtc = $startedUtc.AddSeconds($TimeoutSeconds)
+    if ($configuredDeadlineUnix) {
+        [long]$deadlineUnix = 0
+        if (-not [long]::TryParse($configuredDeadlineUnix, [ref]$deadlineUnix)) {
+            $configurationError = $true
+            throw "LIZZIE_CI_DEADLINE_UNIX_SECONDS is not a valid integer: $configuredDeadlineUnix"
+        }
+        try {
+            $workflowDeadlineUtc = [System.DateTimeOffset]::FromUnixTimeSeconds($deadlineUnix).UtcDateTime
+        }
+        catch {
+            $configurationError = $true
+            throw "LIZZIE_CI_DEADLINE_UNIX_SECONDS is outside the supported range: $configuredDeadlineUnix"
+        }
+        if ($workflowDeadlineUtc -lt $absoluteDeadlineUtc) {
+            $absoluteDeadlineUtc = $workflowDeadlineUtc
+        }
+    }
+    if ($absoluteDeadlineUtc -le [datetime]::UtcNow) {
+        $deadlineExpired = $true
+        throw 'The effective CI deadline has already passed; the command was not started.'
+    }
+    $captureReserveSeconds = $DumpIntervalSeconds + (2 * $DumpTimeoutSeconds) + 2
+    $availableSeconds = [math]::Max(1, ($absoluteDeadlineUtc - $startedUtc).TotalSeconds - 1)
+    $deadlineCaptureUtc = $absoluteDeadlineUtc.AddSeconds(-[math]::Min($captureReserveSeconds, $availableSeconds))
+
+    $startInfo = [System.Diagnostics.ProcessStartInfo]::new()
+    $startInfo.FileName = (Get-Command -Name $Executable -CommandType Application -ErrorAction Stop | Select-Object -First 1).Source
+    $startInfo.WorkingDirectory = $WorkingDirectory
+    $startInfo.Environment['LIZZIE_CI_EVIDENCE_DIR'] = $OutputDirectory
+    foreach ($argument in $CommandArguments) {
+        $startInfo.ArgumentList.Add($argument)
+    }
+
+    $script:JobHandle = [WindowsCiJob]::CreateKillOnClose()
+    Write-Host "Starting Windows CI command (timeout ${TimeoutSeconds}s, stall ${StallSeconds}s)."
+    $launched = [WindowsCiChild]::Start($script:JobHandle, $startInfo)
+    $process = $launched.Process
+    $stdoutCopy = $launched.StandardOutput.CopyToAsync($stdoutFile)
+    $stderrCopy = $launched.StandardError.CopyToAsync($stderrFile)
+
+    while (-not $process.HasExited) {
+        if ([LizzieCiCancellation]::Requested) {
+            $status = 'interrupted'
+            $supervisorExitCode = 130
+            if (-not $pairCapturedThisEpisode -and [datetime]::UtcNow -lt $absoluteDeadlineUtc) {
+                $episode++
+                Save-DiagnosticPair -Reason 'interrupted' -Episode $episode -HardDeadlineUtc $absoluteDeadlineUtc
+                $pairCapturedThisEpisode = $true
+            }
+            break
+        }
+
+        $now = [datetime]::UtcNow
+        if ($now -ge $absoluteDeadlineUtc) {
+            $status = 'timed_out'
+            $supervisorExitCode = 124
+            break
+        }
+
+        $junit = Read-JunitProgress -KnownFiles $knownJunitFiles
+        $outputLength = $stdoutFile.Length + $stderrFile.Length
+        $outputChanged = $outputLength -ne $lastOutputLength
+        $lastOutputLength = $outputLength
+
+        $realProgress = $junit.Changed -or ((-not $junit.ActivePlan) -and $outputChanged)
+        if ($realProgress) {
+            $lastProgressUtc = $now
+            $pairCapturedThisEpisode = $false
+        }
+
+        if ($junit.LastEvent) {
+            $eventName = [string]$junit.LastEvent.event
+            $displayProperty = $junit.LastEvent.PSObject.Properties['displayName']
+            if ($displayProperty -and $displayProperty.Value) {
+                Write-Host ("JUnit {0}: {1}" -f $eventName, $displayProperty.Value)
+            }
+            else {
+                Write-Host ("JUnit {0}" -f $eventName)
+            }
+            $lastConsoleProgressUtc = $now
+        }
+        elseif ($outputChanged -and ($now - $lastConsoleProgressUtc).TotalSeconds -ge 30) {
+            Write-Host ("Command output continues (stdout {0} bytes, stderr {1} bytes)." -f $stdoutFile.Length, $stderrFile.Length)
+            $lastConsoleProgressUtc = $now
+        }
+
+        $deadlineCaptureDue = (-not $deadlinePairCaptured) -and (-not $pairCapturedThisEpisode) -and $now -ge $deadlineCaptureUtc
+        $stallCaptureDue = (-not $pairCapturedThisEpisode) -and ($now - $lastProgressUtc).TotalSeconds -ge $StallSeconds
+        if ($stallCaptureDue -or $deadlineCaptureDue) {
+            $episode++
+            $reason = if ($deadlineCaptureDue) { 'deadline' } else { 'stall' }
+            Write-Warning "Capturing $reason diagnostics (episode $episode)."
+            Save-DiagnosticPair -Reason $reason -Episode $episode -HardDeadlineUtc $absoluteDeadlineUtc
+            $pairCapturedThisEpisode = $true
+            if ($deadlineCaptureDue) { $deadlinePairCaptured = $true }
+        }
+
+        Start-Sleep -Milliseconds 250
+    }
+
+    if ($status -in @('timed_out', 'interrupted')) {
+        $cleanup = Stop-OwnedTree
+    }
+    else {
+        $process.WaitForExit()
+        $childExitCode = $process.ExitCode
+        $remaining = @(Get-JobProcessIds | Where-Object { $_ -ne $process.Id })
+        if (@($remaining).Count -gt 0) {
+            $cleanup = Stop-OwnedTree
+            $status = 'failed'
+            $supervisorExitCode = if ($childExitCode -ne 0) { $childExitCode } else { 125 }
+            $monitorError = 'The command exited with owned descendants still running; they were cleaned up.'
+        }
+        elseif ($childExitCode -eq 0) {
+            $status = 'completed'
+            $supervisorExitCode = 0
+        }
+        else {
+            $status = 'failed'
+            $supervisorExitCode = $childExitCode
+        }
+    }
+}
+catch {
+    $monitorError = $_.Exception.ToString()
+    if ($script:JobHandle -ne [IntPtr]::Zero) {
+        $cleanup = Stop-OwnedTree
+    }
+    if ($deadlineExpired) {
+        $status = 'timed_out'
+        $supervisorExitCode = 124
+    }
+    elseif ($configurationError) {
+        $status = 'monitor_error'
+        $supervisorExitCode = 125
+    }
+    else {
+        $status = if ($process) { 'monitor_error' } else { 'start_failed' }
+        $supervisorExitCode = 125
+    }
+}
+finally {
+    try { [LizzieCiCancellation]::Uninstall() } catch { }
+
+    if ($script:JobHandle -ne [IntPtr]::Zero) {
+        try {
+            [WindowsCiJob]::Close($script:JobHandle)
+        }
+        catch {
+            $closeError = "Could not close the owned Windows job: $($_.Exception.Message)"
+            $monitorError = if ($monitorError) { "$monitorError`n$closeError" } else { $closeError }
+            if ($supervisorExitCode -eq 0) {
+                $status = 'monitor_error'
+                $supervisorExitCode = 125
+            }
+        }
+        finally {
+            $script:JobHandle = [IntPtr]::Zero
+        }
+    }
+
+    $copyDeadline = [datetime]::UtcNow.AddSeconds(2)
+    foreach ($copyTask in @($stdoutCopy, $stderrCopy)) {
+        if (-not $copyTask) { continue }
+        $waitMs = [math]::Max(0, [int]($copyDeadline - [datetime]::UtcNow).TotalMilliseconds)
+        try { $copyTask.Wait($waitMs) | Out-Null } catch { }
+    }
+    if ($launched) {
+        if ($stdoutCopy -and -not $stdoutCopy.IsCompleted) { try { $launched.StandardOutput.Dispose() } catch { } }
+        if ($stderrCopy -and -not $stderrCopy.IsCompleted) { try { $launched.StandardError.Dispose() } catch { } }
+    }
+    foreach ($copyTask in @($stdoutCopy, $stderrCopy)) {
+        if ($copyTask -and -not $copyTask.IsCompleted) {
+            try { $copyTask.Wait(250) | Out-Null } catch { }
+        }
+    }
+    $copyIncomplete = ($stdoutCopy -and -not $stdoutCopy.IsCompletedSuccessfully) -or ($stderrCopy -and -not $stderrCopy.IsCompletedSuccessfully)
+    if ($stdoutFile) { try { $stdoutFile.Dispose() } catch { } }
+    if ($stderrFile) { try { $stderrFile.Dispose() } catch { } }
+    if ($copyIncomplete -and $supervisorExitCode -eq 0) {
+        $status = 'monitor_error'
+        $supervisorExitCode = 125
+        $monitorError = 'Console drain failed or did not finish within its bounded shutdown window.'
+    }
+    $finishedUtc = [datetime]::UtcNow
+
+    $javaCommand = Get-Command java.exe, java -ErrorAction SilentlyContinue | Select-Object -First 1
+    $summary = [ordered]@{
+        schemaVersion = 1
+        status = $status
+        exitCode = $supervisorExitCode
+        childExitCode = $childExitCode
+        startedUtc = $startedUtc.ToString('o')
+        finishedUtc = $finishedUtc.ToString('o')
+        durationSeconds = ($finishedUtc - $startedUtc).TotalSeconds
+        pid = if ($process) { $process.Id } else { $null }
+        executable = $Executable
+        workingDirectory = $WorkingDirectory
+        outputDirectory = $OutputDirectory
+        timeoutSeconds = $TimeoutSeconds
+        effectiveDeadlineUtc = if ($absoluteDeadlineUtc) { $absoluteDeadlineUtc.ToString('o') } else { $null }
+        configuredDeadlineUnixSeconds = $configuredDeadlineUnix
+        stallSeconds = $StallSeconds
+        dumpIntervalSeconds = $DumpIntervalSeconds
+        dumpTimeoutSeconds = $DumpTimeoutSeconds
+        diagnosticEpisodes = $episode
+        cleanup = if ($cleanup) { [ordered]@{ stoppedPids = @($cleanup.Stopped); failures = @($cleanup.Failed) } } else { $null }
+        error = $monitorError
+        identity = [ordered]@{
+            githubSha = $env:GITHUB_SHA
+            githubRunId = $env:GITHUB_RUN_ID
+            githubRunAttempt = $env:GITHUB_RUN_ATTEMPT
+            imageOs = $env:ImageOS
+            imageVersion = $env:ImageVersion
+            javaHome = $env:JAVA_HOME
+            javaPath = if ($javaCommand) { $javaCommand.Source } else { $null }
+        }
+    }
+    try {
+        Write-JsonFile -Path (Join-Path -Path $OutputDirectory -ChildPath 'summary.json') -Value $summary
+    }
+    catch {
+        Write-Error "Could not save supervisor summary: $($_.Exception.Message)" -ErrorAction Continue
+        if ($supervisorExitCode -eq 0) { $supervisorExitCode = 125 }
+    }
+    if ($process) { $process.Dispose() }
+    if ($launched) { $launched.Dispose() }
+}
+
+Write-Host "Windows CI supervisor status: $status (exit $supervisorExitCode)."
+exit $supervisorExitCode

--- a/scripts/test_windows_ci_diagnostics.py
+++ b/scripts/test_windows_ci_diagnostics.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""Exercise the Windows CI supervisor against real owned process trees."""
+
+import ctypes
+import json
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+
+
+@unittest.skipUnless(os.name == "nt", "requires native Windows process ownership")
+class WindowsCiDiagnosticsTest(unittest.TestCase):
+    def setUp(self):
+        self.pwsh = shutil.which("pwsh")
+        if not self.pwsh:
+            self.fail("PowerShell 7 is required for Windows CI supervision checks")
+        self.temporary = tempfile.TemporaryDirectory(prefix="ci supervisor ")
+        self.addCleanup(self.temporary.cleanup)
+        self.root = Path(self.temporary.name)
+        self.output = self.root / "evidence"
+        self.driver = self.root / "invoke.ps1"
+        self.driver.write_text(
+            "$ErrorActionPreference = 'Stop'\n"
+            "$options = $env:CI_SUPERVISOR_TEST_OPTIONS | ConvertFrom-Json -AsHashtable\n"
+            "& $env:CI_SUPERVISOR_TEST_SCRIPT @options\n"
+            "exit $LASTEXITCODE\n",
+            encoding="utf-8",
+        )
+
+    def invoke(self, code, *, timeout=15, stall=2, deadline=None, arguments=()):
+        environment = os.environ.copy()
+        environment.pop("LIZZIE_CI_DEADLINE_UNIX_SECONDS", None)
+        if deadline is not None:
+            environment["LIZZIE_CI_DEADLINE_UNIX_SECONDS"] = str(deadline)
+        environment["CI_SUPERVISOR_TEST_SCRIPT"] = str(
+            Path(__file__).resolve().with_name("run_windows_ci_diagnostics.ps1")
+        )
+        environment["CI_SUPERVISOR_TEST_OPTIONS"] = json.dumps({
+            "Executable": sys.executable,
+            "CommandArguments": ["-c", code, *arguments],
+            "WorkingDirectory": str(self.root),
+            "OutputDirectory": str(self.output),
+            "TimeoutSeconds": timeout,
+            "StallSeconds": stall,
+            "DumpIntervalSeconds": 1,
+            "DumpTimeoutSeconds": 1,
+        })
+        return subprocess.run(
+            [self.pwsh, "-NoLogo", "-NoProfile", "-NonInteractive", "-File", str(self.driver)],
+            env=environment, capture_output=True, text=True, timeout=timeout + 30,
+        )
+
+    def summary(self):
+        return json.loads((self.output / "summary.json").read_text(encoding="utf-8-sig"))
+
+    def assert_process_stopped(self, pid):
+        kernel = ctypes.WinDLL("kernel32", use_last_error=True)
+        kernel.OpenProcess.argtypes = [ctypes.c_ulong, ctypes.c_int, ctypes.c_ulong]
+        kernel.OpenProcess.restype = ctypes.c_void_p
+        kernel.WaitForSingleObject.argtypes = [ctypes.c_void_p, ctypes.c_ulong]
+        kernel.CloseHandle.argtypes = [ctypes.c_void_p]
+        handle = kernel.OpenProcess(0x00100000, False, pid)
+        if not handle:
+            self.assertEqual(87, ctypes.get_last_error(), "unable to verify child process exit")
+            return
+        try:
+            self.assertEqual(0, kernel.WaitForSingleObject(handle, 0), "owned child survived cleanup")
+        finally:
+            kernel.CloseHandle(handle)
+
+    def test_expired_job_deadline_does_not_start_work(self):
+        marker = self.root / "started"
+        result = self.invoke(
+            f"from pathlib import Path; Path({str(marker)!r}).touch()", deadline=1,
+        )
+        self.assertNotEqual(0, result.returncode, result.stdout + result.stderr)
+        self.assertFalse(marker.exists(), "expired job deadline still started work")
+        self.assertNotEqual("completed", self.summary()["status"])
+
+    def test_preserves_failure_arguments_and_drains_both_output_streams(self):
+        arguments = ["argument with spaces", "", 'quoted"value', "trailing\\", 'slash\\"quote', "围棋"]
+        result = self.invoke(
+            "import json,sys; print(json.dumps(sys.argv[1:])); print('o'*200000); "
+            "sys.stderr.write('e'*200000+'\\nerror-tail\\n'); print('output-tail'); sys.exit(7)",
+            arguments=arguments,
+        )
+        self.assertEqual(7, result.returncode, result.stdout + result.stderr)
+        self.assertEqual(7, self.summary()["exitCode"])
+        stdout = (self.output / "console.stdout.log").read_text()
+        self.assertEqual(arguments, json.loads(stdout.splitlines()[0]))
+        self.assertIn("output-tail", stdout)
+        self.assertIn("error-tail", (self.output / "console.stderr.log").read_text())
+
+    def test_quiet_work_gets_two_snapshots_without_being_failed(self):
+        result = self.invoke("import time; time.sleep(7)", stall=1)
+        self.assertEqual(0, result.returncode, result.stdout + result.stderr)
+        self.assertEqual("completed", self.summary()["status"])
+        self.assertEqual(2, len(list(self.output.glob("snapshot-*.json"))))
+
+    def test_nested_active_plan_ignores_console_noise_for_stall_detection(self):
+        result = self.invoke(
+            "import json,os,pathlib,time; "
+            "p=pathlib.Path(os.environ['LIZZIE_CI_EVIDENCE_DIR'])/f'junit-{os.getpid()}.jsonl'; "
+            "events=['PLAN_STARTED','PLAN_STARTED','PLAN_FINISHED']; "
+            "p.write_text(''.join(json.dumps({'event':e,'pid':os.getpid()})+'\\n' "
+            "for e in events),encoding='utf-8'); "
+            "[(print('output while outer plan is blocked',flush=True),time.sleep(.1)) "
+            "for _ in range(70)]",
+            stall=1,
+        )
+        self.assertEqual(0, result.returncode, result.stdout + result.stderr)
+        snapshots = sorted(self.output.glob("snapshot-*.json"))
+        self.assertEqual(2, len(snapshots), result.stdout + result.stderr)
+        for path in snapshots:
+            self.assertEqual("stall", json.loads(path.read_text(encoding="utf-8-sig"))["reason"])
+
+    def test_timeout_keeps_evidence_and_terminates_owned_descendants(self):
+        marker = self.root / "child.pid"
+        result = self.invoke(
+            "import subprocess,sys,time,pathlib; "
+            "child=subprocess.Popen([sys.executable,'-c','import time; time.sleep(120)']); "
+            f"pathlib.Path({str(marker)!r}).write_text(str(child.pid)); "
+            "time.sleep(120)",
+            timeout=8, stall=1,
+        )
+        self.assertNotEqual(0, result.returncode, result.stdout + result.stderr)
+        self.assertEqual("timed_out", self.summary()["status"])
+        self.assertEqual(2, len(list(self.output.glob("snapshot-*.json"))))
+        self.assert_process_stopped(int(marker.read_text()))
+
+    def test_parent_exit_cannot_hide_a_stranded_descendant(self):
+        marker = self.root / "orphan.pid"
+        result = self.invoke(
+            "import subprocess,sys,pathlib; "
+            "child=subprocess.Popen([sys.executable,'-c','import time; time.sleep(120)']); "
+            f"pathlib.Path({str(marker)!r}).write_text(str(child.pid))"
+        )
+        self.assertNotEqual(0, result.returncode, result.stdout + result.stderr)
+        self.assertNotEqual("completed", self.summary()["status"])
+        self.assert_process_stopped(int(marker.read_text()))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/test/java/featurecat/lizzie/ci/CiProgressListener.java
+++ b/src/test/java/featurecat/lizzie/ci/CiProgressListener.java
@@ -1,0 +1,197 @@
+package featurecat.lizzie.ci;
+
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.lang.management.ManagementFactory;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.time.Instant;
+import org.json.JSONObject;
+import org.junit.platform.engine.TestExecutionResult;
+import org.junit.platform.launcher.TestExecutionListener;
+import org.junit.platform.launcher.TestIdentifier;
+import org.junit.platform.launcher.TestPlan;
+
+/**
+ * Emits flushed, append-only JUnit execution evidence for the CI stall supervisor.
+ *
+ * <p>This listener is intentionally test-scope only. It does no work unless {@value
+ * #EVIDENCE_DIRECTORY_ENV} names an output directory.
+ */
+public final class CiProgressListener implements TestExecutionListener {
+  static final String EVIDENCE_DIRECTORY_ENV = "LIZZIE_CI_EVIDENCE_DIR";
+  private final Path evidenceDirectory;
+  private final long processId;
+  private static final Object FILE_WRITE_LOCK = new Object();
+  private BufferedWriter writer;
+  private boolean outputFailed;
+  private boolean failureReported;
+
+  /** Creates a listener configured from {@value #EVIDENCE_DIRECTORY_ENV}. */
+  public CiProgressListener() {
+    this(readEvidenceDirectory());
+  }
+
+  /**
+   * Creates a listener writing to the supplied directory.
+   *
+   * <p>Package-private so focused behavior tests can use a temporary directory without changing the
+   * child process environment.
+   */
+  CiProgressListener(Path evidenceDirectory) {
+    this.evidenceDirectory = evidenceDirectory;
+    this.processId = evidenceDirectory == null ? -1L : ProcessHandle.current().pid();
+  }
+
+  @Override
+  public void testPlanExecutionStarted(TestPlan testPlan) {
+    emitPlanEvent("PLAN_STARTED", true);
+  }
+
+  @Override
+  public void testPlanExecutionFinished(TestPlan testPlan) {
+    emitPlanEvent("PLAN_FINISHED", false);
+    synchronized (FILE_WRITE_LOCK) {
+      closeWriter();
+    }
+  }
+
+  @Override
+  public void executionStarted(TestIdentifier testIdentifier) {
+    emitIdentifierEvent("START", testIdentifier, null, null);
+  }
+
+  @Override
+  public void executionFinished(
+      TestIdentifier testIdentifier, TestExecutionResult testExecutionResult) {
+    if (evidenceDirectory != null) {
+      emitIdentifierEvent("FINISH", testIdentifier, testExecutionResult.getStatus().name(), null);
+    }
+  }
+
+  @Override
+  public void executionSkipped(TestIdentifier testIdentifier, String reason) {
+    emitIdentifierEvent("SKIPPED", testIdentifier, "SKIPPED", reason);
+  }
+
+  private static Path readEvidenceDirectory() {
+    try {
+      String configured = System.getenv(EVIDENCE_DIRECTORY_ENV);
+      if (configured == null || configured.isBlank()) {
+        return null;
+      }
+      return Path.of(configured);
+    } catch (RuntimeException exception) {
+      reportFailure(exception);
+      return null;
+    }
+  }
+
+  private void emitPlanEvent(String event, boolean includeJvmIdentity) {
+    if (evidenceDirectory == null) {
+      return;
+    }
+    synchronized (FILE_WRITE_LOCK) {
+      if (outputFailed) {
+        return;
+      }
+      try {
+        JSONObject record = newRecord(event);
+        if (includeJvmIdentity) {
+          record.put("jvm", ManagementFactory.getRuntimeMXBean().getName());
+          record.put("javaVersion", System.getProperty("java.runtime.version"));
+          record.put("javaVendor", System.getProperty("java.vendor"));
+        }
+        writeRecord(record);
+      } catch (IOException | RuntimeException exception) {
+        disableOutput(exception);
+      }
+    }
+  }
+
+  private void emitIdentifierEvent(
+      String event, TestIdentifier testIdentifier, String status, String reason) {
+    if (evidenceDirectory == null) {
+      return;
+    }
+    synchronized (FILE_WRITE_LOCK) {
+      if (outputFailed) {
+        return;
+      }
+      try {
+        JSONObject record = newRecord(event);
+        record.put("id", testIdentifier.getUniqueId());
+        record.put("displayName", testIdentifier.getDisplayName());
+        if (status != null) {
+          record.put("status", status);
+        }
+        if (reason != null && !reason.isBlank()) {
+          record.put("reason", reason);
+        }
+        writeRecord(record);
+      } catch (IOException | RuntimeException exception) {
+        disableOutput(exception);
+      }
+    }
+  }
+
+  private JSONObject newRecord(String event) {
+    return new JSONObject()
+        .put("time", Instant.now().toString())
+        .put("pid", processId)
+        .put("event", event);
+  }
+
+  private void writeRecord(JSONObject record) throws IOException {
+    if (writer == null) {
+      Files.createDirectories(evidenceDirectory);
+      Path outputFile = evidenceDirectory.resolve("junit-" + processId + ".jsonl");
+      writer =
+          Files.newBufferedWriter(
+              outputFile,
+              StandardCharsets.UTF_8,
+              StandardOpenOption.CREATE,
+              StandardOpenOption.WRITE,
+              StandardOpenOption.APPEND);
+    }
+    writer.write(record.toString());
+    writer.newLine();
+    writer.flush();
+  }
+
+  private void disableOutput(Exception exception) {
+    outputFailed = true;
+    closeWriter();
+    reportFailureOnce(exception);
+  }
+
+  private void closeWriter() {
+    if (writer == null) {
+      return;
+    }
+    try {
+      writer.close();
+    } catch (IOException exception) {
+      reportFailureOnce(exception);
+    } finally {
+      writer = null;
+    }
+  }
+
+  private void reportFailureOnce(Exception exception) {
+    if (!failureReported) {
+      failureReported = true;
+      reportFailure(exception);
+    }
+  }
+
+  private static void reportFailure(Exception exception) {
+    System.err.println(
+        "CiProgressListener: unable to write CI evidence ("
+            + exception.getClass().getSimpleName()
+            + "): "
+            + exception.getMessage());
+  }
+}

--- a/src/test/java/featurecat/lizzie/ci/CiProgressListenerTest.java
+++ b/src/test/java/featurecat/lizzie/ci/CiProgressListenerTest.java
@@ -1,0 +1,121 @@
+package featurecat.lizzie.ci;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.json.JSONObject;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.platform.engine.discovery.DiscoverySelectors;
+import org.junit.platform.launcher.Launcher;
+import org.junit.platform.launcher.LauncherDiscoveryRequest;
+import org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder;
+import org.junit.platform.launcher.core.LauncherFactory;
+
+class CiProgressListenerTest {
+  @TempDir Path temporaryDirectory;
+
+  @Test
+  void actualLauncherEmitsChronologyIdentifiersAndStatuses() throws IOException {
+    Path evidenceDirectory = temporaryDirectory.resolve("evidence");
+    CiProgressListener listener = new CiProgressListener(evidenceDirectory);
+    LauncherDiscoveryRequest request =
+        LauncherDiscoveryRequestBuilder.request()
+            .selectors(DiscoverySelectors.selectClass(LauncherFixture.class))
+            .build();
+
+    Launcher launcher = LauncherFactory.create();
+    launcher.registerTestExecutionListeners(listener);
+    launcher.execute(request);
+
+    List<Path> evidenceFiles;
+    try (var files = Files.list(evidenceDirectory)) {
+      evidenceFiles = files.collect(Collectors.toList());
+    }
+    assertEquals(1, evidenceFiles.size());
+    assertTrue(evidenceFiles.get(0).getFileName().toString().matches("junit-\\d+\\.jsonl"));
+
+    List<JSONObject> events =
+        Files.readAllLines(evidenceFiles.get(0), StandardCharsets.UTF_8).stream()
+            .map(JSONObject::new)
+            .toList();
+    assertEquals("PLAN_STARTED", events.get(0).getString("event"));
+    assertEquals("PLAN_FINISHED", events.get(events.size() - 1).getString("event"));
+
+    long processId = ProcessHandle.current().pid();
+    JSONObject planStarted = events.get(0);
+    assertEquals(processId, planStarted.getLong("pid"));
+    assertFalse(planStarted.getString("jvm").isBlank());
+    assertFalse(planStarted.has("id"));
+    assertFalse(planStarted.has("displayName"));
+
+    for (JSONObject event : events) {
+      assertEquals(processId, event.getLong("pid"));
+    }
+
+    JSONObject passingStart = findEvent(events, "START", "[method:passingTest()]");
+    JSONObject passingFinish = findEvent(events, "FINISH", "[method:passingTest()]");
+    assertEquals("passingTest()", passingFinish.getString("displayName"));
+    assertEquals("SUCCESSFUL", passingFinish.getString("status"));
+    assertTrue(events.indexOf(passingStart) < events.indexOf(passingFinish));
+
+    JSONObject failingStart = findEvent(events, "START", "[method:failingTest()]");
+    JSONObject failingFinish = findEvent(events, "FINISH", "[method:failingTest()]");
+    assertEquals("failingTest()", failingFinish.getString("displayName"));
+    assertEquals("FAILED", failingFinish.getString("status"));
+    assertTrue(events.indexOf(failingStart) < events.indexOf(failingFinish));
+
+    JSONObject skipped = findEvent(events, "SKIPPED", "[method:skippedTest()]");
+    assertEquals("skippedTest()", skipped.getString("displayName"));
+    assertEquals("SKIPPED", skipped.getString("status"));
+    assertEquals("fixture skip", skipped.getString("reason"));
+    assertTrue(skipped.getString("id").contains("LauncherFixture"));
+  }
+
+  @Test
+  void unwritableEvidenceDoesNotChangeTestResults() throws IOException {
+    Path occupied = temporaryDirectory.resolve("not-a-directory");
+    Files.writeString(occupied, "existing file");
+    Launcher launcher = LauncherFactory.create();
+    var summary = new org.junit.platform.launcher.listeners.SummaryGeneratingListener();
+    launcher.registerTestExecutionListeners(new CiProgressListener(occupied), summary);
+    launcher.execute(
+        LauncherDiscoveryRequestBuilder.request()
+            .selectors(DiscoverySelectors.selectClass(LauncherFixture.class))
+            .build());
+    assertEquals(1, summary.getSummary().getTestsSucceededCount());
+    assertEquals(1, summary.getSummary().getTestsFailedCount());
+    assertEquals(1, summary.getSummary().getTestsSkippedCount());
+    assertEquals("existing file", Files.readString(occupied));
+  }
+
+  private static JSONObject findEvent(List<JSONObject> events, String event, String idPart) {
+    return events.stream()
+        .filter(candidate -> event.equals(candidate.getString("event")))
+        .filter(candidate -> candidate.getString("id").contains(idPart))
+        .findFirst()
+        .orElseThrow(() -> new AssertionError("Missing " + event + " for " + idPart));
+  }
+
+  static class LauncherFixture {
+    @Test
+    void passingTest() {}
+
+    @Test
+    void failingTest() {
+      throw new AssertionError("intentional fixture failure");
+    }
+
+    @Test
+    @Disabled("fixture skip")
+    void skippedTest() {}
+  }
+}

--- a/src/test/resources/META-INF/services/org.junit.platform.launcher.TestExecutionListener
+++ b/src/test/resources/META-INF/services/org.junit.platform.launcher.TestExecutionListener
@@ -1,0 +1,1 @@
+featurecat.lizzie.ci.CiProgressListener


### PR DESCRIPTION
## Why

Intermittent Windows Java CI stalls can exhaust the job timeout before
the local runner writes its summary. Preserve execution evidence so the
next occurrence identifies the active test and JVM state.

## Changes

- Add an opt-in, test-scope JUnit listener that flushes per-process
  execution events with timestamps, test identifiers, and JVM identity.
- Supervise the existing Windows Java verification command with a bounded
  execution budget and Windows Job Object process ownership.
- Capture paired process/CPU snapshots and JVM thread dumps on stalled
  progress. Console output does not reset progress during an active
  JUnit plan.
- Preserve command exit codes, fail and clean up stranded descendants,
  and write an independent supervisor summary.
- Retain the 30-minute job limit and reserve time for diagnostic uploads.
  Upload console logs, JUnit events, snapshots, and available test reports.
- Add native Windows regression checks and document diagnostic usage.

## Validation

- Passed 6 native Windows supervision checks covering deadlines, quiet
  completion, nested JUnit plans, output draining, exit codes, and
  descendant cleanup.
- Re-ran the affected checks after adding empty, quoted, Unicode, and
  trailing-backslash argument coverage.
- Passed 2 JUnit listener tests and 10 local CI runner regression tests.
- Exercised a real JDK 21 blocked-test fixture with continuous console
  output: captured two thread dumps containing CountDownLatch.await,
  returned timeout exit code 124, and cleaned up owned processes.
- Verified that unavailable jcmd still leaves two process snapshots,
  JUnit events, and a failure summary.
- Passed focused Java formatting, line-ending checks, and workflow YAML
  validation.

## Limitations

The original intermittent hosted CI stall remains undiagnosed.
Controlled local Windows probes validate evidence collection and cleanup;
the upstream GitHub Actions run remains to be completed.